### PR TITLE
Set multiprocessing to use spawn by default

### DIFF
--- a/src/tensorlake/function_executor/main.py
+++ b/src/tensorlake/function_executor/main.py
@@ -8,6 +8,7 @@ configure_logging_early()
 
 import argparse
 from typing import Any
+import multiprocessing as mp
 
 import structlog
 
@@ -27,6 +28,7 @@ def validate_args(args, logger: Any):
 
 
 def main():
+    mp.set_start_method("spawn")
     parser = argparse.ArgumentParser(
         description="Runs Function Executor with the specified API server address"
     )


### PR DESCRIPTION
This change sets the multiprocessing library's default process creation mechanism to `spawn`, creating a new Python process when required instead of simply forking the current process.

Fixes #153 