### PR TITLE
Add executor-id CLI parameter to Function Executor and bind it to logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.15"
+version = "0.1.16"
 description = "Petabyte scale data framework for unstructured data of any modality"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/function_executor/main.py
+++ b/src/tensorlake/function_executor/main.py
@@ -23,11 +23,20 @@ def validate_args(args):
         logger.error("--address argument is required")
         exit(1)
 
+    if args.executor_id is None:
+        logger.error("--executor-id argument is required")
+        exit(1)
+
 
 def main():
     global logger
     parser = argparse.ArgumentParser(
         description="Runs Function Executor with the specified API server address"
+    )
+    parser.add_argument(
+        "--executor-id",
+        help="ID of Executor that started this Function Executor",
+        type=str,
     )
     parser.add_argument("--address", help="API server address to listen on", type=str)
     parser.add_argument(
@@ -40,9 +49,10 @@ def main():
     else:
         configure_production_mode_logging()
 
-    logger = structlog.get_logger(module=__name__).bind(**info_response_kv_args())
+    logger = structlog.get_logger(module=__name__)
     validate_args(args)
 
+    logger = logger.bind(executor_id=args.executor_id, **info_response_kv_args())
     logger.info("starting function executor server", address=args.address, dev=args.dev)
 
     Server(

--- a/tests/function_executor/testing.py
+++ b/tests/function_executor/testing.py
@@ -28,6 +28,8 @@ class FunctionExecutorProcessContextManager:
             "--dev",
             "--address",
             f"localhost:{port}",
+            "--executor-id",
+            "test-executor",
         ]
         self._process: Optional[subprocess.Popen] = None
         self.port = port


### PR DESCRIPTION
This helps to understand what's going on a particular Executor machine when reading logs.