### PR TITLE
Fix bug with wrong invocation state check and add tests

### DIFF
--- a/examples/datasets.py
+++ b/examples/datasets.py
@@ -127,4 +127,5 @@ async def main():
         for key_info, data in items.items():
             writer.writerow([key_info.job_id, key_info.file_name, data])
 
+
 asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.26"
+version = "0.1.27"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/http_client.py
+++ b/src/tensorlake/http_client.py
@@ -416,8 +416,10 @@ class TensorlakeClient:
         )
         response.raise_for_status()
         graph_outputs = GraphOutputs(**response.json())
-        if graph_outputs.status == "pending":
+        # "pending" is old server API behavior, left here for backward compatibility.
+        if graph_outputs.status in ["pending", "Pending", "Running"]:
             raise GraphStillProcessing()
+
         outputs = []
         for output in graph_outputs.outputs:
             if output.compute_fn == fn_name:

--- a/src/tensorlake/remote_graph.py
+++ b/src/tensorlake/remote_graph.py
@@ -90,6 +90,9 @@ class RemoteGraph:
             Not used if client is provided.
         :param client: The IndexifyClient used to communicate with the server.
             Preferred over server_url.
+        :param upgrade_tasks_to_latest_version: If True, all not started and running invocations
+            will be upgraded to run on the latest version of the graph. This requires the graph
+            code to be backward compatible between the versions.
         """
         g.validate_graph()
         if not client:

--- a/tests/tensorlake/test_invocation_output.py
+++ b/tests/tensorlake/test_invocation_output.py
@@ -1,0 +1,57 @@
+import unittest
+
+from testing import test_graph_name, wait_function_output
+
+from tensorlake import Graph, RemoteGraph, tensorlake_function
+
+
+@tensorlake_function()
+def start_func() -> str:
+    return "start_func"
+
+
+@tensorlake_function()
+def end_func(_: str) -> str:
+    return "end_func"
+
+
+class TestInvocationOutput(unittest.TestCase):
+    def test_function_outputs_in_sync_invocation(self):
+        g = Graph(
+            name=test_graph_name(self),
+            start_node=start_func,
+        )
+        g.add_edge(start_func, end_func)
+        g = RemoteGraph.deploy(g)
+
+        invocation_id = g.run(block_until_done=True)
+
+        output = g.output(invocation_id, "start_func")
+        self.assertEqual(len(output), 1, output)
+        self.assertEqual(output[0], "start_func", output)
+
+        output = g.output(invocation_id, "end_func")
+        self.assertEqual(len(output), 1, output)
+        self.assertEqual(output[0], "end_func", output)
+
+    def test_function_outputs_in_async_invocation(self):
+        g = Graph(
+            name=test_graph_name(self),
+            start_node=start_func,
+        )
+        g.add_edge(start_func, end_func)
+        g = RemoteGraph.deploy(g)
+
+        invocation_id = g.run(block_until_done=False)
+
+        output = wait_function_output(g, invocation_id, "start_func")
+        self.assertEqual(len(output), 1, output)
+        self.assertEqual(output[0], "start_func", output)
+
+        output = wait_function_output(g, invocation_id, "end_func")
+        self.assertEqual(len(output), 1, output)
+        self.assertEqual(output[0], "end_func", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tensorlake/testing.py
+++ b/tests/tensorlake/testing.py
@@ -1,6 +1,8 @@
+import time
 import unittest
 from typing import Any, List, Union
 
+from tensorlake.error import GraphStillProcessing
 from tensorlake.functions_sdk.graph import Graph
 from tensorlake.remote_graph import RemoteGraph
 
@@ -25,3 +27,11 @@ def test_graph_name(test_case: unittest.TestCase) -> str:
     ...         # test_graph_reduce_test_simple
     """
     return unittest.TestCase.id(test_case).replace(".", "_")
+
+
+def wait_function_output(graph: RemoteGraph, invocation_id: str, func_name: str) -> Any:
+    while True:
+        try:
+            return graph.output(invocation_id, func_name)
+        except GraphStillProcessing:
+            time.sleep(1)


### PR DESCRIPTION
Looks like in PR https://github.com/tensorlakeai/indexify/pull/1235 invocation status values were changed and SDK started to return empty outputs for all async invocations. This resulted in failures of graph update tests that use async invocations.

I also added tests for sync and async invocations outputs and a test for running invocation graph version update.

I'm not sure why tests that run async invocations didn't fail in PR https://github.com/tensorlakeai/indexify/pull/1235 but now they are failing because of this. It looks like some transient error with tensorlake submodule resulted in tensorlake SDK tests not running for it.

I ran SDK tests also in Indexify mainline and this PR fixes the failures there.