### PR TITLE
Test fixes

### DIFF
--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -28,6 +28,6 @@ services:
       server:
     deploy:
       mode: replicated
-      replicas: 2
+      replicas: 1 # Some tests require a single executor
 volumes:
   data:

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,13 +7,22 @@ if [[ -z "$INDEXIFY_URL" ]]; then
     exit 1
 fi
 
+EXCLUDE_ARGS=""
+if [[ "$1" == "--exclude" ]]; then
+  shift
+  for arg in "$@"; do
+    echo "Excluding test: $arg"
+    EXCLUDE_ARGS+="! -name $arg "
+  done
+fi
+
 # cd to the script's directory.
 cd "$(dirname "$0")"
 
 # Run each test file one by one sequentially. Returns non zero status
 # code if any of the test commands return non zero status code. Doesn't
 # stop if a test command fails.
-find src -name 'test_*.py' | xargs -L1 poetry run python
+find src -name 'test_*.py' $EXCLUDE_ARGS | xargs -L1 poetry run python
 TESTS_EXIT_CODE=$?
 
 if [ $TESTS_EXIT_CODE -eq 0 ]; then

--- a/tests/src/test_file_descriptor_caching.py
+++ b/tests/src/test_file_descriptor_caching.py
@@ -1,61 +1,59 @@
 import os
-import tempfile
 import unittest
 from typing import Optional
 
-from parameterized import parameterized
-from testing import remote_or_local_graph
+from testing import test_graph_name
 
 from tensorlake import Graph, tensorlake_function
+from tensorlake.remote_graph import RemoteGraph
 
-cached_file_descriptor: Optional[int] = None
+cached_pipe_in_fd: Optional[int] = None
+cached_pipe_out_fd: Optional[int] = None
 
 
 @tensorlake_function()
-def write_to_cacheable_fd_1(file_path: str) -> str:
-    global cached_file_descriptor
+def caching_function(action: str) -> str:
+    global cached_pipe_in_fd
+    global cached_pipe_out_fd
 
-    if cached_file_descriptor is None:
-        cached_file_descriptor = os.open(file_path, os.O_WRONLY | os.O_TRUNC)
-    os.write(cached_file_descriptor, "write_to_cacheable_fd_1\n".encode())
+    if action == "create_fd":
+        cached_pipe_in_fd, cached_pipe_out_fd = os.pipe()
+    elif action == "write_fd":
+        if cached_pipe_out_fd is None:
+            raise ValueError("cached_pipe_out_fd is None")
+        os.write(cached_pipe_out_fd, "write_to_cacheable_fd\n".encode())
+    elif action == "read_fd":
+        if cached_pipe_in_fd is None:
+            raise ValueError("cached_pipe_in_fd is None")
+        return os.read(cached_pipe_in_fd, 1024).decode()
+    else:
+        raise ValueError("Invalid action")
 
     return "success"
 
 
 class TestFileDescriptorCaching(unittest.TestCase):
-    @parameterized.expand([(False), (True)])
-    def test_second_write_goes_to_cached_file_descriptor_if_same_func(self, is_remote):
-        global cached_file_descriptor
-        # Make sure that this test executed in local graph mode doesn't affect the remote graph mode test.
-        cached_file_descriptor = None
+    def test_second_write_goes_to_cached_file_descriptor_if_same_func(self):
+        graph = Graph(
+            name=test_graph_name(self),
+            description="test",
+            start_node=caching_function,
+        )
+        graph = RemoteGraph.deploy(graph)
 
-        with tempfile.NamedTemporaryFile("rb") as file:
-            graph = Graph(
-                name="test_file_descriptor_caching",
-                description="test",
-                start_node=write_to_cacheable_fd_1,
-            )
-            graph = remote_or_local_graph(graph, is_remote)
+        create_fd_invocation_id = graph.run(block_until_done=True, action="create_fd")
+        output = graph.output(create_fd_invocation_id, "caching_function")
+        self.assertEqual(output, ["success"])
 
-            first_invocation_id = graph.run(
-                block_until_done=True, file_path=file.name
-            )  # file.name is actually the path
-            output = graph.output(first_invocation_id, "write_to_cacheable_fd_1")
-            self.assertEqual(output, ["success"])
+        # Fails if the file descriptor is not cached.
+        write_fd_invocation_id = graph.run(block_until_done=True, action="write_fd")
+        output = graph.output(write_fd_invocation_id, "caching_function")
+        self.assertEqual(output, ["success"])
 
-            second_invocation_id = graph.run(
-                block_until_done=True, file_path=file.name
-            )  # file.name is actually the path
-            output = graph.output(second_invocation_id, "write_to_cacheable_fd_1")
-            self.assertEqual(output, ["success"])
-
-            # If the file descriptor is cached between runs of write_to_cacheable_fd_1 then the file
-            # will contain two lines, otherwise it'll contain only one line because the second write
-            # will create a new file descriptor and overwrite the first write.
-            self.assertEqual(
-                file.read(),
-                "write_to_cacheable_fd_1\nwrite_to_cacheable_fd_1\n".encode(),
-            )
+        # Fail if the write to the cached file descriptor didn's happen for any reason.
+        read_file_invocation_id = graph.run(block_until_done=True, action="read_fd")
+        output = graph.output(read_file_invocation_id, "caching_function")
+        self.assertEqual(output, ["write_to_cacheable_fd\n"])
 
 
 if __name__ == "__main__":

--- a/tests/src/test_function_process_crash.py
+++ b/tests/src/test_function_process_crash.py
@@ -24,7 +24,7 @@ class TestFunctionProcessCrash(unittest.TestCase):
         graph = RemoteGraph.deploy(graph)
 
         print("Running a function that will crash FunctionExecutor process...")
-        for i in range(10):
+        for i in range(2):
             crash_invocation_id = graph.run(
                 block_until_done=True,
                 crash=True,


### PR DESCRIPTION
run_tests.sh:
Add --exclude arg to exclude some tests temporarily.

test_broken_graphs.py:
removed unused import, fix flaky errors

test_file_descriptor_caching.py:
make it work with read only file system and not depend on host OS filesystem state.

test_function_process_crash.py:
Reduce number of iterations to speed up the test.

test_function_concurrency.py:
Use processes instead of threads to run invocations really concurrently.
This should reduce test flakiness and fix its current failures.