### PR TITLE
Fix bug in logging utils, allow FE invocation state proxy reconnects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.33"
+version = "0.1.34"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/utils/logging.py
+++ b/src/tensorlake/utils/logging.py
@@ -57,11 +57,13 @@ _suppress_logging = False
 
 def structlog_suppressor(logger, name, event_dict):
     global _suppress_logging
-    return None if _suppress_logging else event_dict
+    if _suppress_logging:
+        raise structlog.DropEvent
+    else:
+        return event_dict
 
 
 def suppress():
-    """Sets the log level for the root logger to the new level."""
     global _suppress_logging
     _suppress_logging = True
     logging.getLogger().setLevel(logging.CRITICAL)


### PR DESCRIPTION
FE invocation state proxy disconnects were very noisy in logs and this was because they didn't allow reconnects. Now they do so we don't need to be noisy in logs anymore.

The logging library bug was really bad. Once we called suppress() on Executor shutdown all logging calls were raising "'NoneType' object does not support item assignment" Exceptions but we didn't see them because there was nothing logged. This resulted in Executor code paths that do info logging silently failing. The bugfix is to raise the right exception to drop the logging event instead of returning None.
See https://www.structlog.org/en/stable/processors.html#filtering

This logging bug was invesigated in:
https://github.com/tensorlakeai/compute-engine-internal/issues/65

Also bump package version so we can release and use the bugfix.