### PR TITLE
Refactor and fix remote APIClient

### DIFF
--- a/src/tensorlake/applications/interface/exceptions.py
+++ b/src/tensorlake/applications/interface/exceptions.py
@@ -57,7 +57,7 @@ class RemoteAPIError(TensorlakeError):
 
 
 class SDKUsageError(TensorlakeError):
-    """Raised when a Tensorlake Function uses Applications SDK incorrectly."""
+    """Raised when Applications SDK is used incorrectly."""
 
     def __init__(self, message: str) -> None:
         super().__init__(message)

--- a/src/tensorlake/applications/remote/deploy.py
+++ b/src/tensorlake/applications/remote/deploy.py
@@ -29,6 +29,9 @@ def deploy_applications(
                                Should be set to True when called from CLI, False when called programmatically from test code
                                because applications in test code are already loaded into registry.
     `api_client` is an optional APIClient to use for deployment. If not supplied, a new client will be created from environment.
+
+    Raises SDKUsageError if the APIClient configuration is not valid for the operation.
+    Raises TensorlakeError on other errors.
     """
     # Work with absolute paths to make sure that the path comparisons work correctly.
     applications_file_path: str = os.path.abspath(applications_file_path)

--- a/src/tensorlake/cli/_common.py
+++ b/src/tensorlake/cli/_common.py
@@ -13,9 +13,6 @@ from tensorlake.cli._configuration import (
     load_credentials,
     load_local_config,
 )
-from tensorlake.utils.http_client import (
-    EventHook,
-)
 
 try:
     VERSION = importlib.metadata.version("tensorlake")
@@ -116,7 +113,6 @@ class Context:
                 organization_id=org_id,
                 project_id=proj_id,
                 namespace=self.namespace,
-                event_hooks=HTTP_EVENT_HOOKS,
             )
 
         return self._api_client

--- a/src/tensorlake/cli/applications.py
+++ b/src/tensorlake/cli/applications.py
@@ -4,6 +4,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from tensorlake.applications import SDKUsageError, TensorlakeError
 from tensorlake.cli._common import Context, require_auth_and_project
 
 
@@ -13,7 +14,12 @@ def ls(ctx: Context):
     """
     List all applications in the current project.
     """
-    applications = ctx.api_client.applications()
+    try:
+        applications = ctx.api_client.applications()
+    except SDKUsageError as e:
+        raise click.UsageError(str(e)) from None
+    except TensorlakeError as e:
+        raise click.ClickException(f"Failed to fetch applications: {e}") from None
 
     # Filter out tombstoned applications
     active_applications = [app for app in applications if not app.tombstoned]

--- a/src/tensorlake/cli/deploy.py
+++ b/src/tensorlake/cli/deploy.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 import click
 
-from tensorlake.applications import Function, Image
+from tensorlake.applications import Function, Image, SDKUsageError, TensorlakeError
 from tensorlake.applications.applications import filter_applications
 from tensorlake.applications.image import ImageInformation, image_infos
 from tensorlake.applications.interface.function import (
@@ -182,8 +182,10 @@ curl {auth.api_url}/applications/{func_name} \\
 """,
                 )
         return
-    except click.UsageError as error:
-        raise error
+    except SDKUsageError as e:
+        raise click.UsageError(str(e)) from None
+    except TensorlakeError as e:
+        raise click.ClickException(f"Failed to deploy applications: {e}") from e
     except Exception as e:
         click.echo(
             f"Applications could not be deployed, please check the error message: {e}",

--- a/src/tensorlake/utils/http_client.py
+++ b/src/tensorlake/utils/http_client.py
@@ -3,9 +3,6 @@ from typing import Any, Callable
 import httpx
 import yaml
 
-TRANSIENT_HTTPX_ERRORS = (httpx.NetworkError, httpx.RemoteProtocolError)
-
-
 EventHook = Callable[..., Any]
 
 

--- a/tests/cli/test_applications.py
+++ b/tests/cli/test_applications.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 from test_helpers import get_base_url
 
 import tensorlake.cli._configuration as config_module
-from tensorlake.applications.remote.api_client import ApplicationListItem
+from tensorlake.applications.remote.api_client import Application
 from tensorlake.cli import cli
 from tensorlake.cli._common import Context
 
@@ -67,7 +67,7 @@ class TestApplicationsList(unittest.TestCase):
         runner = CliRunner()
 
         applications = [
-            ApplicationListItem(
+            Application(
                 name="app1",
                 description="First app",
                 tags={},
@@ -75,7 +75,7 @@ class TestApplicationsList(unittest.TestCase):
                 tombstoned=False,
                 created_at=1697539200000,  # 2023-10-17 12:00:00 UTC in milliseconds
             ),
-            ApplicationListItem(
+            Application(
                 name="app2",
                 description="Second app",
                 tags={},
@@ -103,7 +103,7 @@ class TestApplicationsList(unittest.TestCase):
         runner = CliRunner()
 
         applications = [
-            ApplicationListItem(
+            Application(
                 name="single_app",
                 description="Only app",
                 tags={},
@@ -142,7 +142,7 @@ class TestApplicationsList(unittest.TestCase):
         runner = CliRunner()
 
         applications = [
-            ApplicationListItem(
+            Application(
                 name="active_app",
                 description="Active",
                 tags={},
@@ -150,7 +150,7 @@ class TestApplicationsList(unittest.TestCase):
                 tombstoned=False,
                 created_at=1697539200000,
             ),
-            ApplicationListItem(
+            Application(
                 name="deleted_app",
                 description="Deleted",
                 tags={},
@@ -176,7 +176,7 @@ class TestApplicationsList(unittest.TestCase):
         runner = CliRunner()
 
         applications = [
-            ApplicationListItem(
+            Application(
                 name="test_app",
                 description="Test",
                 tags={},
@@ -204,7 +204,7 @@ class TestApplicationsList(unittest.TestCase):
         runner = CliRunner()
 
         applications = [
-            ApplicationListItem(
+            Application(
                 name="test_app",
                 description="Test",
                 tags={},
@@ -232,7 +232,7 @@ class TestApplicationsList(unittest.TestCase):
         runner = CliRunner()
 
         applications = [
-            ApplicationListItem(
+            Application(
                 name="test_app",
                 description="Test",
                 tags={},
@@ -256,7 +256,7 @@ class TestApplicationsList(unittest.TestCase):
         runner = CliRunner()
 
         applications = [
-            ApplicationListItem(
+            Application(
                 name="test_app",
                 description="",
                 tags={},
@@ -280,7 +280,7 @@ class TestApplicationsList(unittest.TestCase):
         runner = CliRunner()
 
         applications = [
-            ApplicationListItem(
+            Application(
                 name="test_app",
                 description="Test",
                 tags={},


### PR DESCRIPTION
The current remote APIClient code was derived from a fairly old SDK code base. Because of this remote APIClient has both stylistic issues and coding bugs now.

This PR does the following:

* Add type hints everywhere to make it easier to read code.
* Don't user variadic args and kwargs as it makes reading code harder.
* Only raise exceptions derived from TensorlakeError. We were raising arbitrary unexpected exception types directly into user code while all SDK code should raise exceptions derived from TensorlakeError.
* Use consistent retry policy in sse stream and regular http requests.
* Remove unused pydantic model definitions for Server API. We'll add the models back if we need them in future projects. Having them in remote APIClient requires us keeping them updated which might slow down some future work. This is also effectively a dead code.
* Define code structure in remote APIClient that other people can follow in the future and not introduce hard to notice mistakes because it's Python.
* Give more descriptive user friendly error messages in certain cases like no auth credentials present on HTTP 401 code.
* Don't use httpx client event hooks because they make the APIClient error handling behavior hard to reason about i.e. it makes exceptions raised by ApiClient dependant on how it was created. The existing hooks raise ClickException which has nothing to do with TensorlakeError which is a base class for all errors in SDK components which include APIClient.

Testing:

* Checked all callers of APIClient methods to make sure that none of them break if we start only raising TensorlakeError derived exceptions.
* Manually ran all tensorlake CLI commands.
* All integration tests pass.