### PR TITLE
Fix race condition in FE watch allocation state stream

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -509,14 +509,14 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "isort"
-version = "6.1.0"
+version = "7.0.0"
 description = "A Python utility / library to sort Python imports."
 optional = false
-python-versions = ">=3.9.0"
+python-versions = ">=3.10.0"
 groups = ["dev"]
 files = [
-    {file = "isort-6.1.0-py3-none-any.whl", hash = "sha256:58d8927ecce74e5087aef019f778d4081a3b6c98f15a80ba35782ca8a2097784"},
-    {file = "isort-6.1.0.tar.gz", hash = "sha256:9b8f96a14cfee0677e78e941ff62f03769a06d412aabb9e2a90487b3b7e8d481"},
+    {file = "isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1"},
+    {file = "isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187"},
 ]
 
 [package.extras]
@@ -1033,14 +1033,14 @@ py = ">=1.4.26,<2.0.0"
 
 [[package]]
 name = "rich"
-version = "14.1.0"
+version = "14.2.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.8.0"
 groups = ["main"]
 files = [
-    {file = "rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f"},
-    {file = "rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8"},
+    {file = "rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd"},
+    {file = "rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4"},
 ]
 
 [package.dependencies]
@@ -1223,4 +1223,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "df9729a18efc12ff50671f6ecb3057648fa007e0320d3d3f9efe8843d2c0412f"
+content-hash = "39491382b5fe98747970b427c63db29c2cae84318aa22cd843f1fe1014f1417c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.70"
+version = "0.2.71"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
@@ -15,7 +15,7 @@ cloudpickle = "^3.1.0"
 pydantic = ">=2.0, <3.0"
 httpx-sse = "^0.4.1"
 # TODO: Look into consolidating this with click
-rich = "14.1.0"
+rich = "14.2.0"
 pyyaml = "^6.0.3"
 click = "8.3.0"
 retry = "^0.9.2"
@@ -40,7 +40,7 @@ black = "25.9.0"
 parameterized = "^0.9.0"
 respx = "^0.22.0"
 psutil = "^7.1.0"
-isort = "^6.1.0"
+isort = "^7.0.0"
 pre-commit = "^4.3.0"
 
 [tool.poetry.plugins."poetry.command"]

--- a/src/tensorlake/applications/interface/image.py
+++ b/src/tensorlake/applications/interface/image.py
@@ -2,6 +2,7 @@ import sys
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List
+
 from tensorlake.vendor.nanoid.nanoid import generate as nanoid_generate
 
 _LOCAL_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"

--- a/src/tensorlake/function_executor/allocation_runner/allocation_state_wrapper.py
+++ b/src/tensorlake/function_executor/allocation_runner/allocation_state_wrapper.py
@@ -39,6 +39,10 @@ class AllocationStateWrapper:
             self._update_hash()
             self._allocation_state_update_lock.notify_all()
 
+    def has_result(self) -> bool:
+        with self._allocation_state_update_lock:
+            return self._allocation_state.HasField("result")
+
     def add_function_call(
         self, execution_plan_updates: ExecutionPlanUpdates, args_blob: BLOB | None
     ) -> None:

--- a/src/tensorlake/function_executor/service.py
+++ b/src/tensorlake/function_executor/service.py
@@ -3,7 +3,6 @@ import json
 import sys
 import tempfile
 import time
-import traceback
 import zipfile
 from dataclasses import dataclass
 from typing import Any, Dict, Generator, Iterator, List
@@ -306,10 +305,7 @@ class Service(FunctionExecutorServicer):
             )
             last_seen_hash = allocation_state.sha256_hash
             yield allocation_state
-            # NB: We have to check allocation_state.result here instead of
-            # allocation_info.runner.finished because the runner may have finished
-            # but there may still be pending allocation state update with the result to send.
-            if allocation_state.HasField("result"):
+            if AllocationRunner.is_terminal_state(allocation_state):
                 break
 
     def send_allocation_update(

--- a/tests/applications/test_reduce.py
+++ b/tests/applications/test_reduce.py
@@ -10,8 +10,8 @@ from tensorlake.applications import (
     application,
     function,
 )
-from tensorlake.applications.remote.deploy import deploy_applications
 from tensorlake.applications.applications import run_application
+from tensorlake.applications.remote.deploy import deploy_applications
 
 
 class AccumulatedState(BaseModel):


### PR DESCRIPTION
_finished bool flag in AllocationRunner is not always in sync with allocation result being availble. This results in precondition check failure when Executor calls FE.delete_allocation.

CI is failing until indexify gets released. Succeeds locally.