### PR TITLE
Fix for DatasetJob and Job have slightly different fields

### DIFF
--- a/examples/datasets.py
+++ b/examples/datasets.py
@@ -120,7 +120,7 @@ async def main():
         writer = csv.writer(f)
         writer.writerow(["job_id", "file_name", "output"])
         for key_info, data in items.items():
-            writer.writerow([key_info.job_id, key_info.file_name, data])
+            writer.writerow([key_info.id, key_info.file_name, data])
 
 
 asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.52"
+version = "0.1.53"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -107,7 +107,7 @@ class DocumentAI:
         while finished_job.status in ["pending", "processing"]:
             print("waiting 5s...")
             time.sleep(5)
-            finished_job = self.get_job(job.job_id)
+            finished_job = self.get_job(job.id)
             print(f"job status: {finished_job.status}")
 
         return finished_job
@@ -121,7 +121,7 @@ class DocumentAI:
         while finished_job.status in ["pending", "processing"]:
             print("waiting 5s...")
             await asyncio.sleep(5)
-            finished_job = await self.get_job_async(job.job_id)
+            finished_job = await self.get_job_async(job.id)
             print(f"job_id: {job_id}, job status: {finished_job.status}")
 
         return finished_job

--- a/src/tensorlake/documentai/jobs.py
+++ b/src/tensorlake/documentai/jobs.py
@@ -5,7 +5,7 @@ DocumentAI job classes.
 from enum import Enum
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class JobStatus(str, Enum):
@@ -155,7 +155,9 @@ class Job(BaseModel):
     DocumentAI job class.
     """
 
-    job_id: str = Field(alias="id")
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(alias="jobId")
     status: JobStatus = Field(alias="status")
     file_name: str = Field(alias="fileName")
     file_id: str = Field(alias="fileId")


### PR DESCRIPTION
Inkwell server uses job_id and id. Fix this using pydantic to unblock the docs.

Ideal fix - align dataset job and the regular job objects within inkwell (also fix the optional fields, see https://github.com/tensorlakeai/tensorlake/pull/92/)