### PR TITLE
Add created_at to the request progress updates.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.2.98"
+version = "0.2.99"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]

--- a/src/tensorlake/applications/request_context/progress.py
+++ b/src/tensorlake/applications/request_context/progress.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any
 
 from tensorlake.applications.cloud_events import print_cloud_event
@@ -32,14 +33,17 @@ def print_progress_update(
         "step": current,
         "total": total,
         "attributes": attributes,
+        "created_at": int(datetime.now().timestamp() * 1000),
     }
 
     if local_mode:
         print(f"Progress Update: {event}", flush=True)
     else:
         try:
-            # Keep seemingly redundant "RequestProgressUpdated" key for backward compatibility.
             print_cloud_event(
+                # The shape of the object is important because these events
+                # get merged with events sent by Indexify server,
+                # which sets a key with the struct name with the event as value.
                 {"RequestProgressUpdated": event},
                 type="ai.tensorlake.progress_update",
                 source="/tensorlake/applications/progress",

--- a/tests/function_executor/test_print_progress_updates.py
+++ b/tests/function_executor/test_print_progress_updates.py
@@ -108,18 +108,18 @@ class TestPrintProgressUpdates(unittest.TestCase):
 
         for num in range(arg):
             data = {
-                "RequestProgressUpdated": {
-                    "request_id": "123",
-                    "function_name": "prints_progress_updates",
-                    "message": f"prints_progress_updates: executing step {num} of {arg}",
-                    "step": num,
-                    "total": arg,
-                    "attributes": {"key": "value"},
-                }
+                "request_id": "123",
+                "function_name": "prints_progress_updates",
+                "message": f"prints_progress_updates: executing step {num} of {arg}",
+                "step": num,
+                "total": arg,
+                "attributes": {"key": "value"},
             }
 
             self.assertIn(
-                json.dumps(data),
+                # strip the closing braket because there might be other fields after attributes,
+                # but we don't care about them.
+                json.dumps(data).strip("}"),
                 fe_stdout,
             )
 
@@ -170,18 +170,18 @@ class TestPrintProgressUpdates(unittest.TestCase):
 
         for num in range(arg):
             data = {
-                "RequestProgressUpdated": {
-                    "request_id": "123",
-                    "function_name": "prints_progress_updates_with_message",
-                    "message": f"this is step {num} of {arg} steps in this function",
-                    "step": num,
-                    "total": arg,
-                    "attributes": {"key": "value"},
-                }
+                "request_id": "123",
+                "function_name": "prints_progress_updates_with_message",
+                "message": f"this is step {num} of {arg} steps in this function",
+                "step": num,
+                "total": arg,
+                "attributes": {"key": "value"},
             }
 
             self.assertIn(
-                json.dumps(data),
+                # strip the closing braket because there might be other fields after attributes,
+                # but we don't care about them.
+                json.dumps(data).strip("}"),
                 fe_stdout,
             )
 


### PR DESCRIPTION
That way we can better trace when the events were emitted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds timestamping to progress update events and aligns tests with the new payload while preserving cloud event shape.
> 
> - Add `created_at` (ms epoch) to progress updates in `request_context/progress.py`
> - Preserve cloud event payload shape by wrapping as `{ "RequestProgressUpdated": event }` and update comments for clarity
> - Update tests to assert on event fields without requiring the wrapper and to tolerate additional fields
> - Bump package version to `0.2.99`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d01c6e7c64d35d767a5e4e3c4bd92b1506b0a810. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->