### PR TITLE
Fix process crash test

### DIFF
--- a/tests/src/test_function_process_crash.py
+++ b/tests/src/test_function_process_crash.py
@@ -1,5 +1,4 @@
 import os
-import signal
 import unittest
 
 from testing import test_graph_name
@@ -10,7 +9,11 @@ from tensorlake import Graph, RemoteGraph, tensorlake_function
 @tensorlake_function()
 def function(crash: bool) -> str:
     if crash:
-        os.kill(os.getpid(), signal.SIGKILL)
+        # os.kill(getpid(), signal.SIGKILL) won't work for container init process,
+        # see https://stackoverflow.com/questions/21031537/sigkill-init-process-pid-1.
+        # sys.exit(1) hangs the function for some unknown reason,
+        # see some ideas at https://stackoverflow.com/questions/5422831/what-does-sys-exit-do-in-python.
+        os._exit(1)
     return "success"
 
 


### PR DESCRIPTION
The test is failing when the function is executed as PID 1 in a container/VM.