### PR TITLE
use PIP_BREAK_SYSTEM_PACKAGES env var to handle new versions of pip on ubuntu 

### DIFF
--- a/src/tensorlake/applications/image.py
+++ b/src/tensorlake/applications/image.py
@@ -75,6 +75,9 @@ def dockerfile_content(img: Image) -> str:
     dockerfile_lines: List[str] = [
         f"FROM {img._base_image}",
         "WORKDIR /app",
+        # Handle externally-managed environments (PEP 668) on modern Linux distros
+        # like Ubuntu 24.04. This env var allows pip to install packages globally.
+        "ENV PIP_BREAK_SYSTEM_PACKAGES=1",
     ]
 
     for op in img._build_operations:
@@ -82,12 +85,7 @@ def dockerfile_content(img: Image) -> str:
 
     # Run tensorlake install after all user commands. There's implicit dependency
     # of tensorlake install success on user commands right now.
-    # Use PIP_BREAK_SYSTEM_PACKAGES env var to handle externally-managed environments
-    # (PEP 668) on modern Linux distros like Ubuntu 24.04. Using env var instead of
-    # --break-system-packages flag for compatibility with older pip versions.
-    dockerfile_lines.append(
-        f"RUN PIP_BREAK_SYSTEM_PACKAGES=1 pip install tensorlake=={_SDK_VERSION}"
-    )
+    dockerfile_lines.append(f"RUN pip install tensorlake=={_SDK_VERSION}")
 
     return "\n".join(dockerfile_lines)
 

--- a/src/tensorlake/applications/interface/image.py
+++ b/src/tensorlake/applications/interface/image.py
@@ -87,62 +87,6 @@ class Image:
             )
         )
 
-    def pip_install(self, packages: str | List[str]) -> "Image":
-        """
-        Install Python packages using pip, handling externally-managed environments.
-
-        Args:
-            packages: A single package name/specifier or a list of packages to install.
-                     Supports version specifiers, e.g., "requests>=2.28" or ["numpy", "pandas==2.0"]
-
-        Returns:
-            Self for method chaining.
-
-        Example:
-            image = (
-                Image(base_image="ubuntu:24.04", name="my-image")
-                .pip_install("requests")
-                .pip_install(["numpy", "pandas>=2.0", "scikit-learn"])
-            )
-        """
-        pkgs = packages if isinstance(packages, str) else " ".join(packages)
-        # Use env var instead of --break-system-packages flag for compatibility
-        # with older pip versions. The env var is ignored if there's no
-        # EXTERNALLY-MANAGED marker (PEP 668).
-        return self.run(f"PIP_BREAK_SYSTEM_PACKAGES=1 pip install {pkgs}")
-
-    def setup_venv(self, path: str = "/venv") -> "Image":
-        """
-        Set up a Python virtual environment for pip installs.
-
-        This is an alternative to pip_install() for users who prefer using virtual
-        environments instead of --break-system-packages. After calling this method,
-        subsequent pip install commands will use the virtual environment.
-
-        Note: The base image must have python3-venv installed. For Ubuntu/Debian,
-        you may need to run: .run("apt-get update && apt-get install -y python3-venv")
-
-        Args:
-            path: The path where the virtual environment will be created.
-                  Defaults to "/venv".
-
-        Returns:
-            Self for method chaining.
-
-        Example:
-            image = (
-                Image(base_image="ubuntu:24.04", name="my-image")
-                .run("apt-get update && apt-get install -y python3-venv")
-                .setup_venv()  # Creates /venv and adds to PATH
-                .run("pip install requests numpy")  # Now works without --break-system-packages
-            )
-        """
-        return (
-            self.run(f"python3 -m venv {path}")
-            .env("PATH", f"{path}/bin:$PATH")
-            .run("pip install --upgrade pip wheel setuptools")
-        )
-
     def _add_operation(self, op: _ImageBuildOperation) -> "Image":
         self._build_operations.append(op)
         return self


### PR DESCRIPTION
New versions of ubuntu requires workarounds to install packages. Passing break system packages to make it easy to install packages systemwide, and a function to install venvs. 