### PR TITLE
Add subcommand to fetch application logs from the telemetry service.

### DIFF
--- a/src/tensorlake/applications/remote/api_client.py
+++ b/src/tensorlake/applications/remote/api_client.py
@@ -146,7 +146,6 @@ class LogEntry(BaseModel):
 class LogsPayload(BaseModel):
     logs: list[LogEntry]
     next_token: str | None = Field(default=None, alias="nextToken")
-    last_event_time: int | None = Field(default=None, alias="lastEventTime")
 
 
 def log_retries(e: BaseException, sleep_time: float, retries: int):
@@ -319,7 +318,11 @@ class APIClient:
                 f"v1/namespaces/{self._namespace}/applications/{application}/logs{query_params_str}"
             )
             response.raise_for_status()
-            return LogsPayload(**response.json())
+            payload = LogsPayload(**response.json())
+            # Logs default ordering is descending, having the most recent logs first.
+            # Reverse the logs to have the oldest logs first to print on the console.
+            payload.logs.reverse()
+            return payload
         except RemoteAPIError as e:
             print(f"failed to fetch logs: {e}")
             return None

--- a/src/tensorlake/applications/remote/api_client.py
+++ b/src/tensorlake/applications/remote/api_client.py
@@ -316,7 +316,7 @@ class APIClient:
 
         try:
             response = self._get(
-                f"v1/namespaces/{self.namespace}/applications/{application}/logs{query_params_str}"
+                f"v1/namespaces/{self._namespace}/applications/{application}/logs{query_params_str}"
             )
             response.raise_for_status()
             return LogsPayload(**response.json())

--- a/src/tensorlake/cli/applications.py
+++ b/src/tensorlake/cli/applications.py
@@ -111,7 +111,7 @@ def info(ctx: Context, json: bool, application_name: str):
     print(table)
 
 
-@graph.command(
+@application.command(
     epilog="""
 \b
 Use 'tensorlake config set default.application <name>' to set a default application name.
@@ -136,6 +136,13 @@ Use 'tensorlake config set default.application <name>' to set a default applicat
     default=None,
     help="Container ID to filter logs by",
 )
+@click.option(
+    "--format",
+    "-F",
+    default="compact",
+    help="Format of the logs",
+    type=click.Choice(["compact", "expanded", "long", "json"]),
+)
 @click.argument("application-name", required=False)
 @pass_auth
 def logs(
@@ -145,6 +152,7 @@ def logs(
     function: str | None,
     request: str | None,
     container: str | None,
+    format: str,
 ):
     """
     View logs for a remote application
@@ -161,6 +169,5 @@ def logs(
     logs = ctx.api_client.application_logs(
         application_name, function, request, container
     )
-    format = LogFormat.TEXT if not json else LogFormat.JSON
 
-    print_application_logs(logs, format)
+    print_application_logs(logs, LogFormat(format))

--- a/src/tensorlake/cli/requests.py
+++ b/src/tensorlake/cli/requests.py
@@ -7,7 +7,12 @@ from rich import print, print_json
 from rich.table import Table
 
 from tensorlake.applications.remote.api_client import FunctionRun, RequestMetadata
-from tensorlake.cli._common import Context, pass_auth
+from tensorlake.cli._common import (
+    Context,
+    LogFormat,
+    pass_auth,
+    print_application_logs,
+)
 
 
 @click.group()
@@ -108,35 +113,7 @@ def info(
     """
     Info about a request
     """
-    # Parse arguments: if one arg provided, treat it as request_id
-    # If two args provided, treat them as application_name and request_id
-    if len(args) == 1:
-        application_name = None
-        request_id = args[0]
-    elif len(args) == 2:
-        application_name = args[0]
-        request_id = args[1]
-    else:
-        application_name = None
-        request_id = None
-
-    if not application_name:
-        if ctx.default_application:
-            application_name = ctx.default_application
-            click.echo(f"Using default application from config: {application_name}")
-        else:
-            raise click.UsageError(
-                "No application name provided and no default.application configured"
-            )
-
-    if not request_id:
-        if ctx.default_request:
-            request_id = ctx.default_request
-            click.echo(f"Using default request from config: {request_id}")
-        else:
-            raise click.UsageError(
-                "No request ID provided and no default.request configured"
-            )
+    [application_name, request_id] = parse_args(args)
 
     request: RequestMetadata = ctx.api_client.request(application_name, request_id)
 
@@ -183,3 +160,64 @@ def info(
                 )
 
             print(allocations_table)
+
+
+@request.command(
+    epilog="""
+Arguments:
+  tensorlake request logs <request-id>              # Uses default graph
+  tensorlake request logs <graph-name> <request-id> # Explicit graph name
+\b
+Use 'tensorlake config set default.graph <name>' to set a default graph name.
+Use 'tensorlake config set default.request <id>' to set a default request ID.
+"""
+)
+@click.option("--json", "-j", is_flag=True, help="Format output as JSON")
+@click.argument("args", nargs=-1, required=False)
+@pass_auth
+def logs(ctx: Context, json: bool, args: tuple):
+    """
+    View logs for a remote request
+    """
+    [application_name, request_id] = parse_args(ctx, args)
+
+    logs = ctx.tensorlake_client.application_logs(
+        application_name, None, request_id, None
+    )
+
+    format = LogFormat.TEXT if not json else LogFormat.JSON
+    print_application_logs(logs, format)
+
+
+def parse_args(ctx: Context, args: tuple) -> tuple[str, str]:
+    """
+    Parse arguments: if one arg provided, treat it as request_id
+    If two args provided, treat them as application_name and request_id
+    """
+    if len(args) == 1:
+        application_name = None
+        request_id = args[0]
+    elif len(args) == 2:
+        application_name = args[0]
+        request_id = args[1]
+    else:
+        application_name = None
+        request_id = None
+
+    if not application_name:
+        if ctx.default_application:
+            application_name = ctx.default_application
+            click.echo(f"Using default application from config: {application_name}")
+        else:
+            raise click.UsageError(
+                "No application name provided and no default.application configured"
+            )
+
+    if not request_id:
+        if ctx.default_request:
+            request_id = ctx.default_request
+            click.echo(f"Using default request from config: {request_id}")
+        else:
+            raise click.UsageError(
+                "No request ID provided and no default.request configured"
+            )

--- a/src/tensorlake/cli/requests.py
+++ b/src/tensorlake/cli/requests.py
@@ -113,7 +113,7 @@ def info(
     """
     Info about a request
     """
-    [application_name, request_id] = parse_args(args)
+    (application_name, request_id) = parse_args(ctx, args)
 
     request: RequestMetadata = ctx.api_client.request(application_name, request_id)
 
@@ -172,21 +172,24 @@ Use 'tensorlake config set default.graph <name>' to set a default graph name.
 Use 'tensorlake config set default.request <id>' to set a default request ID.
 """
 )
-@click.option("--json", "-j", is_flag=True, help="Format output as JSON")
+@click.option(
+    "--format",
+    "-F",
+    default="compact",
+    help="Format of the logs",
+    type=click.Choice(["compact", "expanded", "long", "json"]),
+)
 @click.argument("args", nargs=-1, required=False)
 @pass_auth
-def logs(ctx: Context, json: bool, args: tuple):
+def logs(ctx: Context, format: str, args: tuple):
     """
     View logs for a remote request
     """
-    [application_name, request_id] = parse_args(ctx, args)
+    (application_name, request) = parse_args(ctx, args)
 
-    logs = ctx.tensorlake_client.application_logs(
-        application_name, None, request_id, None
-    )
+    logs = ctx.api_client.application_logs(application_name, None, request, None)
 
-    format = LogFormat.TEXT if not json else LogFormat.JSON
-    print_application_logs(logs, format)
+    print_application_logs(logs, LogFormat(format))
 
 
 def parse_args(ctx: Context, args: tuple) -> tuple[str, str]:
@@ -221,3 +224,5 @@ def parse_args(ctx: Context, args: tuple) -> tuple[str, str]:
             raise click.UsageError(
                 "No request ID provided and no default.request configured"
             )
+
+    return (application_name, request_id)


### PR DESCRIPTION
This change adds two new subcommands under application and request to be able to fetch application logs for them.

The application subcommand accepts additional filters besides the request, like the function and container where the function runs.

Formats:

I ended up going a little bit overboard with formatting, but I think it gives people flexibility. These are the, not 2, not 3, but 4!!!!! format options:

**Compact formatting**

This is the default format. It uses two lines to make it nicely to read in laptop screens as well as big screens.

<img width="812" height="437" alt="image" src="https://github.com/user-attachments/assets/0423ab46-d0a7-49ad-b546-2c16ec2feb19" />

**Expanded formatting**

This is like the compact format, but it shows the `logAttributes` that a user, or us, might have added to the log.

<img width="1349" height="979" alt="image" src="https://github.com/user-attachments/assets/39d20112-923d-4598-b8d5-f9e1936be17f" />

**Long formatting**

This prints everything in one line of long text.

<img width="1709" height="936" alt="image" src="https://github.com/user-attachments/assets/f1bb550c-906b-4674-a7ff-b519811c48dd" />

**JSON formatting**

This prints each log entry as a pretty json object.

<img width="1701" height="886" alt="image" src="https://github.com/user-attachments/assets/f5598ef9-99a4-4501-907e-8a82deb1b097" />
