### PR TITLE
Feat: Parse structured extraction also accepts single object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.31"
+version = "0.2.32"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 homepage = "https://github.com/tensorlakeai/tensorlake"

--- a/src/tensorlake/documentai/__init__.py
+++ b/src/tensorlake/documentai/__init__.py
@@ -17,7 +17,6 @@ from tensorlake.documentai.models import (
     PageClassConfig,
     PageFragment,
     PageFragmentType,
-    ParseRequestOptions,
     ParseResult,
     ParseStatus,
     ParsingOptions,
@@ -50,7 +49,6 @@ __all__ = [
     "StructuredExtractionOptions",
     # Results models
     "PageClass",
-    "ParseRequestOptions",
     "ParseResult",
     "Chunk",
     "Figure",

--- a/src/tensorlake/documentai/_parse.py
+++ b/src/tensorlake/documentai/_parse.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import json
 import time
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from pydantic import BaseModel
 
@@ -465,7 +465,9 @@ class _ParseMixin(_BaseClient):
 def _create_parse_req(
     file: str,
     parsing_options: Optional[ParsingOptions] = None,
-    structured_extraction_options: Optional[List[StructuredExtractionOptions]] = None,
+    structured_extraction_options: Optional[
+        Union[StructuredExtractionOptions, List[StructuredExtractionOptions]]
+    ] = None,
     enrichment_options: Optional[EnrichmentOptions] = None,
     page_classifications: Optional[List[PageClassConfig]] = None,
     page_range: Optional[str] = None,
@@ -497,10 +499,17 @@ def _create_parse_req(
             pc.model_dump(exclude_none=True) for pc in page_classifications
         ]
 
+    print("structured_extraction_options:", structured_extraction_options)
+
     if structured_extraction_options:
-        payload["structured_extraction_options"] = [
-            _convert_seo(opt) for opt in structured_extraction_options
-        ]
+        if isinstance(structured_extraction_options, StructuredExtractionOptions):
+            payload["structured_extraction_options"] = [
+                _convert_seo(structured_extraction_options)
+            ]
+        else:
+            payload["structured_extraction_options"] = [
+                _convert_seo(opt) for opt in structured_extraction_options
+            ]
 
     return payload
 

--- a/src/tensorlake/documentai/_parse.py
+++ b/src/tensorlake/documentai/_parse.py
@@ -499,8 +499,6 @@ def _create_parse_req(
             pc.model_dump(exclude_none=True) for pc in page_classifications
         ]
 
-    print("structured_extraction_options:", structured_extraction_options)
-
     if structured_extraction_options:
         if isinstance(structured_extraction_options, StructuredExtractionOptions):
             payload["structured_extraction_options"] = [

--- a/src/tensorlake/documentai/models/__init__.py
+++ b/src/tensorlake/documentai/models/__init__.py
@@ -2,10 +2,7 @@
 DocumentAI models package.
 """
 
-from ._datasets import (
-    Dataset,
-    DatasetStatus,
-)
+from ._datasets import Dataset, DatasetStatus
 
 # Enums
 from ._enums import (
@@ -37,7 +34,6 @@ from ._results import (
     PageClass,
     PageFragment,
     PageFragmentType,
-    ParseRequestOptions,
     ParseResult,
     Signature,
     StructuredData,
@@ -63,7 +59,6 @@ __all__ = [
     "StructuredExtractionOptions",
     # Results models
     "PageClass",
-    "ParseRequestOptions",
     "ParseResult",
     "Chunk",
     "Figure",

--- a/src/tensorlake/documentai/models/_results.py
+++ b/src/tensorlake/documentai/models/_results.py
@@ -111,40 +111,6 @@ class Chunk(BaseModel):
     content: str
 
 
-class ParseRequestOptions(BaseModel):
-    """
-    The options used for scheduling the parse job.
-    """
-
-    configuration: Options = Field(
-        description="The configuration used for the parse job. This is derived from the configuration settings submitted with the parse request. It can be used to understand how the parse job was configured, such as the parsing strategy, extraction methods, etc. Values not provided in the request will be set to their default values."
-    )
-    file_id: Optional[str] = Field(
-        None,
-        description="The tensorlake file ID. This is the ID of the file used for the parse job. It has `tensorlake_` prefix. It can be undefined if the parse operation was created with a `file_url` or `raw_text` field instead of a file ID.",
-    )
-    file_name: Optional[str] = Field(
-        None,
-        description="The name of the file used for the parse job. This is only populated if the parse operation was created with a `file_id`.",
-    )
-    file_url: Optional[str] = Field(
-        None,
-        description="The URL of the file used for the parse job. It can be undefined if the parse operation was created with a `file_id` or `raw_text` field instead of a file URL.",
-    )
-    page_range: Optional[str] = Field(
-        None,
-        description="The page range that was requested for parsing. This is the same as the value provided in the `pages` field of the request. It can be undefined if the parse operation was created without a specific page range. Meaning the whole document was parsed.",
-    )
-    raw_text: Optional[str] = Field(
-        None,
-        description="The raw_text for the parse job. This is only populated if the parse operation was created with a `raw_text` field. And the mime type is of a text-based format (e.g., plain text, HTML). It can be undefined if the parse operation was created with a `file_id` or `file_url` field instead of raw_text.",
-    )
-    trace_id: Optional[str] = Field(
-        None,
-        description="The trace ID for the parse job. It can be undefined if the operation is still in pending state. This is used for debugging purposes.",
-    )
-
-
 class ParseResult(BaseModel):
     """
     Result of a parse operation in the v2 API.


### PR DESCRIPTION
## Description

- Parse accepts both a single `StructuredExtractionOptions` object and of `StructuredExtractionOptions`
- Adds test case for single object structured extraction parse request
- Removes deprecated `ParseRequestOptions`