### PR TITLE
Support async function in exponential_backoff decorator

### DIFF
--- a/tests/utils/test_retries.py
+++ b/tests/utils/test_retries.py
@@ -4,14 +4,17 @@ from unittest.mock import ANY, Mock, patch
 from tensorlake.utils.retries import exponential_backoff
 
 
-class TestExponentialBackoff(unittest.TestCase):
+class TestExponentialBackoffWithSyncFunction(unittest.TestCase):
     def test_successful_execution(self):
+        mock_func = Mock(side_effect=["Success"])
+
         @exponential_backoff(retryable_exceptions=(ValueError,))
         def always_succeeds():
-            return "Success"
+            return mock_func()
 
         result = always_succeeds()
         self.assertEqual(result, "Success")
+        self.assertEqual(mock_func.call_count, 1)
 
     def test_retry_on_exception(self):
         mock_func = Mock(side_effect=[ValueError("Fail"), "Success"])
@@ -34,7 +37,7 @@ class TestExponentialBackoff(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             always_fails()
-        self.assertEqual(mock_func.call_count, 3)
+        self.assertEqual(mock_func.call_count, 4)  # Initial call + 3 retries
 
     @patch("time.sleep", return_value=None)
     def test_is_retryable(self, mock_sleep):
@@ -63,6 +66,74 @@ class TestExponentialBackoff(unittest.TestCase):
             return mock_func()
 
         result = flaky_function()
+        self.assertEqual(result, "Success")
+        self.assertEqual(mock_func.call_count, 2)
+        self.assertEqual(mock_callback.call_count, 1)
+        mock_callback.assert_called_with(fail_exception, ANY, 1)
+
+
+class TestExponentialBackoffWithAsyncFunction(unittest.IsolatedAsyncioTestCase):
+    async def test_successful_execution(self):
+        mock_func = Mock(side_effect=["Success"])
+
+        @exponential_backoff(retryable_exceptions=(ValueError,))
+        async def always_succeeds():
+            return mock_func()
+
+        result = await always_succeeds()
+        self.assertEqual(result, "Success")
+        self.assertEqual(mock_func.call_count, 1)
+
+    async def test_retry_on_exception(self):
+        mock_func = Mock(side_effect=[ValueError("Fail"), "Success"])
+
+        @exponential_backoff(retryable_exceptions=(ValueError,))
+        async def flaky_function():
+            return mock_func()
+
+        result = await flaky_function()
+        self.assertEqual(result, "Success")
+        self.assertEqual(mock_func.call_count, 2)
+
+    @patch("asyncio.sleep", return_value=None)
+    async def test_max_retries_exceeded(self, mock_sleep):
+        mock_func = Mock(side_effect=ValueError("Fail"))
+
+        @exponential_backoff(retryable_exceptions=(ValueError,), max_retries=3)
+        async def always_fails():
+            return mock_func()
+
+        with self.assertRaises(ValueError):
+            await always_fails()
+        self.assertEqual(mock_func.call_count, 4)  # Initial call + 3 retries
+
+    @patch("asyncio.sleep", return_value=None)
+    async def test_is_retryable(self, mock_sleep):
+        mock_func = Mock(side_effect=ValueError("Fail"))
+
+        @exponential_backoff(
+            retryable_exceptions=(ValueError,),
+            max_retries=3,
+            is_retryable=lambda e: False,
+        )
+        async def always_fails():
+            return mock_func()
+
+        with self.assertRaises(ValueError):
+            await always_fails()
+        self.assertEqual(mock_func.call_count, 1)
+
+    @patch("asyncio.sleep", return_value=None)
+    async def test_on_retry_callback(self, mock_sleep):
+        fail_exception = ValueError("Fail")
+        mock_func = Mock(side_effect=[fail_exception, "Success"])
+        mock_callback = Mock()
+
+        @exponential_backoff(retryable_exceptions=(ValueError,), on_retry=mock_callback)
+        async def flaky_function():
+            return mock_func()
+
+        result = await flaky_function()
         self.assertEqual(result, "Success")
         self.assertEqual(mock_func.call_count, 2)
         self.assertEqual(mock_callback.call_count, 1)


### PR DESCRIPTION
The decorator never retried async functions because it just returned coroutine returned by the async function without awaiting for it.

Also fix retry logic to not count the first function execution attempt as a retry. Previously 3 max retries meant 3 max total function execution, now it means 4 max total function executions. This looks more correct to me.