### PR TITLE
skip_ocr fix

### DIFF
--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -171,8 +171,8 @@ class DocumentAI:
                 else False
             ),
             "structuredExtractionSkipOcr": (
-                options.structured_extraction_skip_ocr
-                if options.structured_extraction_skip_ocr is not None
+                options.extraction_options.skip_ocr
+                if options.extraction_options.skip_ocr is not None
                 else False
             ),
             "disableLayoutDetection": (

--- a/src/tensorlake/documentai/parse.py
+++ b/src/tensorlake/documentai/parse.py
@@ -70,6 +70,7 @@ class ExtractionOptions(BaseModel):
     schema: Union[Type[BaseModel], Json]
     prompt: Optional[str] = None
     provider: ModelProvider = ModelProvider.TENSORLAKE
+    skip_ocr: bool = False
 
 
 class FormDetectionMode(str, Enum):
@@ -103,7 +104,6 @@ class ParsingOptions(BaseModel):
     detect_signature: Optional[bool] = False
     table_summary: Optional[bool] = False
     figure_summary: Optional[bool] = False
-    structured_extraction_skip_ocr: Optional[bool] = False
     disable_layout_detection: Optional[bool] = False
     form_detection_mode: Optional[FormDetectionMode] = (
         FormDetectionMode.OBJECT_DETECTION


### PR DESCRIPTION
`skip_ocr` should be a boolean parameter in `ExtractionOptions`, not just a top-level parameter in `ParsingOptions`. 

In `parse.py`:  
- Removed `structured_extraction_skip_ocr` from `ParsingOptions`
- Added `skip_ocr: bool = False` in 'ExtractionOptions`

In `client.py`:  
- Changed `structuredExtractionSkipOcr` from `options.structured_extraction_skip_ocr` to `options.extraction_options.skip_ocr`

Confirmed locally this fixes the issue where a job initiated from the SDK ignores `skip_ocr`

Before fix:
```
options = ParsingOptions(
    page_range='1',
    chunk_strategy=ChunkingStrategy.NONE,
    table_parsing_strategy=TableParsingStrategy.TSR,
    table_output_mode=TableOutputMode.MARKDOWN,
    form_detection_mode=FormDetectionMode.VLM,
    extraction_options=ExtractionOptions(
        schema=schema_string,
    ),
    detect_signature=True,
    structured_extraction_skip_ocr=True,
)
```

After fix:
```
options = ParsingOptions(
    page_range='1',
    chunk_strategy=ChunkingStrategy.NONE,
    table_parsing_strategy=TableParsingStrategy.TSR,
    table_output_mode=TableOutputMode.MARKDOWN,
    form_detection_mode=FormDetectionMode.VLM,
    extraction_options=ExtractionOptions(
        schema=schema_string,
        skip_ocr=True,
    ),
    detect_signature=True,
)
```