### PR TITLE
Fix variable because it's breaking integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.55"
+version = "0.1.56"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/builder/client.py
+++ b/src/tensorlake/builder/client.py
@@ -17,7 +17,7 @@ class ImageBuilderClient:
     @classmethod
     def from_env(cls):
         api_key = os.getenv("TENSORLAKE_API_KEY")
-        server_url = os.getenv("TENSORLAKE_SERVER_URL", "https://api.tensorlake.ai")
+        server_url = os.getenv("INDEXIFY_URL", "https://api.tensorlake.ai")
         build_url = os.getenv(
             "TENSORLAKE_BUILD_SERVICE", f"{server_url}/images"
         )  # Mainly used for debugging/local testing

--- a/src/tensorlake/cli/_common.py
+++ b/src/tensorlake/cli/_common.py
@@ -29,7 +29,7 @@ class AuthContext:
         if self._client is None:
             if not self.api_key:
                 raise click.UsageError(
-                    "API key is not configured properly. The TENSORLAKE_API_KEY environment variable is required."
+                    "API key is not configured properly. The INDEXIFY_URL environment variable is required."
                 )
 
             base_url = os.getenv("TENSORLAKE_SERVER_URL", "https://api.tensorlake.ai")

--- a/src/tensorlake/documentai/common.py
+++ b/src/tensorlake/documentai/common.py
@@ -8,7 +8,7 @@ from typing import Generic, List, Optional, TypeVar
 from pydantic import BaseModel, Field
 
 # Get base URL from environment variable or use default
-_server_url = os.getenv("TENSORLAKE_SERVER_URL", "https://api.tensorlake.ai")
+_server_url = os.getenv("INDEXIFY_URL", "https://api.tensorlake.ai")
 DOC_AI_BASE_URL = os.getenv("TENSORLAKE_DOCAI_URL", f"{_server_url}/documents/v1/")
 
 T = TypeVar("T")

--- a/src/tensorlake/http_client.py
+++ b/src/tensorlake/http_client.py
@@ -58,13 +58,12 @@ def log_retries(e: BaseException, sleep_time: float, retries: int):
 class TensorlakeClient:
     def __init__(
         self,
-        service_url: str = DEFAULT_SERVICE_URL,
+        service_url: str = DEFAULT_SERVICE_URL, # service_url is already set from DEFAULT_SERVICE_URL, which reads from env var
         config_path: Optional[str] = None,
         namespace: str = "default",
         api_key: Optional[str] = None,
         **kwargs,
     ):
-        # service_url is already set from DEFAULT_SERVICE_URL, which reads from env var
 
         self.service_url = service_url
         self._config_path = config_path

--- a/src/tensorlake/settings.py
+++ b/src/tensorlake/settings.py
@@ -1,3 +1,3 @@
 import os
 
-DEFAULT_SERVICE_URL = os.getenv("TENSORLAKE_SERVER_URL", "https://api.tensorlake.ai")
+DEFAULT_SERVICE_URL = os.getenv("INDEXIFY_URL", "https://api.tensorlake.ai")


### PR DESCRIPTION
Revert variable name change to avoid breaking existing integrations.

export INDEXIFY_URL="https://api.tensorlake.dev"

Verified in dev: https://cloud.tensorlake.dev/organizations/org_PPrPm9Q7zbgCBbjhFRJ6j/projects/project_zQ7hpFKWkMtHbCkzRkCqd/documents/playground?jobId=job-mFFhCqbPkJGWwBPDjfBqD&documentId=tensorlake-kgCbgBHzTHmp9ghhDdGj8