### PR TITLE
Remove dep for asyncio stdlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ pyyaml = "^6.0.2"
 click = "^8.1.8"
 retry = "^0.9.2"
 aiofiles = "^24.1.0"
-asyncio = "^3.4.3"
 tqdm = "^4.67.1"
 
 # Required only by Function Executor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.40"
+version = "0.1.41"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"


### PR DESCRIPTION
Asyncio is part of the stdlib and doesn't need to be used via a dep package. 

This package was setup for python 3.3.

I ran into an issue where asyncio code with fastapi was interacting with this dep code path from the asyncio package. The fastapi server we're running is a part of `arxivsearch-client`.