### PR TITLE
Handle async connection re-use: close connection after call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.48"
+version = "0.1.49"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -38,6 +38,7 @@ class DocumentAI:
         return {
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
+            "Connection": "close",
         }
 
     def get_job(self, job_id: str) -> Job:


### PR DESCRIPTION
See https://github.com/encode/httpx/discussions/2959

For the SDK close the connection once we are done with it.