### PR TITLE
Add env var that disables function output capturing and bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.39"
+version = "0.1.40"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/function_executor/handlers/run_function/handler.py
+++ b/src/tensorlake/function_executor/handlers/run_function/handler.py
@@ -1,4 +1,5 @@
 import io
+import os
 import sys
 import time
 import traceback
@@ -72,6 +73,15 @@ class Handler:
         using the response.
         """
         try:
+            if (
+                os.getenv("INDEXIFY_FUNCTION_EXECUTOR_DISABLE_OUTPUT_CAPTURE", "0")
+                == "1"
+            ):
+                self._func_stdout.write(
+                    "Function output capture is disabled using INDEXIFY_FUNCTION_EXECUTOR_DISABLE_OUTPUT_CAPTURE env var.\n"
+                )
+                return self._run_func(inputs)
+
             # Flush any logs buffered in memory before doing stdout, stderr capture.
             # Otherwise our logs logged before this point will end up in the function's stdout capture.
             self._flush_logs()


### PR DESCRIPTION
The new env var INDEXIFY_FUNCTION_EXECUTOR_DISABLE_OUTPUT_CAPTURE disables function stdout, stderr capturing so users can see their functions' output live streamed in Function Executor logs. This helps to debug complex problems in customer functions when e.g. a function never finishes so its stdout and stderr are not available to users unless they set this new env var.