### PR TITLE
Install tensorlake after user commands in docker file (#186)

### DIFF
--- a/src/tensorlake/functions_sdk/image.py
+++ b/src/tensorlake/functions_sdk/image.py
@@ -181,11 +181,14 @@ class Image:
         docker_contents = [
             f"FROM {self._base_image}",
             "WORKDIR /app",
-            f"RUN pip install tensorlake=={self._sdk_version}",
         ]
 
         for build_op in self._build_ops:
             docker_contents.append(build_op.render())
+
+        # Run tensorlake install after all user commands. There's implicit dependency
+        # of tensorlake install success on user commands right now.
+        docker_contents.append(f"RUN pip install tensorlake=={self._sdk_version}")
 
         docker_file = "\n".join(docker_contents)
         return docker_file


### PR DESCRIPTION
The previous approach where Indexify was installed instead of tensorlake was doing this after the user commands too. This might fix the issue we have now during deployments.