### PR TITLE
Add more exact types to request context interfaces and validate them

### DIFF
--- a/src/tensorlake/applications/interface/request_context.py
+++ b/src/tensorlake/applications/interface/request_context.py
@@ -32,7 +32,7 @@ class RequestState:
 class RequestMetrics:
     """Abstract interface for reporting application request metrics."""
 
-    def timer(self, name: str, value: float) -> None:
+    def timer(self, name: str, value: int | float) -> None:
         """Records a duration metric with the supplied name and value.
 
         Raises TensorlakeError on error.
@@ -54,8 +54,8 @@ class FunctionProgress:
 
     def update(
         self,
-        current: float,
-        total: float,
+        current: int | float,
+        total: int | float,
         message: str | None = None,
         attributes: dict[str, str] | None = None,
     ) -> None:

--- a/src/tensorlake/applications/request_context/http_client/metrics.py
+++ b/src/tensorlake/applications/request_context/http_client/metrics.py
@@ -22,7 +22,14 @@ class RequestMetricsHTTPClient(RequestMetrics):
         self._allocation_id: str = allocation_id
         self._http_client: httpx.Client = http_client
 
-    def timer(self, name: str, value: float):
+    def timer(self, name: str, value: int | float):
+        # If we don't validate user supplied inputs here then there will be a Pydantic validation error
+        # below which will raise an InternalError instead of SDKUsageError.
+        if not isinstance(name, str):
+            raise SDKUsageError(f"Timer name must be a string, got: {name}")
+        if not isinstance(value, (int, float)):
+            raise SDKUsageError(f"Timer value must be a number, got: {value}")
+
         request_payload: AddMetricsRequest = AddMetricsRequest(
             request_id=self._request_id,
             allocation_id=self._allocation_id,
@@ -32,6 +39,13 @@ class RequestMetricsHTTPClient(RequestMetrics):
         self._run_add_request(request_payload)
 
     def counter(self, name: str, value: int = 1):
+        # If we don't validate user supplied inputs here then there will be a Pydantic validation error
+        # below which will raise an InternalError instead of SDKUsageError.
+        if not isinstance(name, str):
+            raise SDKUsageError(f"Counter name must be a string, got: {name}")
+        if not isinstance(value, int):
+            raise SDKUsageError(f"Counter value must be an int, got: {value}")
+
         request_payload: AddMetricsRequest = AddMetricsRequest(
             request_id=self._request_id,
             allocation_id=self._allocation_id,

--- a/src/tensorlake/applications/request_context/http_client/state.py
+++ b/src/tensorlake/applications/request_context/http_client/state.py
@@ -53,6 +53,10 @@ class RequestStateHTTPClient(RequestState):
         # NB: This is called from user code, user code is blocked.
         # Any exception raised here goes directly to user code.
 
+        # If we don't validate user supplied inputs here then there will be a Pydantic validation error
+        # below which will raise an InternalError instead of SDKUsageError.
+        if not isinstance(key, str):
+            raise SDKUsageError(f"State key must be a string, got: {key}")
         # Raises SerializationError to customer code on failure.
         serialized_value: bytes = REQUEST_STATE_USER_DATA_SERIALIZER.serialize(value)
 
@@ -75,6 +79,12 @@ class RequestStateHTTPClient(RequestState):
     def get(self, key: str, default: Any | None = None) -> Any | None:
         # NB: This is called from user code, user code is blocked.
         # Any exception raised here goes directly to user code.
+
+        # If we don't validate user supplied inputs here then there will be a Pydantic validation error
+        # below which will raise an InternalError instead of SDKUsageError.
+        if not isinstance(key, str):
+            raise SDKUsageError(f"State key must be a string, got: {key}")
+
         try:
             blob: BLOB | None = self._get_read_only_blob(key=key)
             if blob is None:

--- a/src/tensorlake/applications/request_context/http_server/handlers/add_metrics.py
+++ b/src/tensorlake/applications/request_context/http_server/handlers/add_metrics.py
@@ -8,7 +8,7 @@ ADD_METRICS_VERB: str = "POST"
 
 class AddTimerRequest(BaseModel):
     name: str
-    value: float
+    value: int | float
 
 
 class AddCounterRequest(BaseModel):


### PR DESCRIPTION
If we don't validate ourselfs then we'd be getting internal errors now because we're using pydantic models to pass user data from request context client to server.