### PR TITLE
Remove/fix legacy image build features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.1.87"
+version = "0.1.88"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/functions_sdk/graph_serialization.py
+++ b/src/tensorlake/functions_sdk/graph_serialization.py
@@ -150,7 +150,6 @@ def _create_graph_manifest(
     function_manifests: Dict[str, FunctionManifest] = {}
     for node in graph.nodes.values():
         function_manifests[node.name] = _create_function_manifest(node, code_dir_path)
-        print(node.name, function_manifests[node.name])
 
     return GraphManifest(version="0.1.0", functions=function_manifests)
 


### PR DESCRIPTION
* Remove Indexify from the function images. This can lead to installing (e.g. upgrading to) tensorlake package version which is not compatible with the one used by the user who builds the image.
* Install tensorlake package with exactly the same version as `tensorlake deploy` command is using to ensure compatibility with what the user who builds the image is using.
* Don't allows installing indexify/tensorlake from source into the image. The use case for this is not clear. We're not using it even for testing in Platform Executor.

Tested with `tensorlake deploy ./reference_graph.py`