### PR TITLE
Remove ' '  from pip install tensorlake

### DIFF
--- a/src/tensorlake/functions_sdk/image.py
+++ b/src/tensorlake/functions_sdk/image.py
@@ -181,7 +181,7 @@ class Image:
         docker_contents = [
             f"FROM {self._base_image}",
             "WORKDIR /app",
-            f"RUN pip install 'tensorlake=={self._sdk_version}'",
+            f"RUN pip install tensorlake=={self._sdk_version}",
         ]
 
         for build_op in self._build_ops:


### PR DESCRIPTION
It's not clear why but this fails a GH action deployment. The ' ' were not present in the original code that installed Indexify instead of tensorlake so this PR reverts back to the previous code that didn't have the bug.