### PR TITLE
Bugfix logging of httpx S3 exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.57"
+version = "0.2.58"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]


### PR DESCRIPTION
We have errors:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/tensorlake/function_executor/blob_store/s3_blob_store.py", line 86, in get
    return get_with_retries()
  File "/usr/local/lib/python3.13/site-packages/tensorlake/utils/retries.py", line 67, in wrapper
    on_retry(e, sleep_time, retries)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/tensorlake/function_executor/blob_store/s3_blob_store.py", line 54, in on_retry
    status_code=e.response.status_code,
                ^^^^^^^^^^
AttributeError: 'RemoteProtocolError' object has no attribute 'response'
```

This should fix it.