### PR TITLE
Function Executor logging fix and add timestamps to prod logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.12"
+version = "0.1.13"
 description = "Petabyte scale data framework for unstructured data of any modality"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/function_executor/main.py
+++ b/src/tensorlake/function_executor/main.py
@@ -7,6 +7,7 @@ from tensorlake.utils.logging import (
 configure_logging_early()
 
 import argparse
+from typing import Any
 
 import structlog
 
@@ -14,7 +15,7 @@ from .info import info_response_kv_args
 from .server import Server
 from .service import Service
 
-logger = structlog.get_logger(module=__name__).bind(**info_response_kv_args())
+logger: Any = None
 
 
 def validate_args(args):
@@ -24,6 +25,7 @@ def validate_args(args):
 
 
 def main():
+    global logger
     parser = argparse.ArgumentParser(
         description="Runs Function Executor with the specified API server address"
     )
@@ -37,9 +39,11 @@ def main():
         configure_development_mode_logging()
     else:
         configure_production_mode_logging()
+
+    logger = structlog.get_logger(module=__name__).bind(**info_response_kv_args())
     validate_args(args)
 
-    logger.info("starting function executor server", address=args.address)
+    logger.info("starting function executor server", address=args.address, dev=args.dev)
 
     Server(
         server_address=args.address,

--- a/src/tensorlake/utils/logging.py
+++ b/src/tensorlake/utils/logging.py
@@ -2,9 +2,6 @@ import logging
 import sys
 
 import structlog
-from structlog.contextvars import merge_contextvars
-from structlog.dev import ConsoleRenderer, set_exc_info
-from structlog.processors import StackInfoRenderer, TimeStamper, add_log_level
 
 # Using this module allows us to be consistent with the logging configuration across all Python programs.
 
@@ -29,13 +26,13 @@ def configure_logging_early():
 
 def configure_development_mode_logging():
     processors = [
+        structlog.contextvars.merge_contextvars,
         structlog_suppressor,
-        merge_contextvars,
-        add_log_level,
-        StackInfoRenderer(),
-        set_exc_info,
-        TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False),
-        ConsoleRenderer(),
+        structlog.processors.add_log_level,
+        structlog.processors.StackInfoRenderer(),
+        structlog.dev.set_exc_info,
+        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False),
+        structlog.dev.ConsoleRenderer(),
     ]
     structlog.configure(
         processors=processors,
@@ -44,8 +41,12 @@ def configure_development_mode_logging():
 
 def configure_production_mode_logging():
     processors = [
+        structlog.contextvars.merge_contextvars,
         structlog_suppressor,
+        structlog.processors.add_log_level,
+        structlog.dev.set_exc_info,
         structlog.processors.format_exc_info,
+        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S", utc=False),
         structlog.processors.JSONRenderer(),
     ]
     structlog.configure(processors=processors)


### PR DESCRIPTION
Logs looks like this now:

Dev mode:

```
2025-01-30 20:42:59 [info     ] starting function executor server address=0.0.0.0:50000 dev=True module=tensorlake.function_executor.main sdk_language=python sdk_language_version=3.9.21 sdk_version=0.1.13 version=0.1.0
```

Prod mode:

```
{"module": "tensorlake.function_executor.main", "version": "0.1.0", "sdk_version": "0.1.13", "sdk_language": "python", "sdk_language_version": "3.9.21", "address": "0.0.0.0:50000", "dev": false, "event": "starting function executor server", "level": "info", "timestamp": "2025-01-30 20:42:47"}
```