### PR TITLE
improve upload validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.28"
+version = "0.2.29"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/_files.py
+++ b/src/tensorlake/documentai/_files.py
@@ -92,7 +92,6 @@ class _FilesMixin(_BaseClient):
         resp = await self._arequest_v1("GET", "files", params=params)
         return PaginatedResult[FileInfo].model_validate(resp.json())
 
-    @retry(tries=10, delay=2)
     def upload(self, path: Union[str, Path]) -> str:
         """
         Upload a file to Tensorlake.

--- a/src/tensorlake/documentai/files.py
+++ b/src/tensorlake/documentai/files.py
@@ -73,6 +73,11 @@ class FileUploader:
             FileNotFoundError: If the file doesn't exist
         """
 
+        if file_path.startswith("http://") or file_path.startswith("https://"):
+            raise ValueError(
+                "file upload supports only local files. If you want to parse a remote file, please call the parse method with the remote file URL."
+            )
+
         path = Path(file_path)
         if not path.exists():
             raise FileNotFoundError(f"File not found: {path}")


### PR DESCRIPTION
Throwing an exception to indicate that users can't upload a remote file url and suggest using the parse api.

Removing the retry logic here since we don't want to retry uploads