### PR TITLE
SDK update: ignore_sections available in parsing options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.25"
+version = "0.2.26"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/models/enums.py
+++ b/src/tensorlake/documentai/models/enums.py
@@ -5,6 +5,34 @@ Enums for document parsing.
 from enum import Enum
 
 
+class PageFragmentType(str, Enum):
+    """
+    Type of a page fragment.
+    """
+
+    SECTION_HEADER = "section_header"
+    TITLE = "title"
+
+    TEXT = "text"
+    TABLE = "table"
+    FIGURE = "figure"
+    FORMULA = "formula"
+    FORM = "form"
+    KEY_VALUE_REGION = "key_value_region"
+    DOCUMENT_INDEX = "document_index"
+    LIST_ITEM = "list_item"
+
+    TABLE_CAPTION = "table_caption"
+    FIGURE_CAPTION = "figure_caption"
+    FORMULA_CAPTION = "formula_caption"
+
+    PAGE_FOOTER = "page_footer"
+    PAGE_HEADER = "page_header"
+    PAGE_NUMBER = "page_number"
+    SIGNATURE = "signature"
+    STRIKETHROUGH = "strikethrough"
+
+
 class ChunkingStrategy(str, Enum):
     """
     Chunking strategy for parsing a document.

--- a/src/tensorlake/documentai/models/options.py
+++ b/src/tensorlake/documentai/models/options.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Type, Union, Set
 
 from pydantic import BaseModel, Field, Json
 
@@ -8,6 +8,7 @@ from .enums import (
     PartitionStrategy,
     TableOutputMode,
     TableParsingFormat,
+    PageFragmentType,
 )
 
 
@@ -80,6 +81,10 @@ class ParsingOptions(BaseModel):
     table_parsing_format: TableParsingFormat = Field(
         TableParsingFormat.TSR,
         description="Determines how the system identifies and extracts tables from the document. Default is `table_structure_recognition`, which is better suited for clean, grid-like tables.",
+    )
+    ignore_sections: Optional[Set[PageFragmentType]] = Field(
+        None,
+        description="Set of page fragment types to ignore during parsing. This can be used to skip certain types of content, such as headers, footers, or other non-essential elements. If not provided, all page fragment types will be considered.",
     )
 
 

--- a/src/tensorlake/documentai/models/options.py
+++ b/src/tensorlake/documentai/models/options.py
@@ -1,14 +1,14 @@
-from typing import List, Optional, Type, Union, Set
+from typing import List, Optional, Set, Type, Union
 
 from pydantic import BaseModel, Field, Json
 
 from .enums import (
     ChunkingStrategy,
     ModelProvider,
+    PageFragmentType,
     PartitionStrategy,
     TableOutputMode,
     TableParsingFormat,
-    PageFragmentType,
 )
 
 

--- a/src/tensorlake/documentai/models/results.py
+++ b/src/tensorlake/documentai/models/results.py
@@ -2,12 +2,11 @@
 This module contains the data models for the parsing results of a document.
 """
 
-from enum import Enum
 from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from .enums import ParseStatus
+from .enums import ParseStatus, PageFragmentType
 from .options import Options
 
 
@@ -69,34 +68,6 @@ class Signature(BaseModel):
     """
 
     content: str
-
-
-class PageFragmentType(str, Enum):
-    """
-    Type of a page fragment.
-    """
-
-    SECTION_HEADER = "section_header"
-    TITLE = "title"
-
-    TEXT = "text"
-    TABLE = "table"
-    FIGURE = "figure"
-    FORMULA = "formula"
-    FORM = "form"
-    KEY_VALUE_REGION = "key_value_region"
-    DOCUMENT_INDEX = "document_index"
-    LIST_ITEM = "list_item"
-
-    TABLE_CAPTION = "table_caption"
-    FIGURE_CAPTION = "figure_caption"
-    FORMULA_CAPTION = "formula_caption"
-
-    PAGE_FOOTER = "page_footer"
-    PAGE_HEADER = "page_header"
-    PAGE_NUMBER = "page_number"
-    SIGNATURE = "signature"
-    STRIKETHROUGH = "strikethrough"
 
 
 class PageFragment(BaseModel):

--- a/src/tensorlake/documentai/models/results.py
+++ b/src/tensorlake/documentai/models/results.py
@@ -6,7 +6,7 @@ from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from .enums import ParseStatus, PageFragmentType
+from .enums import PageFragmentType, ParseStatus
 from .options import Options
 
 


### PR DESCRIPTION
### Description

Extends the ParsingOptions object with a set of Page Fragment Types called `ignore_sections`, which should help with getting cleaner parse results.