### PR TITLE
Run secrets test only in local graph mode

### DIFF
--- a/src/tensorlake/cli/auth.py
+++ b/src/tensorlake/cli/auth.py
@@ -1,4 +1,5 @@
 import json
+
 import click
 
 from tensorlake.cli._common import AuthContext, with_auth


### PR DESCRIPTION
Remote graph behavior with secrets depends on testing environment because not all of them implement or not secrets. The environment specific secrets test will be added to environment specific test suite as a follow up to this.