### PR TITLE
fix: abort deployment when graph fails to build image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.83"
+version = "0.1.84"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"
@@ -15,7 +15,7 @@ pydantic = "2.11.5"
 docker = "^7.1.0"
 nanoid = "^2.0.0"
 httpx-sse = "^0.4.0"
-rich = "14.0.0"                                  # TODO: Look into consolidating this with click
+rich = "14.0.0"                                    # TODO: Look into consolidating this with click
 pyyaml = "^6.0.2"
 click = "8.2.1"
 retry = "^0.9.2"

--- a/src/tensorlake/builder/client_v2.py
+++ b/src/tensorlake/builder/client_v2.py
@@ -247,4 +247,15 @@ class ImageBuilderV2Client:
             timeout=60,
         )
         res.raise_for_status()
-        return BuildInfo.model_validate(res.json())
+        build_info = BuildInfo.model_validate(res.json())
+
+        if build_info.status == "failed":
+            click.secho(
+                f"Build {build_info.id} failed with error: {build_info.error_message}",
+                fg="red",
+            )
+            raise RuntimeError(
+                f"Build {build_info.id} failed with error: {build_info.error_message}"
+            )
+
+        return build_info

--- a/src/tensorlake/cli/deploy.py
+++ b/src/tensorlake/cli/deploy.py
@@ -171,18 +171,7 @@ async def _prepare_images_v2(
 ):
     for image_info in images.values():
         for build_context in image_info.build_contexts:
-
-            build = await builder_v2.build(build_context, image_info.image)
-            if build.status == "failed":
-                click.secho(
-                    f"Building {image_info.image.name()} failed with error message: {build.error_message}",
-                    fg="red",
-                )
-                click.secho(
-                    f"Image {image_info.image.name()} could not be built, this is blocking deployment",
-                    fg="red",
-                )
-                raise click.Abort
+            await builder_v2.build(build_context, image_info.image)
 
     click.secho(f"Built {len(images)} images with builder v2", fg="green")
 

--- a/src/tensorlake/cli/deploy.py
+++ b/src/tensorlake/cli/deploy.py
@@ -172,7 +172,17 @@ async def _prepare_images_v2(
     for image_info in images.values():
         for build_context in image_info.build_contexts:
 
-            await builder_v2.build(build_context, image_info.image)
+            build = await builder_v2.build(build_context, image_info.image)
+            if build.status == "failed":
+                click.secho(
+                    f"Building {image_info.image.name()} failed with error message: {build.error_message}",
+                    fg="red",
+                )
+                click.secho(
+                    f"Image {image_info.image.name()} could not be built, this is blocking deployment",
+                    fg="red",
+                )
+                raise click.Abort
 
     click.secho(f"Built {len(images)} images with builder v2", fg="green")
 


### PR DESCRIPTION
### Description

When an image fails to build with the builder V2, the deploy command should be aborted.