### PR TITLE
Wrap function call user errors into an event.

### DIFF
--- a/src/tensorlake/applications/user_data_serializer.py
+++ b/src/tensorlake/applications/user_data_serializer.py
@@ -88,7 +88,7 @@ class JSONUserDataSerializer(UserDataSerializer):
                 return json.dumps(object).encode("utf-8")
         except Exception as e:
             raise ValueError(
-                f"failed to serialize data with json serializer: {e}"
+                f"Failed to serialize data with json serializer: {e}"
             ) from e
 
     def deserialize(self, data: bytes, possible_types: List[Any]) -> Any:
@@ -118,7 +118,7 @@ class JSONUserDataSerializer(UserDataSerializer):
             return json.loads(decoded_data)
         except Exception as e:
             raise ValueError(
-                f"failed to deserialize data with json serializer: {e}"
+                f"Failed to deserialize data with json serializer: {e}"
             ) from e
 
 
@@ -153,7 +153,7 @@ class PickleUserDataSerializer(UserDataSerializer):
             return pickle.dumps(object, protocol=self._PROTOCOL_LEVEL)
         except Exception as e:
             raise ValueError(
-                f"failed to serialize data with pickle serializer: {e}"
+                f"Failed to serialize data with pickle serializer: {e}"
             ) from e
 
     def deserialize(self, data: bytes, possible_types: List[Any]) -> Any:
@@ -161,7 +161,7 @@ class PickleUserDataSerializer(UserDataSerializer):
             return pickle.loads(data)
         except Exception as e:
             raise ValueError(
-                f"failed to deserialize data with pickle serializer: {e}"
+                f"Failed to deserialize data with pickle serializer: {e}"
             ) from e
 
 

--- a/src/tensorlake/function_executor/allocation_runner/allocation_runner.py
+++ b/src/tensorlake/function_executor/allocation_runner/allocation_runner.py
@@ -566,7 +566,9 @@ class AllocationRunner:
             )
         except BaseException as e:
             # This is internal FE code.
-            return self._result_helper.from_user_exception(e)
+            return self._result_helper.from_user_exception(
+                self._allocation_event_details, e
+            )
 
         # This is internal FE code.
         args, kwargs = reconstruct_function_call_args(
@@ -591,7 +593,9 @@ class AllocationRunner:
             try:
                 utf8_message: bytes = e.message.encode("utf-8")
             except BaseException:
-                return self._result_helper.from_user_exception(e)
+                return self._result_helper.from_user_exception(
+                    self._allocation_event_details, e
+                )
 
             # This is internal FE code.
             request_error_so, uploaded_outputs_blob = upload_request_error(
@@ -607,7 +611,9 @@ class AllocationRunner:
             )
         except BaseException as e:
             # This is internal FE code.
-            return self._result_helper.from_user_exception(e)
+            return self._result_helper.from_user_exception(
+                self._allocation_event_details, e
+            )
 
         # This is user code.
         try:
@@ -623,7 +629,9 @@ class AllocationRunner:
             )
         except BaseException as e:
             # This is internal FE code.
-            return self._result_helper.from_user_exception(e)
+            return self._result_helper.from_user_exception(
+                self._allocation_event_details, e
+            )
 
         # This is internal FE code.
         serialized_objects: Dict[str, SerializedObjectInsideBLOB] = {}
@@ -658,7 +666,9 @@ class AllocationRunner:
             else:
                 output_pb = serialized_objects[output.metadata.id]
         except BaseException as e:
-            return self._result_helper.from_user_exception(e)
+            return self._result_helper.from_user_exception(
+                self._allocation_event_details, e
+            )
 
         return self._result_helper.from_function_output(
             output=output_pb, uploaded_outputs_blob=uploaded_outputs_blob

--- a/src/tensorlake/function_executor/allocation_runner/result_helper.py
+++ b/src/tensorlake/function_executor/allocation_runner/result_helper.py
@@ -4,6 +4,10 @@ from tensorlake.applications import Function, RequestError
 from tensorlake.applications.request_context.request_metrics_recorder import (
     RequestMetricsRecorder,
 )
+from tensorlake.function_executor.user_events import (
+    AllocationEventDetails,
+    log_user_event_function_call_failed,
+)
 
 from ..logger import FunctionExecutorLogger
 from ..proto.function_executor_pb2 import (
@@ -40,15 +44,13 @@ class ResultHelper:
             metrics=self._generate_metrics_proto(),
         )
 
-    def from_user_exception(self, exception: BaseException) -> AllocationResult:
+    def from_user_exception(
+        self, details: AllocationEventDetails, exception: BaseException
+    ) -> AllocationResult:
         """Creates an AllocationResult representing a user exception raised during function execution."""
-        try:
-            # This is user code.
-            # Give the full traceback to the user for debugging.
-            traceback.print_exception(exception)
-        except BaseException as e:
-            # Don't log the exception as it might contain customer data.
-            self._logger.info("Failed to print user exception traceback")
+        # This is user code.
+        # Give the full traceback to the user for debugging.
+        log_user_event_function_call_failed(details, exception)
 
         # This is FE internal code.
         # Don't log the user exception as it might contain customer data.

--- a/src/tensorlake/function_executor/user_events.py
+++ b/src/tensorlake/function_executor/user_events.py
@@ -125,3 +125,23 @@ def log_user_event_allocations_finished(
             ],
         }
     )
+
+
+def log_user_event_function_call_failed(
+    details: AllocationEventDetails, error: BaseException
+) -> None:
+    print_cloud_event(
+        {
+            "level": "error",
+            "event": "function_call_failed",
+            "message": str(error),
+            "namespace": details.namespace,
+            "application": details.application_name,
+            "application_version": details.application_version,
+            "function": details.function_name,
+            "request_id": details.request_id,
+            "function_call_id": details.function_call_id,
+            "allocation_id": details.allocation_id,
+            "error": traceback.format_exception(error),
+        }
+    )

--- a/tests/applications/test_user_data_serializer.py
+++ b/tests/applications/test_user_data_serializer.py
@@ -1,0 +1,209 @@
+import unittest
+from typing import Any
+
+from pydantic import BaseModel
+
+from tensorlake.applications.function.user_data_serializer import (
+    deserialize_value,
+    serialize_value,
+)
+from tensorlake.applications.metadata import ValueMetadata
+from tensorlake.applications.user_data_serializer import (
+    JSONUserDataSerializer,
+    PickleUserDataSerializer,
+)
+
+
+class TestPydanticModel(BaseModel):
+    name: str
+    age: int
+
+
+class ModelA(BaseModel):
+    value: str
+
+
+class ModelB(BaseModel):
+    value: int
+
+
+class TestModel(BaseModel):
+    name: str
+
+
+class TestUserDataSerializer(unittest.TestCase):
+    """Tests for user data serializers."""
+
+    def test_serialize_deserialize_basic_types_json(self):
+        """Test serialization and deserialization of basic Python types with JSON serializer."""
+        serializer = JSONUserDataSerializer()
+        test_values = [
+            "David",  # The critical test case
+            42,
+            3.14,
+            True,
+            None,
+            [1, 2, 3],
+            {"key": "value"},
+        ]
+
+        for value in test_values:
+            data, metadata = serialize_value(
+                value, serializer, f"test_{type(value).__name__}"
+            )
+            result = deserialize_value(data, metadata)
+            self.assertEqual(result, value)
+            self.assertEqual(type(result), type(value))
+
+    def test_serialize_deserialize_basic_types_pickle(self):
+        """Test serialization and deserialization of basic Python types with Pickle serializer."""
+        serializer = PickleUserDataSerializer()
+        test_values = [
+            "David",  # The critical test case
+            42,
+            3.14,
+            True,
+            None,
+            [1, 2, 3],
+            {"key": "value"},
+        ]
+
+        for value in test_values:
+            data, metadata = serialize_value(
+                value, serializer, f"test_{type(value).__name__}"
+            )
+            result = deserialize_value(data, metadata)
+            self.assertEqual(result, value)
+            self.assertEqual(type(result), type(value))
+
+    def test_deserialize_david_to_str_no_exception(self):
+        """Ensure that 'David' can be deserialized to str without raising an exception."""
+        serializer = JSONUserDataSerializer()
+        value = "David"
+        data, metadata = serialize_value(value, serializer, "david_test")
+        # This should not raise an exception
+        result = deserialize_value(data, metadata)
+        self.assertEqual(result, "David")
+        self.assertIsInstance(result, str)
+
+    def test_serialize_deserialize_pydantic_model_json(self):
+        """Test serialization and deserialization of Pydantic models with JSON serializer."""
+        serializer = JSONUserDataSerializer()
+        model = TestPydanticModel(name="Alice", age=30)
+        data, metadata = serialize_value(model, serializer, "model_test")
+        result = deserialize_value(data, metadata)
+        self.assertEqual(result, model)
+        self.assertIsInstance(result, TestPydanticModel)
+
+    def test_serialize_deserialize_pydantic_model_pickle(self):
+        """Test serialization and deserialization of Pydantic models with Pickle serializer."""
+        serializer = PickleUserDataSerializer()
+        model = TestPydanticModel(name="Alice", age=30)
+        data, metadata = serialize_value(model, serializer, "model_test")
+        result = deserialize_value(data, metadata)
+        self.assertEqual(result, model)
+        self.assertIsInstance(result, TestPydanticModel)
+
+    def test_json_serializer_with_multiple_possible_types(self):
+        """Test JSON deserializer with multiple possible types including Pydantic models."""
+        serializer = JSONUserDataSerializer()
+
+        # Test with ModelA
+        model_a = ModelA(value="test")
+        data_a, metadata_a = serialize_value(model_a, serializer, "model_a")
+        result_a = deserialize_value(data_a, metadata_a)
+        self.assertEqual(result_a, model_a)
+        self.assertIsInstance(result_a, ModelA)
+
+        # Test with basic type
+        value_str = "David"
+        data_str, metadata_str = serialize_value(value_str, serializer, "str_test")
+        result_str = deserialize_value(data_str, metadata_str)
+        self.assertEqual(result_str, "David")
+        self.assertIsInstance(result_str, str)
+
+    def test_pickle_serializer_arbitrary_objects(self):
+        """Test pickle serializer with arbitrary Python objects."""
+        import datetime
+
+        serializer = PickleUserDataSerializer()
+        obj = {"complex": [1, 2, datetime.date.today()]}
+        data, metadata = serialize_value(obj, serializer, "complex_test")
+        result = deserialize_value(data, metadata)
+        self.assertEqual(result, obj)
+
+    def test_deserialize_value_with_file(self):
+        """Test deserialization of File objects."""
+        from tensorlake.applications.interface.file import File
+
+        # For File, metadata.cls = File, content_type set
+        metadata = ValueMetadata(
+            id="file_test", cls=File, serializer_name=None, content_type="text/plain"
+        )
+        data = b"Hello World"
+        result = deserialize_value(data, metadata)
+        self.assertIsInstance(result, File)
+        self.assertEqual(result.content, b"Hello World")
+        self.assertEqual(result.content_type, "text/plain")
+
+    def test_deserialize_value_file_missing_content_type(self):
+        """Test that deserializing File without content_type raises ValueError."""
+        from tensorlake.applications.interface.file import File
+
+        metadata = ValueMetadata(
+            id="file_test", cls=File, serializer_name=None, content_type=None
+        )
+        data = b"Hello"
+        with self.assertRaises(ValueError) as cm:
+            deserialize_value(data, metadata)
+        self.assertIn(
+            "Deserializing to File requires a content type", str(cm.exception)
+        )
+
+    def test_deserialize_value_non_file_missing_serializer(self):
+        """Test that deserializing non-File without serializer_name raises ValueError."""
+        metadata = ValueMetadata(
+            id="test", cls=str, serializer_name=None, content_type=None
+        )
+        data = b'"test"'
+        with self.assertRaises(ValueError) as cm:
+            deserialize_value(data, metadata)
+        self.assertIn("Serializer name is None for non-File value", str(cm.exception))
+
+    def test_json_deserializer_fallback_to_json_loads(self):
+        """Test that JSON deserializer falls back to json.loads for non-Pydantic types."""
+        serializer = JSONUserDataSerializer()
+        data, metadata = serialize_value("David", serializer, "fallback_test")
+        result = deserialize_value(data, metadata)
+        self.assertEqual(result, "David")
+        self.assertIsInstance(result, str)
+
+    def test_json_deserializer_with_pydantic_models_priority(self):
+        """Test that Pydantic models are tried before falling back to json.loads."""
+        serializer = JSONUserDataSerializer()
+
+        # Valid model data
+        model = TestModel(name="David")
+        data, metadata = serialize_value(model, serializer, "model_priority")
+        result = deserialize_value(data, metadata)
+        self.assertEqual(result, model)
+        self.assertIsInstance(result, TestModel)
+
+    def test_json_deserializer_fails_with_unencoded_data(self):
+        """Test that JSON deserializer falls back to json.loads for non-Pydantic types."""
+        metadata = ValueMetadata(
+            id="file_test",
+            cls=type("David"),
+            serializer_name="json",
+            content_type="application/json",
+        )
+        with self.assertRaises(ValueError) as cm:
+            _ = deserialize_value(b"David", metadata)
+        self.assertEqual(
+            "Failed to deserialize data with json serializer: Expecting value: line 1 column 1 (char 0)",
+            str(cm.exception),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/function_executor/test_request_state.py
+++ b/tests/function_executor/test_request_state.py
@@ -254,8 +254,8 @@ class TestSetRequestState(unittest.TestCase):
                 client_thread.join()
 
         self.assertIn(
-            'RuntimeError("failed to set the request state for key")',
-            fe.read_stderr(),
+            "failed to set the request state for key",
+            fe.read_stdout(),
         )
 
 
@@ -488,8 +488,8 @@ class TestGetInvocationState(unittest.TestCase):
                 client_thread.join()
 
         self.assertIn(
-            'RuntimeError("failed to get the request state for key")',
-            fe.read_stderr(),
+            "failed to get the request state for key",
+            fe.read_stdout(),
         )
 
 

--- a/tests/function_executor/test_run_allocation.py
+++ b/tests/function_executor/test_run_allocation.py
@@ -1005,7 +1005,7 @@ class TestRunAllocation(unittest.TestCase):
         self.assertIn("allocations_finished", fe_stdout)
 
         # Check function output in stderr
-        self.assertIn("this extractor throws an exception.", process.read_stderr())
+        self.assertIn("this extractor throws an exception.", process.read_stdout())
 
     def test_function_initialization_raises_error(self):
         with FunctionExecutorProcessContextManager(capture_std_outputs=True) as process:


### PR DESCRIPTION
Instead of printing the raw backtrace into the log, print a structured JSON event. This will be more friendly for people to debug when they go see the remote logs.

I've also added a bunch of tests for the serializers to help people understand their behavior.