### PR TITLE
[http hook] They need to be async

### DIFF
--- a/src/tensorlake/cli/_common.py
+++ b/src/tensorlake/cli/_common.py
@@ -27,7 +27,7 @@ except importlib.metadata.PackageNotFoundError:
     VERSION = "unknown"
 
 
-def raise_on_authn_authz(response: httpx.Response):
+async def raise_on_authn_authz(response: httpx.Response):
     if response.status_code == 401:
         raise click.UsageError(
             "The credentials to access Tensorlake's API are not valid"


### PR DESCRIPTION
Otherwise it breaks with `object NoneType can't be used in 'await' expression`