### PR TITLE
Ctx Improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.9"
+version = "0.1.10"
 description = "Petabyte scale data framework for unstructured data of any modality"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/__init__.py
+++ b/src/tensorlake/__init__.py
@@ -2,7 +2,6 @@ from . import data_loaders
 from .functions_sdk.functions import (
     TensorlakeCompute,
     TensorlakeRouter,
-    get_ctx,
     tensorlake_function,
     tensorlake_router,
 )
@@ -20,7 +19,6 @@ __all__ = [
     "RemotePipeline",
     "Image",
     "tensorlake_function",
-    "get_ctx",
     "TensorlakeCompute",
     "TensorlakeRouter",
     "tensorlake_router",

--- a/src/tensorlake/__init__.py
+++ b/src/tensorlake/__init__.py
@@ -4,6 +4,7 @@ from .functions_sdk.functions import (
     TensorlakeRouter,
     tensorlake_function,
     tensorlake_router,
+    GraphInvocationContext,
 )
 from .functions_sdk.graph import Graph
 from .functions_sdk.image import Image
@@ -14,6 +15,7 @@ from .settings import DEFAULT_SERVICE_URL
 __all__ = [
     "data_loaders",
     "Graph",
+    "GraphInvocationContext",
     "RemoteGraph",
     "Pipeline",
     "RemotePipeline",

--- a/src/tensorlake/functions_sdk/functions.py
+++ b/src/tensorlake/functions_sdk/functions.py
@@ -331,7 +331,7 @@ class TensorlakeFunctionWrapper:
         return FunctionCallResult(ser_outputs=ser_outputs, traceback_msg=err)
 
     def invoke_router(self, ctx: GraphInvocationContext, name: str, input: TensorlakeData) -> RouterCallResult:
-        input = self.deserialize_input(ctx, name, input)
+        input = self.deserialize_input(name, input)
         edges, err = self.run_router(ctx, input)
         return RouterCallResult(edges=edges, traceback_msg=err)
 

--- a/src/tensorlake/functions_sdk/graph.py
+++ b/src/tensorlake/functions_sdk/graph.py
@@ -100,7 +100,7 @@ class Graph:
     def get_function(self, name: str) -> TensorlakeFunctionWrapper:
         if name not in self.nodes:
             raise ValueError(f"Function {name} not found in graph")
-        return TensorlakeFunctionWrapper(self.nodes[name], self._local_graph_ctx)
+        return TensorlakeFunctionWrapper(self.nodes[name])
 
     def get_accumulators(self) -> Dict[str, Any]:
         return self.accumulator_zero_values
@@ -330,18 +330,14 @@ class Graph:
     ) -> Optional[Union[RouterCallResult, FunctionCallResult]]:
         node = self.nodes[node_name]
         if node_name in self.routers and len(self.routers[node_name]) > 0:
-            result = TensorlakeFunctionWrapper(
-                node, self._local_graph_ctx
-            ).invoke_router(node_name, input)
+            result = TensorlakeFunctionWrapper(node).invoke_router(self._local_graph_ctx, node_name, input)
             for dynamic_edge in result.edges:
                 if dynamic_edge in self.nodes:
                     print(f"[bold]dynamic router returned node: {dynamic_edge}[/bold]")
             return result
 
         acc_value = self._accumulator_values.get(node_name, None)
-        return TensorlakeFunctionWrapper(
-            node, context=self._local_graph_ctx
-        ).invoke_fn_ser(node_name, input, acc_value)
+        return TensorlakeFunctionWrapper(node).invoke_fn_ser(self._local_graph_ctx, node_name, input, acc_value)
 
     def _log_local_exec_tracebacks(
         self, results: Union[FunctionCallResult, RouterCallResult]

--- a/tests/src/test_graph_behaviours.py
+++ b/tests/src/test_graph_behaviours.py
@@ -12,8 +12,8 @@ from tensorlake import (
     Graph,
     RemoteGraph,
     TensorlakeCompute,
+    GraphInvocationContext,
     TensorlakeRouter,
-    get_ctx,
     tensorlake_function,
     tensorlake_router,
 )
@@ -62,9 +62,8 @@ class ComplexObject(BaseModel):
     graph_version: str
 
 
-@tensorlake_function()
-def simple_function_ctx(x: MyObject) -> ComplexObject:
-    ctx = get_ctx()
+@tensorlake_function(inject_ctx=True)
+def simple_function_ctx(ctx: GraphInvocationContext, x: MyObject) -> ComplexObject:
     ctx.invocation_state.set("my_key", 10)
     return ComplexObject(
         invocation_id=ctx.invocation_id,
@@ -73,21 +72,20 @@ def simple_function_ctx(x: MyObject) -> ComplexObject:
     )
 
 
-@tensorlake_function()
-def simple_function_ctx_b(x: ComplexObject) -> int:
-    ctx = get_ctx()
+@tensorlake_function(inject_ctx=True)
+def simple_function_ctx_b(ctx: GraphInvocationContext, x: ComplexObject) -> int:
     val = ctx.invocation_state.get("my_key")
     return val + 1
 
 
 class SimpleFunctionCtxC(TensorlakeCompute):
     name = "SimpleFunctionCtxC"
+    inject_ctx = True
 
     def __init__(self):
         super().__init__()
 
-    def run(self, x: ComplexObject) -> int:
-        ctx = get_ctx()
+    def run(self, ctx: GraphInvocationContext, x: ComplexObject) -> int:
         print(f"ctx: {ctx}")
         val = ctx.invocation_state.get("my_key")
         assert val == 10


### PR DESCRIPTION
SDK Changes to improve CTX -

* Removed get_ctx() which depended on looking at the frame of the call and getting the context from the FunctionWrapper. 
* Allows FunctionWrapper to be used as a cache for instantiated TensorlakeCompute objects 
* Making context injection into function more explicit 

DX -

```
@tensorlake_function(inject_ctx=True)
def foo(ctx: GraphInvocationCtx, a: int) -> int:
   pass
```

Default is false 
```
@tensorlake_function
def foo(a: int) -> int:
   pass
```

Tensorlake Compute Objects -
```
class MyFunc(TensorlakeCompute):
   inject_ctx = True
   
   def run(self, ctx: GraphInvocationCtx, a: int) -> int:
     pass
```

default is false 

```
class MyFunc(TensorlakeCompute):
   
   def run(self, a: int) -> int:
     pass
```