### PR TITLE
wait for completion with SSE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.40"
+version = "0.2.41"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]

--- a/src/tensorlake/documentai/_base.py
+++ b/src/tensorlake/documentai/_base.py
@@ -115,7 +115,7 @@ class _BaseClient:
 
         error_response = _deserialize_error_response(resp)
         _print_error_line(
-            error_response.code, error_response.message, error_response.trace_id
+            error_response.code.value, error_response.message, error_response.trace_id
         )
 
         raise DocumentAIError(

--- a/src/tensorlake/documentai/_parse.py
+++ b/src/tensorlake/documentai/_parse.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
+import time
 from typing import Any, Dict, List, Mapping, Optional, Union
 
-from httpx_sse import aconnect_sse, connect_sse
+from httpx_sse import ServerSentEvent, aconnect_sse, connect_sse
 from pydantic import BaseModel, ValidationError
 
 from ._base import _BaseClient
@@ -132,100 +134,119 @@ class _ParseMixin(_BaseClient):
         """
         Wait for the completion of a parse operation.
 
-        This method polls the status of a parse operation until it is complete. It checks the status every 5 seconds
-        and returns the final ParseResult once the operation is no longer pending or processing.
+        This methods establishes a connection to the server-sent events (SSE) endpoint for the specified parse ID
+        and listens for updates until the parse operation is complete.
 
         Args:
             parse_id: The ID of the parse operation to wait for. This is the string returned by the parse method.
         """
         _print_bold("Waiting for completion of parse job.")
         _print_info(f"Parse ID: {parse_id}")
+        retry_count = 0
 
-        with connect_sse(
-            client=self._client,
-            method="GET",
-            url=f"parse/{parse_id}",
-            headers=self._headers(),
-        ) as sse:
-            for sse_event in sse.iter_sse():
-                match sse_event.event:
-                    case "parse_update":
-                        try:
-                            parse_result = ParseResult.model_validate_json(
-                                sse_event.data
-                            )
-                            _print_update("Parse job update:")
-                            _print_magenta(f"  Status: {parse_result.status.value}")
-                        except ValidationError:
-                            _print_update(f"Parse update received: {sse_event.data}")
+        while retry_count < 5:
+            try:
+                with connect_sse(
+                    client=self._client,
+                    method="GET",
+                    url=f"parse/{parse_id}",
+                    headers=self._headers(),
+                ) as sse:
+                    for sse_event in sse.iter_sse():
+                        if self._handle_sse_event(sse_event):
+                            return self.get_parsed_result(parse_id)
 
-                    case "parse_done":
-                        _print_success("Parse done.")
+                    _print_warn("SSE connection ended without completion event")
 
-                    case "parse_failed":
-                        try:
-                            parse_result = ParseResult.model_validate_json(
-                                sse_event.data
-                            )
-                            _print_error("Parse job failed.")
-                            _print_warn(f"  Parse ID: {parse_result.parse_id}")
-                            _print_magenta(f"  Status: {parse_result.status}")
-                            _print_error(f"  Error: {parse_result.error}")
-                        except ValidationError:
-                            _print_error(f"Parse failed received: {sse_event.data}")
+            except (ConnectionError, TimeoutError) as e:
+                retry_count += 1
+                _print_warn(f"Connection issue (attempt {retry_count} / 5): {e}")
+                if retry_count < 5:
+                    wait_time = min(2**retry_count, 30)
+                    _print_warn(f"Retrying in {wait_time} seconds...")
+                    time.sleep(wait_time)
 
-                    case "parse_queued":
-                        _print_warn("Parse job waiting in queue.")
-
+        _print_warn("Max retries reached. Checking final status...")
         return self.get_parsed_result(parse_id)
 
     async def wait_for_completion_async(self, parse_id: str) -> ParseResult:
         """
         Wait for the completion of a parse operation asynchronously.
 
-        This method polls the status of a parse operation until it is complete. It checks the status every 5 seconds
-        and returns the final ParseResult once the operation is no longer pending or processing.
+        This methods establishes a connection to the server-sent events (SSE) endpoint for the specified parse ID
+        and listens for updates until the parse operation is complete.
 
         Args:
             parse_id: The ID of the parse operation to wait for. This is the string returned by the parse method.
         """
-        async with aconnect_sse(
-            client=self._client,
-            method="GET",
-            url=f"parse/{parse_id}",
-            headers=self._headers(),
-        ) as sse:
-            async for sse_event in sse.aiter_sse():
-                match sse_event.event:
-                    case "parse_update":
-                        try:
-                            parse_result = ParseResult.model_validate_json(
-                                sse_event.data
-                            )
-                            _print_update("Parse job update:")
-                            _print_magenta(f"  Status: {parse_result.status.value}")
-                        except ValidationError:
-                            _print_update(f"Parse update received: {sse_event.data}")
+        retry_count = 0
 
-                    case "parse_done":
-                        _print_success("Parse done.")
+        while retry_count < 5:
+            try:
+                async with aconnect_sse(
+                    client=self._client,
+                    method="GET",
+                    url=f"parse/{parse_id}",
+                    headers=self._headers(),
+                ) as sse:
+                    async for sse_event in sse.aiter_sse():
+                        if self._handle_sse_event(sse_event):
+                            return await self.get_parsed_result_async(parse_id)
 
-                    case "parse_failed":
-                        try:
-                            parse_result = ParseResult.model_validate_json(
-                                sse_event.data
-                            )
-                            _print_error("Parse job failed.")
-                            _print_warn(f"  Parse ID: {parse_result.parse_id}")
-                            _print_magenta(f"  Status: {parse_result.status}")
-                            _print_error(f"  Error: {parse_result.error}")
-                        except ValidationError:
-                            _print_error(f"Parse failed received: {sse_event.data}")
+                        # Always yield after processing each event
+                        await asyncio.sleep(0)
 
-                    case "parse_queued":
-                        _print_warn("Parse job waiting in queue.")
+                    _print_warn("SSE connection ended without completion event")
+            except (ConnectionError, TimeoutError) as e:
+                retry_count += 1
+                _print_warn(f"Connection issue (attempt {retry_count} / 5): {e}")
+                if retry_count < 5:
+                    wait_time = min(2**retry_count, 30)
+                    _print_warn(f"Retrying in {wait_time} seconds...")
+                    await asyncio.sleep(
+                        wait_time
+                    )
 
+        _print_warn("Max retries reached. Checking final status...")
         return await self.get_parsed_result_async(parse_id)
+
+    def _handle_sse_event(self, sse_event: ServerSentEvent) -> bool:
+        """
+        Handle SSE event and return True if parse is complete (success or failure).
+        """
+        match sse_event.event:
+            case "parse_update":
+                try:
+                    parse_result = ParseResult.model_validate_json(sse_event.data)
+                    _print_update("Parse job update:")
+                    _print_magenta(f"  Status: {parse_result.status.value}")
+                except ValidationError:
+                    _print_update(f"Parse update received: {sse_event.data}")
+                return False
+
+            case "parse_done":
+                _print_success("Parse done.")
+                return True
+
+            case "parse_failed":
+                try:
+                    parse_result = ParseResult.model_validate_json(sse_event.data)
+                    _print_error("Parse job failed.")
+                    _print_warn(f"  Parse ID: {parse_result.parse_id}")
+                    _print_magenta(f"  Status: {parse_result.status}")
+                    _print_error(f"  Error: {parse_result.error}")
+                except ValidationError:
+                    _print_error(f"Parse failed received: {sse_event.data}")
+
+                return True
+
+            case "parse_queued":
+                _print_warn("Parse job waiting in queue.")
+                return False
+
+            case _:
+                _print_info(f"Unknown SSE event: {sse_event.event}")
+                return False
 
     def parse_and_wait(
         self,

--- a/src/tensorlake/documentai/_parse.py
+++ b/src/tensorlake/documentai/_parse.py
@@ -203,9 +203,7 @@ class _ParseMixin(_BaseClient):
                 if retry_count < 5:
                     wait_time = min(2**retry_count, 30)
                     _print_warn(f"Retrying in {wait_time} seconds...")
-                    await asyncio.sleep(
-                        wait_time
-                    )
+                    await asyncio.sleep(wait_time)
 
         _print_warn("Max retries reached. Checking final status...")
         return await self.get_parsed_result_async(parse_id)

--- a/src/tensorlake/documentai/common.py
+++ b/src/tensorlake/documentai/common.py
@@ -9,6 +9,43 @@ from pydantic import BaseModel, Field
 
 from .models import Region
 
+RESET = "\033[0m"
+BOLD = "\033[1m"
+CYAN = "\033[36m"
+YELLOW = "\033[33m"
+BLUE = "\033[34m"
+MAGENTA = "\033[35m"
+GREEN = "\033[32m"
+RED = "\033[31m"
+
+
+def _print_info(message: str):
+    print(f"{CYAN}{message}{RESET}")
+
+
+def _print_warn(message: str):
+    print(f"{YELLOW}{message}{RESET}")
+
+
+def _print_success(message: str):
+    print(f"{GREEN}{message}{RESET}")
+
+
+def _print_error(message: str):
+    print(f"{RED}{message}{RESET}")
+
+
+def _print_update(message: str):
+    print(f"{BLUE}{message}{RESET}")
+
+
+def _print_magenta(message: str):
+    print(f"{MAGENTA}{message}{RESET}")
+
+
+def _print_bold(message: str):
+    print(f"{BOLD}{message}{RESET}")
+
 
 def get_server_url(region: Region) -> str:
     """

--- a/src/tensorlake/documentai/models/_enums.py
+++ b/src/tensorlake/documentai/models/_enums.py
@@ -81,6 +81,12 @@ class ParseStatus(str, Enum):
     PENDING = "pending"
     PROCESSING = "processing"
     SUCCESSFUL = "successful"
+    DETECTING_LAYOUT = "detecting_layout"
+    LAYOUT_DETECTED = "layout_detected"
+    EXTRACTING_DATA = "extracting_data"
+    EXTRACTED_DATA = "extracted_data"
+    FORMATTING_OUTPUT = "formatting_output"
+    FORMATTED_OUTPUT = "formatted_output"
 
 
 class PartitionStrategy(str, Enum):

--- a/src/tensorlake/documentai/models/_enums.py
+++ b/src/tensorlake/documentai/models/_enums.py
@@ -82,7 +82,7 @@ class ParseStatus(str, Enum):
     PROCESSING = "processing"
     SUCCESSFUL = "successful"
     DETECTING_LAYOUT = "detecting_layout"
-    LAYOUT_DETECTED = "layout_detected"
+    LAYOUT_DETECTED = "detected_layout"
     EXTRACTING_DATA = "extracting_data"
     EXTRACTED_DATA = "extracted_data"
     FORMATTING_OUTPUT = "formatting_output"

--- a/src/tensorlake/documentai/models/_results.py
+++ b/src/tensorlake/documentai/models/_results.py
@@ -121,6 +121,7 @@ class ParseResult(BaseModel):
         default=None,
         description="Chunks of layout text extracted from the document. This is a vector of `Chunk` objects, each containing a piece of text extracted from the document. The chunks are typically used for further processing, such as indexing or searching. The value will vary depending on the chunking strategy used during parsing.",
     )
+
     pages: Optional[List[Page]] = Field(
         default=None,
         description="The layout of the document. This is a JSON object that contains the layout information of the document. It can be used to understand the structure of the document, such as the position of text, tables, figures, etc.",
@@ -145,13 +146,15 @@ class ParseResult(BaseModel):
     )
 
     # Optional fields
-    errors: Optional[dict] = Field(
-        None, description="Error occurred during any part of the parse execution."
+    error: Optional[str] = Field(
+        default=None,
+        description="Error occurred during any part of the parse execution.",
     )
     finished_at: Optional[str] = Field(
-        None,
+        default=None,
         description="The date and time when the parse job was finished in RFC 3339 format.",
     )
     labels: Optional[dict] = Field(
-        None, description="Labels associated with the parse job."
+        default=None,
+        description="Labels associated with the parse job.",
     )

--- a/tests/document_ai/test_parse.py
+++ b/tests/document_ai/test_parse.py
@@ -67,7 +67,6 @@ class TestParse(unittest.TestCase):
         print(f"Parse ID: {parse_id}")
 
         parse_result = doc_ai_eu.wait_for_completion(parse_id=parse_id)
-        print(parse_result)
         self.assertEqual(parse_result.status, ParseStatus.SUCCESSFUL)
         self.assertIsNotNone(parse_result)
         self.assertIsNotNone(parse_result.pages)

--- a/tests/document_ai/test_parse.py
+++ b/tests/document_ai/test_parse.py
@@ -67,6 +67,7 @@ class TestParse(unittest.TestCase):
         print(f"Parse ID: {parse_id}")
 
         parse_result = doc_ai_eu.wait_for_completion(parse_id=parse_id)
+        print(parse_result)
         self.assertEqual(parse_result.status, ParseStatus.SUCCESSFUL)
         self.assertIsNotNone(parse_result)
         self.assertIsNotNone(parse_result.pages)


### PR DESCRIPTION
### Description

This PR changes the way the SDK polls for errors. Basically removes polling and now it uses the SSE that Inkwell supports.

#### Examples

```
Waiting for completion of parse job.
Parse ID: parse_qRPbLRQLQHBg667jffQPB
Parse job waiting in queue.
Parse job update:
  Status: processing
Parse job update:
  Status: detecting_layout
Parse job update:
  Status: processing
Parse job update:
  Status: processing
Parse job update:
  Status: layout_detected
Parse job update:
  Status: extracting_data
Parse job update:
  Status: processing
Parse job update:
  Status: processing
Parse job update:
  Status: extracted_data
Parse job update:
  Status: formatting_output
Parse job update:
  Status: processing
Parse job update:
  Status: processing
Parse job update:
  Status: formatted_output
Parse job update:
  Status: processing
Parse done.
```

### Tests

https://github.com/tensorlakeai/tensorlake/actions/runs/16947630077/job/48032476676