### PR TITLE
remove router abstraction

### DIFF
--- a/src/tensorlake/functions_sdk/graph.py
+++ b/src/tensorlake/functions_sdk/graph.py
@@ -32,7 +32,6 @@ from .functions import (
 from .graph_definition import (
     ComputeGraphMetadata,
     FunctionMetadata,
-    NodeMetadata,
     RetryPolicyMetadata,
     RuntimeInformation,
 )
@@ -209,44 +208,42 @@ class Graph:
         metadata_edges = self.edges.copy()
         metadata_nodes = {}
         for node_name, node in self.nodes.items():
-            metadata_nodes[node_name] = NodeMetadata(
-                compute_fn=FunctionMetadata(
-                    name=node_name,
-                    fn_name=node.name,
-                    description=node.description,
-                    reducer=node.accumulate is not None,
-                    image_information=(
-                        node.image.to_image_information()
-                        if node.image
-                        else _none_image_information
-                    ),
-                    input_encoder=node.input_encoder,
-                    output_encoder=node.output_encoder,
-                    secret_names=node.secrets,
-                    timeout_sec=node.timeout,
-                    resources=resource_metadata_for_graph_node(node),
-                    retry_policy=(
-                        graph_retry_policy
-                        if node.retries is None
-                        else RetryPolicyMetadata(
-                            max_retries=node.retries.max_retries,
-                            initial_delay_sec=node.retries.initial_delay,
-                            max_delay_sec=node.retries.max_delay,
-                            delay_multiplier=node.retries.delay_multiplier,
-                        )
-                    ),
-                    cache_key=(
-                        f"version_function={self.version}:{node.name}"
-                        if node.cacheable
-                        else None
-                    ),
-                )
+            metadata_nodes[node_name] = FunctionMetadata(
+                name=node_name,
+                fn_name=node.name,
+                description=node.description,
+                reducer=node.accumulate is not None,
+                image_information=(
+                    node.image.to_image_information()
+                    if node.image
+                    else _none_image_information
+                ),
+                input_encoder=node.input_encoder,
+                output_encoder=node.output_encoder,
+                secret_names=node.secrets,
+                timeout_sec=node.timeout,
+                resources=resource_metadata_for_graph_node(node),
+                retry_policy=(
+                    graph_retry_policy
+                    if node.retries is None
+                    else RetryPolicyMetadata(
+                        max_retries=node.retries.max_retries,
+                        initial_delay_sec=node.retries.initial_delay,
+                        max_delay_sec=node.retries.max_delay,
+                        delay_multiplier=node.retries.delay_multiplier,
+                    )
+                ),
+                cache_key=(
+                    f"version_function={self.version}:{node.name}"
+                    if node.cacheable
+                    else None
+                ),
             )
 
         return ComputeGraphMetadata(
             name=self.name,
             description=self.description or "",
-            start_node=NodeMetadata(compute_fn=start_node),
+            start_node=start_node,
             nodes=metadata_nodes,
             edges=metadata_edges,
             tags=self.tags,

--- a/src/tensorlake/functions_sdk/graph_definition.py
+++ b/src/tensorlake/functions_sdk/graph_definition.py
@@ -30,11 +30,6 @@ class FunctionMetadata(BaseModel):
     cache_key: Optional[str] = None
 
 
-class NodeMetadata(BaseModel):
-    compute_fn: Optional[FunctionMetadata] = None
-
-
-# RuntimeInformation is a class that holds data about the environment in which the graph should run.
 class RuntimeInformation(BaseModel):
     major_version: int
     minor_version: int
@@ -44,9 +39,9 @@ class RuntimeInformation(BaseModel):
 class ComputeGraphMetadata(BaseModel):
     name: str
     description: str
-    start_node: NodeMetadata
+    start_node: FunctionMetadata
     tags: Dict[str, str] = {}
-    nodes: Dict[str, NodeMetadata]
+    nodes: Dict[str, FunctionMetadata]
     edges: Dict[str, List[str]]
     accumulator_zero_values: Dict[str, bytes] = {}
     runtime_information: RuntimeInformation
@@ -57,7 +52,7 @@ class ComputeGraphMetadata(BaseModel):
         return get_serializer(self.start_node.compute_fn.input_encoder)
 
     def get_input_encoder(self) -> str:
-        if self.start_node.compute_fn:
-            return self.start_node.compute_fn.input_encoder
+        if self.start_node.input_encoder:
+            return self.start_node.input_encoder
 
         raise ValueError("start node is not set on the graph")

--- a/src/tensorlake/http_client.py
+++ b/src/tensorlake/http_client.py
@@ -477,7 +477,7 @@ class TensorlakeClient:
             raise GraphStillProcessing()
 
         graph_metadata: ComputeGraphMetadata = self.graph(graph)
-        output_encoder = graph_metadata.nodes[fn_name].compute_fn.output_encoder
+        output_encoder = graph_metadata.nodes[fn_name].output_encoder
 
         outputs = []
         for output in graph_outputs.outputs:


### PR DESCRIPTION
Remove the router abstraction completely from server and had to make some changes to the SDK which will be backward incompatible with the current server.

Can't merge this until we hardcode the document ai workflows to use the last version of tensorlake sdk temporarily