### PR TITLE
feat: automatically upload file if user provided a file_path as file input

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.20"
+version = "0.2.21"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/models/__init__.py
+++ b/src/tensorlake/documentai/models/__init__.py
@@ -17,7 +17,6 @@ from .enums import (
     TableParsingFormat,
 )
 
-
 # Options
 from .options import (
     EnrichmentOptions,
@@ -32,14 +31,14 @@ from .parse import ParseRequest
 
 # Results models
 from .results import (
-    PageClass,
-    ParseRequestOptions,
-    ParseResult,
     Chunk,
     Figure,
     Page,
+    PageClass,
     PageFragment,
     PageFragmentType,
+    ParseRequestOptions,
+    ParseResult,
     Signature,
     StructuredData,
     Table,

--- a/src/tensorlake/documentai/models/results.py
+++ b/src/tensorlake/documentai/models/results.py
@@ -2,8 +2,8 @@
 This module contains the data models for the parsing results of a document.
 """
 
-from typing import List, Optional, Union, Any
 from enum import Enum
+from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, Field
 

--- a/tests/document_ai/test_parse.py
+++ b/tests/document_ai/test_parse.py
@@ -168,6 +168,34 @@ class TestParse(unittest.TestCase):
         self.assertIn("form125", page_classes)
         self.assertIn("form140", page_classes)
 
+    def test_parse_with_file_from_filesystem(self):
+        server_url = os.getenv("INDEXIFY_URL")
+        self.assertIsNotNone(
+            server_url, "INDEXIFY_URL environment variable is not set."
+        )
+
+        api_key = os.getenv("TENSORLAKE_API_KEY")
+        self.assertIsNotNone(
+            api_key, "TENSORLAKE_API_KEY environment variable is not set."
+        )
+
+        doc_ai = DocumentAI(
+            server_url=server_url,
+            api_key=api_key,
+        )
+
+        parse_id = doc_ai.parse(
+            file="./document_ai/testdata/example_bank_statement.pdf",
+            page_range="1",
+        )
+        self.assertIsNotNone(parse_id)
+        print(f"Parse ID: {parse_id}")
+
+        parse_result = doc_ai.wait_for_completion(parse_id=parse_id)
+        self.assertIsNotNone(parse_result)
+        self.assertIsNotNone(parse_result.pages)
+        self.assertIsNotNone(parse_result.chunks)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description

To reduce friction when using the SDK, we will automatically identify if the user is trying to use a local filepath as input for the parse operation, be it from a dataset or directly.

The SDK will upload the file to the associated Project and use it as parse input.

Test run:
https://github.com/tensorlakeai/tensorlake/actions/runs/16199420480