### PR TITLE
Remove GPU spec from customer function resources test

### DIFF
--- a/tests/tensorlake/test_function_resources.py
+++ b/tests/tensorlake/test_function_resources.py
@@ -10,7 +10,7 @@ from tensorlake import (
 from tensorlake.functions_sdk.graph_serialization import graph_code_dir_path
 
 
-@tensorlake_function(cpu=1.1, memory=1.3, ephemeral_disk=1.0, gpu=["H100", "T4"])
+@tensorlake_function(cpu=1.1, memory=1.3, ephemeral_disk=1.0)
 def function_with_custom_resources(x: int) -> str:
     return "success"
 


### PR DESCRIPTION
This test fails on machines that don't have GPUs when Executor is not ignoring GPU specs in functions.

We test GPUs using separate test suites in such environments. The SDK tests need to work in all environments.