### PR TITLE
Create the builder_v2 client in all cases. Part of deprecating v1.

### DIFF
--- a/src/tensorlake/cli/deploy.py
+++ b/src/tensorlake/cli/deploy.py
@@ -39,7 +39,7 @@ def deploy(
     """Deploy a workflow to tensorlake."""
 
     click.echo(f"Preparing deployment for {workflow_file.name}")
-    builder_v2 = ImageBuilderV2Client.from_env() if builder_v2 else None
+    builder_v2 = ImageBuilderV2Client.from_env()
 
     try:
         workflow_module_info: WorkflowModuleInfo = load_workflow_module_info(


### PR DESCRIPTION
Fixes using builder v2 by default, not back porting to stable branch since that behaviour is unchanged there.

## Contribution Checklist

- [ ] If doing a Document AI SDK change then please create the same PR for [server-sse-stream-stable](https://github.com/tensorlakeai/tensorlake/tree/server-sse-stream-stable) branch, merge it and add a link to it here.
