### PR TITLE
feat(API): expose invocation wait and fallback on it on blocking requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ pydantic = "2.10.4"
 docker = "^7.1.0"
 nanoid = "^2.0.0"
 httpx-sse = "^0.4.0"
-rich = "^13.9.4" # TODO: Look into consolidating this with click
+rich = "^13.9.4"                                  # TODO: Look into consolidating this with click
 pyyaml = "^6.0.2"
 click = "^8.1.8"
 

--- a/src/tensorlake/error.py
+++ b/src/tensorlake/error.py
@@ -1,6 +1,10 @@
 class ApiException(Exception):
-    def __init__(self, message: str) -> None:
+    def __init__(self, status_code: int, message: str) -> None:
         super().__init__(message)
+        self.status_code = status_code
+
+    def __str__(self):
+        return f"{super().__str__()} (Status Code: {self.status_code})"
 
 
 class GraphStillProcessing(Exception):

--- a/src/tensorlake/remote_graph.py
+++ b/src/tensorlake/remote_graph.py
@@ -53,7 +53,7 @@ class RemoteGraph:
             self._name,
             block_until_done,
             self._graph_definition.get_input_encoder(),
-            **kwargs
+            **kwargs,
         )
 
     def metadata(self) -> ComputeGraphMetadata:

--- a/src/tensorlake/utils/http_client.py
+++ b/src/tensorlake/utils/http_client.py
@@ -4,6 +4,8 @@ import httpx
 import yaml
 from httpx import AsyncClient, Client
 
+_TRANSIENT_HTTPX_ERRORS = (httpx.NetworkError, httpx.RemoteProtocolError)
+
 
 def get_httpx_client(
     config_path: Optional[str] = None, make_async: Optional[bool] = False

--- a/src/tensorlake/utils/retries.py
+++ b/src/tensorlake/utils/retries.py
@@ -1,0 +1,73 @@
+import random
+import time
+from functools import wraps
+from typing import Any, Callable, Type, TypeVar, Union
+
+R = TypeVar("R")
+
+
+def exponential_backoff(
+    max_retries: int = 3,
+    initial_delay_seconds: float = 0.1,
+    max_delay_seconds: float = 15.0,
+    jitter_range: tuple[float, float] = (0.5, 1.0),
+    retryable_exceptions: tuple[Type[BaseException], ...] = (),
+    is_retryable: Callable[[BaseException], bool] = lambda e: True,
+    on_retry: Union[Callable[[BaseException, float, int], None], None] = None,
+) -> Callable[[Callable[..., R]], Callable[..., R]]:
+    """
+    Decorator that implements exponential backoff retry logic.
+
+    Args:
+        func: The function to retry.
+        max_retries: Maximum number of retry attempts.
+        initial_delay_seconds: Initial delay in seconds between retries.
+        max_delay_seconds: Maximum delay in seconds between retries.
+        jitter_range: Tuple of (min, max) multipliers for jitter to randomize the delay.
+        retryable_exceptions: Tuple of exception types that should trigger a retry.
+        is_retryable: Optional callable that determines if an exception is retryable.
+        on_retry: Optional callback function called before each retry
+                  with (exception, sleep_time, retry_count).
+
+    Returns:
+        Wrapped function that implements retry logic.
+
+    Example:
+        ```
+        @exponential_backoff(retryable_exceptions=(ValueError,))
+        def flaky_function() -> str:
+            if random.random() < 0.5:
+                raise ValueError("Random failure!")
+            return "Success"
+        ```
+    """
+
+    def decorator(func: Callable[..., R]) -> Callable[..., R]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> R:
+            retries = 0
+
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except retryable_exceptions as e:
+                    if not is_retryable(e):
+                        raise
+
+                    retries += 1
+                    if retries >= max_retries:
+                        raise
+
+                    base_delay = initial_delay_seconds * (2**retries)
+                    sleep_time = min(base_delay, max_delay_seconds)
+                    jitter = random.uniform(*jitter_range)
+                    sleep_time *= jitter
+
+                    if on_retry:
+                        on_retry(e, sleep_time, retries)
+
+                    time.sleep(sleep_time)
+
+        return wrapper
+
+    return decorator

--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -13,7 +13,7 @@ services:
       - data:/tmp/indexify-blob-storage
   executor:
     # Note: This must match the python version uses in test.yaml
-    image: tensorlake/indexify-executor-default:3.13
+    image: tensorlake/indexify-executor-default:3.9
     environment:
       - INDEXIFY_URL=http://indexify:8900
     command:

--- a/tests/src/test_graph_update.py
+++ b/tests/src/test_graph_update.py
@@ -197,11 +197,11 @@ class TestGraphUpdate(unittest.TestCase):
             RemoteGraph.deploy(g)
             self.fail("Expected an exception to be raised")
         except ApiException as e:
+            self.assertEqual(e.status_code, 400)
             self.assertIn(
                 "This graph version already exists, please update the graph version",
                 str(e),
             )
-            self.assertIn("status code: 400", str(e))
         except Exception as e:
             self.fail(f"Unexpected exception: {e}")
 

--- a/tests/src/utils/test_retries.py
+++ b/tests/src/utils/test_retries.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest.mock import ANY, Mock, patch
+
+from tensorlake.utils.retries import exponential_backoff
+
+
+class TestExponentialBackoff(unittest.TestCase):
+    def test_successful_execution(self):
+        @exponential_backoff(retryable_exceptions=(ValueError,))
+        def always_succeeds():
+            return "Success"
+
+        result = always_succeeds()
+        self.assertEqual(result, "Success")
+
+    def test_retry_on_exception(self):
+        mock_func = Mock(side_effect=[ValueError("Fail"), "Success"])
+
+        @exponential_backoff(retryable_exceptions=(ValueError,))
+        def flaky_function():
+            return mock_func()
+
+        result = flaky_function()
+        self.assertEqual(result, "Success")
+        self.assertEqual(mock_func.call_count, 2)
+
+    @patch("time.sleep", return_value=None)
+    def test_max_retries_exceeded(self, mock_sleep):
+        mock_func = Mock(side_effect=ValueError("Fail"))
+
+        @exponential_backoff(retryable_exceptions=(ValueError,), max_retries=3)
+        def always_fails():
+            return mock_func()
+
+        with self.assertRaises(ValueError):
+            always_fails()
+        self.assertEqual(mock_func.call_count, 3)
+
+    @patch("time.sleep", return_value=None)
+    def test_is_retryable(self, mock_sleep):
+        mock_func = Mock(side_effect=ValueError("Fail"))
+
+        @exponential_backoff(
+            retryable_exceptions=(ValueError,),
+            max_retries=3,
+            is_retryable=lambda e: False,
+        )
+        def always_fails():
+            return mock_func()
+
+        with self.assertRaises(ValueError):
+            always_fails()
+        self.assertEqual(mock_func.call_count, 1)
+
+    @patch("time.sleep", return_value=None)
+    def test_on_retry_callback(self, mock_sleep):
+        fail_exception = ValueError("Fail")
+        mock_func = Mock(side_effect=[fail_exception, "Success"])
+        mock_callback = Mock()
+
+        @exponential_backoff(retryable_exceptions=(ValueError,), on_retry=mock_callback)
+        def flaky_function():
+            return mock_func()
+
+        result = flaky_function()
+        self.assertEqual(result, "Success")
+        self.assertEqual(mock_func.call_count, 2)
+        self.assertEqual(mock_callback.call_count, 1)
+        mock_callback.assert_called_with(fail_exception, ANY, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Running ` graph.run(block_until_done=True, text=text)`, if there were any blips with the server or the client, the function would throw without a way to resume waiting.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

This PR leverages a new wait invocation endpoint (https://github.com/tensorlakeai/indexify/pull/1179) to add a new http_client method that allows waiting on a invocation using its invocation id.

We also leverage this new endpoint to do exponential backoff retries when `graph.run(block_until_done=True` is disconnected.

## Testing

Start a long running graph, stop the server and restart it multiple times.

<img width="1238" alt="image" src="https://github.com/user-attachments/assets/372215d8-d0e3-4c6d-b4f8-50b34a90a04a" />


<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] please run `make fmt`
- [x] Make sure all PR Checks are passing.