### PR TITLE
Fix bug

### DIFF
--- a/src/tensorlake/function_executor/handlers/run_function/handler.py
+++ b/src/tensorlake/function_executor/handlers/run_function/handler.py
@@ -110,7 +110,7 @@ class Handler:
         )
         if _is_router(self._function_wrapper):
             result: RouterCallResult = self._function_wrapper.invoke_router(
-                ctx, self._function_name, inputs.input
+                ctx, inputs.input
             )
             return self._response_helper.router_response(
                 result=result,
@@ -119,7 +119,7 @@ class Handler:
             )
         else:
             result: FunctionCallResult = self._function_wrapper.invoke_fn_ser(
-                ctx, self._function_name, inputs.input, inputs.init_value
+                ctx, inputs.input, inputs.init_value
             )
             return self._response_helper.function_response(
                 result=result,

--- a/tests/tensorlake/test_graph_behaviours.py
+++ b/tests/tensorlake/test_graph_behaviours.py
@@ -46,7 +46,7 @@ def simple_function_multiple_inputs_json(x: str, y: int) -> str:
     return x + suf
 
 
-@tensorlake_function()
+@tensorlake_function(input_encoder="json")
 def simple_function_with_str_as_input(x: str) -> str:
     return x + "cc"
 


### PR DESCRIPTION
This test should have never passed. We were setting output encoder as json in the first function, and the second function was expecting cloudpickle as input (default). 