### PR TITLE
ZIP functions correctly when their names in graph and in Python differ

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.76"
+version = "0.1.77"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/function_executor/service.py
+++ b/src/tensorlake/function_executor/service.py
@@ -99,10 +99,12 @@ class Service(FunctionExecutorServicer):
             function_module = importlib.import_module(
                 function_manifest.module_import_name
             )
-            function = getattr(function_module, request.function_name)
+            function_class = getattr(
+                function_module, function_manifest.class_import_name
+            )
 
             # TODO: capture stdout and stderr and report exceptions the same way as when we run a task.
-            self._function_wrapper = TensorlakeFunctionWrapper(function)
+            self._function_wrapper = TensorlakeFunctionWrapper(function_class)
         except Exception as e:
             self._logger.error(
                 "function executor service initialization failed",

--- a/src/tensorlake/functions_sdk/functions.py
+++ b/src/tensorlake/functions_sdk/functions.py
@@ -98,6 +98,10 @@ class TensorlakeCompute:
     def run(self, *args, **kwargs) -> Union[List[Any], Any]:
         pass
 
+    _created_by_decorator: bool = (
+        False  # True if class was created using @tensorlake_function
+    )
+
     def _call_run(self, *args, **kwargs) -> Union[List[Any], Any]:
         # Process dictionary argument mapping it to args or to kwargs.
         if self.accumulate and len(args) == 2 and isinstance(args[1], dict):
@@ -138,6 +142,10 @@ class TensorlakeRouter:
 
     def run(self, *args, **kwargs) -> Optional[List[TensorlakeCompute]]:
         pass
+
+    _created_by_decorator: bool = (
+        False  # True if class was created using @tensorlake_function
+    )
 
     # Create run method that preserves signature
     def _call_run(self, *args, **kwargs):
@@ -189,6 +197,7 @@ def tensorlake_router(
 ):
     def construct(fn):
         attrs = {
+            "_created_by_decorator": True,
             "name": name if name else fn.__name__,
             "description": (
                 description
@@ -232,6 +241,7 @@ def tensorlake_function(
 ):
     def construct(fn):
         attrs = {
+            "_created_by_decorator": True,
             "name": name if name else fn.__name__,
             "description": (
                 description

--- a/tests/tensorlake/graph_code_serialization/hello_world/subpackage/subpackage.py
+++ b/tests/tensorlake/graph_code_serialization/hello_world/subpackage/subpackage.py
@@ -5,6 +5,8 @@ from hello_world.subpackage.const import (
     WORLD_NAME,
 )
 
+from tensorlake import TensorlakeCompute, tensorlake_function
+
 # Import from parent module using relative import path. We can do this because this Python file is part of a package
 # and the parent directory is a Python package too.
 from ..hello_world import hello_world
@@ -15,3 +17,15 @@ from .const import WORLD_NAME as WORLD_NAME_2
 
 def subpackage_hello_world() -> str:
     return hello_world() + " from " + WORLD_NAME + " and " + WORLD_NAME_2
+
+
+@tensorlake_function(name="foo")
+def tensorlale_function_subpackage_hello_world() -> str:
+    return subpackage_hello_world()
+
+
+class TensorlakeComputeSubpackageHelloWorld(TensorlakeCompute):
+    name = "tensorlake_compute_subpackage_hello_world"
+
+    def run(self) -> str:
+        return subpackage_hello_world()

--- a/tests/tensorlake/graph_code_serialization/test_graph_code_serialization.py
+++ b/tests/tensorlake/graph_code_serialization/test_graph_code_serialization.py
@@ -3,7 +3,11 @@ from typing import List
 
 # Import from local package using absolute import path.
 from hello_world.hello_world import hello_world
-from hello_world.subpackage.subpackage import subpackage_hello_world
+from hello_world.subpackage.subpackage import (
+    TensorlakeComputeSubpackageHelloWorld,
+    subpackage_hello_world,
+    tensorlale_function_subpackage_hello_world,
+)
 
 # Import local module using absolute import path, works because the the code dir zip is added to PYTHONPATH.
 from repeat import repeat_hello_world
@@ -136,6 +140,40 @@ class TestGraphCodeSerialization(unittest.TestCase):
         output = graph.output(invocation_id, "import_from_subdir_fails")
         self.assertEqual(len(output), 1)
         self.assertTrue(output[0])
+
+    def test_imported_tensorlake_function(self):
+        # Check that the function imported from the module works.
+        graph = Graph(
+            name=test_graph_name(self),
+            description="test",
+            start_node=tensorlale_function_subpackage_hello_world,
+        )
+        graph = RemoteGraph.deploy(
+            graph=graph, code_dir_path=graph_code_dir_path(__file__)
+        )
+
+        invocation_id = graph.run(block_until_done=True)
+        output = graph.output(
+            invocation_id, tensorlale_function_subpackage_hello_world.name
+        )
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], subpackage_hello_world())
+
+    def test_imported_tensorlake_compute(self):
+        # Check that the function imported from the module works.
+        graph = Graph(
+            name=test_graph_name(self),
+            description="test",
+            start_node=TensorlakeComputeSubpackageHelloWorld,
+        )
+        graph = RemoteGraph.deploy(
+            graph=graph, code_dir_path=graph_code_dir_path(__file__)
+        )
+
+        invocation_id = graph.run(block_until_done=True)
+        output = graph.output(invocation_id, TensorlakeComputeSubpackageHelloWorld.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], subpackage_hello_world())
 
 
 # TODO: Add test case that validates that multiprocessing works.


### PR DESCRIPTION
When running functions from ZIP we need to import them not using their names in graphs but using their Python names. These names can differ easily e.g. because Python code style is different from the one they want to use in the graph, e.g.

```
class AStarSearch(TensorlakeFunction):
  name = "find_shortest_path"

  def run(self):
     pass
```