### PR TITLE
Retry 502 Bad Gateway HTTP errors in apps remote api client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.92"
+version = "0.2.93"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]


### PR DESCRIPTION
Got it while restarting Indexify Server in Dev.