### PR TITLE
feat: parse results updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.12"
+version = "0.2.13"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -282,7 +282,7 @@ class DocumentAI:
                 headers=self.__headers__(),
             )
             response.raise_for_status()
-            return response.json()
+            return ParseResult.model_validate(response.json())
         finally:
             client.close()
 
@@ -297,7 +297,7 @@ class DocumentAI:
                 headers=self.__headers__(),
             )
             response.raise_for_status()
-            return response.json()
+            return ParseResult.model_validate(response.json())
         finally:
             await client.aclose()
 
@@ -307,13 +307,11 @@ class DocumentAI:
         """
         parse = self.get_parse(parse_id)
         finished_parse = parse
-        print(f"Waiting for job {parse} to complete...")
-        while finished_parse["status"] in [ParseStatus.PENDING, ParseStatus.PROCESSING]:
+        while finished_parse.status in [ParseStatus.PENDING, ParseStatus.PROCESSING]:
             print("waiting 5s...")
             time.sleep(5)
             finished_parse = self.get_parse(parse_id)
-            print(f"parse status: {finished_parse['status']}")
-
+            print(f"parse status: {finished_parse.status}")
         return finished_parse
 
     async def wait_for_completion_async(self, parse_id: str) -> ParseResult:
@@ -322,12 +320,11 @@ class DocumentAI:
         """
         parse = await self.get_parse_async(parse_id)
         finished_parse = parse
-        while finished_parse["status"] in [ParseStatus.PENDING, ParseStatus.PROCESSING]:
+        while finished_parse.status in [ParseStatus.PENDING, ParseStatus.PROCESSING]:
             print("waiting 5s...")
             await asyncio.sleep(5)
             finished_parse = await self.get_parse_async(parse_id)
-            print(f"parse_id: {parse_id}, job status: {finished_parse['status']}")
-
+            print(f"parse status: {finished_parse.status}")
         return finished_parse
 
     # -------------------------------------------------------------------------

--- a/src/tensorlake/documentai/models/jobs.py
+++ b/src/tensorlake/documentai/models/jobs.py
@@ -135,15 +135,6 @@ class Document(BaseModel):
     pages: List[Page]
 
 
-class StructuredDataPage(BaseModel):
-    """
-    DocumentAI structured data page class.
-    """
-
-    page_number: Optional[Union[int, List[int]]] = Field(default=None)
-    data: dict = Field(alias="json_result", default_factory=dict)
-
-
 class StructuredData(BaseModel):
     """
     DocumentAI structured data class.

--- a/src/tensorlake/documentai/models/jobs.py
+++ b/src/tensorlake/documentai/models/jobs.py
@@ -3,7 +3,7 @@ DocumentAI job classes.
 """
 
 from enum import Enum
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -34,27 +34,36 @@ class Text(BaseModel):
 
 
 class TableCell(BaseModel):
+    """
+    Table cell content with text and bounding box information.
+    Based on PageFragmentTableCell schema.
+    """
+
     text: str
-    bounding_box: Tuple[float, float, float, float]
+    bounding_box: dict[str, float]  # Changed from Tuple to match OpenAPI spec
 
 
 class Table(BaseModel):
     """
     Table content of a page fragment.
+    Based on PageFragmentTable schema with content, cells, and optional formatting fields.
     """
 
     content: str
-    table_summary: Optional[str] = None
     cells: List[TableCell]
+    html: Optional[str] = None  # Added from OpenAPI spec
+    markdown: Optional[str] = None  # Added from OpenAPI spec
+    table_summary: Optional[str] = None
 
 
 class Figure(BaseModel):
     """
     Figure content of a page fragment.
+    Based on PageFragmentFigure schema with content and optional summary.
     """
 
     content: str
-    figure_summary: Optional[str] = None
+    summary: Optional[str] = None  # Renamed from figure_summary to match OpenAPI spec
 
 
 class Signature(BaseModel):
@@ -101,7 +110,6 @@ class PageFragment(BaseModel):
     fragment_type: PageFragmentType
     content: Union[Text, Table, Figure, Signature]
     reading_order: Optional[int] = None
-    page_number: Optional[int] = None
     bbox: Optional[dict[str, float]] = None
 
 
@@ -110,9 +118,10 @@ class Page(BaseModel):
     Page in a document.
     """
 
+    dimensions: Optional[List[int]]
+    layout: Optional[dict] = {}
     page_number: int
     page_fragments: Optional[List[PageFragment]] = []
-    layout: Optional[dict] = {}
 
 
 class Document(BaseModel):
@@ -135,9 +144,12 @@ class StructuredDataPage(BaseModel):
 class StructuredData(BaseModel):
     """
     DocumentAI structured data class.
+    Can contain either a single data item or a list of data items.
     """
 
-    pages: List[StructuredDataPage] = Field(alias="pages", default_factory=list)
+    data: Any = Field()
+    page_numbers: Union[int, List[int]] = Field()
+    schema_name: Optional[str] = Field(default=None)
 
 
 class Chunk(BaseModel):

--- a/src/tensorlake/documentai/models/jobs.py
+++ b/src/tensorlake/documentai/models/jobs.py
@@ -43,7 +43,7 @@ class TableCell(BaseModel):
     """
 
     text: str
-    bounding_box: dict[str, float]  # Changed from Tuple to match OpenAPI spec
+    bounding_box: dict[str, float]
 
 
 class Table(BaseModel):
@@ -54,8 +54,8 @@ class Table(BaseModel):
 
     content: str
     cells: List[TableCell]
-    html: Optional[str] = None  # Added from OpenAPI spec
-    markdown: Optional[str] = None  # Added from OpenAPI spec
+    html: Optional[str] = None
+    markdown: Optional[str] = None
     table_summary: Optional[str] = None
 
 
@@ -66,7 +66,7 @@ class Figure(BaseModel):
     """
 
     content: str
-    summary: Optional[str] = None  # Renamed from figure_summary to match OpenAPI spec
+    summary: Optional[str] = None
 
 
 class Signature(BaseModel):
@@ -140,7 +140,7 @@ class StructuredDataPage(BaseModel):
     DocumentAI structured data page class.
     """
 
-    page_number: Optional[Union[int, List[int]]] = Field(default=None)  # OneOrMany_i32
+    page_number: Optional[Union[int, List[int]]] = Field(default=None)
     data: dict = Field(alias="json_result", default_factory=dict)
 
 

--- a/src/tensorlake/documentai/models/jobs.py
+++ b/src/tensorlake/documentai/models/jobs.py
@@ -16,13 +16,16 @@ class JobListItem(BaseModel):
     """
 
     id: str
-    file_id: str = Field(alias="fileId")
-    file_name: str = Field(alias="fileName")
     status: JobStatus
-    job_type: str = Field(alias="jobType")
-    error_message: Optional[str] = Field(alias="errorMessage")
     created_at: str = Field(alias="createdAt")
     updated_at: str = Field(alias="updatedAt")
+    dataset_id: Optional[str] = Field(alias="datasetId", default=None)
+    file_id: Optional[str] = Field(alias="fileId", default=None)
+    file_name: Optional[str] = Field(alias="fileName", default=None)
+    finished_at: Optional[str] = Field(alias="finishedAt", default=None)
+    message: Optional[str] = Field(default=None)
+    pages_parsed: Optional[int] = Field(alias="pagesParsed", default=None)
+    trace_id: Optional[str] = Field(alias="traceId", default=None)
 
 
 class Text(BaseModel):
@@ -118,10 +121,10 @@ class Page(BaseModel):
     Page in a document.
     """
 
-    dimensions: Optional[List[int]]
-    layout: Optional[dict] = {}
+    dimensions: Optional[List[int]] = None
+    layout: Optional[dict] = None
+    page_fragments: Optional[List[PageFragment]] = None
     page_number: int
-    page_fragments: Optional[List[PageFragment]] = []
 
 
 class Document(BaseModel):
@@ -134,10 +137,10 @@ class Document(BaseModel):
 
 class StructuredDataPage(BaseModel):
     """
-    DocumentAI structured data class.
+    DocumentAI structured data page class.
     """
 
-    page_number: int
+    page_number: Optional[Union[int, List[int]]] = Field(default=None)  # OneOrMany_i32
     data: dict = Field(alias="json_result", default_factory=dict)
 
 

--- a/src/tensorlake/documentai/models/options.py
+++ b/src/tensorlake/documentai/models/options.py
@@ -48,7 +48,7 @@ class ParsingOptions(BaseModel):
     """
 
     chunking_strategy: Optional[ChunkingStrategy] = Field(
-        ChunkingStrategy.NONE,
+        None,
         description="The chunking strategy determines how the document is chunked into smaller pieces. Different strategies can be used to optimize the parsing process. Choose the one that best fits your use case. The default is `None`, which means no chunking is applied.",
     )
     disable_layout_detection: bool = Field(

--- a/src/tensorlake/documentai/models/results.py
+++ b/src/tensorlake/documentai/models/results.py
@@ -13,14 +13,12 @@ from .options import Options
 
 class PageClass(BaseModel):
     """
-    Page class classification result.
-
-    Contains page numbers (1-indexed) where a specific page class appears in the document.
+    Page class information containing the class name and page numbers.
     """
 
-    pages: List[int] = Field(
-        description="Vector of page numbers (1-indexed) where this page class appears.",
-        default=[],
+    page_class: str = Field(description="The name of the page class")
+    page_numbers: List[int] = Field(
+        description="List of page numbers (1-indexed) where this page class appears"
     )
 
 
@@ -68,13 +66,13 @@ class ParseResult(BaseModel):
         default=None,
         description="Chunks of layout text extracted from the document. This is a vector of `Chunk` objects, each containing a piece of text extracted from the document. The chunks are typically used for further processing, such as indexing or searching. The value will vary depending on the chunking strategy used during parsing.",
     )
-    document: Optional[Document] = Field(
+    document_layout: Optional[Document] = Field(
         default=None,
         description="The layout of the document. This is a JSON object that contains the layout information of the document. It can be used to understand the structure of the document, such as the position of text, tables, figures, etc.",
     )
     page_classes: Optional[Dict[str, PageClass]] = Field(
         default=None,
-        description="Page classes extracted from the document. This is a map where the keys are page class names provided in the parse request under the `page_classification_options` field, and the values are vectors of page numbers (1-indexed) where each page class appears. This is used to categorize pages in the document based on the classification options provided.",
+        description="Page classes extracted from the document. This is a map where the keys are page class names provided in the parse request under the `page_classification_options` field, and the values are PageClass objects containing the class name and page numbers where each page class appears.",
     )
     structured_data: Optional[
         Dict[str, Union[StructuredData, List[StructuredData]]]


### PR DESCRIPTION
## Description

- Refactor of Data Models for Document AI
- Updated get_parse and get_parse_async methods in client.py to return validated ParseResult Pydantic model instances instead of raw JSON.

## Contribution Checklist

- [ ] If doing a Document AI SDK change then please create the same PR for [server-sse-stream-stable](https://github.com/tensorlakeai/tensorlake/tree/server-sse-stream-stable) branch, merge it and add a link to it here.
