### PR TITLE
Print exceptions raised by functions in local mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.81"
+version = "0.2.82"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]

--- a/src/tensorlake/applications/function/function_call.py
+++ b/src/tensorlake/applications/function/function_call.py
@@ -1,3 +1,4 @@
+from traceback import format_exception
 from typing import Any, List
 
 from ..interface import Awaitable, FunctionError, InternalError
@@ -20,11 +21,12 @@ def set_self_arg(args: List[Any], self_instance: Any) -> None:
 
 
 def create_function_error(
-    awaitable: Awaitable, cause: str | None = None
+    awaitable: Awaitable, cause: str | BaseException | None
 ) -> FunctionError:
-    # We currently don't provide cause details because except in rare cases we don't know them
-    # at function caller side. The cause details are printed in called function's logs instead.
-    if cause is None:
-        return FunctionError(f"{awaitable} failed")
-    else:
+    if isinstance(cause, BaseException):
+        exception_str: str = "".join(format_exception(cause))
+        return FunctionError(f"{awaitable} failed due to exception: \n{exception_str}")
+    elif isinstance(cause, str):
         return FunctionError(f"{awaitable} failed: {cause}")
+    elif cause is None:
+        return FunctionError(f"{awaitable} failed")

--- a/src/tensorlake/applications/local/future_run/function_call_future_run.py
+++ b/src/tensorlake/applications/local/future_run/function_call_future_run.py
@@ -10,13 +10,12 @@ from ...interface.awaitables import (
     FunctionCallAwaitable,
     FunctionCallFuture,
 )
-from ...interface.exceptions import FunctionError, InternalError, RequestError
+from ...interface.exceptions import InternalError, RequestError
 from ...interface.function import Function
 from ...interface.request_context import RequestContext
 from ...interface.retries import Retries
 from ...request_context.contextvar import set_current_request_context
 from ..future import LocalFuture
-from ..utils import print_exception
 from .future_run import (
     LocalFutureRun,
     LocalFutureRunResult,
@@ -99,7 +98,7 @@ class FunctionCallFutureRun(LocalFutureRun):
                 return LocalFutureRunResult(
                     id=awaitable.id,
                     output=None,
-                    error=create_function_error(awaitable, "stopped"),
+                    error=create_function_error(awaitable, cause="stopped"),
                 )
             except BaseException as e:
                 runs_left -= 1
@@ -107,5 +106,5 @@ class FunctionCallFutureRun(LocalFutureRun):
                     return LocalFutureRunResult(
                         id=awaitable.id,
                         output=None,
-                        error=create_function_error(awaitable),
+                        error=create_function_error(awaitable, cause=e),
                     )

--- a/src/tensorlake/applications/local/runner.py
+++ b/src/tensorlake/applications/local/runner.py
@@ -485,12 +485,6 @@ class LocalRunner:
     ) -> None:
         self._handle_user_exception(error)
 
-        if not isinstance(error, FunctionError):
-            # A future failure is always reported to user as FunctionError.
-            error = create_function_error(
-                future_run.local_future.user_future.awaitable, cause=str(error)
-            )
-
         self._handle_future_run_final_output(
             future_run=future_run,
             blob=None,

--- a/src/tensorlake/applications/local/utils.py
+++ b/src/tensorlake/applications/local/utils.py
@@ -2,9 +2,9 @@ import traceback
 
 
 def print_exception(e: BaseException) -> None:
-    # We only print exceptions in remote mode and we don't propagate them to
-    # SDK remote clients. We return a generic RequestFailed instead
-    # from remote clients. To do the same in local mode, we print the exception here.
+    # In remote mode we only print exceptions and we don't propagate them to
+    # SDK remote clients. We return a generic RequestFailed instead from
+    # remote clients. To do the same in local mode, we print the exception here.
     #
     # KeyboardInterrupt is intentional by user, no need to print it.
     if not isinstance(e, KeyboardInterrupt):

--- a/src/tensorlake/function_executor/allocation_runner/allocation_runner.py
+++ b/src/tensorlake/function_executor/allocation_runner/allocation_runner.py
@@ -435,12 +435,19 @@ class AllocationRunner:
                         )
                     )
                 else:
-                    future.set_exception(create_function_error(future.awaitable))
+                    # We don't have a user visible cause of failure.
+                    future.set_exception(
+                        create_function_error(future.awaitable, cause=None)
+                    )
             else:
                 self._logger.error(
                     f"Unexpected outcome code in function call result: {result.outcome_code}"
                 )
-                future.set_exception(create_function_error(future.awaitable))
+                future.set_exception(
+                    InternalError(
+                        f"Unexpected outcome code in function call result: {result.outcome_code}"
+                    )
+                )
         else:
             # timeout and no result or error are available.
             future.set_exception(TimeoutError())

--- a/tests/function_executor/test_run_allocation.py
+++ b/tests/function_executor/test_run_allocation.py
@@ -1004,7 +1004,7 @@ class TestRunAllocation(unittest.TestCase):
         self.assertIn("allocations_started", fe_stdout)
         self.assertIn("allocations_finished", fe_stdout)
 
-        # Check function output in stderr
+        # Check original function exception is printed in stdout
         self.assertIn("this extractor throws an exception.", process.read_stdout())
 
     def test_function_initialization_raises_error(self):


### PR DESCRIPTION
This was a bug in existing logic. It was swallowing original exception raised by a function. Added test that verifies that we're printing the function exception backtrace in local mode. We already have a test for this in FE tests (remote mode).

I also fixed a few inconsistencies in existing SDK logic. This was introduced as a result of multiple major changes to exception related logic in SDK and some parts weren't brought into sync. This is why tests are so important to be added and maintained for all user visible features.

The following CI tests are failing:

```
One or more tests failed in ./applications/app_code_serialization/test_complex_graph_symlink.py for Applications test suite.
One or more tests failed in ./applications/test_complex_graph.py for Applications test suite.
One or more tests failed in ./applications/test_request_state.py for Applications test suite.
```

This is expected until https://github.com/tensorlakeai/tensorlake/pull/448 gets merged.