### PR TITLE
Remove contribution checklist with SDK stable branch instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,0 @@
-## Contribution Checklist
-
-- [ ] If doing a Document AI SDK change then please create the same PR for [server-sse-stream-stable](https://github.com/tensorlakeai/tensorlake/tree/server-sse-stream-stable) branch, merge it and add a link to it here.


### PR DESCRIPTION
The stable branch is not going to be used anymore, we're moving all development to main branch.
