### PR TITLE
Use builder by v2 by default.

### DIFF
--- a/src/tensorlake/cli/deploy.py
+++ b/src/tensorlake/cli/deploy.py
@@ -24,7 +24,7 @@ from tensorlake.remote_graph import RemoteGraph
 @click.option("-p", "--parallel-builds", is_flag=True, default=False)
 @click.option("-r", "--retry", is_flag=True, default=False)
 @click.option("--upgrade-queued-requests", is_flag=True, default=False)
-@click.option("--builder-v2", is_flag=True, default=False)
+@click.option("--builder-v2", is_flag=True, default=True)
 @click.argument("workflow_file", type=click.File("r"))
 @pass_auth
 def deploy(


### PR DESCRIPTION
Use v2 by default since v1 infra is being spun down, v2 switch and v1 code will be removed at a later date when we have dropped usage of the `--builder-v2` parameter from our CI/docs