### PR TITLE
Fix broken graph tests and add more

### DIFF
--- a/tests/src/test_broken_graphs.py
+++ b/tests/src/test_broken_graphs.py
@@ -1,9 +1,13 @@
+import io
 import sys
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
+
+from testing import test_graph_name
 
 from tensorlake import RemoteGraph
 from tensorlake.functions_sdk.data_objects import File
-from tensorlake.functions_sdk.functions import tensorlake_function
+from tensorlake.functions_sdk.functions import TensorlakeCompute, tensorlake_function
 from tensorlake.functions_sdk.graph import Graph
 
 
@@ -12,12 +16,9 @@ def extractor_a(url: str) -> File:
     """
     Download pdf from url
     """
-    print("`extractor_a` is writing to stdout")
-    # print("`extractor_a` is writing to stderr", file=sys.stderr)
-    sys.stderr.write(
-        "===================== extractor_a is writing to stderr================="
-    )
-    return File(data="abc", mime_type="application/pdf")
+    print("extractor_a is writing to stdout")
+    print("extractor_a is writing to stderr", file=sys.stderr)
+    return File(data=b"abc", mime_type="application/pdf")
 
 
 @tensorlake_function()
@@ -25,8 +26,8 @@ def extractor_b(file: File) -> str:
     """
     Download pdf from url
     """
-    print("`extractor_b` is writing to stdout", file=sys.stdout)
-    print("`extractor_b` is writing to stderr", file=sys.stderr)
+    print("extractor_b is writing to stdout", file=sys.stdout)
+    print("extractor_b is writing to stderr", file=sys.stderr)
     raise Exception("this exception was raised from extractor_b")
 
 
@@ -38,38 +39,103 @@ def extractor_c(s: str) -> str:
     return "this is a return from extractor_c"
 
 
-def create_broken_graph():
-    g = Graph(
-        "test-graph-has-an-exception-for-stdout-stderr",
-        start_node=extractor_a,
-    )
+class TensorlakeComputeWithFailingConstructor(TensorlakeCompute):
+    name = "TensorlakeComputeWithFailingConstructor"
 
-    # Parse the PDF which was downloaded
-    g.add_edge(extractor_a, extractor_b)
-    g.add_edge(extractor_b, extractor_c)
-    return g
+    def __init__(self):
+        super().__init__()
+        raise Exception(
+            "this exception was raised by TensorlakeComputeWithFailingConstructor constructor"
+        )
+
+    def run(self) -> str:
+        return "success"
 
 
 class TestBrokenGraphs(unittest.TestCase):
-    def test_broken_graph(self):
-        g = create_broken_graph()
+    def test_expected_stdout_stderr_content(self):
+        g = Graph(
+            name=test_graph_name(self),
+            start_node=extractor_a,
+        )
+        g.add_edge(extractor_a, extractor_b)
+        g.add_edge(extractor_b, extractor_c)
         g = RemoteGraph.deploy(g)
 
-        self.assertRaises(
-            Exception,
-            g.run(
+        # We don't have a public SDK API to read a functions' stderr
+        # so we rely on internal SDK behavior where it prints a failed function's
+        # stderr to the current stdout.
+        sdk_stdout: io.StringIO = io.StringIO()
+        with redirect_stdout(sdk_stdout):
+            invocation_id = g.run(
                 block_until_done=True,
                 url="https://www.youtube.com/watch?v=gjHv4pM8WEQ",
-            ),
+            )
+        sdk_stdout_str: str = sdk_stdout.getvalue()
+
+        # extractor_a output is not written by SDK because it succeeded.
+        self.assertTrue("extractor_a is writing to stdout" not in sdk_stdout_str)
+        self.assertTrue("extractor_a is writing to stderr" not in sdk_stdout_str)
+
+        # extractor_b output is written by SDK because it failed to help user to debug.
+        self.assertTrue("extractor_b is writing to stdout" in sdk_stdout_str)
+        self.assertTrue("extractor_b is writing to stderr" in sdk_stdout_str)
+        self.assertTrue(
+            "Exception: this exception was raised from extractor_b" in sdk_stdout_str
         )
 
-        self.assertRaises(
-            Exception,
-            g.run(
-                block_until_done=True,
-                maybe="https://www.youtube.com/watch?v=gjHv4pM8WEQ",
-            ),
+        # extractor_c should not have been executed after failed extractor_b.
+        extractor_c_output = g.output(invocation_id, "extractor_c")
+        self.assertEqual(len(extractor_c_output), 0)
+
+    def test_unexpected_function_argument(self):
+        g = Graph(
+            name=test_graph_name(self),
+            start_node=extractor_a,
         )
+        g = RemoteGraph.deploy(g)
+
+        sdk_stdout: io.StringIO = io.StringIO()
+        with redirect_stdout(sdk_stdout):
+            invocation_id = g.run(
+                block_until_done=True,
+                unexpected_argument="https://www.youtube.com/watch?v=gjHv4pM8WEQ",
+            )
+        sdk_stdout_str: str = sdk_stdout.getvalue()
+
+        # Use regex because rich formatting characters are present in the output.
+        self.assertRegex(
+            sdk_stdout_str,
+            r"TypeError: .*extractor_a.*() got an unexpected keyword argument .*'unexpected_argument'.*",
+        )
+
+        # No output from extractor_a because it failed.
+        extractor_c_output = g.output(invocation_id, "extractor_a")
+        self.assertEqual(len(extractor_c_output), 0)
+
+    def test_compute_with_failing_constructor(self):
+        g = Graph(
+            name=test_graph_name(self),
+            start_node=TensorlakeComputeWithFailingConstructor,
+        )
+        g = RemoteGraph.deploy(g)
+
+        sdk_stdout: io.StringIO = io.StringIO()
+        with redirect_stdout(sdk_stdout):
+            invocation_id = g.run(
+                block_until_done=True,
+            )
+        sdk_stdout_str: str = sdk_stdout.getvalue()
+
+        self.assertTrue(
+            "Exception: this exception was raised by TensorlakeComputeWithFailingConstructor constructor"
+            in sdk_stdout_str
+        )
+        # No output from extractor_a because it failed.
+        extractor_c_output = g.output(
+            invocation_id, "TensorlakeComputeWithFailingConstructor"
+        )
+        self.assertEqual(len(extractor_c_output), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
self.assertRaises didn't do any validation because we weren't passing a callable their. We were passing a function call result instead.

Also added a test that validates expected behavior when a TensorlakeCompute constructor fails.