### PR TITLE
chore: skip superflous headers in large file upload & TENSORLAKE_API_KEY precedence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.79"
+version = "0.1.80"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -26,9 +26,15 @@ class DocumentAI:
     """
 
     def __init__(self, api_key: str = ""):
-        self.api_key = api_key
-        if not self.api_key:
+        if os.getenv("TENSORLAKE_API_KEY"):
             self.api_key = os.getenv("TENSORLAKE_API_KEY").strip()
+        else:
+            self.api_key = api_key
+
+        if not self.api_key:
+            raise ValueError(
+                "API key is required. Set the TENSORLAKE_API_KEY environment variable or pass it as an argument."
+            )
 
         self._client = httpx.Client(base_url=DOC_AI_BASE_URL, timeout=None)
         self.__file_uploader__ = FileUploader(api_key=api_key)


### PR DESCRIPTION
### Description

This PR fixes two things:

1. The large file upload now aligns with the current iteration of the API.
2. Before, the TENSORLAKE_API_KEY would only be considered if the DocumentAI client did not have an API_KEY set. Now, the TENSORLAKE_API_KEY has precedence over whatever api_key is passed as an argument.