### PR TITLE
Make sure `skip_ocr` defaults to False

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.77"
+version = "0.1.78"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -130,7 +130,7 @@ class DocumentAI:
 
     def __create_parse_settings__(self, options: ParsingOptions) -> dict:
         json_schema = None
-        if options.extraction_options:
+        if options.extraction_options and options.extraction_options.schema:
             if isinstance(options.extraction_options.schema, str):
                 json_schema = json.loads(options.extraction_options.schema)
             elif isinstance(options.extraction_options.schema, dict):

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -130,7 +130,7 @@ class DocumentAI:
 
     def __create_parse_settings__(self, options: ParsingOptions) -> dict:
         json_schema = None
-        if options.extraction_options and options.extraction_options.schema:
+        if options.extraction_options:
             if isinstance(options.extraction_options.schema, str):
                 json_schema = json.loads(options.extraction_options.schema)
             elif isinstance(options.extraction_options.schema, dict):

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -172,7 +172,7 @@ class DocumentAI:
             ),
             "structuredExtractionSkipOcr": (
                 options.extraction_options.skip_ocr
-                if options.extraction_options.skip_ocr is not None
+                if options.extraction_options and options.extraction_options.skip_ocr is not None
                 else False
             ),
             "disableLayoutDetection": (

--- a/src/tensorlake/documentai/parse.py
+++ b/src/tensorlake/documentai/parse.py
@@ -5,7 +5,7 @@ This module contains the data models for parsing a document.
 from enum import Enum
 from typing import Optional, Type, Union
 
-from pydantic import BaseModel, Json
+from pydantic import BaseModel, Json, Field
 
 
 class ChunkingStrategy(str, Enum):
@@ -67,7 +67,7 @@ class ExtractionOptions(BaseModel):
     Options for structured data extraction.
     """
 
-    schema: Union[Type[BaseModel], Json]
+    schema: Optional[Union[Type[BaseModel], Json]] = None
     prompt: Optional[str] = None
     provider: ModelProvider = ModelProvider.TENSORLAKE
     skip_ocr: bool = False
@@ -99,7 +99,7 @@ class ParsingOptions(BaseModel):
     figure_summarization_prompt: Optional[str] = None
     table_output_mode: TableOutputMode = TableOutputMode.MARKDOWN
     page_range: Optional[str] = None
-    extraction_options: Optional[ExtractionOptions] = None
+    extraction_options: Optional[ExtractionOptions] = Field(default_factory=ExtractionOptions),
     deliver_webhook: bool = False
     detect_signature: Optional[bool] = False
     table_summary: Optional[bool] = False

--- a/src/tensorlake/documentai/parse.py
+++ b/src/tensorlake/documentai/parse.py
@@ -67,7 +67,7 @@ class ExtractionOptions(BaseModel):
     Options for structured data extraction.
     """
 
-    schema: Optional[Union[Type[BaseModel], Json]] = None
+    schema: Union[Type[BaseModel], Json] = None
     prompt: Optional[str] = None
     provider: ModelProvider = ModelProvider.TENSORLAKE
     skip_ocr: bool = False

--- a/src/tensorlake/documentai/parse.py
+++ b/src/tensorlake/documentai/parse.py
@@ -5,7 +5,7 @@ This module contains the data models for parsing a document.
 from enum import Enum
 from typing import Optional, Type, Union
 
-from pydantic import BaseModel, Json, Field
+from pydantic import BaseModel, Json
 
 
 class ChunkingStrategy(str, Enum):
@@ -67,7 +67,7 @@ class ExtractionOptions(BaseModel):
     Options for structured data extraction.
     """
 
-    schema: Union[Type[BaseModel], Json] = None
+    schema: Union[Type[BaseModel], Json]
     prompt: Optional[str] = None
     provider: ModelProvider = ModelProvider.TENSORLAKE
     skip_ocr: bool = False
@@ -99,7 +99,7 @@ class ParsingOptions(BaseModel):
     figure_summarization_prompt: Optional[str] = None
     table_output_mode: TableOutputMode = TableOutputMode.MARKDOWN
     page_range: Optional[str] = None
-    extraction_options: Optional[ExtractionOptions] = None,
+    extraction_options: Optional[ExtractionOptions] = None
     deliver_webhook: bool = False
     detect_signature: Optional[bool] = False
     table_summary: Optional[bool] = False

--- a/src/tensorlake/documentai/parse.py
+++ b/src/tensorlake/documentai/parse.py
@@ -99,7 +99,7 @@ class ParsingOptions(BaseModel):
     figure_summarization_prompt: Optional[str] = None
     table_output_mode: TableOutputMode = TableOutputMode.MARKDOWN
     page_range: Optional[str] = None
-    extraction_options: Optional[ExtractionOptions] = Field(default_factory=ExtractionOptions),
+    extraction_options: Optional[ExtractionOptions] = None,
     deliver_webhook: bool = False
     detect_signature: Optional[bool] = False
     table_summary: Optional[bool] = False


### PR DESCRIPTION
When `ExtractionOptions` were `None`, `skip_ocr` wasn't defaulting to `False` correctly. 

There might be a better way to do this, but I tested with:
- [x] No `ExtractionOptions` provided
- [x] `ExtractionOptions` provided, but `skip_ocr` was not set
- [x] `ExtractionOptions` provided, and `skip_ocr` was set

All three worked when testing with this branch.