### PR TITLE
Add new tensorlake-python-analyzer script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![Documentation](https://img.shields.io/badge/docs-tensorlake.ai-blue)](https://docs.tensorlake.ai)
 [![Slack](https://img.shields.io/badge/slack-TensorlakeCloud-purple?logo=slack)](https://join.slack.com/t/tensorlakecloud/shared_invite/zt-32fq4nmib-gO0OM5RIar3zLOBm~ZGqKg)
 
-TensorLake transforms unstructured documents into AI-ready data through Document Ingestion APIs and enables building scalable data processing pipelines with a serverless workflow runtime. 
+TensorLake transforms unstructured documents into AI-ready data through Document Ingestion APIs and enables building scalable data processing pipelines with a serverless workflow runtime.
 
 ![gh_animation](https://github.com/user-attachments/assets/bc57d5f5-c745-4a36-926a-d85767b9115e)
 </div>
@@ -293,9 +293,28 @@ run_workflow(cloud_workflow)
 python examples/readme_example.py
 ```
 
-## Learn more about workflows 
+## Extra Tools
 
-* [Serverless Workflows Documentation](https://docs.tensorlake.ai/workflows/quickstart)
-* [Key programming concepts in Tensorlake Workflows](https://docs.tensorlake.ai/workflows/compute)
-* [Dependencies and container images in Tensorlake Workflows](https://docs.tensorlake.ai/workflows/images)
+### Python Analyzer
+
+Analyze Python files containing Tensorlake applications without deploying them. This tool extracts metadata about images, functions, and applications in JSON format.
+
+**Note**: The analyzer extracts ALL functions with `@function()` decorator, including standalone functions that don't have `@application()`.
+
+```bash
+# Output to stdout
+tensorlake-python-analyzer myapp.py
+
+# Pretty-print JSON
+tensorlake-python-analyzer --pretty myapp.py
+
+# Save to file
+tensorlake-python-analyzer myapp.py -o analysis.json --pretty
+```
+
+## Learn more about Tensorlake Applications
+
+* [Serverless Applications Documentation](https://docs.tensorlake.ai/applications/quickstart)
+* [Key programming concepts in Tensorlake Workflows](https://docs.tensorlake.ai/applications/compute)
+* [Dependencies and container images in Tensorlake Workflows](https://docs.tensorlake.ai/applications/images)
 * [Open Source Workflow Compute Engine](https://docs.tensorlake.ai/opensource/indexify)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ grpcio-tools = "1.75.1"
 
 [tool.poetry.scripts]
 tensorlake = "tensorlake.cli:cli"
+tensorlake-python-analyzer = "tensorlake.analyzer.main:main"
 function-executor = "tensorlake.function_executor.main:main"
 
 [build-system]

--- a/src/tensorlake/analyzer/README.md
+++ b/src/tensorlake/analyzer/README.md
@@ -1,0 +1,141 @@
+# Tensorlake Python Analyzer
+
+An isolated, self-contained tool for extracting metadata from Python files containing Tensorlake applications.
+
+## Overview
+
+The analyzer is a standalone component that parses Tensorlake application files and extracts structured information about:
+- **Images**: Docker image configurations and build operations
+- **Functions**: ALL functions with `@function()` decorator (including standalone functions without `@application()`)
+- **Applications**: Application-level configurations and associated functions (only for functions with both `@function()` and `@application()`)
+
+## Design Principles
+
+1. **Isolated**: No dependencies on CLI framework or external libraries (except standard library)
+2. **Self-contained**: All code is in this directory
+3. **Simple**: Uses dataclasses and standard library JSON encoding
+4. **Fast**: Minimal overhead, direct conversion to dictionaries
+
+## Architecture
+
+```
+analyzer/
+├── __init__.py        # Package initialization
+├── main.py            # CLI entry point (uses argparse)
+├── core.py            # Core analysis logic
+├── converter.py       # Convert Tensorlake objects to models
+├── models.py          # Data models (using dataclasses)
+└── README.md          # This file
+```
+
+## Usage
+
+### As a CLI Tool
+
+```bash
+# Output to stdout
+tensorlake-python-analyzer myapp.py
+
+# Pretty-print JSON
+tensorlake-python-analyzer --pretty myapp.py
+
+# Save to file
+tensorlake-python-analyzer myapp.py -o output.json --pretty
+```
+
+### Programmatic Usage
+
+```python
+from tensorlake.analyzer.core import analyze_code
+
+# Analyze an application file
+result = analyze_code("myapp.py")
+
+# Get as dictionary
+data = result.to_dict()
+
+# Or convert to JSON
+import json
+json_str = json.dumps(data, indent=2)
+
+# Access specific data
+for image_name, image_data in data['images'].items():
+    print(f"Image: {image_name}")
+
+for func_name, func_data in data['functions'].items():
+    config = func_data['function_config']
+    print(f"Function: {func_name} - CPU: {config['cpu']}")
+```
+
+## Output Schema
+
+The analyzer outputs a JSON object with three main sections:
+
+```json
+{
+  "images": {
+    "<image-name>": {
+      "name": "string",
+      "tag": "string",
+      "base_image": "string",
+      "build_operations": [...]
+    }
+  },
+  "functions": {
+    "<function-name>": {
+      "function_name": "string",
+      "function_config": {...},
+      "application_config": {...}
+    }
+  },
+  "applications": {
+    "<app-name>": {
+      "application_name": "string",
+      "version": "string",
+      "functions": [...],
+      "config": {...}
+    }
+  }
+}
+```
+
+## Dependencies
+
+**Standard Library Only:**
+- `argparse` - Command line argument parsing
+- `json` - JSON encoding/decoding
+- `dataclasses` - Data models
+- `os` - File path operations
+- `sys` - System operations
+- `traceback` - Error reporting
+
+**Tensorlake Internal:**
+- `tensorlake.applications.registry` - Access registered functions
+- `tensorlake.applications.image` - Image utilities
+- `tensorlake.applications.remote.code.loader` - Code loading
+
+## Differences from CLI Version
+
+The original CLI version used:
+- `click` for command-line parsing → Now uses `argparse` (stdlib)
+- `pydantic` for models → Now uses `dataclasses` (stdlib)
+
+This makes the analyzer truly standalone with no external dependencies.
+
+## Testing
+
+Tests are located in `tests/analyzer/test_analyzer.py` and cover:
+- Model creation and validation
+- JSON serialization
+- Backward compatibility
+- Integration with Tensorlake components
+
+## Future Enhancements
+
+Potential improvements:
+1. Output format options (YAML, TOML)
+2. Filter/query capabilities
+3. Validation rules
+4. Diff between versions
+5. Resource statistics
+

--- a/src/tensorlake/analyzer/__init__.py
+++ b/src/tensorlake/analyzer/__init__.py
@@ -1,0 +1,3 @@
+"""Tensorlake Python Analyzer - Extract metadata from Tensorlake applications."""
+
+__version__ = "0.1.0"

--- a/src/tensorlake/analyzer/converter.py
+++ b/src/tensorlake/analyzer/converter.py
@@ -1,0 +1,200 @@
+"""Convert internal Tensorlake objects to analyzer models."""
+
+import inspect
+import os
+from typing import Dict, List, Optional
+
+from tensorlake.applications.image import ImageInformation, image_infos
+from tensorlake.applications.interface.function import (
+    _ApplicationConfiguration,
+    _FunctionConfiguration,
+)
+from tensorlake.applications.registry import get_functions
+
+from .models import (
+    ApplicationConfigModel,
+    ApplicationModel,
+    CodeZIPManifest,
+    FunctionConfigModel,
+    FunctionModel,
+    FunctionZIPManifest,
+    ImageBuildOperationModel,
+    ImageModel,
+    RetriesModel,
+)
+
+
+def convert_image_to_model(image) -> ImageModel:
+    """Convert Image object to model."""
+    build_ops = []
+    for op in image._build_operations:
+        build_ops.append(
+            ImageBuildOperationModel(
+                type=op.type.name,
+                args=op.args,
+                options=op.options if hasattr(op, "options") else {},
+            )
+        )
+
+    return ImageModel(
+        name=image.name,
+        tag=image.tag,
+        base_image=image._base_image,
+        build_operations=build_ops,
+    )
+
+
+def convert_retries_to_model(retries) -> Optional[RetriesModel]:
+    """Convert Retries object to model."""
+    if retries is None:
+        return None
+
+    return RetriesModel(
+        max_retries=retries.max_retries,
+        initial_delay=retries.initial_delay,
+        max_delay=retries.max_delay,
+        delay_multiplier=retries.delay_multiplier,
+    )
+
+
+def convert_function_config_to_model(
+    fn_config: _FunctionConfiguration,
+) -> FunctionConfigModel:
+    """Convert _FunctionConfiguration to model."""
+    return FunctionConfigModel(
+        class_name=fn_config.class_name,
+        class_method_name=fn_config.class_method_name,
+        class_init_timeout=fn_config.class_init_timeout,
+        function_name=fn_config.function_name,
+        description=fn_config.description,
+        image_name=fn_config.image.name,
+        secrets=fn_config.secrets if fn_config.secrets else [],
+        retries=convert_retries_to_model(fn_config.retries),
+        timeout=fn_config.timeout,
+        cpu=fn_config.cpu,
+        memory=fn_config.memory,
+        ephemeral_disk=fn_config.ephemeral_disk,
+        gpu=fn_config.gpu,
+        region=fn_config.region,
+        cacheable=fn_config.cacheable,
+        max_concurrency=fn_config.max_concurrency,
+    )
+
+
+def convert_application_config_to_model(
+    app_config: _ApplicationConfiguration,
+) -> ApplicationConfigModel:
+    """Convert _ApplicationConfiguration to model."""
+    return ApplicationConfigModel(
+        tags=app_config.tags if app_config.tags else {},
+        retries=convert_retries_to_model(app_config.retries),
+        region=app_config.region,
+        input_serializer=app_config.input_serializer,
+        output_serializer=app_config.output_serializer,
+        version=app_config.version,
+    )
+
+
+def extract_images() -> Dict[str, ImageModel]:
+    """Extract all images from registered functions."""
+    images_dict: Dict[str, ImageModel] = {}
+    image_info_dict: Dict = image_infos()
+
+    for image_info in image_info_dict.values():
+        image_info: ImageInformation
+        image_model = convert_image_to_model(image_info.image)
+        images_dict[image_model.name] = image_model
+
+    return images_dict
+
+
+def create_function_zip_manifest(
+    function, code_dir_path: str
+) -> Optional[FunctionZIPManifest]:
+    """Create ZIP manifest entry for a function."""
+    try:
+        function_name: str = function.function_config.function_name
+        import_file_path: str = inspect.getsourcefile(function.original_function)
+
+        if import_file_path is None:
+            return None
+
+        import_file_path = os.path.abspath(import_file_path)
+
+        if not import_file_path.startswith(code_dir_path):
+            return None
+
+        import_file_path_in_code_dir: str = os.path.relpath(
+            import_file_path, start=code_dir_path
+        )
+
+        # Converts relative path "foo/bar/buzz.py" to "foo.bar.buzz"
+        module_import_name: str = os.path.splitext(import_file_path_in_code_dir)[
+            0
+        ].replace(os.sep, ".")
+
+        return FunctionZIPManifest(
+            name=function_name,
+            module_import_name=module_import_name,
+        )
+    except Exception:
+        return None
+
+
+def extract_functions_and_applications(
+    code_dir_path: str,
+) -> tuple[Dict[str, FunctionModel], Dict[str, ApplicationModel], CodeZIPManifest]:
+    """Extract ALL functions, applications, and code manifest from registered functions.
+
+    This includes:
+    - Functions with @function() only (no application config)
+    - Functions with both @function() and @application() (have application config)
+    """
+    functions_dict: Dict[str, FunctionModel] = {}
+    applications_dict: Dict[str, ApplicationModel] = {}
+    code_manifest = CodeZIPManifest()
+
+    functions: List = get_functions()
+
+    # Process ALL functions, not just those with applications
+    for function in functions:
+        # Skip if the function doesn't have a function_config
+        if not hasattr(function, "function_config") or function.function_config is None:
+            continue
+
+        fn_config: _FunctionConfiguration = function.function_config
+        app_config: Optional[_ApplicationConfiguration] = function.application_config
+
+        # Add function (all functions, whether they have app config or not)
+        function_model = FunctionModel(
+            function_name=fn_config.function_name,
+            function_config=convert_function_config_to_model(fn_config),
+            application_config=(
+                convert_application_config_to_model(app_config) if app_config else None
+            ),
+        )
+        functions_dict[fn_config.function_name] = function_model
+
+        # Create ZIP manifest entry for this function
+        zip_manifest = create_function_zip_manifest(function, code_dir_path)
+        if zip_manifest:
+            code_manifest.functions[fn_config.function_name] = zip_manifest
+
+        # Only create application entries for functions that have application config
+        if app_config is not None:
+            app_name = fn_config.function_name
+
+            if app_name not in applications_dict:
+                applications_dict[app_name] = ApplicationModel(
+                    application_name=app_name,
+                    version=app_config.version,
+                    functions=[fn_config.function_name],
+                    config=convert_application_config_to_model(app_config),
+                )
+            else:
+                if fn_config.function_name not in applications_dict[app_name].functions:
+                    applications_dict[app_name].functions.append(
+                        fn_config.function_name
+                    )
+
+    return functions_dict, applications_dict, code_manifest

--- a/src/tensorlake/analyzer/core.py
+++ b/src/tensorlake/analyzer/core.py
@@ -1,0 +1,41 @@
+"""Core analysis functionality."""
+
+import os
+
+from tensorlake.applications.remote.code.loader import load_code
+
+from .converter import extract_functions_and_applications, extract_images
+from .models import AnalysisOutput
+
+
+def analyze_code(application_file_path: str) -> AnalysisOutput:
+    """Analyze Python code and extract image, function, and application information.
+
+    Args:
+        application_file_path: Path to the Python file containing Tensorlake applications
+
+    Returns:
+        AnalysisOutput containing images, functions, applications, and code manifest
+
+    Raises:
+        Exception: If the file cannot be loaded or analyzed
+    """
+    # Load the code
+    application_file_path = os.path.abspath(application_file_path)
+    code_dir_path = os.path.dirname(application_file_path)
+    load_code(application_file_path)
+
+    # Extract images
+    images_dict = extract_images()
+
+    # Extract functions, applications, and code manifest
+    functions_dict, applications_dict, code_manifest = (
+        extract_functions_and_applications(code_dir_path)
+    )
+
+    return AnalysisOutput(
+        images=images_dict,
+        functions=functions_dict,
+        applications=applications_dict,
+        code_manifest=code_manifest,
+    )

--- a/src/tensorlake/analyzer/main.py
+++ b/src/tensorlake/analyzer/main.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Main entry point for tensorlake-python-analyzer."""
+
+import argparse
+import json
+import sys
+import traceback
+
+from .core import analyze_code
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create command line argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="tensorlake-python-analyzer",
+        description="Analyzes Python applications and outputs metadata in JSON format",
+        epilog="""
+Example:
+    tensorlake-python-analyzer myapp.py
+    tensorlake-python-analyzer --pretty myapp.py
+    tensorlake-python-analyzer myapp.py -o output.json --pretty
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "application_file_path",
+        metavar="APPLICATION-FILE-PATH",
+        type=str,
+        help="Path to the Python file containing Tensorlake applications",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default=None,
+        help="Output file path. If not provided, outputs to stdout.",
+    )
+
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print the JSON output with indentation.",
+    )
+
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 0.1.0",
+    )
+
+    return parser
+
+
+def main():
+    """Main function for the analyzer CLI."""
+    parser = create_parser()
+    args = parser.parse_args()
+
+    # Print status message to stderr so it doesn't interfere with JSON output
+    print(
+        f"Analyzing applications from {args.application_file_path}",
+        file=sys.stderr,
+    )
+
+    try:
+        # Analyze the code
+        analysis_result = analyze_code(args.application_file_path)
+
+        # Convert to dictionary
+        result_dict = analysis_result.to_dict()
+
+        # Convert to JSON
+        if args.pretty:
+            json_output = json.dumps(result_dict, indent=2)
+        else:
+            json_output = json.dumps(result_dict)
+
+        # Output to file or stdout
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(json_output)
+            print(
+                f"\033[92mAnalysis complete. Output written to {args.output}\033[0m",
+                file=sys.stderr,
+            )
+        else:
+            # Output to stdout (not stderr)
+            print(json_output)
+            print("\033[92mAnalysis complete.\033[0m", file=sys.stderr)
+
+    except Exception as e:
+        print(
+            f"\033[91mFailed to analyze the application file: {e}\033[0m",
+            file=sys.stderr,
+        )
+        traceback.print_exception(type(e), e, e.__traceback__, file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tensorlake/analyzer/models.py
+++ b/src/tensorlake/analyzer/models.py
@@ -1,0 +1,171 @@
+"""Data models for analyzer output using standard library only."""
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ImageBuildOperationModel:
+    """Represents a single build operation in an image."""
+
+    type: str
+    args: List[str]
+    options: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ImageModel:
+    """Represents a Docker image configuration."""
+
+    name: str
+    tag: str
+    base_image: str
+    build_operations: List[ImageBuildOperationModel] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "tag": self.tag,
+            "base_image": self.base_image,
+            "build_operations": [op.to_dict() for op in self.build_operations],
+        }
+
+
+@dataclass
+class RetriesModel:
+    """Represents retry configuration."""
+
+    max_retries: int = 0
+    initial_delay: float = 1.0
+    max_delay: float = 60.0
+    delay_multiplier: float = 2.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class FunctionConfigModel:
+    """Represents function configuration."""
+
+    function_name: str
+    description: str
+    image_name: str
+    timeout: int
+    cpu: float
+    memory: float
+    ephemeral_disk: float
+    cacheable: bool
+    max_concurrency: int
+    class_name: Optional[str] = None
+    class_method_name: Optional[str] = None
+    class_init_timeout: Optional[int] = None
+    secrets: List[str] = field(default_factory=list)
+    retries: Optional[RetriesModel] = None
+    gpu: Optional[Any] = None
+    region: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result = asdict(self)
+        if self.retries:
+            result["retries"] = self.retries.to_dict()
+        return result
+
+
+@dataclass
+class ApplicationConfigModel:
+    """Represents application configuration."""
+
+    retries: RetriesModel
+    input_serializer: str
+    output_serializer: str
+    version: str
+    tags: Dict[str, str] = field(default_factory=dict)
+    region: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result = asdict(self)
+        result["retries"] = self.retries.to_dict()
+        return result
+
+
+@dataclass
+class FunctionModel:
+    """Represents a complete function with its configuration."""
+
+    function_name: str
+    function_config: FunctionConfigModel
+    application_config: Optional[ApplicationConfigModel] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "function_name": self.function_name,
+            "function_config": self.function_config.to_dict(),
+            "application_config": (
+                self.application_config.to_dict() if self.application_config else None
+            ),
+        }
+
+
+@dataclass
+class ApplicationModel:
+    """Represents an application with its associated functions."""
+
+    application_name: str
+    version: str
+    config: ApplicationConfigModel
+    functions: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "application_name": self.application_name,
+            "version": self.version,
+            "functions": self.functions,
+            "config": self.config.to_dict(),
+        }
+
+
+@dataclass
+class FunctionZIPManifest:
+    """Function metadata for ZIP manifest."""
+
+    name: str
+    module_import_name: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class CodeZIPManifest:
+    """Code ZIP manifest containing all function metadata."""
+
+    functions: Dict[str, FunctionZIPManifest] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "functions": {name: fn.to_dict() for name, fn in self.functions.items()}
+        }
+
+
+@dataclass
+class AnalysisOutput:
+    """Complete analysis output schema."""
+
+    images: Dict[str, ImageModel] = field(default_factory=dict)
+    functions: Dict[str, FunctionModel] = field(default_factory=dict)
+    applications: Dict[str, ApplicationModel] = field(default_factory=dict)
+    code_manifest: CodeZIPManifest = field(default_factory=CodeZIPManifest)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "images": {name: img.to_dict() for name, img in self.images.items()},
+            "functions": {name: fn.to_dict() for name, fn in self.functions.items()},
+            "applications": {
+                name: app.to_dict() for name, app in self.applications.items()
+            },
+            "code_manifest": self.code_manifest.to_dict(),
+        }

--- a/src/tensorlake/applications/image.py
+++ b/src/tensorlake/applications/image.py
@@ -6,10 +6,11 @@ import logging
 import os
 import pathlib
 import tarfile
-from dataclasses import dataclass
 from io import BytesIO
 from typing import Any, Dict, List
 from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field
 
 from .interface.function import Function
 from .interface.image import Image, _ImageBuildOperation, _ImageBuildOperationType
@@ -19,11 +20,15 @@ _HASH_BUFF_SIZE: int = 1024**2
 _SDK_VERSION: str = importlib.metadata.version("tensorlake")
 
 
-@dataclass
-class ImageInformation:
+class ImageInformation(BaseModel):
+    """Information about an image and its associated functions."""
+
     image: Image
     # Functions that are using the image.
-    functions: List[Function]
+    functions: List[Function] = Field(default_factory=list)
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 def image_infos() -> Dict[Image, ImageInformation]:

--- a/src/tensorlake/applications/interface/function.py
+++ b/src/tensorlake/applications/interface/function.py
@@ -1,41 +1,50 @@
-from dataclasses import dataclass
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
+
+from pydantic import BaseModel, Field
 
 from .function_call import RegularFunctionCall
 from .image import Image
 from .retries import Retries
 
 
-@dataclass
-class _FunctionConfiguration:
+class _FunctionConfiguration(BaseModel):
+    """Function configuration with validation."""
+
     # None for non-method functions, only available after all modules are loaded
     # because class objects are created after their methods.
-    class_name: str | None
-    class_method_name: str | None
-    class_init_timeout: int | None
+    class_name: Optional[str] = None
+    class_method_name: Optional[str] = None
+    class_init_timeout: Optional[int] = None
     function_name: str
     description: str
     image: Image
-    secrets: List[str]
-    retries: Retries | None  # Uses application retry policy if None
+    secrets: List[str] = Field(default_factory=list)
+    retries: Optional[Retries] = None  # Uses application retry policy if None
     timeout: int
     cpu: float
     memory: float
     ephemeral_disk: float
-    gpu: None | str | List[str]
-    region: str | None
+    gpu: Optional[str | List[str]] = None
+    region: Optional[str] = None
     cacheable: bool
     max_concurrency: int
 
+    class Config:
+        arbitrary_types_allowed = True
 
-@dataclass
-class _ApplicationConfiguration:
-    tags: Dict[str, str]
+
+class _ApplicationConfiguration(BaseModel):
+    """Application configuration with validation."""
+
+    tags: Dict[str, str] = Field(default_factory=dict)
     retries: Retries
-    region: str | None
+    region: Optional[str] = None
     input_serializer: str
     output_serializer: str
     version: str
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class Function:

--- a/src/tensorlake/applications/interface/image.py
+++ b/src/tensorlake/applications/interface/image.py
@@ -1,7 +1,8 @@
 import sys
-from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List
+
+from pydantic import BaseModel, Field
 
 _LOCAL_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 _DEFAULT_BASE_IMAGE_NAME = f"python:{_LOCAL_PYTHON_VERSION}-slim-bookworm"
@@ -14,14 +15,24 @@ class _ImageBuildOperationType(Enum):
     RUN = 4
 
 
-@dataclass
-class _ImageBuildOperation:
+class _ImageBuildOperation(BaseModel):
+    """Image build operation with validation."""
+
     type: _ImageBuildOperationType
     args: List[str]
-    options: Dict[str, str]
+    options: Dict[str, str] = Field(default_factory=dict)
+
+    class Config:
+        arbitrary_types_allowed = True
 
 
 class Image:
+    """Container image configuration.
+
+    Note: This class maintains compatibility with existing code by not directly
+    inheriting from BaseModel, but its internal data is structured for easy conversion.
+    """
+
     def __init__(
         self,
         name: str = "default",

--- a/src/tensorlake/applications/interface/retries.py
+++ b/src/tensorlake/applications/interface/retries.py
@@ -1,25 +1,29 @@
-class Retries:
-    def __init__(
-        self,
-        max_retries: int = 0,
-    ):
-        """Creates a Retries object.
+from pydantic import BaseModel, Field
 
-        Retries set on an application defines default retry policy for all functions in the application.
-        If a function has its own retry policy, it will override the application's retry policy.
 
-        Args:
-            max_retries (int): Maximum number of retries.
-        """
-        self.max_retries = max_retries
-        # The rest of the parameters are not implemented yet.
-        # Documentation for the not implemented parameters:
-        #
-        # initial_delay (float): Delay in seconds before the first retry.
-        # delay_multiplier (float): Multiplier applied to the delay on each retry after the first one.
-        #                             A delay_multiplier of 1.0 means that the delay will always be equal to the initial_delay.
-        #                             A delay_multiplier of 2.0 means that the delay will double after each retry.
-        # max_delay (float): Maximum delay in seconds between retries.
-        self.initial_delay = 1.0
-        self.max_delay = 60.0
-        self.delay_multiplier = 2.0
+class Retries(BaseModel):
+    """Retries configuration with validation.
+
+    Retries set on an application defines default retry policy for all functions in the application.
+    If a function has its own retry policy, it will override the application's retry policy.
+    """
+
+    max_retries: int = Field(default=0, description="Maximum number of retries")
+
+    # The rest of the parameters are not implemented yet.
+    # Documentation for the not implemented parameters:
+    #
+    # initial_delay (float): Delay in seconds before the first retry.
+    # delay_multiplier (float): Multiplier applied to the delay on each retry after the first one.
+    #                             A delay_multiplier of 1.0 means that the delay will always be equal to the initial_delay.
+    #                             A delay_multiplier of 2.0 means that the delay will double after each retry.
+    # max_delay (float): Maximum delay in seconds between retries.
+    initial_delay: float = Field(
+        default=1.0, description="Delay in seconds before the first retry"
+    )
+    max_delay: float = Field(
+        default=60.0, description="Maximum delay in seconds between retries"
+    )
+    delay_multiplier: float = Field(
+        default=2.0, description="Multiplier applied to the delay on each retry"
+    )

--- a/tests/analyzer/test_analyzer.py
+++ b/tests/analyzer/test_analyzer.py
@@ -1,0 +1,248 @@
+"""Tests for the tensorlake-python-analyzer tool."""
+
+import json
+
+
+def test_models_importable():
+    """Test that all models can be imported."""
+    from tensorlake.analyzer.models import (
+        ApplicationConfigModel,
+        ApplicationModel,
+        AnalysisOutput,
+        FunctionConfigModel,
+        FunctionModel,
+        ImageBuildOperationModel,
+        ImageModel,
+        RetriesModel,
+    )
+
+    assert ApplicationConfigModel is not None
+    assert ApplicationModel is not None
+    assert AnalysisOutput is not None
+    assert FunctionConfigModel is not None
+    assert FunctionModel is not None
+    assert ImageBuildOperationModel is not None
+    assert ImageModel is not None
+    assert RetriesModel is not None
+
+
+def test_retries_model_creation():
+    """Test that RetriesModel can be created with default values."""
+    from tensorlake.analyzer.models import RetriesModel
+
+    retries = RetriesModel()
+    assert retries.max_retries == 0
+    assert retries.initial_delay == 1.0
+    assert retries.max_delay == 60.0
+    assert retries.delay_multiplier == 2.0
+
+    # Test with custom values
+    custom_retries = RetriesModel(
+        max_retries=3,
+        initial_delay=2.0,
+        max_delay=120.0,
+        delay_multiplier=3.0,
+    )
+    assert custom_retries.max_retries == 3
+    assert custom_retries.initial_delay == 2.0
+
+
+def test_image_model_creation():
+    """Test that ImageModel can be created."""
+    from tensorlake.analyzer.models import ImageBuildOperationModel, ImageModel
+
+    image = ImageModel(
+        name="test-image",
+        tag="v1.0",
+        base_image="python:3.10-slim",
+        build_operations=[
+            ImageBuildOperationModel(
+                type="RUN",
+                args=["pip install numpy"],
+                options={},
+            )
+        ],
+    )
+
+    assert image.name == "test-image"
+    assert image.tag == "v1.0"
+    assert image.base_image == "python:3.10-slim"
+    assert len(image.build_operations) == 1
+    assert image.build_operations[0].type == "RUN"
+
+
+def test_function_config_model_creation():
+    """Test that FunctionConfigModel can be created."""
+    from tensorlake.analyzer.models import FunctionConfigModel, RetriesModel
+
+    func_config = FunctionConfigModel(
+        function_name="test_function",
+        description="Test function",
+        image_name="test-image",
+        secrets=["SECRET1", "SECRET2"],
+        retries=RetriesModel(max_retries=3),
+        timeout=300,
+        cpu=2.0,
+        memory=4.0,
+        ephemeral_disk=10.0,
+        cacheable=True,
+        max_concurrency=5,
+    )
+
+    assert func_config.function_name == "test_function"
+    assert func_config.description == "Test function"
+    assert func_config.image_name == "test-image"
+    assert len(func_config.secrets) == 2
+    assert func_config.retries.max_retries == 3
+    assert func_config.cpu == 2.0
+    assert func_config.cacheable is True
+
+
+def test_analysis_output_serialization():
+    """Test that AnalysisOutput can be serialized to JSON."""
+    from tensorlake.analyzer.models import (
+        AnalysisOutput,
+        ApplicationConfigModel,
+        ApplicationModel,
+        FunctionConfigModel,
+        FunctionModel,
+        ImageModel,
+        RetriesModel,
+    )
+
+    output = AnalysisOutput(
+        images={
+            "test-image": ImageModel(
+                name="test-image",
+                tag="latest",
+                base_image="python:3.10",
+                build_operations=[],
+            )
+        },
+        functions={
+            "test_func": FunctionModel(
+                function_name="test_func",
+                function_config=FunctionConfigModel(
+                    function_name="test_func",
+                    description="Test",
+                    image_name="test-image",
+                    secrets=[],
+                    timeout=300,
+                    cpu=1.0,
+                    memory=1.0,
+                    ephemeral_disk=2.0,
+                    cacheable=False,
+                    max_concurrency=1,
+                ),
+                application_config=ApplicationConfigModel(
+                    tags={"env": "test"},
+                    retries=RetriesModel(),
+                    input_serializer="json",
+                    output_serializer="json",
+                    version="v1",
+                ),
+            )
+        },
+        applications={
+            "test_app": ApplicationModel(
+                application_name="test_app",
+                version="v1",
+                functions=["test_func"],
+                config=ApplicationConfigModel(
+                    tags={"env": "test"},
+                    retries=RetriesModel(),
+                    input_serializer="json",
+                    output_serializer="json",
+                    version="v1",
+                ),
+            )
+        },
+    )
+
+    # Test dict conversion
+    result_dict = output.to_dict()
+    assert result_dict is not None
+
+    # Test that it's valid JSON
+    json_str = json.dumps(result_dict)
+    parsed = json.loads(json_str)
+    assert "images" in parsed
+    assert "functions" in parsed
+    assert "applications" in parsed
+    assert "test-image" in parsed["images"]
+    assert "test_func" in parsed["functions"]
+    assert "test_app" in parsed["applications"]
+
+
+def test_existing_retries_class_compatibility():
+    """Test that the original Retries class still works with Pydantic."""
+    from tensorlake.applications.interface.retries import Retries
+
+    # Test default instantiation
+    retries = Retries()
+    assert retries.max_retries == 0
+    assert retries.initial_delay == 1.0
+
+    # Test with custom values
+    custom_retries = Retries(max_retries=5)
+    assert custom_retries.max_retries == 5
+
+    # Test that it has Pydantic methods
+    assert hasattr(retries, "model_dump")
+    assert hasattr(retries, "model_dump_json")
+
+
+def test_function_configuration_compatibility():
+    """Test that _FunctionConfiguration works as a Pydantic model."""
+    from tensorlake.applications.interface.function import _FunctionConfiguration
+    from tensorlake.applications.interface.image import Image
+    from tensorlake.applications.interface.retries import Retries
+
+    img = Image(name="test")
+
+    config = _FunctionConfiguration(
+        function_name="test",
+        description="Test function",
+        image=img,
+        secrets=["SECRET1"],
+        timeout=300,
+        cpu=1.0,
+        memory=1.0,
+        ephemeral_disk=2.0,
+        cacheable=False,
+        max_concurrency=1,
+    )
+
+    assert config.function_name == "test"
+    assert config.image.name == "test"
+    assert len(config.secrets) == 1
+
+    # Test that attributes can be mutated (required for decorators.py)
+    config.class_name = "TestClass"
+    config.class_method_name = "test_method"
+    assert config.class_name == "TestClass"
+    assert config.class_method_name == "test_method"
+
+    # Test Pydantic features
+    assert hasattr(config, "model_dump")
+
+
+def test_application_configuration_compatibility():
+    """Test that _ApplicationConfiguration works as a Pydantic model."""
+    from tensorlake.applications.interface.function import _ApplicationConfiguration
+    from tensorlake.applications.interface.retries import Retries
+
+    config = _ApplicationConfiguration(
+        tags={"env": "test"},
+        retries=Retries(max_retries=3),
+        input_serializer="json",
+        output_serializer="json",
+        version="v1.0",
+    )
+
+    assert config.version == "v1.0"
+    assert config.tags["env"] == "test"
+    assert config.retries.max_retries == 3
+
+    # Test Pydantic features
+    assert hasattr(config, "model_dump")


### PR DESCRIPTION
This change adds a new script to the package that can be used to debug and instrospect the metadata that the Tensorlake SDK generates to build and deploy applications.

warning: This code was mostly generated by an ai agent. It probably needs a cleanup. Please, call out anything you notice that's terribly wrong.