### PR TITLE
Remove SDK side resource validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.62"
+version = "0.1.63"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/functions_sdk/functions.py
+++ b/src/tensorlake/functions_sdk/functions.py
@@ -70,7 +70,7 @@ class TensorlakeCompute:
         ephemeral_disk (float): The amount of ephemeral disk space available to the function in GB.
         gpu (Optional[str]): GPU(s) available to the function. No GPU is allocated by default.
                              The value should be a string "GPU_MODEL:COUNT" representing the GPU model and the number of GPUs.
-                             Supported GPU models are string values from GPU_MODEL enum.
+                             See supported GPU models and counts in Tensorlake Cloud documentation.
     """
 
     name: str = ""

--- a/src/tensorlake/functions_sdk/resources.py
+++ b/src/tensorlake/functions_sdk/resources.py
@@ -1,50 +1,30 @@
 import math
-from enum import Enum
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from pydantic import BaseModel
 
 from .functions import TensorlakeCompute, TensorlakeRouter
 
 
-class GPU_MODEL(str, Enum):
-    """GPU models available in Tensorlake Cloud."""
-
-    H100 = "H100"
-    A100_40GB = "A100-40GB"
-    A100_80GB = "A100-80GB"
-
-
-_ALLOWED_GPU_MODELS = set(item.value for item in GPU_MODEL)
-
-
 class GPUResourceMetadata(BaseModel):
     count: int
-    model: GPU_MODEL
+    model: str
 
 
 def _parse_gpu_resource_metadata(gpu: str) -> GPUResourceMetadata:
-    parts = gpu.split(":")
+    # Example: "A100-80GB:2", "H100", "A100-40GB:4"
+    parts: List[str] = gpu.split(":")
     if len(parts) > 2:
         raise ValueError(
             f"Invalid GPU format: {gpu}. Expected format is 'GPU_MODEL:COUNT'."
         )
 
-    count: int = 1
+    gpu_model: str = parts[0]
+    gpu_count: int = 1
     if len(parts) == 2:
-        count = int(parts[1])
-        if count < 1 or count > 8:
-            raise ValueError(
-                f"Invalid GPU count: {count}. Count must be between 1 and 8."
-            )
+        gpu_count = int(parts[1])
 
-    gpu_model = parts[0]
-    if gpu_model not in _ALLOWED_GPU_MODELS:
-        raise ValueError(
-            f"Unsupported GPU model: {gpu_model}. Supported models are: {', '.join(_ALLOWED_GPU_MODELS)}."
-        )
-
-    return GPUResourceMetadata(count=count, model=GPU_MODEL(gpu_model))
+    return GPUResourceMetadata(count=gpu_count, model=gpu_model)
 
 
 class ResourceMetadata(BaseModel):

--- a/tests/tensorlake/test_graph_metadata.py
+++ b/tests/tensorlake/test_graph_metadata.py
@@ -13,7 +13,7 @@ from tensorlake.functions_sdk.graph_definition import (
     ResourceMetadata,
     RetryPolicyMetadata,
 )
-from tensorlake.functions_sdk.resources import GPU_MODEL, GPUResourceMetadata
+from tensorlake.functions_sdk.resources import GPUResourceMetadata
 from tensorlake.functions_sdk.retries import Retries
 
 
@@ -167,7 +167,7 @@ class TestGraphMetadataFunctionResources(unittest.TestCase):
         self.assertIsNone(resource_metadata.gpu)
 
     def test_custom_function_resources(self):
-        @tensorlake_function(cpu=2.25, memory=2, ephemeral_disk=10, gpu=GPU_MODEL.H100)
+        @tensorlake_function(cpu=2.25, memory=2, ephemeral_disk=10, gpu="H100")
         def function_with_resources(x: int) -> str:
             return "success"
 
@@ -187,7 +187,7 @@ class TestGraphMetadataFunctionResources(unittest.TestCase):
         self.assertIsNotNone(resource_metadata.gpu)
         gpu_metadata: GPUResourceMetadata = resource_metadata.gpu
         self.assertEqual(gpu_metadata.count, 1)
-        self.assertEqual(gpu_metadata.model, GPU_MODEL.H100)
+        self.assertEqual(gpu_metadata.model, "H100")
 
     def test_custom_function_resources_many_gpus(self):
         @tensorlake_function(gpu="A100-40GB:4")
@@ -210,23 +210,7 @@ class TestGraphMetadataFunctionResources(unittest.TestCase):
         self.assertIsNotNone(resource_metadata.gpu)
         gpu_metadata: GPUResourceMetadata = resource_metadata.gpu
         self.assertEqual(gpu_metadata.count, 4)
-        self.assertEqual(gpu_metadata.model, GPU_MODEL.A100_40GB)
-
-    def test_custom_function_resources_not_supported_gpu_model(self):
-        @tensorlake_function(gpu="NOT_SUPPORTED:4")
-        def function_with_resources(x: int) -> str:
-            return "success"
-
-        graph = Graph(
-            name=test_graph_name(self),
-            description="test",
-            start_node=function_with_resources,
-        )
-        try:
-            graph.definition()
-            self.fail("Expected ValueError not raised")
-        except ValueError as e:
-            self.assertIn("Unsupported GPU model", str(e))
+        self.assertEqual(gpu_metadata.model, "A100-40GB")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The available resources depend on region, Indexify cluster configuration and etc. So SDK (client) can't make any assumptions about possible resorce constraints.