### PR TITLE
Fix Hardcoded Env URL for Tensorlake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.54"
+version = "0.1.55"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/builder/client.py
+++ b/src/tensorlake/builder/client.py
@@ -17,9 +17,9 @@ class ImageBuilderClient:
     @classmethod
     def from_env(cls):
         api_key = os.getenv("TENSORLAKE_API_KEY")
-        indexify_url = os.getenv("INDEXIFY_URL", "https://api.tensorlake.ai")
+        server_url = os.getenv("TENSORLAKE_SERVER_URL", "https://api.tensorlake.ai")
         build_url = os.getenv(
-            "TENSORLAKE_BUILD_SERVICE", f"{indexify_url}/images"
+            "TENSORLAKE_BUILD_SERVICE", f"{server_url}/images"
         )  # Mainly used for debugging/local testing
         return cls(build_url, api_key)
 

--- a/src/tensorlake/cli/_common.py
+++ b/src/tensorlake/cli/_common.py
@@ -32,7 +32,7 @@ class AuthContext:
                     "API key is not configured properly. The TENSORLAKE_API_KEY environment variable is required."
                 )
 
-            base_url = os.getenv("INDEXIFY_URL", "https://api.tensorlake.ai")
+            base_url = os.getenv("TENSORLAKE_SERVER_URL", "https://api.tensorlake.ai")
 
             self._client = httpx.Client(
                 base_url=base_url,

--- a/src/tensorlake/documentai/common.py
+++ b/src/tensorlake/documentai/common.py
@@ -2,11 +2,14 @@
 Common types and constants for the Document AI API.
 """
 
+import os
 from typing import Generic, List, Optional, TypeVar
 
 from pydantic import BaseModel, Field
 
-DOC_AI_BASE_URL = "https://api.tensorlake.ai/documents/v1/"
+# Get base URL from environment variable or use default
+_server_url = os.getenv("TENSORLAKE_SERVER_URL", "https://api.tensorlake.ai")
+DOC_AI_BASE_URL = os.getenv("TENSORLAKE_DOCAI_URL", f"{_server_url}/documents/v1/")
 
 T = TypeVar("T")
 

--- a/src/tensorlake/http_client.py
+++ b/src/tensorlake/http_client.py
@@ -64,9 +64,7 @@ class TensorlakeClient:
         api_key: Optional[str] = None,
         **kwargs,
     ):
-        if os.environ.get("INDEXIFY_URL"):
-            print("Using INDEXIFY_URL environment variable to connect to Indexify")
-            service_url = os.environ["INDEXIFY_URL"]
+        # service_url is already set from DEFAULT_SERVICE_URL, which reads from env var
 
         self.service_url = service_url
         self._config_path = config_path

--- a/src/tensorlake/settings.py
+++ b/src/tensorlake/settings.py
@@ -1,1 +1,3 @@
-DEFAULT_SERVICE_URL = "https://api.tensorlake.ai"
+import os
+
+DEFAULT_SERVICE_URL = os.getenv("TENSORLAKE_SERVER_URL", "https://api.tensorlake.ai")


### PR DESCRIPTION
Verified locally for `readme_example.py`, using `export TENSORLAKE_SERVER_URL="https://api.tensorlake.dev"`

`job id: job-Kk97PjKq6gMQ9PjJm6ppK` and https://cloud.tensorlake.dev/organizations/org_PPrPm9Q7zbgCBbjhFRJ6j/projects/project_zQ7hpFKWkMtHbCkzRkCqd/documents/playground?jobId=job-Kk97PjKq6gMQ9PjJm6ppK&documentId=tensorlake-kgCbgBHzTHmp9ghhDdGj8