### PR TITLE
Fix intermittent @parametrized issue with python3.9

### DIFF
--- a/tests/src/tests/test_graph_update.py
+++ b/tests/src/tests/test_graph_update.py
@@ -83,9 +83,14 @@ class TestGraphUpdate(unittest.TestCase):
         self.assertEqual(output[0].x, "9b")
 
     @parameterized.parameterized.expand(
-        [("second_graph_new_name",), ("second_graph_reused_function_names",)]
+        [
+            ("new_function_names", "second_graph_new_name"),
+            ("existing_function_names", "second_graph_reused_function_names"),
+        ]
     )
-    def test_running_invocation_unaffected_by_update(self, second_graph_name: str):
+    def test_running_invocation_unaffected_by_update(
+        self, test_case_name: str, second_graph_name: str
+    ):
         graph_name = test_graph_name(self)
 
         def initial_graph():


### PR DESCRIPTION
According to @parametrized docs if the first value in the list is a string then it's treated as a test case name. This is most probably why we get the test failures in some environments.