### PR TITLE
Refactor tests to not use function closures where remote graph is used

### DIFF
--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -10,9 +10,8 @@ from pathlib import Path
 from typing import Optional, Union
 
 import httpx
-from pydantic import Json
+from pydantic import BaseModel, Json
 from retry import retry
-from pydantic import BaseModel
 
 from tensorlake.documentai.common import DOC_AI_BASE_URL, PaginatedResult
 from tensorlake.documentai.datasets import Dataset, DatasetOptions
@@ -185,7 +184,7 @@ class DocumentAI:
                 options.form_detection_mode.value
                 if options.form_detection_mode is not None
                 else "object_detection"
-            )
+            ),
         }
 
     def __create_parse_req__(self, file: str, options: ParsingOptions) -> dict:

--- a/src/tensorlake/documentai/parse.py
+++ b/src/tensorlake/documentai/parse.py
@@ -71,13 +71,14 @@ class ExtractionOptions(BaseModel):
     prompt: Optional[str] = None
     provider: ModelProvider = ModelProvider.TENSORLAKE
 
+
 class FormDetectionMode(str, Enum):
     """
     Algorithm to use for detecting forms in a document.
 
-    VLM: Uses a VLM to identify questions and answers in a form. 
+    VLM: Uses a VLM to identify questions and answers in a form.
          Does not provide bounding boxes and is prone to hallucinations.
-    OBJECT_DETECTION: Uses a layout detector to identify questions and answers. 
+    OBJECT_DETECTION: Uses a layout detector to identify questions and answers.
                      Does not work well with very complex forms.
     """
 
@@ -104,4 +105,6 @@ class ParsingOptions(BaseModel):
     figure_summary: Optional[bool] = False
     structured_extraction_skip_ocr: Optional[bool] = False
     disable_layout_detection: Optional[bool] = False
-    form_detection_mode: Optional[FormDetectionMode] = FormDetectionMode.OBJECT_DETECTION
+    form_detection_mode: Optional[FormDetectionMode] = (
+        FormDetectionMode.OBJECT_DETECTION
+    )

--- a/tests/tensorlake/test_graph_metrics.py
+++ b/tests/tensorlake/test_graph_metrics.py
@@ -9,14 +9,15 @@ from tensorlake import (
 )
 
 
+@tensorlake_function(inject_ctx=True)
+def node_with_metrics(ctx: GraphInvocationContext, x: int) -> int:
+    ctx.invocation_state.timer("test_timer", 1.8)
+    ctx.invocation_state.counter("test_counter", 8)
+    return x + 1
+
+
 class TestGraphMetrics(unittest.TestCase):
     def test_metrics_settable(self):
-        @tensorlake_function(inject_ctx=True)
-        def node_with_metrics(ctx: GraphInvocationContext, x: int) -> int:
-            ctx.invocation_state.timer("test_timer", 1.8)
-            ctx.invocation_state.counter("test_counter", 8)
-            return x + 1
-
         # Only test local graph mode here because behavior of secrets in remote graph depends
         # on Executor flavor.
         graph = Graph(

--- a/tests/tensorlake/test_graph_secrets.py
+++ b/tests/tensorlake/test_graph_secrets.py
@@ -11,12 +11,31 @@ from tensorlake import (
 from tensorlake.functions_sdk.functions import tensorlake_router
 
 
+@tensorlake_function(secrets=["SECRET_NAME"])
+def node_with_secret(x: int) -> int:
+    return x + 1
+
+
+@tensorlake_function()
+def add_two(x: int) -> int:
+    return x + 2
+
+
+@tensorlake_function()
+def add_three(x: int) -> int:
+    return x + 3
+
+
+@tensorlake_router(secrets=["SECRET_NAME_ROUTER"])
+def route_if_even(x: int) -> List[Union[add_two, add_three]]:
+    if x % 2 == 0:
+        return add_three
+    else:
+        return add_two
+
+
 class TestGraphSecrets(unittest.TestCase):
     def test_secrets_settable(self):
-        @tensorlake_function(secrets=["SECRET_NAME"])
-        def node_with_secret(x: int) -> int:
-            return x + 1
-
         # Only test local graph mode here because behavior of secrets in remote graph depends
         # on Executor flavor.
         graph = Graph(
@@ -28,21 +47,6 @@ class TestGraphSecrets(unittest.TestCase):
         self.assertEqual(output[0], 2)
 
     def test_graph_router_secrets_settable(self):
-        @tensorlake_function()
-        def add_two(x: int) -> int:
-            return x + 2
-
-        @tensorlake_function()
-        def add_three(x: int) -> int:
-            return x + 3
-
-        @tensorlake_router(secrets=["SECRET_NAME_ROUTER"])
-        def route_if_even(x: int) -> List[Union[add_two, add_three]]:
-            if x % 2 == 0:
-                return add_three
-            else:
-                return add_two
-
         # Only test local graph mode here because behavior of secrets in remote graph depends
         # on Executor flavor.
         graph = Graph(

--- a/tests/tensorlake/test_graph_update.py
+++ b/tests/tensorlake/test_graph_update.py
@@ -1,8 +1,6 @@
 import time
 import unittest
 
-import parameterized
-import testing
 from testing import test_graph_name, wait_function_output
 
 from tensorlake import Graph, RemoteGraph, tensorlake_function
@@ -49,125 +47,33 @@ class TestGraphUpdate(unittest.TestCase):
         self.assertEqual(len(output), 1, output)
         self.assertEqual(output[0], "end_func_v2", output)
 
-    @parameterized.parameterized.expand(
-        [
-            # FIXME: This test is currently failing.
-            # ("new_function_names", "second_graph_new_name"),
-            ("existing_function_names", "second_graph_reused_function_names"),
-        ]
-    )
-    def test_running_invocation_unaffected_by_update(
-        self, test_case_name: str, second_graph_name: str
-    ):
-        graph_name = test_graph_name(self)
-
-        def initial_graph():
-            @tensorlake_function()
-            def start_node(x: int) -> int:
-                # Sleep to provide enough time for a graph update to happen
-                # while this graph version is running.
-                time.sleep(1)
-                return x
-
-            @tensorlake_function()
-            def middle_node(x: int) -> int:
-                return x + 1
-
-            @tensorlake_function()
-            def end_node(x: int) -> int:
-                return x + 2
-
-            g = Graph(
-                name=graph_name,
-                start_node=start_node,
-                version="1.0",
-                additional_modules=[testing, parameterized],
-            )
-            g.add_edge(start_node, middle_node)
-            g.add_edge(middle_node, end_node)
-            return g
-
-        def second_graph_new_name():
-            @tensorlake_function()
-            def start_node2(x: int) -> dict:
-                return {"data": dict(num=x)}
-
-            @tensorlake_function()
-            def middle_node2(data: dict) -> dict:
-                return {"data": dict(num=data["num"] + 1)}
-
-            @tensorlake_function()
-            def end_node2(data: dict) -> int:
-                return data["num"] + 3
-
-            g = Graph(
-                name=graph_name,
-                start_node=start_node2,
-                version="2.0",
-                additional_modules=[testing, parameterized],
-            )
-            g.add_edge(start_node2, middle_node2)
-            g.add_edge(middle_node2, end_node2)
-            return g, end_node2.name
-
-        def second_graph_reused_function_names():
-            @tensorlake_function()
-            def start_node(x: int) -> dict:
-                return {"data": dict(num=x)}
-
-            @tensorlake_function()
-            def middle_node(data: dict) -> dict:
-                return {"data": dict(num=data["num"] + 1)}
-
-            @tensorlake_function()
-            def end_node(data: dict) -> int:
-                return data["num"] + 3
-
-            g = Graph(
-                name=graph_name,
-                start_node=start_node,
-                version="3.0",
-                additional_modules=[testing, parameterized],
-            )
-            g.add_edge(start_node, middle_node)
-            g.add_edge(middle_node, end_node)
-            return g, end_node.name
-
-        g = initial_graph()
+    def test_running_invocation_doesnt_get_its_graph_version_updated(self):
+        g = Graph(
+            name=test_graph_name(self),
+            start_node=start_func_v1,
+        )
+        g.add_edge(start_func_v1, end_func_v1)
         g = RemoteGraph.deploy(g)
-        first_invocation_id = g.run(block_until_done=False, x=0)
 
-        if second_graph_name == "second_graph_new_name":
-            g, end_node_name = second_graph_new_name()
-        else:
-            g, end_node_name = second_graph_reused_function_names()
-        # The first invocation should not be affected by the second graph version
-        # This loop waits for the first invocation to finish and checks its output.
-        time.sleep(0.25)
-        g = RemoteGraph.deploy(g)
-        g.metadata()
-        invocation_id = g.run(block_until_done=True, x=0)
-        output = g.output(invocation_id, fn_name=end_node_name)
-        self.assertEqual(len(output), 1)
-        self.assertEqual(output[0], 4)
-
-        # The first invocation should not be affected by the second graph version
-        # This loop waits for the first invocation to finish and checks its output.
-        output = wait_function_output(g, first_invocation_id, "end_node")
-        self.assertEqual(len(output), 1, output)
-        self.assertEqual(output[0], 3)
-
-    def test_graph_update_fails_without_version_update(self):
-        graph_name = test_graph_name(self)
-
-        @tensorlake_function()
-        def function_a() -> str:
-            return "success"
+        invocation_id = g.run(block_until_done=False, sleep_sec=10)
 
         g = Graph(
-            name=graph_name,
+            name=test_graph_name(self),
+            start_node=start_func_v1,
+            version="2.0",
+        )
+        g.add_edge(start_func_v1, end_func_v1)
+        g.add_edge(end_func_v1, end_func_v2)
+        g = RemoteGraph.deploy(g, upgrade_tasks_to_latest_version=False)
+
+        output = wait_function_output(g, invocation_id, "end_func_v2")
+        self.assertEqual(len(output), 0, output)
+
+    def test_graph_update_fails_without_version_update(self):
+        g = Graph(
+            name=test_graph_name(self),
             description="test description",
-            start_node=function_a,
+            start_node=start_func_v1,
         )
         RemoteGraph.deploy(g)
         g.description = "updated description without version update"


### PR DESCRIPTION
When moving to ZIP graph serialization we won't be able to use graph closures. This is a preparation for ZIP serialization PR so that PR is smaller and has the most relevant changes only.