### PR TITLE
Rework function stdout, stderr capturing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.16"
+version = "0.2.17"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/function_executor/main.py
+++ b/src/tensorlake/function_executor/main.py
@@ -28,6 +28,7 @@ def validate_args(args, logger: Any):
 
 
 def main():
+    # Set "spawn" method because grpc Server only works correctly if there's exec after fork.
     mp.set_start_method("spawn")
     parser = argparse.ArgumentParser(
         description="Runs Function Executor with the specified API server address"

--- a/src/tensorlake/function_executor/proto/function_executor_pb2_grpc.py
+++ b/src/tensorlake/function_executor/proto/function_executor_pb2_grpc.py
@@ -103,7 +103,9 @@ class FunctionExecutorServicer(object):
         raise NotImplementedError("Method not implemented!")
 
     def check_health(self, request, context):
-        """Health check method to check if the Function Executor is healthy."""
+        """Health check method to check if the FE is able to run tasks.
+        The FE should be initialized before calling this method.
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")

--- a/src/tensorlake/function_executor/service.py
+++ b/src/tensorlake/function_executor/service.py
@@ -1,10 +1,13 @@
 import importlib
+import io
 import json
+import os
 import sys
 import tempfile
 import time
 import traceback
 import zipfile
+from contextlib import redirect_stderr, redirect_stdout
 from typing import Any, Generator, Iterator, Optional
 
 import grpc
@@ -42,6 +45,7 @@ from .proto.function_executor_pb2 import (
     RunTaskResponse,
 )
 from .proto.function_executor_pb2_grpc import FunctionExecutorServicer
+from .std_outputs_capture import flush_logs, read_till_the_end
 
 
 class Service(FunctionExecutorServicer):
@@ -53,6 +57,8 @@ class Service(FunctionExecutorServicer):
         self._graph_version: Optional[str] = None
         self._function_name: Optional[str] = None
         self._function_wrapper: Optional[TensorlakeFunctionWrapper] = None
+        self._function_stdout: Optional[io.StringIO] = None
+        self._function_stderr: Optional[io.StringIO] = None
         self._graph_metadata: Optional[ComputeGraphMetadata] = None
         self._invocation_state_proxy_server: Optional[InvocationStateProxyServer] = None
         self._check_health_handler: Optional[CheckHealthHandler] = None
@@ -78,6 +84,14 @@ class Service(FunctionExecutorServicer):
             graph_version=request.graph_version,
             fn=request.function_name,
         )
+
+        # The files don't have paths in filesystem so they get deleted on process exit including crashes.
+        # Using buffered files instead of memory buffers for stdout, stderr puts a natural rate limit on the rate
+        # of writes and allows to not consume expensive memory for function logs.
+        # The same files should be used for stdout and stderr throughout the function lifetime because its code or
+        # dependencies save the files during function creation and the can write to them later while we're running it.
+        self._function_stdout = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
+        self._function_stderr = tempfile.TemporaryFile(mode="w+", encoding="utf-8")
 
         graph_modules_zip_fd, graph_modules_zip_path = tempfile.mkstemp(suffix=".zip")
         with open(graph_modules_zip_fd, "wb") as graph_modules_zip_file:
@@ -108,21 +122,28 @@ class Service(FunctionExecutorServicer):
             function_manifest: FunctionManifest = graph_manifest.functions[
                 request.function_name
             ]
-            function_module = importlib.import_module(
-                function_manifest.module_import_name
-            )
-            function_class = getattr(
-                function_module, function_manifest.class_import_name
-            )
 
-            # The function is only loaded once per Function Executor. It's important to use a single
-            # loaded function so all the tasks when executed are sharing the same memory. This allows
-            # implementing smart caching in customer code. E.g. load a model into GPU only once and
-            # share the model's file descriptor between all tasks or download function configuration
-            # only once.
-            #
-            # TODO: capture stdout and stderr the same way as when we run tasks.
-            self._function_wrapper = TensorlakeFunctionWrapper(function_class)
+            # Flush any logs buffered in memory before doing stdout, stderr capture.
+            # Otherwise our logs logged before this point will end up in the function's stdout capture.
+            flush_logs(self._function_stdout, self._function_stderr)
+            with redirect_stdout(self._function_stdout), redirect_stderr(
+                self._function_stderr
+            ):
+                # Capture output before loading function code.
+                function_module = importlib.import_module(
+                    function_manifest.module_import_name
+                )
+                function_class = getattr(
+                    function_module, function_manifest.class_import_name
+                )
+                # The function is only loaded once per Function Executor. It's important to use a single
+                # loaded function so all the tasks when executed are sharing the same memory. This allows
+                # implementing smart caching in customer code. E.g. load a model into GPU only once and
+                # share the model's file descriptor between all tasks or download function configuration
+                # only once.
+                self._function_wrapper = TensorlakeFunctionWrapper(function_class)
+                # Ensure that whatever outputted by the function gets captured.
+                flush_logs(self._function_stdout, self._function_stderr)
         except Exception as e:
             self._logger.error(
                 "function executor service initialization failed",
@@ -130,10 +151,14 @@ class Service(FunctionExecutorServicer):
                 duration_sec=f"{time.monotonic() - start_time:.3f}",
                 # Don't log the exception to FE log as it contains customer data
             )
+            formatted_exception: str = "".join(traceback.format_exception(e))
             return InitializeResponse(
                 outcome_code=InitializationOutcomeCode.INITIALIZE_OUTCOME_CODE_FAILURE,
                 failure_reason=InitializationFailureReason.INITIALIZATION_FAILURE_REASON_FUNCTION_ERROR,
-                stderr="".join(traceback.format_exception(e)),
+                stdout=read_till_the_end(self._function_stdout, 0),
+                stderr="\n".join(
+                    [read_till_the_end(self._function_stderr, 0), formatted_exception]
+                ),
             )
 
         # Only pass health checks if FE was initialized successfully.
@@ -143,7 +168,9 @@ class Service(FunctionExecutorServicer):
             duration_sec=f"{time.monotonic() - start_time:.3f}",
         )
         return InitializeResponse(
-            outcome_code=InitializationOutcomeCode.INITIALIZE_OUTCOME_CODE_SUCCESS
+            outcome_code=InitializationOutcomeCode.INITIALIZE_OUTCOME_CODE_SUCCESS,
+            stdout=read_till_the_end(self._function_stdout, 0),
+            stderr=read_till_the_end(self._function_stderr, 0),
         )
 
     def initialize_invocation_state_server(
@@ -209,6 +236,8 @@ class Service(FunctionExecutorServicer):
                 request.task_id, self._invocation_state_proxy_server
             ),
             function_wrapper=self._function_wrapper,
+            function_stdout=self._function_stdout,
+            function_stderr=self._function_stderr,
             graph_metadata=self._graph_metadata,
             logger=self._logger,
         ).run()

--- a/src/tensorlake/function_executor/std_outputs_capture.py
+++ b/src/tensorlake/function_executor/std_outputs_capture.py
@@ -1,0 +1,17 @@
+# Common code for capturing function standard outputs
+
+import io
+
+
+def flush_logs(stdout_file: io.StringIO, stderr_file: io.StringIO) -> None:
+    print("", end="", flush=True)
+    stdout_file.flush()
+    stderr_file.flush()
+
+
+def read_till_the_end(file: io.StringIO, start: int) -> str:
+    end: int = file.tell()
+    file.seek(start)
+    text: str = file.read(end - start)
+    file.seek(0, io.SEEK_END)  # Move the position back to the end
+    return text

--- a/tests/function_executor/test_task_outputs.py
+++ b/tests/function_executor/test_task_outputs.py
@@ -24,9 +24,8 @@ from tensorlake.function_executor.proto.function_executor_pb2 import (
 from tensorlake.function_executor.proto.function_executor_pb2_grpc import (
     FunctionExecutorStub,
 )
-from tensorlake.functions_sdk.functions import tensorlake_function
+from tensorlake.functions_sdk.functions import TensorlakeCompute, tensorlake_function
 from tensorlake.functions_sdk.graph_serialization import (
-    ZIPPED_GRAPH_CODE_CONTENT_TYPE,
     graph_code_dir_path,
     zip_graph_code,
 )
@@ -38,54 +37,102 @@ GRAPH_CODE_DIR_PATH = graph_code_dir_path(__file__)
 TEST_ITERATIONS = 100
 
 
-@tensorlake_function()
-def print_function(content: str) -> str:
-    print(content)
-    return "success"
+class PrintFunction(TensorlakeCompute):
+    name = "print_function"
+
+    def __init__(self):
+        super().__init__()
+        print(f"{self.name} initialized")
+
+    def run(self, content: str) -> str:
+        print(content)
+        return "success"
 
 
 def validate_print_function_output(
-    test_case: unittest.TestCase, content: str, run_task_response: RunTaskResponse
+    test_case: unittest.TestCase,
+    content: str,
+    initialize_response: InitializeResponse,
+    run_task_response: RunTaskResponse,
 ):
+    test_case.assertEqual("print_function initialized\n", initialize_response.stdout)
+    test_case.assertEqual("", initialize_response.stderr)
     test_case.assertEqual(content + "\n", run_task_response.stdout)
+    test_case.assertEqual("", run_task_response.stderr)
 
 
-@tensorlake_function()
-def stdout_function(content: str) -> str:
-    sys.stdout.write(content)
-    return "success"
+class StdoutFunction(TensorlakeCompute):
+    name = "stdout_function"
+
+    def __init__(self):
+        super().__init__()
+        sys.stdout.write(f"{self.name} initialized")
+
+    def run(self, content: str) -> str:
+        sys.stdout.write(content)
+        return "success"
 
 
 def validate_stdout_function_output(
-    test_case: unittest.TestCase, content: str, run_task_response: RunTaskResponse
+    test_case: unittest.TestCase,
+    content: str,
+    initialize_response: InitializeResponse,
+    run_task_response: RunTaskResponse,
 ):
+    test_case.assertEqual("stdout_function initialized", initialize_response.stdout)
+    test_case.assertEqual("", initialize_response.stderr)
     test_case.assertEqual(content, run_task_response.stdout)
+    test_case.assertEqual("", run_task_response.stderr)
 
 
-@tensorlake_function()
-def stderr_function(content: str) -> str:
-    sys.stderr.write(content)
-    return "success"
+class StderrFunction(TensorlakeCompute):
+    name = "stderr_function"
+
+    def __init__(self):
+        super().__init__()
+        sys.stderr.write(f"{self.name} initialized")
+
+    def run(self, content: str) -> str:
+        sys.stderr.write(content)
+        return "success"
 
 
 def validate_stderr_function_output(
-    test_case: unittest.TestCase, content: str, run_task_response: RunTaskResponse
+    test_case: unittest.TestCase,
+    content: str,
+    initialize_response: InitializeResponse,
+    run_task_response: RunTaskResponse,
 ):
+    test_case.assertEqual("stderr_function initialized", initialize_response.stderr)
+    test_case.assertEqual("", initialize_response.stdout)
     test_case.assertEqual(content, run_task_response.stderr)
+    test_case.assertEqual("", run_task_response.stdout)
 
 
-@tensorlake_function()
-def stdlog_function(content: str) -> str:
-    logging.error(content)
-    return "success"
+class StdlogFunction(TensorlakeCompute):
+    name = "stdlog_function"
+
+    def __init__(self):
+        super().__init__()
+        logging.error(f"{self.name} initialized")
+
+    def run(self, content: str) -> str:
+        logging.error(content)
+        return "success"
 
 
 def validate_stdlog_function_output(
-    test_case: unittest.TestCase, content: str, run_task_response: RunTaskResponse
+    test_case: unittest.TestCase,
+    content: str,
+    initialize_response: InitializeResponse,
+    run_task_response: RunTaskResponse,
 ):
     # FIXME: This test is validating empty stderr, stdout because
     # currently standard logging doesn't work in functions because root logger of std logging module
     # is created on its first use and it uses the sys.stderr file handle that existed at that moment.
+    # This can only be fixed if we split customer code into a separate process.
+    test_case.assertEqual(initialize_response.stdout, "")
+    test_case.assertEqual(initialize_response.stderr, "")
     test_case.assertEqual(run_task_response.stdout, "")
     test_case.assertEqual(run_task_response.stderr, "")
 
@@ -95,26 +142,26 @@ class TestRunTask(unittest.TestCase):
         [
             (
                 "print function call",
-                print_function,
-                "print_function",
+                PrintFunction,
+                PrintFunction.name,
                 validate_print_function_output,
             ),
             (
                 "stdout file descriptor write",
-                stdout_function,
-                "stdout_function",
+                StdoutFunction,
+                StdoutFunction.name,
                 validate_stdout_function_output,
             ),
             (
                 "stderr file descriptor write",
-                stderr_function,
-                "stderr_function",
+                StderrFunction,
+                StderrFunction.name,
                 validate_stderr_function_output,
             ),
             (
                 "standard logging library call",
-                stdlog_function,
-                "stdlog_function",
+                StdlogFunction,
+                StdlogFunction.name,
                 validate_stdlog_function_output,
             ),
         ]
@@ -164,61 +211,9 @@ class TestRunTask(unittest.TestCase):
                     )
                     self.assertEqual(len(fn_outputs), 1)
                     self.assertEqual("success", fn_outputs[0])
-                    validation_function(self, content, run_task_response)
-
-    def test_expected_run_task_response_stdout_stderr_with_disabled_capture_env_var(
-        self,
-    ):
-        with FunctionExecutorProcessContextManager(
-            DEFAULT_FUNCTION_EXECUTOR_PORT + 1,
-            extra_env={"INDEXIFY_FUNCTION_EXECUTOR_DISABLE_OUTPUT_CAPTURE": "1"},
-        ) as process:
-            with rpc_channel(process) as channel:
-                graph = Graph(
-                    name="test", description="test", start_node=print_function
-                )
-                stub: FunctionExecutorStub = FunctionExecutorStub(channel)
-                initialize_response: InitializeResponse = stub.initialize(
-                    InitializeRequest(
-                        namespace="test",
-                        graph_name="test",
-                        graph_version="1",
-                        function_name="print_function",
-                        graph=SerializedObject(
-                            data=zip_graph_code(
-                                graph=graph,
-                                code_dir_path=GRAPH_CODE_DIR_PATH,
-                            ),
-                            encoding=SerializedObjectEncoding.SERIALIZED_OBJECT_ENCODING_BINARY_ZIP,
-                            encoding_version=0,
-                        ),
+                    validation_function(
+                        self, content, initialize_response, run_task_response
                     )
-                )
-                self.assertEqual(
-                    initialize_response.outcome_code,
-                    InitializationOutcomeCode.INITIALIZE_OUTCOME_CODE_SUCCESS,
-                )
-
-                run_task_response: RunTaskResponse = run_task(
-                    stub,
-                    function_name="print_function",
-                    input="print function argument to print",
-                )
-
-                self.assertEqual(
-                    run_task_response.outcome_code,
-                    TaskOutcomeCode.TASK_OUTCOME_CODE_SUCCESS,
-                )
-                fn_outputs = deserialized_function_output(
-                    self, run_task_response.function_outputs
-                )
-                self.assertEqual(len(fn_outputs), 1)
-                self.assertEqual("success", fn_outputs[0])
-                self.assertEqual(
-                    "Function output capture is disabled using INDEXIFY_FUNCTION_EXECUTOR_DISABLE_OUTPUT_CAPTURE env var.\n",
-                    run_task_response.stdout,
-                )
-                self.assertEqual("", run_task_response.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Use a buffered /tmp file for function stdout, stderr capturing The file allows us to randomly seek over the captured stdout, stderr, read parts of the captured std output streams and send them incrementally to Executor (function logs streaming scenario).
* The buffered files limit the amount of memory used by the stdout, stderr capturing and throttle writes to stdout, stderr the same was as any local file system writes would do.
* Capture function creation stdout, stderr. So it can be saved and uploaded to blob store by executor.
* Use the same stdout, stderr files for function creation and all funtion runs so any loggers created during function creation keep logging to the same stdout, stderr files and we keep capturing them while running functions.

I'll be using these stdout,stderr files while implementing the new stream based protocol for FE.