### PR TITLE
Ask user to provide application function type hint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.72"
+version = "0.2.73"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]

--- a/src/tensorlake/applications/interface/request.py
+++ b/src/tensorlake/applications/interface/request.py
@@ -16,6 +16,7 @@ class Request:
         Raises RequestFailureException on error during the request execution.
         Raises RequestNotFinished if the request is not yet completed.
         Raises RemoteAPIError on error communicating with the remote API.
+        Raises ApplicationValidationError on application validation errors.
         """
         raise NotImplementedError("output is implemented in subclasses.")
 

--- a/src/tensorlake/applications/remote/request.py
+++ b/src/tensorlake/applications/remote/request.py
@@ -3,7 +3,7 @@ from typing import Any, List
 
 from ..function.type_hints import deserialize_type_hints
 from ..function.user_data_serializer import deserialize_value
-from ..interface.request import Request
+from ..interface import ApplicationValidationError, Request
 from ..metadata import ValueMetadata
 from .api_client import APIClient
 from .manifests.application import ApplicationManifest
@@ -56,6 +56,12 @@ class RemoteRequest(Request):
 
         last_exception: BaseException | None = None
 
+        if len(return_type_hints) == 0:
+            raise ApplicationValidationError(
+                "Can't deserialize request output. Please add a return type hint to the application function "
+                f"{self._application_name} to enable deserialization of the request output."
+            )
+
         for type_hint in return_type_hints:
             try:
                 return deserialize_value(
@@ -70,4 +76,5 @@ class RemoteRequest(Request):
             except BaseException as e:
                 last_exception = e
 
+        # last_exception is Never None here if return_type_hints is not empty.
         raise last_exception


### PR DESCRIPTION
Instead of failing with an obscure error:

```
output = request.output()
  File "/Users/drguthals/Documents/GitHub/tensorlakeai/partners/snowflake/sec-filings/venv/lib/python3.13/site-paco
    raise last_exception
TypeError: exceptions must derive from BaseException
```

Now we raise:

```
Traceback (most recent call last):
  File "/Users/eugene/workplace/compute-engine-internal/indexify/tensorlake/./reference_app/reference_app.py", line 44, in <module>
    assert request.output().val == sum(x**2 for x in range(10))
  File "/Users/eugene/workplace/compute-engine-internal/indexify/tensorlake/src/tensorlake/applications/remote/request.py", line 60, in output
    raise ApplicationValidationError(
tensorlake.applications.interface.exceptions.ApplicationValidationError: Can't deserialize request output. Please add a return type hint to the application function sequence_summer to enable deserialization of the request output.
```