### PR TITLE
feat: improve error response UX and fix files V2 parse support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.39"
+version = "0.2.40"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]

--- a/src/tensorlake/documentai/_base.py
+++ b/src/tensorlake/documentai/_base.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import httpx
 
 from .common import get_doc_ai_base_url_v1, get_doc_ai_base_url_v2
-from .models import (Region, ErrorResponse, ErrorCode, DocumentAIError)
+from .models import DocumentAIError, ErrorCode, ErrorResponse, Region
 
 
 class _BaseClient:
@@ -92,7 +92,9 @@ class _BaseClient:
             return resp
 
         error_response = _deserialize_error_response(resp)
-        _print_error_line(error_response.code, error_response.message, error_response.trace_id)
+        _print_error_line(
+            error_response.code, error_response.message, error_response.trace_id
+        )
 
         raise DocumentAIError(
             message=error_response.message,
@@ -112,7 +114,9 @@ class _BaseClient:
             return resp
 
         error_response = _deserialize_error_response(resp)
-        _print_error_line(error_response.code, error_response.message, error_response.trace_id)
+        _print_error_line(
+            error_response.code, error_response.message, error_response.trace_id
+        )
 
         raise DocumentAIError(
             message=error_response.message,
@@ -133,10 +137,11 @@ def _deserialize_error_response(resp: httpx.Response) -> ErrorResponse:
             code=ErrorCode.INTERNAL_ERROR,
             timestamp=int(resp.headers.get("Date", 0)),
             trace_id=resp.headers.get("X-Trace-ID"),
-            details=None
+            details=None,
         )
 
         return error_response
+
 
 # --- simple color helpers ---
 _RESET = "\033[0m"
@@ -144,16 +149,19 @@ _BOLD = "\033[1m"
 _RED = "\033[31m"
 _YELLOW = "\033[33m"
 
+
 def _use_color() -> bool:
     env = os.getenv("TENSORLAKE_SDK_COLOR")
     if env is not None:
         return env.lower() not in ("0", "false", "no")
     return hasattr(sys.stderr, "isatty") and sys.stderr.isatty()
 
+
 def _c(s: str, color: str) -> str:
     if not _use_color():
         return s
     return f"{color}{s}{_RESET}"
+
 
 def _print_error_line(code: Any, message: str, trace_id: str | None = None) -> None:
     prefix = _c("Error:", _BOLD + _RED)

--- a/src/tensorlake/documentai/_parse.py
+++ b/src/tensorlake/documentai/_parse.py
@@ -30,7 +30,7 @@ class _ParseMixin(_BaseClient):
         file: str,
         parsing_options: Optional[ParsingOptions] = None,
         structured_extraction_options: Optional[
-            List[StructuredExtractionOptions]
+            Union[StructuredExtractionOptions, List[StructuredExtractionOptions]]
         ] = None,
         enrichment_options: Optional[EnrichmentOptions] = None,
         page_classifications: Optional[List[PageClassConfig]] = None,

--- a/src/tensorlake/documentai/_parse.py
+++ b/src/tensorlake/documentai/_parse.py
@@ -478,7 +478,7 @@ def _create_parse_req(
 
     if file.startswith(("http://", "https://")):
         payload["file_url"] = file
-    elif file.startswith("tensorlake-"):
+    elif file.startswith("tensorlake-") or file.startswith("file_"):
         payload["file_id"] = file
     else:
         payload["raw_text"] = file

--- a/src/tensorlake/documentai/models/__init__.py
+++ b/src/tensorlake/documentai/models/__init__.py
@@ -43,6 +43,11 @@ from ._results import (
     Text,
 )
 
+from ._errors import (
+    ErrorCode,
+    ErrorResponse,
+)
+
 __all__ = [
     # Enums
     "ChunkingStrategy",
@@ -80,4 +85,7 @@ __all__ = [
     # Filters
     "DatasetDataFilter",
     "Region",
+    # Errors
+    "ErrorCode",
+    "ErrorResponse",
 ]

--- a/src/tensorlake/documentai/models/__init__.py
+++ b/src/tensorlake/documentai/models/__init__.py
@@ -46,6 +46,7 @@ from ._results import (
 from ._errors import (
     ErrorCode,
     ErrorResponse,
+    DocumentAIError
 )
 
 __all__ = [
@@ -88,4 +89,5 @@ __all__ = [
     # Errors
     "ErrorCode",
     "ErrorResponse",
+    "DocumentAIError"
 ]

--- a/src/tensorlake/documentai/models/__init__.py
+++ b/src/tensorlake/documentai/models/__init__.py
@@ -15,6 +15,7 @@ from ._enums import (
     TableOutputMode,
     TableParsingFormat,
 )
+from ._errors import DocumentAIError, ErrorCode, ErrorResponse
 from ._filters import DatasetDataFilter
 
 # Options
@@ -41,12 +42,6 @@ from ._results import (
     Table,
     TableCell,
     Text,
-)
-
-from ._errors import (
-    ErrorCode,
-    ErrorResponse,
-    DocumentAIError
 )
 
 __all__ = [
@@ -89,5 +84,5 @@ __all__ = [
     # Errors
     "ErrorCode",
     "ErrorResponse",
-    "DocumentAIError"
+    "DocumentAIError",
 ]

--- a/src/tensorlake/documentai/models/_errors.py
+++ b/src/tensorlake/documentai/models/_errors.py
@@ -3,6 +3,17 @@ from enum import Enum
 from typing import Optional
 from pydantic import BaseModel, Field
 
+class DocumentAIError(Exception):
+    """
+    Base class for Document AI API errors.
+
+    This exception is raised for errors that occur during the operation of the Document AI API.
+    It can be used to catch and handle errors in a generic way.
+    """
+    def __init__(self, message: str, code: Optional[str] = None):
+        super().__init__(message)
+        self.code = code
+
 class ErrorCode(str, Enum):
     """
     Error codes for Document AI API.

--- a/src/tensorlake/documentai/models/_errors.py
+++ b/src/tensorlake/documentai/models/_errors.py
@@ -1,0 +1,40 @@
+
+from enum import Enum
+from typing import Optional
+from pydantic import BaseModel, Field
+
+class ErrorCode(str, Enum):
+    """
+    Error codes for Document AI API.
+
+    These codes are used to identify specific error conditions in the API.
+    They can be used for programmatic handling of errors.
+    """
+    QUOTA_EXCEEDED = "QUOTA_EXCEEDED"
+    INVALID_JSON_SCHEMA = "INVALID_JSON_SCHEMA"
+    INVALID_CONFIGURATION = "INVALID_CONFIGURATION"
+    INVALID_PAGE_CLASSIFICATION = "INVALID_PAGE_CLASSIFICATION"
+    ENTITY_NOT_FOUND = "ENTITY_NOT_FOUND"
+    ENTITY_ALREADY_EXISTS = "ENTITY_ALREADY_EXISTS"
+    INVALID_FILE = "INVALID_FILE"
+    INVALID_PAGE_RANGE = "INVALID_PAGE_RANGE"
+    INVALID_MIME_TYPE = "INVALID_MIME_TYPE"
+    INVALID_DATASET_NAME = "INVALID_DATASET_NAME"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+    INVALID_MULTIPART = "INVALID_MULTIPART"
+    MULTIPART_STREAM_END = "MULTIPART_STREAM_END"
+    INVALID_QUERY_PARAMS = "INVALID_QUERY_PARAMS"
+
+
+class ErrorResponse(BaseModel):
+    """
+    Error response for Document AI API.
+
+    This model is used to return error information when the Document AI API encounters
+    a user-facing error.
+    """
+    message: str = Field(..., description="A human-readable error message")
+    code: ErrorCode = Field(..., description="The error code for programmatic handling")
+    timestamp: int = Field(..., description="Millis since Unix epoch")
+    trace_id: Optional[str] = Field(None, description="Optional correlation ID for distributed tracing")
+    details: Optional[dict] = Field(None, description="Optional extra details (e.g., field-level validation errors)")

--- a/src/tensorlake/documentai/models/_errors.py
+++ b/src/tensorlake/documentai/models/_errors.py
@@ -1,7 +1,8 @@
-
 from enum import Enum
 from typing import Optional
+
 from pydantic import BaseModel, Field
+
 
 class DocumentAIError(Exception):
     """
@@ -10,9 +11,11 @@ class DocumentAIError(Exception):
     This exception is raised for errors that occur during the operation of the Document AI API.
     It can be used to catch and handle errors in a generic way.
     """
+
     def __init__(self, message: str, code: Optional[str] = None):
         super().__init__(message)
         self.code = code
+
 
 class ErrorCode(str, Enum):
     """
@@ -21,6 +24,7 @@ class ErrorCode(str, Enum):
     These codes are used to identify specific error conditions in the API.
     They can be used for programmatic handling of errors.
     """
+
     QUOTA_EXCEEDED = "QUOTA_EXCEEDED"
     INVALID_JSON_SCHEMA = "INVALID_JSON_SCHEMA"
     INVALID_CONFIGURATION = "INVALID_CONFIGURATION"
@@ -44,8 +48,13 @@ class ErrorResponse(BaseModel):
     This model is used to return error information when the Document AI API encounters
     a user-facing error.
     """
+
     message: str = Field(..., description="A human-readable error message")
     code: ErrorCode = Field(..., description="The error code for programmatic handling")
     timestamp: int = Field(..., description="Millis since Unix epoch")
-    trace_id: Optional[str] = Field(None, description="Optional correlation ID for distributed tracing")
-    details: Optional[dict] = Field(None, description="Optional extra details (e.g., field-level validation errors)")
+    trace_id: Optional[str] = Field(
+        None, description="Optional correlation ID for distributed tracing"
+    )
+    details: Optional[dict] = Field(
+        None, description="Optional extra details (e.g., field-level validation errors)"
+    )

--- a/src/tensorlake/documentai/models/_options.py
+++ b/src/tensorlake/documentai/models/_options.py
@@ -109,23 +109,23 @@ class StructuredExtractionOptions(BaseModel):
 
     # Optional fields
     partition_strategy: Optional[PartitionStrategy] = Field(
-        None,
+        default=None,
         description="Strategy to partition the document before structured data extraction. The API will return one structured data object per partition. This is useful when you want to extract certain fields from every page.",
     )
     model_provider: ModelProvider = Field(
-        ModelProvider.TENSORLAKE,
+        default=ModelProvider.TENSORLAKE,
         description="The model provider to use for structured data extraction. The default is `tensorlake`, which uses our private model, and runs on our servers.",
     )
     page_classes: Optional[List[str]] = Field(
-        None,
+        default=None,
         description="The page classes to use for structured data extraction. If not provided, all the pages will be used to extract structured data. The page_classification_config is used to classify the pages of the document.",
     )
     prompt: Optional[str] = Field(
-        None,
+        default=None,
         description="The prompt to use for structured data extraction. If not provided, the default prompt will be used.",
     )
     skip_ocr: bool = Field(
-        False,
+        default=False,
         description="Boolean flag to skip converting the document blob to OCR text before structured data extraction. If set to `true`, the API will skip the OCR step and directly extract structured data from the document. The default is `false`.",
     )
 

--- a/tests/document_ai/test_datasets.py
+++ b/tests/document_ai/test_datasets.py
@@ -294,6 +294,38 @@ class TestDatasets(unittest.TestCase):
             parse_id,
         )
 
+    def test_dataset_accepts_files_from_files_v2(self):
+        file_id = os.getenv("FILES_V2_FILE_ID")
+        if not file_id:
+            self.skipTest("FILES_V2_FILE_ID environment variable is not set.")
+
+        if not file_id.startswith("file_"):
+            self.skipTest("FILES_V2_FILE_ID must start with 'file_'.")
+
+        random_name = f"test_dataset_{os.urandom(4).hex()}"
+
+        dataset = self.doc_ai.create_dataset(
+            name=random_name,
+            description="This is a test dataset for unit testing.",
+        )
+        self.assertIsNotNone(dataset)
+
+        parse_id = self.doc_ai.parse_dataset_file(
+            dataset=dataset,
+            file=file_id,
+            page_range="1-2",
+            wait_for_completion=False,
+        )
+        self.assertIsNotNone(parse_id)
+
+        parse_result = self.doc_ai.wait_for_completion(parse_id=parse_id)
+        self.assertIsNotNone(parse_result)
+        self.assertEqual(parse_result.status, ParseStatus.SUCCESSFUL)
+
+        self.doc_ai.delete_dataset(dataset)
+        self.assertRaises(Exception, self.doc_ai.get_parsed_result, parse_id)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/document_ai/test_datasets.py
+++ b/tests/document_ai/test_datasets.py
@@ -326,6 +326,5 @@ class TestDatasets(unittest.TestCase):
         self.assertRaises(Exception, self.doc_ai.get_parsed_result, parse_id)
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/document_ai/test_parse.py
+++ b/tests/document_ai/test_parse.py
@@ -403,5 +403,6 @@ class TestParse(unittest.TestCase):
         parse_result = self.doc_ai.wait_for_completion(parse_id=parse_id)
         self.assertEqual(parse_result.status, ParseStatus.SUCCESSFUL)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/document_ai/test_parse.py
+++ b/tests/document_ai/test_parse.py
@@ -137,7 +137,7 @@ class TestParse(unittest.TestCase):
         self.assertIsNotNone(parse_result.structured_data)
 
         structured_extraction_schemas = {}
-        for schema in parse_result.structured_data:
+        for schema in parse_result.structured_data or []:
             structured_extraction_schemas[schema.schema_name] = schema
 
         self.assertIsNotNone(structured_extraction_schemas.get("form125-basic"))
@@ -172,7 +172,7 @@ class TestParse(unittest.TestCase):
         self.assertIsNotNone(parse_result.structured_data)
 
         structured_extraction_schemas = {}
-        for schema in parse_result.structured_data:
+        for schema in parse_result.structured_data or []:
             structured_extraction_schemas[schema.schema_name] = schema
 
         self.assertIsNotNone(structured_extraction_schemas.get("form125-basic"))
@@ -210,7 +210,7 @@ class TestParse(unittest.TestCase):
         )
 
         page_classes = {}
-        for pc in parsed_result.page_classes:
+        for pc in parsed_result.page_classes or []:
             page_classes[pc.page_class] = pc
 
         self.assertIn("form125", page_classes)

--- a/tests/document_ai/test_parse.py
+++ b/tests/document_ai/test_parse.py
@@ -385,6 +385,23 @@ class TestParse(unittest.TestCase):
         self.doc_ai.delete_parse(result.parse_id)
         self.assertRaises(Exception, self.doc_ai.get_parsed_result, result.parse_id)
 
+    def test_parse_accepts_files_from_files_v2(self):
+        file_id = os.getenv("FILES_V2_FILE_ID")
+        if not file_id:
+            self.skipTest("FILES_V2_FILE_ID environment variable is not set.")
+
+        if not file_id.startswith("file_"):
+            self.skipTest("FILES_V2_FILE_ID must start with 'file_'.")
+
+        parse_id = self.doc_ai.parse(
+            file=file_id,
+            page_range="1",
+        )
+        self.assertIsNotNone(parse_id)
+        print(f"Parse ID: {parse_id}")
+
+        parse_result = self.doc_ai.wait_for_completion(parse_id=parse_id)
+        self.assertEqual(parse_result.status, ParseStatus.SUCCESSFUL)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description

The issue found by Diptanu was easy to spot once we added proper error bubbling up to the user. Running the Notebook shared by Diptanu showed me this:

```
❯ python plans.py
File uploaded with ID: file_N9Fwq7HFgPKJ7rH9qPKNk
Error: ErrorCode.INVALID_MIME_TYPE — If content is provided, mime_type must also be provided.
```

With this error, I've found that files from the Files V2 endpoint were getting sent as raw data. This PR fixes that and adds Api Error response deserialization to show these errors to the SDK users.

With this fix, we now get a Parse ID:

```
❯ python plans.py
File uploaded with ID: file_N9Fwq7HFgPKJ7rH9qPKNk
Parse started with ID: parse_qR8f8hhHrrgr8G7jWwD7k
```

### Tests

https://github.com/tensorlakeai/tensorlake/actions/runs/16907024009/job/47899074638