### PR TITLE
Revert "Add model06 to OCR options"

### DIFF
--- a/src/tensorlake/documentai/models/_enums.py
+++ b/src/tensorlake/documentai/models/_enums.py
@@ -82,13 +82,11 @@ class OcrPipelineProvider(str, Enum):
     Tensorlake01: It's fast but could have lower accuracy on complex tables. It's good for legal documents with footnotes.
     Tensorlake02: It's slower but could have higher accuracy on complex tables. It's good for financial documents with merged cells.
     Tensorlake03: A compact model that we deliver to on-premise users. It takes about 2 minutes to startup on Tensorlake's Cloud because it's meant for testing for users who are eventually going to deploy this model on dedicated hardware in their own datacenter.
-    Tensorlake06: Our fastest model, offering the best balance between speed and accuracy. It performs well on plain text or standard documents without complex layouts.
     """
 
     TENSORLAKE01 = "model01"
     TENSORLAKE02 = "model02"
     TENSORLAKE03 = "model03"
-    TENSORLAKE06 = "model06"
 
 
 class ParseStatus(str, Enum):


### PR DESCRIPTION
Reverts tensorlakeai/tensorlake#416

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `TENSORLAKE06` (`model06`) from `OcrPipelineProvider` and its docstring entry.
> 
> - **Models**:
>   - Remove `TENSORLAKE06` from `OcrPipelineProvider` in `src/tensorlake/documentai/models/_enums.py`.
>   - Update OCR provider docstring to drop the Tensorlake06 description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e28585aa8b9413af506067ee72edaa525f4389b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->