### PR TITLE
Use compact traceback logging in dev mode by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.66"
+version = "0.1.67"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"


### PR DESCRIPTION
The default exception printers used in structlog print large outputs in dev mode that are distracting in many cases. Use a compact output by default.