### PR TITLE
fix: return PageFragmentType to results module

### DIFF
--- a/src/tensorlake/documentai/models/enums.py
+++ b/src/tensorlake/documentai/models/enums.py
@@ -5,34 +5,6 @@ Enums for document parsing.
 from enum import Enum
 
 
-class PageFragmentType(str, Enum):
-    """
-    Type of a page fragment.
-    """
-
-    SECTION_HEADER = "section_header"
-    TITLE = "title"
-
-    TEXT = "text"
-    TABLE = "table"
-    FIGURE = "figure"
-    FORMULA = "formula"
-    FORM = "form"
-    KEY_VALUE_REGION = "key_value_region"
-    DOCUMENT_INDEX = "document_index"
-    LIST_ITEM = "list_item"
-
-    TABLE_CAPTION = "table_caption"
-    FIGURE_CAPTION = "figure_caption"
-    FORMULA_CAPTION = "formula_caption"
-
-    PAGE_FOOTER = "page_footer"
-    PAGE_HEADER = "page_header"
-    PAGE_NUMBER = "page_number"
-    SIGNATURE = "signature"
-    STRIKETHROUGH = "strikethrough"
-
-
 class ChunkingStrategy(str, Enum):
     """
     Chunking strategy for parsing a document.

--- a/src/tensorlake/documentai/models/options.py
+++ b/src/tensorlake/documentai/models/options.py
@@ -5,11 +5,12 @@ from pydantic import BaseModel, Field, Json
 from .enums import (
     ChunkingStrategy,
     ModelProvider,
-    PageFragmentType,
     PartitionStrategy,
     TableOutputMode,
     TableParsingFormat,
 )
+
+from . import PageFragmentType
 
 
 class EnrichmentOptions(BaseModel):

--- a/src/tensorlake/documentai/models/options.py
+++ b/src/tensorlake/documentai/models/options.py
@@ -2,6 +2,7 @@ from typing import List, Optional, Set, Type, Union
 
 from pydantic import BaseModel, Field, Json
 
+from . import PageFragmentType
 from .enums import (
     ChunkingStrategy,
     ModelProvider,
@@ -9,8 +10,6 @@ from .enums import (
     TableOutputMode,
     TableParsingFormat,
 )
-
-from . import PageFragmentType
 
 
 class EnrichmentOptions(BaseModel):

--- a/src/tensorlake/documentai/models/results.py
+++ b/src/tensorlake/documentai/models/results.py
@@ -2,11 +2,12 @@
 This module contains the data models for the parsing results of a document.
 """
 
+from enum import Enum
 from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from .enums import PageFragmentType, ParseStatus
+from .enums import ParseStatus
 from .options import Options
 
 
@@ -68,6 +69,34 @@ class Signature(BaseModel):
     """
 
     content: str
+
+
+class PageFragmentType(str, Enum):
+    """
+    Type of a page fragment.
+    """
+
+    SECTION_HEADER = "section_header"
+    TITLE = "title"
+
+    TEXT = "text"
+    TABLE = "table"
+    FIGURE = "figure"
+    FORMULA = "formula"
+    FORM = "form"
+    KEY_VALUE_REGION = "key_value_region"
+    DOCUMENT_INDEX = "document_index"
+    LIST_ITEM = "list_item"
+
+    TABLE_CAPTION = "table_caption"
+    FIGURE_CAPTION = "figure_caption"
+    FORMULA_CAPTION = "formula_caption"
+
+    PAGE_FOOTER = "page_footer"
+    PAGE_HEADER = "page_header"
+    PAGE_NUMBER = "page_number"
+    SIGNATURE = "signature"
+    STRIKETHROUGH = "strikethrough"
 
 
 class PageFragment(BaseModel):


### PR DESCRIPTION
### Description

Make the release non-breaking by keeping PageFragmentType in the results module.