### PR TITLE
style: remove black terminal text

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.60"
+version = "0.2.61"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]

--- a/src/tensorlake/builder/client_v2.py
+++ b/src/tensorlake/builder/client_v2.py
@@ -252,8 +252,6 @@ class ImageBuilderV2Client:
                         event.message,
                         nl=False,
                         err=False,
-                        fg="black",
-                        dim=True,
                     )
                 case "stderr":
                     click.secho(event.message, fg="red", err=True)


### PR DESCRIPTION
## Description

- Black terminal background are common, creates empty looking outputs during the deployment process