### PR TITLE
chore: align document AI dataset SDKs with /dataset/jobs API

### DIFF
--- a/examples/datasets.py
+++ b/examples/datasets.py
@@ -4,20 +4,21 @@ This script demonstrates how to use the DocumentAI class to load and parse a dat
 
 import asyncio
 import csv
+import json
+
+from pydantic import BaseModel, Field
 
 from tensorlake.data_loaders import LocalDirectoryLoader
 from tensorlake.documentai import (
-    IngestArgs,
     DatasetOptions,
     DocumentAI,
+    ExtractionOptions,
+    IngestArgs,
     OutputFormat,
     ParsingOptions,
-    ExtractionOptions,
     TableOutputMode,
     TableParsingStrategy,
 )
-import json
-from pydantic import BaseModel, Field
 
 TENSORLAKE_API_KEY = "tl_apiKey_xxxx"
 
@@ -28,26 +29,45 @@ loader = LocalDirectoryLoader(FILES_DIR, file_extensions=[".pdf"])
 
 files = loader.load()
 
+
 class Transaction(BaseModel):
-    date: str = Field(description="The date of the transaction. Dates should be formatted as dd/mm/yyyy")
+    date: str = Field(
+        description="The date of the transaction. Dates should be formatted as dd/mm/yyyy"
+    )
     description: str = Field(description="The description of the transaction")
-    amount: float = Field(description="The amount of the transaction. Include the currency symbol")
-    transaction_type: str = Field(description="The type of the transaction. Debit or Credit")
+    amount: float = Field(
+        description="The amount of the transaction. Include the currency symbol"
+    )
+    transaction_type: str = Field(
+        description="The type of the transaction. Debit or Credit"
+    )
+
 
 class Statement(BaseModel):
-    beginning_balance: float = Field(description="The beginning balance of the statement. Include the currency symbol")
-    ending_balance: float = Field(description="The ending balance of the statement. Include the currency symbol")
+    beginning_balance: float = Field(
+        description="The beginning balance of the statement. Include the currency symbol"
+    )
+    ending_balance: float = Field(
+        description="The ending balance of the statement. Include the currency symbol"
+    )
     account_number: str = Field(description="The account number")
-    statement_start_date: str = Field(description="The start date of the statement. Dates should be formatted as dd/mm/yyyy")
-    statement_end_date: str = Field(description="The end date of the statement. Dates should be formatted as dd/mm/yyyy")
-    transactions: list[Transaction] = Field(description="The transactions in the statement")
+    statement_start_date: str = Field(
+        description="The start date of the statement. Dates should be formatted as dd/mm/yyyy"
+    )
+    statement_end_date: str = Field(
+        description="The end date of the statement. Dates should be formatted as dd/mm/yyyy"
+    )
+    transactions: list[Transaction] = Field(
+        description="The transactions in the statement"
+    )
+
 
 async def main():
     """
     Main function
     """
-    # Create a dataset, by specifying the document ingestion actions 
-    # The name of the dataset must be unique within a project so you 
+    # Create a dataset, by specifying the document ingestion actions
+    # The name of the dataset must be unique within a project so you
     # can retrieve the dataset later using the name.
     dataset = await document_ai.create_dataset_async(
         DatasetOptions(
@@ -70,10 +90,7 @@ async def main():
 
     # Extend a existing dataset with some files. Tensorlake will automatically
     # parse the files or any other ingestion actions specified in the dataset.
-    tasks = [
-        dataset.ingest_async(IngestArgs(file_path=file.path))
-        for file in files
-    ]
+    tasks = [dataset.ingest_async(IngestArgs(file_path=file.path)) for file in files]
     job_ids = await asyncio.gather(*tasks, return_exceptions=True)
 
     # Debug: Print job results
@@ -87,7 +104,9 @@ async def main():
 
     # Proceed only with valid jobs
     # You can wait for the completion of the jobs using the `wait_for_completion_async` method
-    wait_tasks = [document_ai.wait_for_completion_async(job_id) for job_id in valid_job_ids]
+    wait_tasks = [
+        document_ai.wait_for_completion_async(job_id) for job_id in valid_job_ids
+    ]
     await asyncio.gather(*wait_tasks)
 
     # Retrieve the outputs of the dataset

--- a/src/tensorlake/documentai/__init__.py
+++ b/src/tensorlake/documentai/__init__.py
@@ -4,7 +4,7 @@ TensorLake Document AI SDK
 
 from tensorlake.documentai.client import DocumentAI
 from tensorlake.documentai.common import TableOutputMode, TableParsingStrategy
-from tensorlake.documentai.datasets import Dataset, IngestArgs, DatasetOptions
+from tensorlake.documentai.datasets import Dataset, DatasetOptions, IngestArgs
 from tensorlake.documentai.extract import ExtractionOptions, ModelProvider
 from tensorlake.documentai.jobs import Document, Job
 from tensorlake.documentai.parse import ChunkingStrategy, OutputFormat, ParsingOptions

--- a/src/tensorlake/documentai/datasets.py
+++ b/src/tensorlake/documentai/datasets.py
@@ -2,6 +2,7 @@
 DocumentAI datasets module.
 """
 
+import asyncio
 from enum import Enum
 from pathlib import Path
 from typing import List, Optional, Union
@@ -56,8 +57,6 @@ class DatasetStatus(str, Enum):
 
     IDLE = "idle"
     PROCESSING = "processing"
-    ERROR = "error"
-    DONE = "done"
 
 
 class DownloadableJobOutput(BaseModel):
@@ -104,19 +103,25 @@ class DatasetInfo(BaseModel):
     analytics: DatasetAnalytics
     created_at: str = Field(alias="createdAt")
 
+
 class StructuredDataPage(BaseModel):
     """
     DocumentAI structured data class.
     """
+
     page_number: int
     parsed_page: str
     data: dict = Field(alias="json_result", default_factory=dict)
+
 
 class StructuredData(BaseModel):
     """
     DocumentAI structured data class.
     """
+
     pages: List[StructuredDataPage] = Field(alias="pages", default_factory=list)
+
+
 class DatasetItem(BaseModel):
     """
     DocumentAI downloaded job output class.
@@ -146,16 +151,19 @@ class DatasetOutputFormat(str, Enum):
     CSV = "csv"
 
 
-class DatasetStatus(str, Enum):
-    PROCESSING = "processing"
-    IDLE = "idle"
-
 class Dataset:
     """
     DocumentAI dataset class.
     """
 
-    def __init__(self, dataset_id: str, name: str, api_key: str, settings: Union[ExtractionOptions, ParsingOptions], status: DatasetStatus):
+    def __init__(
+        self,
+        dataset_id: str,
+        name: str,
+        api_key: str,
+        settings: Union[ExtractionOptions, ParsingOptions],
+        status: DatasetStatus,
+    ):
         self.id = dataset_id
         self.name = name
         self.api_key = api_key
@@ -164,11 +172,12 @@ class Dataset:
         elif isinstance(settings, ParsingOptions):
             self.dataset_type = "parse"
         else:
-            raise ValueError("settings must be either ExtractionOptions or ParsingOptions")
+            raise ValueError(
+                "settings must be either ExtractionOptions or ParsingOptions"
+            )
         self.status = status
 
         self.__file_uploader__ = FileUploader(api_key)
-        self._client = httpx.Client(base_url=DOC_AI_BASE_URL, timeout=None)
         self._async_client = httpx.AsyncClient(base_url=DOC_AI_BASE_URL, timeout=None)
 
     def __headers__(self):
@@ -187,45 +196,7 @@ class Dataset:
         Returns:
             The job result. It contains the job ID, the Tensorlake file ID, and the status of the job.
         """
-        if (
-            ingest_args.file_url is not None
-            and ingest_args.file_path is not None
-            and ingest_args.file_id is not None
-        ):
-            raise ValueError(
-                "Only one of file_url, file_path, or file_id should be provided"
-            )
-
-        file_id = None
-        if ingest_args.file_url is not None:
-            file_id = ingest_args.file_url
-        elif ingest_args.file_id is not None:
-            file_id = ingest_args.file_id
-        elif ingest_args.file_path is not None:
-            path = Path(ingest_args.file_path)
-            if not path.exists():
-                raise FileNotFoundError(f"File {path} not found")
-
-            file_id = self.__file_uploader__.upload_file(ingest_args.file_path)
-
-        if file_id is None:
-            raise ValueError("file_url, file_path, or file_id should be provided")
-
-        data = {
-            "file_id": (None, file_id),
-            "deliver_webhook": (None, f"{ingest_args.deliver_webhook}"),
-            "pages": (None, f"{ingest_args.pages}"),
-        }
-
-        response = self._client.post(
-            url=f"datasets/{self.name}",
-            headers={
-                "Authorization": f"Bearer {self.api_key}",
-            },
-            files=data,
-        )
-        response.raise_for_status()
-        return Job.model_validate(response.json())
+        return asyncio.run(self.ingest_async(ingest_args))
 
     async def ingest_async(self, ingest_args: IngestArgs) -> str:
         """
@@ -255,7 +226,9 @@ class Dataset:
             path = Path(ingest_args.file_path)
             if not path.exists():
                 raise FileNotFoundError(f"File {path} not found")
-            file_id = await self.__file_uploader__.upload_file_async(ingest_args.file_path)
+            file_id = await self.__file_uploader__.upload_file_async(
+                ingest_args.file_path
+            )
 
         if file_id is None:
             raise ValueError("file_url, file_path, or file_id should be provided")
@@ -294,43 +267,7 @@ class Dataset:
             The outputs of the dataset.
         """
 
-        url = f"datasets/{self.name}"
-        if cursor:
-            url += f"?cursor={cursor}"
-
-        resp = self._client.get(
-            url=url,
-            headers=self.__headers__(),
-        )
-
-        resp.raise_for_status()
-        raw_outputs = DatasetInfo.model_validate(resp.json())
-
-        outputs = {}
-        for job in raw_outputs.jobs.items:
-            if job.status == JobStatus.SUCCESSFUL:
-                resp = self._client.get(job.outputs_url)
-                resp.raise_for_status()
-
-                resp_json = resp.json()
-                downloaded_output = DatasetItem(
-                    chunks=resp_json["chunks"] if "chunks" in resp_json else [],
-                    document=(
-                        Document.model_validate(resp_json["document"])
-                        if "document" in resp_json
-                        else None
-                    ),
-                )
-                outputs[job.id] = downloaded_output
-
-            if job.status == JobStatus.FAILURE:
-                outputs[job.id] = DatasetItem(error_message=job.error_message)
-
-        return DatasetItems(
-            cursor=raw_outputs.jobs.next_cursor,
-            total_pages=raw_outputs.jobs.total_pages,
-            items=outputs,
-        )
+        return asyncio.run(self.items_async(cursor))
 
     async def items_async(self, cursor: Optional[str] = None) -> DatasetItems:
         """
@@ -339,7 +276,7 @@ class Dataset:
         Returns:
             The outputs of the dataset.
         """
-        url = f"datasets/{self.name}"
+        url = f"datasets/{self.name}/jobs"
         if cursor:
             url += f"?cursor={cursor}"
 
@@ -366,7 +303,11 @@ class Dataset:
                         if "document" in resp_json
                         else None
                     ),
-                    structured_data=(StructuredData.model_validate(resp_json) if self.dataset_type == "extract" else None) 
+                    structured_data=(
+                        StructuredData.model_validate(resp_json)
+                        if self.dataset_type == "extract"
+                        else None
+                    ),
                 )
                 outputs[job.id] = downloaded_output
 

--- a/src/tensorlake/documentai/extract.py
+++ b/src/tensorlake/documentai/extract.py
@@ -1,11 +1,12 @@
 """
 This module defines the data structures used for structured data extraction.
 """
+
 import json
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, Json, Field, field_validator, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, Json, field_validator
 
 from tensorlake.documentai.common import TableParsingStrategy
 
@@ -37,10 +38,14 @@ class ExtractionOptions(BaseModel):
     """
 
     json_schema: Json = Field(alias="jsonSchema")
-    model: ModelProvider = Field(alias="modelProvider", default=ModelProvider.TENSORLAKE)
+    model: ModelProvider = Field(
+        alias="modelProvider", default=ModelProvider.TENSORLAKE
+    )
     deliver_webhook: bool = Field(alias="deliverWebhook", default=False)
     prompt: Optional[str] = None
-    table_parsing_strategy: TableParsingStrategy =  Field(alias="tableParsingStrategy", default=TableParsingStrategy.TSR)
+    table_parsing_strategy: TableParsingStrategy = Field(
+        alias="tableParsingStrategy", default=TableParsingStrategy.TSR
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -48,4 +53,3 @@ class ExtractionOptions(BaseModel):
     @classmethod
     def transform(cls, raw: dict) -> Json:
         return json.dumps(raw)
-


### PR DESCRIPTION
Before this PR, the dataset API would return the jobs and their status when retrieving the dataset. Because the customer is supposed to poll the dataset to understand its status, we needed to make that endpoint lighter.

To get a dataset's outputs, the system uses the /dataset/{dataset_name}/jobs API.