### PR TITLE
chore: move common enums to common document ai module

### DIFF
--- a/examples/readme_documentai.py
+++ b/examples/readme_documentai.py
@@ -1,6 +1,6 @@
 import time
 
-from tensorlake.documentai import DocumentAI, ParsingOptions, TableParsingStrategy
+from tensorlake.documentai import DocumentAI, ParsingOptions
 
 API_KEY = "tl_XXXXX"
 
@@ -8,10 +8,6 @@ doc_ai = DocumentAI(api_key=API_KEY)
 # Skip this if you are passing a pre-signed URL to the `DocumentParser`.
 # or pass an external URL
 file_id = doc_ai.upload(path="./examples/appliance-repair-invoice-2.pdf")
-
-options = ParsingOptions(
-    table_parsing_strategy=TableParsingStrategy.VLM,
-)
 
 job_id = doc_ai.parse(file_id, options=ParsingOptions())
 

--- a/examples/readme_documentai.py
+++ b/examples/readme_documentai.py
@@ -1,6 +1,6 @@
 import time
 
-from tensorlake.documentai import DocumentAI, ParsingOptions
+from tensorlake.documentai import DocumentAI, ParsingOptions, TableParsingStrategy
 
 API_KEY = "tl_XXXXX"
 
@@ -8,6 +8,10 @@ doc_ai = DocumentAI(api_key=API_KEY)
 # Skip this if you are passing a pre-signed URL to the `DocumentParser`.
 # or pass an external URL
 file_id = doc_ai.upload(path="./examples/appliance-repair-invoice-2.pdf")
+
+options = ParsingOptions(
+    table_parsing_strategy=TableParsingStrategy.VLM,
+)
 
 job_id = doc_ai.parse(file_id, options=ParsingOptions())
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.21"
+version = "0.1.22"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/__init__.py
+++ b/src/tensorlake/documentai/__init__.py
@@ -1,5 +1,12 @@
 from tensorlake.documentai.client import DocumentAI, ExtractionOptions, ParsingOptions
-from tensorlake.documentai.common import Document, JobResult
+from tensorlake.documentai.common import (
+    ChunkingStrategy,
+    Document,
+    JobResult,
+    ModelProvider,
+    TableOutputMode,
+    TableParsingStrategy,
+)
 
 __all__ = [
     "DocumentAI",
@@ -7,4 +14,8 @@ __all__ = [
     "ExtractionOptions",
     "Document",
     "JobResult",
+    "TableOutputMode",
+    "ModelProvider",
+    "TableParsingStrategy",
+    "ChunkingStrategy",
 ]

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -8,7 +8,6 @@ import json
 import mimetypes
 import os
 import sys
-from enum import Enum
 from pathlib import Path
 from typing import Optional, Union
 
@@ -19,7 +18,15 @@ from retry import retry
 from tqdm import tqdm
 from tqdm.asyncio import tqdm as async_tqdm
 
-from tensorlake.documentai.common import DOC_AI_BASE_URL, JobResult
+from tensorlake.documentai.common import (
+    DOC_AI_BASE_URL,
+    ChunkingStrategy,
+    JobResult,
+    ModelProvider,
+    OutputFormat,
+    TableOutputMode,
+    TableParsingStrategy,
+)
 
 try:
     import magic
@@ -30,72 +37,6 @@ except ImportError:
     print(
         "Warning: `python-magic` (libmagic) is not installed. Falling back to `mimetypes`. Install it with `pip install python-magic` for better MIME detection."
     )
-
-
-class OutputFormat(str, Enum):
-    """
-    Output format for parsing a document.
-
-    MARKDOWN: The parsed document is returned in Markdown format. Using Markdown requires setting a chunking strategy.
-    JSON: The parsed document is returned in JSON format.
-    """
-
-    MARKDOWN = "markdown"
-    JSON = "json"
-
-
-class ChunkingStrategy(str, Enum):
-    """
-    Chunking strategy for parsing a document.
-
-    NONE: No chunking is applied.
-    PAGE: The document is chunked by page.
-    SECTION_HEADER: The document is chunked by section headers.
-    """
-
-    NONE = "none"
-    PAGE = "page"
-    SECTION_HEADER = "section_header"
-
-
-class TableParsingStrategy(str, Enum):
-    """
-    Algorithm to use for parsing tables in a document.
-
-    TSR: Table Structure Recognition. Great for structured tables.
-    VLM: Visual Layout Model. Great for unstructured tables or semi-structured tables.
-    """
-
-    TSR = "tsr"
-    VLM = "vlm"
-
-
-class TableOutputMode(str, Enum):
-    """
-    Output mode for tables in a document.
-
-    JSON: The table is returned in JSON format.
-    MARKDOWN: The table is returned in Markdown format.
-    HTML: The table is returned in HTML format.
-    """
-
-    JSON = "json"
-    MARKDOWN = "markdown"
-    HTML = "html"
-
-
-class ModelProvider(str, Enum):
-    """
-    The model provider to use for structured data extraction.
-
-    TENSORLAKE: private models, running on Tensorlake infrastructure.
-    SONNET: Claude 3.5 Sonnet model.
-    GPT4OMINI: GPT-4o-mini model.
-    """
-
-    TENSORLAKE = "tensorlake"
-    SONNET = "claude-3-5-sonnet-latest"
-    GPT4OMINI = "gpt-4o-mini"
 
 
 class ParsingOptions(BaseModel):

--- a/src/tensorlake/documentai/common.py
+++ b/src/tensorlake/documentai/common.py
@@ -67,6 +67,72 @@ class Document(BaseModel):
     pages: List[Page]
 
 
+class OutputFormat(str, Enum):
+    """
+    Output format for parsing a document.
+
+    MARKDOWN: The parsed document is returned in Markdown format. Using Markdown requires setting a chunking strategy.
+    JSON: The parsed document is returned in JSON format.
+    """
+
+    MARKDOWN = "markdown"
+    JSON = "json"
+
+
+class ChunkingStrategy(str, Enum):
+    """
+    Chunking strategy for parsing a document.
+
+    NONE: No chunking is applied.
+    PAGE: The document is chunked by page.
+    SECTION_HEADER: The document is chunked by section headers.
+    """
+
+    NONE = "none"
+    PAGE = "page"
+    SECTION_HEADER = "section_header"
+
+
+class TableParsingStrategy(str, Enum):
+    """
+    Algorithm to use for parsing tables in a document.
+
+    TSR: Table Structure Recognition. Great for structured tables.
+    VLM: Visual Layout Model. Great for unstructured tables or semi-structured tables.
+    """
+
+    TSR = "tsr"
+    VLM = "vlm"
+
+
+class TableOutputMode(str, Enum):
+    """
+    Output mode for tables in a document.
+
+    JSON: The table is returned in JSON format.
+    MARKDOWN: The table is returned in Markdown format.
+    HTML: The table is returned in HTML format.
+    """
+
+    JSON = "json"
+    MARKDOWN = "markdown"
+    HTML = "html"
+
+
+class ModelProvider(str, Enum):
+    """
+    The model provider to use for structured data extraction.
+
+    TENSORLAKE: private models, running on Tensorlake infrastructure.
+    SONNET: Claude 3.5 Sonnet model.
+    GPT4OMINI: GPT-4o-mini model.
+    """
+
+    TENSORLAKE = "tensorlake"
+    SONNET = "claude-3-5-sonnet-latest"
+    GPT4OMINI = "gpt-4o-mini"
+
+
 class JobResult(BaseModel):
     job_id: str = Field(alias="jobId")
     file_id: str = Field(alias="fileId")


### PR DESCRIPTION
This PR reorganizes common enums into their own modules and exposes them through the document AI module.