### PR TITLE
Fix Tensorlake CLI and reference app to work with new SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.71"
+version = "0.2.72"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]

--- a/reference_app/reference_app.py
+++ b/reference_app/reference_app.py
@@ -10,10 +10,6 @@ from tensorlake.applications import (
     Request,
     application,
     function,
-)
-from tensorlake.applications import map as tl_map
-from tensorlake.applications import reduce as tl_reduce
-from tensorlake.applications import (
     run_remote_application,
 )
 
@@ -29,7 +25,7 @@ class Total(BaseModel):
 @application()
 @function(image=mapper_image, description="Sums the squares of a sequence of numbers")
 def sequence_summer(a: int) -> Total:
-    return tl_reduce(reducer, tl_map(processor, range(a)))
+    return reducer.awaitable.reduce(processor.awaitable.map(range(a)))
 
 
 @function(image=process_image)

--- a/src/tensorlake/cli/deploy.py
+++ b/src/tensorlake/cli/deploy.py
@@ -142,7 +142,7 @@ def _deploy_applications(
         for application_function in filter_applications(functions):
             app_func_manifest: FunctionManifest = create_function_manifest(
                 application_function,
-                application_function.application_config.version,
+                application_function._application_config.version,
                 application_function,
             )
             func_name = app_func_manifest.name


### PR DESCRIPTION
Tested this in Dev (as you folks know X-D)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CLI to use `_application_config.version`, ref app to new awaitable map/reduce API, and bump package version to 0.2.72.
> 
> - **Examples**:
>   - Update `reference_app/reference_app.py` to use awaitable chaining: `reducer.awaitable.reduce(processor.awaitable.map(range(a)))` and remove `tl_map`/`tl_reduce` imports.
> - **CLI**:
>   - Use `application_function._application_config.version` when creating `FunctionManifest` in `src/tensorlake/cli/deploy.py`.
> - **Versioning**:
>   - Bump `pyproject.toml` version from `0.2.71` to `0.2.72`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e57a085f8f471ff65cd9d50edc1c929c7a59010. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->