### PR TITLE
Refactor/parition strategy and parse result (#221)

### DIFF
--- a/src/tensorlake/documentai/client.py
+++ b/src/tensorlake/documentai/client.py
@@ -271,7 +271,7 @@ class DocumentAI:
         )
         return await self.wait_for_completion_async(parse_id)
 
-    def get_parse(self, parse_id: str) -> ParseResult:
+    def get_parsed_result(self, parse_id: str) -> ParseResult:
         """
         Get the result of a parse job by its parse ID.
         """
@@ -286,7 +286,7 @@ class DocumentAI:
         finally:
             client.close()
 
-    async def get_parse_async(self, parse_id: str) -> ParseResult:
+    async def get_parsed_result_async(self, parse_id: str) -> ParseResult:
         """
         Get the result of a parse job by its parse ID asynchronously.
         """
@@ -305,12 +305,12 @@ class DocumentAI:
         """
         Wait for a job to complete.
         """
-        parse = self.get_parse(parse_id)
+        parse = self.get_parsed_result(parse_id)
         finished_parse = parse
         while finished_parse.status in [ParseStatus.PENDING, ParseStatus.PROCESSING]:
             print("waiting 5s...")
             time.sleep(5)
-            finished_parse = self.get_parse(parse_id)
+            finished_parse = self.get_parsed_result(parse_id)
             print(f"parse status: {finished_parse.status}")
         return finished_parse
 
@@ -318,12 +318,12 @@ class DocumentAI:
         """
         Wait for a job to complete asynchronously.
         """
-        parse = await self.get_parse_async(parse_id)
+        parse = await self.get_parsed_result_async(parse_id)
         finished_parse = parse
         while finished_parse.status in [ParseStatus.PENDING, ParseStatus.PROCESSING]:
             print("waiting 5s...")
             await asyncio.sleep(5)
-            finished_parse = await self.get_parse_async(parse_id)
+            finished_parse = await self.get_parsed_result_async(parse_id)
             print(f"parse status: {finished_parse.status}")
         return finished_parse
 

--- a/src/tensorlake/documentai/models/__init__.py
+++ b/src/tensorlake/documentai/models/__init__.py
@@ -9,6 +9,7 @@ from .enums import (
     MimeType,
     ModelProvider,
     ParseStatus,
+    PartitionStrategy,
     TableOutputMode,
     TableParsingFormat,
 )
@@ -53,6 +54,7 @@ __all__ = [
     "MimeType",
     "ModelProvider",
     "ParseStatus",
+    "PartitionStrategy",
     "TableOutputMode",
     "TableParsingFormat",
     # Options

--- a/src/tensorlake/documentai/models/enums.py
+++ b/src/tensorlake/documentai/models/enums.py
@@ -87,6 +87,18 @@ class ParseStatus(str, Enum):
     SUCCESSFUL = "successful"
 
 
+class PartitionStrategy(str, Enum):
+    """
+    Partition strategy for parsing a document.
+
+    NONE: No partitioning is applied.
+    PAGE: Partition the document into pages.
+    """
+
+    NONE = "none"
+    PAGE = "page"
+
+
 class TableOutputMode(str, Enum):
     """
     Output mode for tables in a document.

--- a/src/tensorlake/documentai/models/options.py
+++ b/src/tensorlake/documentai/models/options.py
@@ -2,7 +2,13 @@ from typing import List, Optional, Type, Union
 
 from pydantic import BaseModel, Field, Json
 
-from .enums import ChunkingStrategy, ModelProvider, TableOutputMode, TableParsingFormat
+from .enums import (
+    ChunkingStrategy,
+    ModelProvider,
+    PartitionStrategy,
+    TableOutputMode,
+    TableParsingFormat,
+)
 
 
 class EnrichmentOptions(BaseModel):
@@ -91,9 +97,9 @@ class StructuredExtractionOptions(BaseModel):
     )
 
     # Optional fields
-    chunking_strategy: Optional[ChunkingStrategy] = Field(
+    partition_strategy: Optional[PartitionStrategy] = Field(
         None,
-        description="The chunking strategy determines how the document is chunked into smaller pieces. This is only supported in `markdown` mode. Not to be confused with the `chunking_strategy` in `DocumentParsingOptions`. which is used to chunk the document into smaller pieces for parsing. The default is `None`, which means no chunking is applied.",
+        description="Strategy to partition the document before structured data extraction. The API will return one structured data object per partition. This is useful when you want to extract certain fields from every page.",
     )
     model_provider: ModelProvider = Field(
         ModelProvider.TENSORLAKE,


### PR DESCRIPTION
## Description

- Renamed methods `get_parse` and `get_parse_async` in `client.py` to `get_parsed_result` and `get_parsed_result_async`
- Updated `StructuredExtractionOptions` to use `partition_strategy` instead of `chunking_strategy`
- Added `PartitionStrategy` enum
