### PR TITLE
Use only alphanumeric characters in applications version

### DIFF
--- a/src/tensorlake/applications/interface/decorators.py
+++ b/src/tensorlake/applications/interface/decorators.py
@@ -41,7 +41,10 @@ def application(
             input_serializer=input_serializer,
             output_serializer=output_serializer,
             # Use a unique random version. We don't provide user controlled versioning at the moment.
-            version=nanoid(),
+            # Use only alphanumeric characters so app version can be used as container tags.
+            version=nanoid(
+                alphabet="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            ),
         )
 
         return fn


### PR DESCRIPTION
We use app version as docker image tags in PE CI.
A docker image tag can't start with '-' character. This is why.