### PR TITLE
fix: ignore_sections serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.26"
+version = "0.2.27"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/builder/client_v2.py
+++ b/src/tensorlake/builder/client_v2.py
@@ -181,7 +181,7 @@ class ImageBuilderV2Client:
             "graph_version": context.graph_version,
             "graph_function_name": context.function_name,
             "image_hash": image.hash(),
-            "image_name": image.image_name
+            "image_name": image.image_name,
         }
 
         res = await self._client.put(

--- a/src/tensorlake/documentai/models/_options.py
+++ b/src/tensorlake/documentai/models/_options.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Set, Type, Union
 
-from pydantic import BaseModel, Field, Json
+from pydantic import BaseModel, Field, Json, field_serializer
 
 from ._enums import (
     ChunkingStrategy,
@@ -86,6 +86,12 @@ class ParsingOptions(BaseModel):
         None,
         description="Set of page fragment types to ignore during parsing. This can be used to skip certain types of content, such as headers, footers, or other non-essential elements. If not provided, all page fragment types will be considered.",
     )
+
+    @field_serializer("ignore_sections")
+    def serialize_ignore_sections(
+        self, ignore_sections: Set[PageFragmentType]
+    ) -> List[str]:
+        return [section.value for section in ignore_sections]
 
 
 class StructuredExtractionOptions(BaseModel):


### PR DESCRIPTION
There was a bug in serializing the ingore_sections field in ParseOptions 