### PR TITLE
WIP don't review, don't merge

### DIFF
--- a/src/tensorlake/applications/applications.py
+++ b/src/tensorlake/applications/applications.py
@@ -1,8 +1,11 @@
-from typing import Any, Generator, Iterator
+from typing import Generator, Iterator
 
 from .interface.function import Function, _is_application_function
 from .interface.request import Request
-from .interface.run import run_local_application, run_remote_application
+from .interface.run import (
+    run_local_application,
+    run_remote_application,
+)
 
 # Internal utilities for working with applications.
 
@@ -18,13 +21,13 @@ def filter_applications(
         yield function
 
 
-def run_application(application: Function | str, payload: Any, remote: bool) -> Request:
+def run_application(application: Function | str, remote: bool, **kwargs) -> Request:
     """Runs the application remotely or locally depending on the `remote` parameter value.
 
     This is a convenience wrapper around the `run_remote_application` and `run_local_application`.
     It's not part of SDK interface, it's a helper function for writing tests.
     """
     if remote:
-        return run_remote_application(application, payload)
+        return run_remote_application(application, **kwargs)
     else:
-        return run_local_application(application, payload)
+        return run_local_application(application, **kwargs)

--- a/src/tensorlake/applications/function/application_call.py
+++ b/src/tensorlake/applications/function/application_call.py
@@ -1,47 +1,105 @@
+from dataclasses import dataclass
 from typing import Any, List
+
+from tensorlake.vendor.nanoid import generate as nanoid
 
 from ..interface import DeserializationError, File, Function
 from ..metadata import ValueMetadata
-from .type_hints import function_arg_type_hint
-from .user_data_serializer import deserialize_value, function_input_serializer
+from ..user_data_serializer import UserDataSerializer
+from .type_hints import function_has_kwarg, function_kwarg_type_hint
+from .user_data_serializer import (
+    deserialize_value,
+    function_input_serializer,
+    serialize_value,
+)
 
 
-def deserialize_application_function_call_payload(
-    application: Function, payload: bytes, payload_content_type: str | None
-) -> Any:
-    """Deserializes the API function call payload.
+@dataclass
+class SerializedKWArg:
+    data: bytes
+    content_type: str | None
+
+
+def serialize_application_function_call_kwargs(
+    input_serializer: UserDataSerializer, kwargs: dict[str, Any]
+) -> dict[str, SerializedKWArg]:
+    """Serializes application function call kwargs.
+
+    Returns a dict with serialized value and content type for each argument.
+
+    raises SerializationError if serialization fails.
+    """
+    # NB: We don't have access to Function here as we might be called from RemoteRunner.
+    serialized_kwargs: dict[str, tuple[bytes, str | None]] = {}
+    for key, value in kwargs.items():
+        data, metadata = serialize_value(
+            value=value, value_serializer=input_serializer, value_id=nanoid()
+        )
+        serialized_kwargs[key] = SerializedKWArg(
+            data=data, content_type=metadata.content_type
+        )
+    return serialized_kwargs
+
+
+def deserialize_application_function_call_kwargs(
+    application: Function, serialized_kwargs: dict[str, SerializedKWArg]
+) -> dict[str, Any | File]:
+    """Deserializes the API function call kwargs.
 
     This is used for API function calls done over HTTP.
     The FunctionCallAwaitable is compliant with API function calling convention.
-    The supplied binary payload is deserialized using the input serializer and type hints of the API function.
-    The payload_content_type is used as File content type when application function expects a File.
+    The supplied binary kwargs are deserialized using the input serializer and type hints of the API function.
+    The content type from serialized_kwargs is used as File content type when application function expects a File.
 
     raises DeserializationError if deserialization fails.
     """
+    deserialized_kwargs: dict[str, Any | File] = {}
+    for key, serialized_kwarg in serialized_kwargs.items():
+        serialized_kwarg: SerializedKWArg
+        if not function_has_kwarg(application, key):
+            continue  # Allow users to pass unknown kwargs to give them more flexibility.
+
+        deserialized_kwargs[key] = _deserialize_application_function_call_kwarg(
+            application=application,
+            key=key,
+            payload=serialized_kwarg.data,
+            payload_content_type=serialized_kwarg.content_type,
+        )
+
+    return deserialized_kwargs
+
+
+def _deserialize_application_function_call_kwarg(
+    application: Function,
+    key: str,
+    payload: bytes,
+    payload_content_type: str | None,
+) -> Any | File:
+    """Deserializes a single application function call kwarg."""
+    input_serializer: UserDataSerializer = function_input_serializer(application)
     # We're using API function payload argument type hint to determine how to deserialize it properly.
-    payload_type_hints: List[Any] = function_arg_type_hint(application, -1)
+    payload_type_hints: List[Any] = function_kwarg_type_hint(application, key)
     if len(payload_type_hints) == 0:
-        payload_type_hints = [object]
+        # We are now doing pre-deployment validation for this so this is never supposed to happen.
+        raise DeserializationError(
+            f"Cannot deserialize application function '{application}' parameter '{key}': parameter is missing type hint."
+        )
 
     last_error: DeserializationError | None = None
 
     for type_hint in payload_type_hints:
         try:
-            deserialized_payload: Any | File = deserialize_value(
+            return deserialize_value(
                 serialized_value=payload,
                 metadata=ValueMetadata(
                     id="fake_id",
                     cls=type_hint,
-                    serializer_name=function_input_serializer(application).name,
+                    serializer_name=input_serializer.name,
                     content_type=payload_content_type,
                 ),
             )
         except DeserializationError as e:
             last_error = e
-            deserialized_payload = None
 
-    if last_error is not None:
-        # If all deserialization attempts failed, raise the last exception.
-        raise last_error
-
-    return deserialized_payload
+    # If all deserialization attempts failed, raise the last exception.
+    raise last_error

--- a/src/tensorlake/applications/function/type_hints.py
+++ b/src/tensorlake/applications/function/type_hints.py
@@ -32,6 +32,12 @@ def function_kwarg_type_hint(function: Function, key: str) -> List[Any]:
     return _resolve_type_hint(parameter.annotation)
 
 
+def function_has_kwarg(function: Function, key: str) -> bool:
+    """Returns True if the function has a keyword argument with the specified key."""
+    signature: inspect.Signature = function_signature(function)
+    return key in signature.parameters
+
+
 def function_return_type_hint(function: Function) -> List[Any]:
     signature: inspect.Signature = function_signature(function)
     if signature.return_annotation is inspect.Signature.empty:

--- a/src/tensorlake/applications/interface/run.py
+++ b/src/tensorlake/applications/interface/run.py
@@ -9,8 +9,8 @@ from .function import Function, _is_application_function
 from .request import Request
 
 
-def run_local_application(application: Function | str, payload: Any) -> Request:
-    """Runs the application function locally with the given payload and returns the request.
+def run_local_application(application: Function | str, **kwargs) -> Request:
+    """Runs the application function locally with the given kwargs and returns the request.
 
     Raises TensorlakeError if failed creating the request.
     """
@@ -26,12 +26,12 @@ def run_local_application(application: Function | str, payload: Any) -> Request:
             "To make it an application function, add @application() decorator to it."
         )
 
-    with LocalRunner(app=application, app_payload=payload) as runner:
+    with LocalRunner(app=application, app_kwargs=dict(kwargs)) as runner:
         return runner.run()
 
 
-def run_remote_application(application: Function | str, payload: Any) -> Request:
-    """Runs the application function remotely (i.e. on Tensorlake Cloud) with the given payload and returns the request.
+def run_remote_application(application: Function | str, **kwargs) -> Request:
+    """Runs the application function remotely (i.e. on Tensorlake Cloud) with the given kwargs and returns the request.
 
     Raises TensorlakeError if failed creating the request.
     """
@@ -50,7 +50,7 @@ def run_remote_application(application: Function | str, payload: Any) -> Request
     # We can't get Function object here because the user's client call might not load the function definitions.
     return RemoteRunner(
         application_name=app_name,
-        payload=payload,
+        app_kwargs=dict(kwargs),
         api_client=_remote_api_client_singleton,
     ).run()
 

--- a/src/tensorlake/function_executor/allocation_runner/sdk_algorithms.py
+++ b/src/tensorlake/function_executor/allocation_runner/sdk_algorithms.py
@@ -6,7 +6,7 @@ from tensorlake.applications import (
     InternalError,
 )
 from tensorlake.applications.function.application_call import (
-    deserialize_application_function_call_payload,
+    deserialize_application_function_call_kwargs,
 )
 from tensorlake.applications.function.function_call import (
     set_self_arg,
@@ -515,7 +515,7 @@ def deserialize_function_arguments(
             # Application payload argument. It's allready validated to be only one argument.
             args["application_payload"] = Value(
                 metadata=None,
-                object=deserialize_application_function_call_payload(
+                object=deserialize_application_function_call_kwargs(
                     application=function,
                     payload=serialized_arg.data,
                     payload_content_type=serialized_arg.content_type,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces kwargs-based application invocation with end-to-end (de)serialization.
> 
> - Replace single `payload` param with `**kwargs` across `run_application`, `run_local_application`, and `run_remote_application`; pass through via `app_kwargs`
> - Add `SerializedKWArg` and helpers to serialize/deserialize application function kwargs using function type hints and content types
> - Update `LocalRunner` to serialize/deserialize app kwargs and invoke `self._app.awaitable(**kwargs)`
> - Extend type hints with `function_has_kwarg` and use `function_kwarg_type_hint` during deserialization
> - Modify function executor (`sdk_algorithms.py`) to use kwargs deserialization for application payloads
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7482d03c2141975f32aa33154bad2cdf547680a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->