### PR TITLE
Use stable Indexify in Tensorlake SDK CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,9 @@ jobs:
         with:
           # Indexify Server storage path has to be that same in container and host
           # so Executor can use local FS BLOB store.
+          #
+          # Pin to Indexify Server version used in DocAI prod cluster to test all
+          # SDK changes for backward compatibility with the cluster.
           run: |
             mkdir -p /tmp/indexify-server-storage/indexify_storage/blobs
             docker run -i -a stdout -a stderr --rm \
@@ -56,7 +59,7 @@ jobs:
               --name indexify-server \
               -v /tmp/indexify-server-storage:/tmp/indexify-server-storage \
               -w /tmp/indexify-server-storage \
-              tensorlake/indexify-server:latest &
+              tensorlake/indexify-server:0.2.63 &
           wait-on: |
             tcp:localhost:8900
           tail: true
@@ -66,7 +69,9 @@ jobs:
           log-output-if: true
 
       - name: Install Indexify from PyPI
-        run: pip install indexify
+        # Pin to Indexify version used in DocAI prod cluster to test all
+        # SDK changes for backward compatibility with the cluster.
+        run: pip install "indexify==0.3.31"
       - name: Install Tensorlake from local source
         run: pip install -e . && pip show tensorlake
       - name: Install dependencies of integration tests globally


### PR DESCRIPTION
These versions are used in Prod Doc AI cluster.
Use them in CI for now to ensure that all the Tensorlake SDK changes are compatible with the cluster.

We're going to publish Indexify images and packages with dynamic scheduling enabled so if we stay on latest versions then we'll start using them in Tensorlake SDK CI which might result in not caught compatibility issues with the current prod cluster in Tensorlake SDK CI.