### PR TITLE
More python3.9 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,6 @@ description = "Petabyte scale data framework for unstructured data of any modali
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"
 repository = "https://github.com/tensorlakeai/tensorlake"
-packages = [
-    { include = "tensorlake", from="src", format = ["sdist", "wheel"] },
-]
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/tests/src/tests/test_graph_reduce.py
+++ b/tests/src/tests/test_graph_reduce.py
@@ -10,111 +10,82 @@ from tensorlake.functions_sdk.functions import tensorlake_function
 from tests.testing import remote_or_local_graph, test_graph_name
 
 
+class AccumulatedState(BaseModel):
+    sum: int = 0
+
+
+@tensorlake_function()
+def generate_seq(x: int) -> List[int]:
+    return [i for i in range(x)]
+
+
+@tensorlake_function()
+def fail_generate_seq(x: int) -> List[int]:
+    raise ValueError("test: fail_generate_seq function failed")
+
+
+@tensorlake_function(accumulate=AccumulatedState)
+def accumulate_reduce(acc: AccumulatedState, y: int) -> AccumulatedState:
+    acc.sum += y
+    return acc
+
+
+@tensorlake_function()
+def store_result(acc: AccumulatedState) -> int:
+    return acc.sum
+
+
+@tensorlake_function()
+def add_one(x: int) -> int:
+    return x + 1
+
+
+@tensorlake_function()
+def add_one_or_fail_at_0(x: int) -> int:
+    if x == 0:
+        raise ValueError("test: add_one_or_fail_at_0 function failed")
+    return x + 1
+
+
 class TestGraphReduce(unittest.TestCase):
     @parameterized.parameterized.expand([(True), (False)])
     def test_simple(self, is_remote: bool):
-        class AccumulatedSate(BaseModel):
-            sum: int = 19
-
-        @tensorlake_function()
-        def generate_seq(x: int) -> List[int]:
-            return [i for i in range(x)]
-
-        @tensorlake_function(accumulate=AccumulatedSate)
-        def accumulate_reduce(acc: AccumulatedSate, y: int) -> AccumulatedSate:
-            acc.sum += y
-            return acc
-
-        @tensorlake_function()
-        def store_result(acc: AccumulatedSate) -> int:
-            return acc.sum
-
         graph = Graph(name=test_graph_name(self), start_node=generate_seq)
         graph.add_edge(generate_seq, accumulate_reduce)
         graph.add_edge(accumulate_reduce, store_result)
 
-        metadata = graph.definition()
-        metadata_json = metadata.model_dump(exclude_none=True)
-        print(metadata_json)
-
-        graph = remote_or_local_graph(
-            graph, remote=is_remote, additional_modules=[tests, parameterized]
-        )
-        invocation_id = graph.run(block_until_done=True, x=3)
+        graph = remote_or_local_graph(graph, remote=is_remote)
+        invocation_id = graph.run(block_until_done=True, x=6)
         result = graph.output(invocation_id, store_result.name)
-        self.assertEqual(result[0], 22)
+        self.assertEqual(result[0], 15)  # 0 + 1 + 2 + 3 + 4 + 5
 
     @parameterized.parameterized.expand([(True)])
     def test_failure_in_parent(self, is_remote: bool):
         # Not running this with local graph because local execution currently
         # raises an exception on function error and fails the test case.
-        class AccumulatedSate(BaseModel):
-            sum: int = 0
-
-        @tensorlake_function()
-        def generate_seq(x: int) -> List[int]:
-            return [i for i in range(x)]
-
-        @tensorlake_function()
-        def add_one(x: int) -> int:
-            if x == 0:
-                raise ValueError("test: add_one function failed")
-            return x + 1
-
-        @tensorlake_function(accumulate=AccumulatedSate)
-        def accumulate_reduce(acc: AccumulatedSate, y: int) -> AccumulatedSate:
-            acc.sum += y
-            return acc
-
-        @tensorlake_function()
-        def store_result(acc: AccumulatedSate) -> int:
-            return acc.sum
-
         graph = Graph(
             name=test_graph_name(self),
             start_node=generate_seq,
         )
-        graph.add_edge(generate_seq, add_one)
-        graph.add_edge(add_one, accumulate_reduce)
+        graph.add_edge(generate_seq, add_one_or_fail_at_0)
+        graph.add_edge(add_one_or_fail_at_0, accumulate_reduce)
         graph.add_edge(accumulate_reduce, store_result)
-        graph = remote_or_local_graph(
-            graph, remote=is_remote, additional_modules=[tests, parameterized]
-        )
+        graph = remote_or_local_graph(graph, remote=is_remote)
 
         invocation_id = graph.run(block_until_done=True, x=3)
-        result = graph.output(invocation_id, store_result.name)
-        self.assertEqual(len(result), 0)
+        outputs = graph.output(invocation_id, store_result.name)
+        self.assertEqual(len(outputs), 0, "Expected zero results")
 
     @parameterized.parameterized.expand([(True)])
     def test_failure_start_node(self, is_remote: bool):
         # Not running this with local graph because local execution currently
         # raises an exception on function error and fails the test case.
-        class AccumulatedSate(BaseModel):
-            sum: int = 0
-
-        @tensorlake_function()
-        def generate_seq(x: int) -> List[int]:
-            raise ValueError("test: generate_seq function failed")
-            # return [i for i in range(x)]
-
-        @tensorlake_function()
-        def add_one(x: int) -> int:
-            return x + 1
-
-        @tensorlake_function(accumulate=AccumulatedSate)
-        def accumulate_reduce(acc: AccumulatedSate, y: int) -> AccumulatedSate:
-            acc.sum += y
-            return acc
-
-        @tensorlake_function()
-        def store_result(acc: AccumulatedSate) -> int:
-            return acc.sum
 
         graph = Graph(
             name=test_graph_name(self),
-            start_node=generate_seq,
+            start_node=fail_generate_seq,
         )
-        graph.add_edge(generate_seq, add_one)
+        graph.add_edge(fail_generate_seq, add_one)
         graph.add_edge(add_one, accumulate_reduce)
         graph.add_edge(accumulate_reduce, store_result)
         graph = remote_or_local_graph(

--- a/tests/src/tests/test_graph_update.py
+++ b/tests/src/tests/test_graph_update.py
@@ -83,7 +83,7 @@ class TestGraphUpdate(unittest.TestCase):
         self.assertEqual(output[0].x, "9b")
 
     @parameterized.parameterized.expand(
-        ["second_graph_new_name", "second_graph_reused_function_names"]
+        [("second_graph_new_name",), ("second_graph_reused_function_names",)]
     )
     def test_running_invocation_unaffected_by_update(self, second_graph_name: str):
         graph_name = test_graph_name(self)

--- a/tests/src/tests/testing.py
+++ b/tests/src/tests/testing.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Any, List
+from typing import Any, List, Union
 
 from tensorlake.functions_sdk.graph import Graph
 from tensorlake.remote_graph import RemoteGraph
@@ -7,7 +7,7 @@ from tensorlake.remote_graph import RemoteGraph
 
 def remote_or_local_graph(
     graph, remote=True, additional_modules: List[Any] = []
-) -> RemoteGraph | Graph:
+) -> Union[RemoteGraph, Graph]:
     if remote:
         return RemoteGraph.deploy(graph, additional_modules=additional_modules)
     return graph


### PR DESCRIPTION
Now all tests are passing on 3.9.
No need to bump package version because all the fixes are in tests