### PR TITLE
Update __init__.py to include table parsing

### DIFF
--- a/src/tensorlake/documentai/__init__.py
+++ b/src/tensorlake/documentai/__init__.py
@@ -5,7 +5,7 @@ TensorLake Document AI SDK
 from tensorlake.documentai.client import DocumentAI
 from tensorlake.documentai.datasets import DatasetOptions, IngestArgs
 from tensorlake.documentai.jobs import Job, JobStatus, Output
-from tensorlake.documentai.parse import ExtractionOptions, ParsingOptions
+from tensorlake.documentai.parse import ExtractionOptions, ParsingOptions, TableOutputMode, TableParsingStrategy
 
 __all__ = [
     "DocumentAI",
@@ -16,4 +16,6 @@ __all__ = [
     "Output",
     "ParsingOptions",
     "ExtractionOptions",
+    "TableOutputMode", 
+    "TableParsingStrategy",
 ]


### PR DESCRIPTION
[Quickstart for Document processing](https://docs.tensorlake.ai/document-ingestion/parsing#quick-start) includes table parsing, but the SDK did not expose `TableOutputModel` or `TableParsingStrategy`.

I was able to confirm that doing this removes the error, but I don't know if there is a reason we hadn't exposed these classes yet. 

Alternatively, I can remove those two classes from the quickstart if we don't want them exposed yet in the SDK.