### PR TITLE
`skip_ocr` default fix

### DIFF
--- a/examples/signature-detection/langgraph-agent-signature-detection-cli/helper_functions.py
+++ b/examples/signature-detection/langgraph-agent-signature-detection-cli/helper_functions.py
@@ -1,9 +1,10 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 SIGNATURE_DATA_DIR = "signature_analysis_data"
+
 
 def extract_signature_data(result, file_name: str, file_path: str) -> Dict[str, Any]:
     """Extract and structure signature data from TensorLake results"""
@@ -14,9 +15,12 @@ def extract_signature_data(result, file_name: str, file_path: str) -> Dict[str, 
     for page in pages:
         # Find signature fragments
         signature_fragments = [
-            frag for frag in page.page_fragments
-            if (frag.fragment_type.name.lower() == "signature" and
-                frag.content.content.strip().lower() != "no signature detected")
+            frag
+            for frag in page.page_fragments
+            if (
+                frag.fragment_type.name.lower() == "signature"
+                and frag.content.content.strip().lower() != "no signature detected"
+            )
         ]
 
         if signature_fragments:
@@ -37,8 +41,9 @@ def extract_signature_data(result, file_name: str, file_path: str) -> Dict[str, 
         "total_signatures": total_signatures,
         "total_pages": len(pages),
         "pages_with_signatures": list(structured_data.keys()),
-        "signatures_per_page": structured_data
+        "signatures_per_page": structured_data,
     }
+
 
 def extract_page_content(page_fragments: List) -> str:
     """Extract readable content from page fragments"""
@@ -51,7 +56,10 @@ def extract_page_content(page_fragments: List) -> str:
             content_parts.append(fragment.content.content.strip())
         elif fragment_type == "key_value_region":
             # Prefer markdown for tables if available
-            if hasattr(fragment.content, "markdown") and fragment.content.markdown.strip():
+            if (
+                hasattr(fragment.content, "markdown")
+                and fragment.content.markdown.strip()
+            ):
                 content_parts.append(fragment.content.markdown.strip())
             elif hasattr(fragment.content, "content"):
                 content_parts.append(fragment.content.content.strip())
@@ -61,11 +69,13 @@ def extract_page_content(page_fragments: List) -> str:
 
 def save_analysis_data(signature_data: Dict[str, Any], file_name: str) -> str:
     """Save signature analysis data to JSON file"""
-    safe_filename = "".join(c for c in file_name if c.isalnum() or c in (' ', '-', '_')).strip()
+    safe_filename = "".join(
+        c for c in file_name if c.isalnum() or c in (" ", "-", "_")
+    ).strip()
     json_filename = f"{safe_filename}_signature_analysis.json"
     json_path = Path(SIGNATURE_DATA_DIR) / json_filename
 
-    with open(json_path, 'w', encoding='utf-8') as f:
+    with open(json_path, "w", encoding="utf-8") as f:
         json.dump(signature_data, f, indent=2, ensure_ascii=False)
 
     print(f"Analysis data saved to: {json_path}")

--- a/examples/signature-detection/langgraph-agent-signature-detection-cli/signature_detection_langgraph_agent.py
+++ b/examples/signature-detection/langgraph-agent-signature-detection-cli/signature_detection_langgraph_agent.py
@@ -9,27 +9,31 @@ and LangGraph for conversational analysis. The system provides:
 3. Persistent storage of analysis data for future reference
 """
 
-import os
-import time
 import json
 import logging
-from typing import Dict, Any, Optional, TypedDict, Annotated, List
+import os
+import time
 from pathlib import Path
-from dotenv import load_dotenv
+from typing import Annotated, Any, Dict, List, Optional, TypedDict
 
-# LangGraph and LangChain imports
-from langgraph.graph import StateGraph, END
-from langgraph.prebuilt import ToolNode
-from langgraph.graph.message import add_messages
-from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
+from dotenv import load_dotenv
+from helper_functions import extract_signature_data, save_analysis_data
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 
-# TensorLake imports
-from tensorlake.documentai import DocumentAI, ParsingOptions, ExtractionOptions
-from tensorlake.documentai.parse import ChunkingStrategy, TableParsingStrategy, TableOutputMode
+# LangGraph and LangChain imports
+from langgraph.graph import END, StateGraph
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode
 
-from helper_functions import extract_signature_data, save_analysis_data
+# TensorLake imports
+from tensorlake.documentai import DocumentAI, ExtractionOptions, ParsingOptions
+from tensorlake.documentai.parse import (
+    ChunkingStrategy,
+    TableOutputMode,
+    TableParsingStrategy,
+)
 
 # Load environment variables
 load_dotenv()
@@ -37,12 +41,13 @@ load_dotenv()
 # Configuration
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 TENSORLAKE_API_KEY = os.getenv("TENSORLAKE_API_KEY")
-SIGNATURE_DATA_DIR = "signature_analysis_data"      # signature data analysis will be stored here
+SIGNATURE_DATA_DIR = (
+    "signature_analysis_data"  # signature data analysis will be stored here
+)
 
 # Logging configuration
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -86,19 +91,29 @@ def detect_signatures_in_document(file_path: str) -> Dict[str, Any]:
         start_time = time.time()
         max_wait_time = 300  # 5 minutes max
         while time.time() - start_time < max_wait_time:
-            result = doc_ai.get_job(job_id)  # Signature detection result after parsing the document
+            result = doc_ai.get_job(
+                job_id
+            )  # Signature detection result after parsing the document
             elapsed = time.time() - start_time
 
             if result.status in ["pending", "processing"]:
                 logger.info(f"Job status: {result.status} ({elapsed:.0f}s elapsed)")
                 time.sleep(5)
             elif result.status == "successful":
-                logger.info(f"Processing completed successfully in {elapsed:.0f} seconds")
+                logger.info(
+                    f"Processing completed successfully in {elapsed:.0f} seconds"
+                )
                 break
             else:
-                return {"success": False, "error": f"Job failed with status: {result.status}"}
+                return {
+                    "success": False,
+                    "error": f"Job failed with status: {result.status}",
+                }
         else:
-            return {"success": False, "error": f"Processing timeout after {max_wait_time} seconds"}
+            return {
+                "success": False,
+                "error": f"Processing timeout after {max_wait_time} seconds",
+            }
 
         # Extract signature data from results
         signature_data = extract_signature_data(result, file_name, file_path)
@@ -114,15 +129,12 @@ def detect_signatures_in_document(file_path: str) -> Dict[str, Any]:
             "pages_with_signatures": signature_data["pages_with_signatures"],
             "signature_data": signature_data["signatures_per_page"],
             "summary": f"Found {signature_data['total_signatures']} signatures across {len(signature_data['pages_with_signatures'])} pages in {file_name}",
-            "data_saved_to": json_path
+            "data_saved_to": json_path,
         }
 
     except Exception as e:
         logger.error(f"Processing failed for {file_path}: {str(e)}")
-        return {
-            "success": False,
-            "error": f"Processing failed: {str(e)}"
-        }
+        return {"success": False, "error": f"Processing failed: {str(e)}"}
 
 
 @tool
@@ -131,7 +143,9 @@ def load_signature_analysis_data() -> Dict[str, Any]:
     Path(SIGNATURE_DATA_DIR).mkdir(exist_ok=True)
 
     try:
-        analysis_files = list(Path(SIGNATURE_DATA_DIR).glob("*_signature_analysis.json"))
+        analysis_files = list(
+            Path(SIGNATURE_DATA_DIR).glob("*_signature_analysis.json")
+        )
         if not analysis_files:
             return {"error": "No signature analysis files found in the directory."}
 
@@ -139,7 +153,7 @@ def load_signature_analysis_data() -> Dict[str, Any]:
 
         for file_path in analysis_files:
             try:
-                with open(file_path, 'r', encoding='utf-8') as f:
+                with open(file_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
                     all_data.append(data)
 
@@ -157,7 +171,7 @@ def load_signature_analysis_data() -> Dict[str, Any]:
             "success": True,
             "total_files_analyzed": total_files,
             "detailed_data": all_data,
-            "note": f"Loaded analysis data from {total_files} document(s)"
+            "note": f"Loaded analysis data from {total_files} document(s)",
         }
 
     except Exception as e:
@@ -167,6 +181,7 @@ def load_signature_analysis_data() -> Dict[str, Any]:
 
 class ConversationState(TypedDict):
     """State schema for the signature conversation agent"""
+
     messages: Annotated[List, add_messages]
 
 
@@ -227,12 +242,7 @@ If the tool returns an error (no data found), explain that no analysis data is a
 
         # Add edges
         workflow.add_conditional_edges(
-            "agent",
-            self._should_continue,
-            {
-                "continue": "tools",
-                "end": END
-            }
+            "agent", self._should_continue, {"continue": "tools", "end": END}
         )
         workflow.add_edge("tools", "agent")
         return workflow.compile()
@@ -249,7 +259,7 @@ If the tool returns an error (no data found), explain that no analysis data is a
     def _should_continue(self, state: ConversationState) -> str:
         """Determine whether to continue to tools or end the conversation"""
         last_message = state["messages"][-1]
-        if hasattr(last_message, 'tool_calls') and last_message.tool_calls:
+        if hasattr(last_message, "tool_calls") and last_message.tool_calls:
             return "continue"
         return "end"
 
@@ -276,7 +286,7 @@ If the tool returns an error (no data found), explain that no analysis data is a
             try:
                 user_input = input("You: ").strip()
 
-                if user_input.lower() in ['quit', 'exit', 'q']:
+                if user_input.lower() in ["quit", "exit", "q"]:
                     print("Goodbye! 👋")
                     break
 
@@ -303,6 +313,7 @@ If the tool returns an error (no data found), explain that no analysis data is a
                 logger.error(f"Error in conversation: {str(e)}")
                 print(f"Error: {e}\n")
 
+
 def main() -> None:
     """Main CLI interface for the signature analysis system"""
     print("Document Signature Analysis System")
@@ -326,7 +337,9 @@ def main() -> None:
                         print("\nSUCCESS!")
                         print(f"Analysis: {result['summary']}")
                         print(f"Data saved to: {result['data_saved_to']}")
-                        print("\nYou can now use option 2 to ask questions about this document!")
+                        print(
+                            "\nYou can now use option 2 to ask questions about this document!"
+                        )
                     else:
                         print(f"\nFAILED: {result.get('error', 'Unknown error')}")
                 print()
@@ -334,7 +347,9 @@ def main() -> None:
             elif choice == "2":
                 # Check for existing analysis files
                 Path(SIGNATURE_DATA_DIR).mkdir(exist_ok=True)
-                analysis_files = list(Path(SIGNATURE_DATA_DIR).glob("*_signature_analysis.json"))
+                analysis_files = list(
+                    Path(SIGNATURE_DATA_DIR).glob("*_signature_analysis.json")
+                )
 
                 if not analysis_files:
                     print("No signature analysis files found!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.78"
+version = "0.1.79"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -172,7 +172,8 @@ class DocumentAI:
             ),
             "structuredExtractionSkipOcr": (
                 options.extraction_options.skip_ocr
-                if options.extraction_options is not None and options.extraction_options.skip_ocr is not None
+                if options.extraction_options is not None
+                and options.extraction_options.skip_ocr is not None
                 else False
             ),
             "disableLayoutDetection": (

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -172,7 +172,7 @@ class DocumentAI:
             ),
             "structuredExtractionSkipOcr": (
                 options.extraction_options.skip_ocr
-                if (options.extraction_options is None) or (options.extraction_options and options.extraction_options.skip_ocr is not None)
+                if options.extraction_options is not None and options.extraction_options.skip_ocr is not None
                 else False
             ),
             "disableLayoutDetection": (

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -172,7 +172,7 @@ class DocumentAI:
             ),
             "structuredExtractionSkipOcr": (
                 options.extraction_options.skip_ocr
-                if options.extraction_options is None or (options.extraction_options and options.extraction_options.skip_ocr is not None)
+                if (options.extraction_options is None) or (options.extraction_options and options.extraction_options.skip_ocr is not None)
                 else False
             ),
             "disableLayoutDetection": (

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -172,7 +172,7 @@ class DocumentAI:
             ),
             "structuredExtractionSkipOcr": (
                 options.extraction_options.skip_ocr
-                if options.extraction_options and options.extraction_options.skip_ocr is not None
+                if options.extraction_options is None or (options.extraction_options and options.extraction_options.skip_ocr is not None)
                 else False
             ),
             "disableLayoutDetection": (

--- a/src/tensorlake/function_executor/main.py
+++ b/src/tensorlake/function_executor/main.py
@@ -7,8 +7,8 @@ from tensorlake.utils.logging import (
 configure_logging_early()
 
 import argparse
-from typing import Any
 import multiprocessing as mp
+from typing import Any
 
 import structlog
 


### PR DESCRIPTION
Fixing the `skip_ocr` defaulting when there are no `extraction_options`

Tested with:
```
parsing_options = ParsingOptions(
        detect_signature=True,  # this needs to be True
        extraction_options=ExtractionOptions(skip_ocr=True),
    )
```

```
parsing_options = ParsingOptions(
        detect_signature=True,  # this needs to be True
        extraction_options=ExtractionOptions(provider="tensorlake"),
    )
```

```
parsing_options = ParsingOptions(
        detect_signature=True,  # this needs to be True
    )
```

All of these work as expected with no errors