### PR TITLE
Remove default Executor images from SDK

### DIFF
--- a/src/tensorlake/cli.py
+++ b/src/tensorlake/cli.py
@@ -36,6 +36,10 @@ def deploy(workflow_file: click.File):
             deployed_graphs.append(obj)
             for node_name, node_obj in obj.nodes.items():
                 image = node_obj.image
+                if image is None:
+                    raise click.ClickException(
+                        f"graph function {node_name} needs to use an image"
+                    )
                 if image in seen_images:
                     continue
                 seen_images[image] = image.hash()
@@ -207,6 +211,10 @@ def prepare(workflow_file: click.File):
             click.echo(f"Found graph {name}")
             for node_name, node_obj in obj.nodes.items():
                 image = node_obj.image
+                if image is None:
+                    raise click.ClickException(
+                        f"graph function {node_name} needs to use an image"
+                    )
                 click.echo(
                     f"graph function {node_name} uses image '{image._image_name}'"
                 )

--- a/src/tensorlake/functions_sdk/functions.py
+++ b/src/tensorlake/functions_sdk/functions.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from typing_extensions import get_type_hints
 
 from .data_objects import TensorlakeData
-from .image import DEFAULT_IMAGE, Image
+from .image import Image
 from .invocation_state.invocation_state import InvocationState
 from .object_serializer import get_serializer
 
@@ -63,7 +63,7 @@ class PlacementConstraints(BaseModel):
 class TensorlakeCompute:
     name: str = ""
     description: str = ""
-    image: Optional[Image] = DEFAULT_IMAGE
+    image: Optional[Image] = None
     placement_constraints: List[PlacementConstraints] = []
     accumulate: Optional[Type[Any]] = None
     input_encoder: Optional[str] = "cloudpickle"
@@ -99,7 +99,7 @@ class TensorlakeCompute:
 class TensorlakeRouter:
     name: str = ""
     description: str = ""
-    image: Optional[Image] = DEFAULT_IMAGE
+    image: Optional[Image] = None
     placement_constraints: List[PlacementConstraints] = []
     input_encoder: Optional[str] = "cloudpickle"
     output_encoder: Optional[str] = "cloudpickle"
@@ -144,7 +144,7 @@ def _process_dict_arg(dict_arg: dict, sig: inspect.Signature) -> Tuple[list, dic
 def tensorlake_router(
     name: Optional[str] = None,
     description: Optional[str] = "",
-    image: Optional[Image] = DEFAULT_IMAGE,
+    image: Optional[Image] = None,
     placement_constraints: List[PlacementConstraints] = [],
     input_encoder: Optional[str] = "cloudpickle",
     output_encoder: Optional[str] = "cloudpickle",
@@ -174,7 +174,7 @@ def tensorlake_router(
 def tensorlake_function(
     name: Optional[str] = None,
     description: Optional[str] = "",
-    image: Optional[Image] = DEFAULT_IMAGE,
+    image: Optional[Image] = None,
     accumulate: Optional[Type[BaseModel]] = None,
     input_encoder: Optional[str] = "cloudpickle",
     output_encoder: Optional[str] = "cloudpickle",

--- a/src/tensorlake/functions_sdk/graph.py
+++ b/src/tensorlake/functions_sdk/graph.py
@@ -40,6 +40,7 @@ from .graph_definition import (
     RuntimeInformation,
 )
 from .graph_validation import validate_node, validate_route
+from .image import ImageInformation
 from .invocation_state.local_invocation_state import LocalInvocationState
 from .object_serializer import get_serializer
 
@@ -64,6 +65,14 @@ def is_pydantic_model_from_annotation(type_annotation):
         return issubclass(type_annotation, BaseModel)
 
     return False
+
+
+# Placeholder for None image information until Server accepts Optional image information.
+_none_image_information = ImageInformation(
+    image_name="fake_image",
+    image_hash="fake_hash",
+    sdk_version="0.0.1",
+)
 
 
 class Graph:
@@ -188,7 +197,11 @@ class Graph:
             fn_name=start_node.name,
             description=start_node.description,
             reducer=is_reducer,
-            image_information=start_node.image.to_image_information(),
+            image_information=(
+                start_node.image.to_image_information()
+                if start_node.image
+                else _none_image_information
+            ),
             input_encoder=start_node.input_encoder,
             output_encoder=start_node.output_encoder,
         )
@@ -204,7 +217,11 @@ class Graph:
                         target_fns=self.routers[node_name],
                         input_encoder=node.input_encoder,
                         output_encoder=node.output_encoder,
-                        image_information=node.image.to_image_information(),
+                        image_information=(
+                            node.image.to_image_information()
+                            if node.image
+                            else _none_image_information
+                        ),
                     )
                 )
             else:
@@ -214,7 +231,11 @@ class Graph:
                         fn_name=node.name,
                         description=node.description,
                         reducer=node.accumulate is not None,
-                        image_information=node.image.to_image_information(),
+                        image_information=(
+                            node.image.to_image_information()
+                            if node.image
+                            else _none_image_information
+                        ),
                         input_encoder=node.input_encoder,
                         output_encoder=node.output_encoder,
                     )

--- a/src/tensorlake/functions_sdk/graph_definition.py
+++ b/src/tensorlake/functions_sdk/graph_definition.py
@@ -12,7 +12,7 @@ class FunctionMetadata(BaseModel):
     fn_name: str
     description: str
     reducer: bool = False
-    image_information: ImageInformation
+    image_information: Optional[ImageInformation]
     input_encoder: str = "cloudpickle"
     output_encoder: str = "cloudpickle"
 
@@ -22,7 +22,7 @@ class RouterMetadata(BaseModel):
     description: str
     source_fn: str
     target_fns: List[str]
-    image_information: ImageInformation
+    image_information: Optional[ImageInformation]
     input_encoder: str = "cloudpickle"
     output_encoder: str = "cloudpickle"
 

--- a/src/tensorlake/functions_sdk/image.py
+++ b/src/tensorlake/functions_sdk/image.py
@@ -217,17 +217,3 @@ class Image:
 
 LOCAL_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 BASE_IMAGE_NAME = f"python:{LOCAL_PYTHON_VERSION}-slim-bookworm"
-
-
-def GetDefaultPythonImage(python_version: str):
-    image = (
-        Image()
-        .name("tensorlake/indexify-executor-default")
-        .base_image(f"python:{python_version}-slim-bookworm")
-        .tag(python_version)
-    )
-    image.uri = f"{image._image_name}:{LOCAL_PYTHON_VERSION}"
-    return image
-
-
-DEFAULT_IMAGE = GetDefaultPythonImage(LOCAL_PYTHON_VERSION)


### PR DESCRIPTION
The default Executor images are not updated anymore so they should be hidden from SDK interface.

The only trace of default Executor images left now is when we send requests to Server endpoint that always requires image information. We'll remove this once Server accepts optional image information object.