### PR TITLE
Couple minor fixes that Bugbot found

### DIFF
--- a/src/tensorlake/applications/remote/manifests/function.py
+++ b/src/tensorlake/applications/remote/manifests/function.py
@@ -231,7 +231,8 @@ def create_function_manifest(
     try:
         docstring_style: DocstringStyle = detect_docstring_style(docstring)
     except Exception as e:
-        pass  # Not a critical error, either docstring is malformed or our parser could be wrong.
+        # Not a critical error, either docstring is malformed or our parser could be wrong.
+        docstring_style: DocstringStyle = DocstringStyle.UNKNOWN
 
     # parameters and return type json schemas are only set for application functions
     # because this is only functions that use JSON serializable parameters and return

--- a/src/tensorlake/applications/validation/validate.py
+++ b/src/tensorlake/applications/validation/validate.py
@@ -17,7 +17,7 @@ from ..function.type_hints import (
     is_file_type_hint,
 )
 from ..function.user_data_serializer import function_input_serializer
-from ..interface import Awaitable, File, Function, InternalError
+from ..interface import Awaitable, File, Function, InternalError, SerializationError
 from ..interface.decorators import (
     _ApplicationDecorator,
     _class_name,
@@ -530,13 +530,13 @@ def _validate_application_function(
                         default_arg_value_serializer.serialize(
                             parameter.default, parameter.annotation
                         )
-                    except Exception as e:
+                    except SerializationError as e:
                         messages.append(
                             ValidationMessage(
                                 message=f"Application function parameter '{parameter.name}' has a default value that can't be serialized with "
                                 f"the type hint of the parameter {parameter.annotation}. "
-                                f"Please follow Pydantic documentation and the following Pydantic error message to make the default value serializable "
-                                "to JSON format.\nPydantic error message:\n{e}\n",
+                                f"Please follow Pydantic documentation and the following SerializationError to make the default value serializable "
+                                f"to JSON format:\n{e}\n",
                                 severity=ValidationMessageSeverity.ERROR,
                                 details=function_details,
                             )

--- a/tests/applications/validation/application/test_default_parameter_value_type_hint.py
+++ b/tests/applications/validation/application/test_default_parameter_value_type_hint.py
@@ -33,10 +33,11 @@ class TestDefaultParameterValueTypeHint(unittest.TestCase):
             ValidationMessageSeverity.ERROR,
         )
         self.assertEqual(
-            f"Application function parameter 'factor2' has a default value that can't be serialized with "
-            f"the type hint of the parameter {float}. "
-            f"Please follow Pydantic documentation and the following Pydantic error message to make the default value serializable "
-            "to JSON format.\nPydantic error message:\n{e}\n",
+            "Application function parameter 'factor2' has a default value that can't be serialized with "
+            f"the type hint of the parameter {float}. Please follow Pydantic documentation and the following SerializationError to "
+            "make the default value serializable to JSON format:\nFailed to serialize '1.0' as '<class 'float'>' to json: Pydantic "
+            "serializer warnings:\n  PydanticSerializationUnexpectedValue(Expected `float` - serialized value may not be as expected "
+            "[input_value='1.0', input_type=str])\n",
             validation_message.message,
         )
 


### PR DESCRIPTION
Couple minor fixes that Bugbot found

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small error-handling and messaging tweaks in manifest generation and validation, plus an updated test expectation. Main risk is slightly changed validation behavior/message matching for default parameter serialization failures.
> 
> **Overview**
> Improves robustness of function manifest generation by treating docstring-style detection failures as non-fatal and explicitly defaulting `docstring_style` to `DocstringStyle.UNKNOWN`.
> 
> Tightens application validation for default parameter values to only catch and report `SerializationError` (instead of any exception), and updates the emitted error message/test to reference `SerializationError` and include the concrete serializer failure output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c471c13b3220bd59d215a28a1ad8449d72f32d2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->