### PR TITLE
Bump default resource limits CPU=1.0 core, memory=1.0 GB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.68"
+version = "0.1.69"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/functions_sdk/functions.py
+++ b/src/tensorlake/functions_sdk/functions.py
@@ -55,8 +55,15 @@ def is_pydantic_model_from_annotation(type_annotation):
 
 
 _DEFAULT_TIMEOUT: int = 300  # 5 minutes
-_DEFAULT_CPU: float = 0.125  # 0.125 CPU = 125 CPU ms per sec
-_DEFAULT_MEMORY_GB: float = 0.125  # 0.125 GB = 128 MB
+# We need full CPU core to start Function Executor and load customer function quickly.
+# Otherwise, starting up Function Executor without loading customer functions takes more
+# than 5 seconds with 0.125 CPU.
+_DEFAULT_CPU: float = 1.0
+# nvidia-smi health checks consume up to 100 MB of memory.
+# Function Executor itself currently consumes up to 75 MB of memory.
+# So we need a large enough minimal memory limit to ensure stability while running customer
+# functions that consume memory too.
+_DEFAULT_MEMORY_GB: float = 1.0
 _DEFAULT_EPHEMERAL_DISK_GB: float = 2.0  # 2 GB
 _DEFAULT_GPU = None  # No GPU by default
 

--- a/tests/tensorlake/test_function_resources.py
+++ b/tests/tensorlake/test_function_resources.py
@@ -9,7 +9,7 @@ from tensorlake import (
 )
 
 
-@tensorlake_function(cpu=0.9, memory=1.0, ephemeral_disk=1.0, gpu=["H100", "T4"])
+@tensorlake_function(cpu=1.1, memory=1.3, ephemeral_disk=1.0, gpu=["H100", "T4"])
 def function_with_custom_resources(x: int) -> str:
     return "success"
 

--- a/tests/tensorlake/test_graph_metadata.py
+++ b/tests/tensorlake/test_graph_metadata.py
@@ -160,8 +160,8 @@ class TestGraphMetadataFunctionResources(unittest.TestCase):
             graph_metadata.start_node.compute_fn.resources
         )
         self.assertIsNotNone(resource_metadata)
-        self.assertEqual(resource_metadata.cpus, 0.125)
-        self.assertEqual(resource_metadata.memory_mb, 128)
+        self.assertEqual(resource_metadata.cpus, 1.0)
+        self.assertEqual(resource_metadata.memory_mb, 1024)
         self.assertEqual(resource_metadata.ephemeral_disk_mb, 2 * 1024)
         self.assertEqual(resource_metadata.gpus, [])
 
@@ -202,8 +202,8 @@ class TestGraphMetadataFunctionResources(unittest.TestCase):
             graph_metadata.start_node.compute_fn.resources
         )
         self.assertIsNotNone(resource_metadata)
-        self.assertEqual(resource_metadata.cpus, 0.125)
-        self.assertEqual(resource_metadata.memory_mb, 128)
+        self.assertEqual(resource_metadata.cpus, 1.0)
+        self.assertEqual(resource_metadata.memory_mb, 1024)
         self.assertEqual(resource_metadata.ephemeral_disk_mb, 2 * 1024)
         self.assertEqual(len(resource_metadata.gpus), 1)
         self.assertEqual(resource_metadata.gpus[0].count, 4)
@@ -224,8 +224,8 @@ class TestGraphMetadataFunctionResources(unittest.TestCase):
             graph_metadata.start_node.compute_fn.resources
         )
         self.assertIsNotNone(resource_metadata)
-        self.assertEqual(resource_metadata.cpus, 0.125)
-        self.assertEqual(resource_metadata.memory_mb, 128)
+        self.assertEqual(resource_metadata.cpus, 1.0)
+        self.assertEqual(resource_metadata.memory_mb, 1024)
         self.assertEqual(resource_metadata.ephemeral_disk_mb, 2 * 1024)
         self.assertEqual(len(resource_metadata.gpus), 3)
         self.assertEqual(resource_metadata.gpus[0].count, 4)


### PR DESCRIPTION
It was found out experimentally that lower resource limits result in unstable funciton execution, e.g. nvidia-smi + Function Executors consume up to 200 MB of memory themself so we need to have a large extra room in function memory to make its execution stable and not OOM.

We need a full CPU core at the very least to ensure fast cold starts (FE startup + loading of customer function). With < 1 CPU core we're artificially slowing it down. Also a lower CPU quota makes FE startup less reliable because it depends on customer set quotas while with 1 full CPU core at a minimum we get enough CPU time to ensure that we're not ever running FE startup with any extreme CPU starvation conditions.

Ran the tests locally - all are passing. CI is blocked right now.