### PR TITLE
Derive image builder service url from indexify url

### DIFF
--- a/src/tensorlake/builder/client_v2.py
+++ b/src/tensorlake/builder/client_v2.py
@@ -126,9 +126,8 @@ class ImageBuilderV2Client:
             ImageBuilderV2Client: An instance of the ImageBuilderV2Client.
         """
         api_key = os.getenv("TENSORLAKE_API_KEY")
-        build_url = os.getenv(
-            "TENSORLAKE_BUILD_SERVICE", "https://api.tensorlake.ai/images/v2"
-        )
+        server_url = os.getenv("INDEXIFY_URL", "https://api.tensorlake.ai")
+        build_url = os.getenv("TENSORLAKE_BUILD_SERVICE", f"{server_url}/images/v2")
         return cls(build_url, api_key)
 
     async def build_collection(


### PR DESCRIPTION
I deleted this logic recently but without it when ppl want to use dev cluster they have now to set two env vars:
- INDEXIFY_URL
- TENSORLAKE_BUILD_SERVICE

Previously we only needed to set INDEXIFY_URL in this case.
This is inconvenient. This also breaks our existing testing infra in dev. So we need to bring this logic back until we have a cleaner approach.