### PR TITLE
Add get-image-uri and get-project-id commands

### DIFF
--- a/src/tensorlake/builder/client.py
+++ b/src/tensorlake/builder/client.py
@@ -70,4 +70,5 @@ class ImageBuilderClient:
         res.raise_for_status()
         builds = [Build.model_validate(b) for b in res.json()]
         builds.sort(key=lambda b: b.created_at, reverse=True)
-        return builds[0]
+        if builds:
+            return builds[0]


### PR DESCRIPTION
Adds two commands so we can leverage the tensorlake SDK during integration tests.

get-image-uri - Will return the URI for the latest build of a given image.
get-project-id - Will return the project ID for the user. This only works when using serverless. 