### PR TITLE
Rewrite all algorithms in non-recursive way

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.3.8"
+version = "0.3.9"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]

--- a/src/tensorlake/applications/algorithms/__init__.py
+++ b/src/tensorlake/applications/algorithms/__init__.py
@@ -1,7 +1,15 @@
+from .copy_awaitable_tree import copy_awaitable_tree
 from .reduce_operation import reduce_operation_to_function_call_chain
-from .validate_user_object import validate_user_object
+from .validate_user_object import (
+    validate_tail_call_user_object,
+    validate_user_awaitable_before_running,
+)
+from .walk_awaitable_tree import dfs_bottom_up
 
 __all__ = [
+    "copy_awaitable_tree",
+    "dfs_bottom_up",
     "reduce_operation_to_function_call_chain",
-    "validate_user_object",
+    "validate_user_awaitable_before_running",
+    "validate_tail_call_user_object",
 ]

--- a/src/tensorlake/applications/algorithms/copy_awaitable_tree.py
+++ b/src/tensorlake/applications/algorithms/copy_awaitable_tree.py
@@ -1,0 +1,73 @@
+import copy
+
+from ..interface.awaitables import (
+    Awaitable,
+    AwaitableList,
+    FunctionCallAwaitable,
+    ReduceOperationAwaitable,
+)
+from ..interface.exceptions import InternalError
+
+
+def copy_awaitable_tree(root: Awaitable) -> Awaitable:
+    """Returns a shallow copy of the supplied awaitable tree.
+
+    Raises InternalError on error.
+    """
+    new_root: Awaitable = _copy_node(root)
+    stack: list[Awaitable] = [new_root]
+
+    while len(stack) > 0:
+        copied_node = stack.pop()
+        if isinstance(copied_node, AwaitableList):
+            for index, item in enumerate(copied_node.items):
+                if isinstance(item, Awaitable):
+                    copied_item_node: Awaitable = _copy_node(item)
+                    stack.append(copied_item_node)
+                    copied_node.items[index] = copied_item_node
+        elif isinstance(copied_node, ReduceOperationAwaitable):
+            for index, input in enumerate(copied_node.inputs):
+                if isinstance(input, Awaitable):
+                    copied_input_node: Awaitable = _copy_node(input)
+                    stack.append(copied_input_node)
+                    copied_node.inputs[index] = copied_input_node
+        elif isinstance(copied_node, FunctionCallAwaitable):
+            for index, arg in enumerate(copied_node.args):
+                if isinstance(arg, Awaitable):
+                    copied_arg_node: Awaitable = _copy_node(arg)
+                    stack.append(copied_arg_node)
+                    copied_node.args[index] = copied_arg_node
+            for key, kwarg in copied_node.kwargs.items():
+                if isinstance(kwarg, Awaitable):
+                    copied_kwarg_node: Awaitable = _copy_node(kwarg)
+                    stack.append(copied_kwarg_node)
+                    copied_node.kwargs[key] = copied_kwarg_node
+        else:
+            raise InternalError(f"Unexpected Awaitable type: {type(copied_node)}")
+
+    return new_root
+
+
+def _copy_node(node: Awaitable) -> Awaitable:
+    """Returns shallow copy of the node without copying its child nodes."""
+    if isinstance(node, AwaitableList):
+        return AwaitableList(
+            id=node.id,
+            items=list(node.items),
+            metadata=copy.copy(node.metadata),
+        )
+    elif isinstance(node, ReduceOperationAwaitable):
+        return ReduceOperationAwaitable(
+            id=node.id,
+            function_name=node.function_name,
+            inputs=list(node.inputs),
+        )
+    elif isinstance(node, FunctionCallAwaitable):
+        return FunctionCallAwaitable(
+            id=node.id,
+            function_name=node.function_name,
+            args=list(node.args),
+            kwargs=dict(node.kwargs),
+        )
+    else:
+        raise InternalError(f"Unexpected Awaitable type: {type(node)}")

--- a/src/tensorlake/applications/algorithms/walk_awaitable_tree.py
+++ b/src/tensorlake/applications/algorithms/walk_awaitable_tree.py
@@ -1,0 +1,69 @@
+from typing import Any, Generator
+
+from ..interface.awaitables import (
+    Awaitable,
+    AwaitableList,
+    FunctionCallAwaitable,
+    Future,
+    ReduceOperationAwaitable,
+)
+from ..interface.exceptions import InternalError
+
+
+def dfs_bottom_up(
+    root: Awaitable | Future,
+    leaf_awaitable_types: tuple[type[Awaitable], ...],
+) -> Generator[Awaitable | Future, None, None]:
+    """Yields all Awaitables and Futures starting from leafs up to the root aka Post-Order DFS.
+
+    This traversal order is useful when at the moment of processing a node, all its children have
+    to be already processed.
+
+    leaf_awaitable_types is a tuple of Awaitable types that should be treated as leafs in the
+    traversal. Their children won't be traversed.
+
+    The traversal order is deterministic (always the same for the same tree).
+
+    Doesn't look inside Futures as they are not currently supported in trees of Awaitables.
+    Doesn't yield user supplied values.
+    Raises InternalError if encounters an unexpected Awaitable type.
+    """
+    dfs_stack: list[Awaitable | Future] = [root]
+    yield_stack: list[Awaitable | Future] = []
+
+    while len(dfs_stack) > 0:
+        node: Awaitable | Future = dfs_stack.pop()
+        yield_stack.append(node)
+
+        if isinstance(node, leaf_awaitable_types):
+            continue
+        elif isinstance(node, AwaitableList):
+            node: AwaitableList
+            for item in node.items:
+                if _is_awaitable_tree_node(item):
+                    dfs_stack.append(item)
+        elif isinstance(node, ReduceOperationAwaitable):
+            node: ReduceOperationAwaitable
+            for item in node.inputs:
+                if _is_awaitable_tree_node(item):
+                    dfs_stack.append(item)
+        elif isinstance(node, FunctionCallAwaitable):
+            node: FunctionCallAwaitable
+            for arg in node.args:
+                if _is_awaitable_tree_node(arg):
+                    dfs_stack.append(arg)
+            # Sort dict keys to ensure deterministic traversal order.
+            for key in sorted(node.kwargs.keys()):
+                arg = node.kwargs[key]
+                if _is_awaitable_tree_node(arg):
+                    dfs_stack.append(arg)
+        elif isinstance(node, Future):
+            pass  # Don't look inside Futures as they are not currently supported in trees of Awaitables.
+        else:
+            raise InternalError(f"Unexpected type of Awaitable tree node: {type(node)}")
+
+    yield from reversed(yield_stack)
+
+
+def _is_awaitable_tree_node(value: Awaitable | Future | Any) -> bool:
+    return isinstance(value, (Awaitable, Future))

--- a/tests/applications/test_map.py
+++ b/tests/applications/test_map.py
@@ -1,5 +1,4 @@
 import unittest
-from typing import List
 
 import parameterized
 import validate_all_applications

--- a/tests/function_executor/test_to_durable_awaitable_tree.py
+++ b/tests/function_executor/test_to_durable_awaitable_tree.py
@@ -65,30 +65,6 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                 ),
             },
             {
-                "name": "Single ReduceOperationAwaitable",
-                "node": ReduceOperationAwaitable(
-                    id="awaitable_1",
-                    function_name="reduce_func",
-                    inputs=[1, 2],
-                ),
-                "parent_function_call_id": "parent_function_call_id_123",
-                "previous_awaitable_id": "previous_awaitable_id_456",
-                "expected_node": FunctionCallAwaitable(
-                    id=_sha256_hash_strings(
-                        [
-                            "parent_function_call_id_123",
-                            "previous_awaitable_id_456",
-                            "0",
-                            "FunctionCall",
-                            "reduce_func",
-                        ]
-                    ),
-                    function_name="reduce_func",
-                    args=[1, 2],
-                    kwargs={},
-                ),
-            },
-            {
                 "name": "Single Map Operation AwaitableList",
                 "node": AwaitableList(
                     id="awaitable_list_1",
@@ -111,13 +87,13 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                         [
                             "parent_function_call_id_123",
                             "previous_awaitable_id_456",
-                            "0",
+                            "1",
                             "MAP_OPERATION:map_func",
                             _sha256_hash_strings(
                                 [
                                     "parent_function_call_id_123",
                                     "previous_awaitable_id_456",
-                                    "1",
+                                    "0",
                                     "FunctionCall",
                                     "map_func",
                                 ]
@@ -130,7 +106,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                 [
                                     "parent_function_call_id_123",
                                     "previous_awaitable_id_456",
-                                    "1",
+                                    "0",
                                     "FunctionCall",
                                     "map_func",
                                 ]
@@ -194,14 +170,14 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                         [
                             "parent_function_call_id_123",
                             "previous_awaitable_id_456",
-                            "0",
+                            "5",
                             "FunctionCall",
                             "func_1",
                             _sha256_hash_strings(
                                 [
                                     "parent_function_call_id_123",
                                     "previous_awaitable_id_456",
-                                    "1",
+                                    "0",
                                     "FunctionCall",
                                     "func_2",
                                 ]
@@ -210,7 +186,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                 [
                                     "parent_function_call_id_123",
                                     "previous_awaitable_id_456",
-                                    "2",
+                                    "4",
                                     "FunctionCall",
                                     "func_3",
                                     _sha256_hash_strings(
@@ -220,12 +196,12 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                             "3",
                                             "FunctionCall",
                                             "func_4",
-                                            # "a" kwarg key first due to alphabetical order
+                                            # "a" kwarg key is before "c" due alphabetical traversal order
                                             _sha256_hash_strings(
                                                 [
                                                     "parent_function_call_id_123",
                                                     "previous_awaitable_id_456",
-                                                    "4",
+                                                    "1",
                                                     "FunctionCall",
                                                     "func_6",
                                                 ]
@@ -234,7 +210,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                                 [
                                                     "parent_function_call_id_123",
                                                     "previous_awaitable_id_456",
-                                                    "5",
+                                                    "2",
                                                     "FunctionCall",
                                                     "func_5",
                                                 ]
@@ -252,7 +228,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                 [
                                     "parent_function_call_id_123",
                                     "previous_awaitable_id_456",
-                                    "1",
+                                    "0",
                                     "FunctionCall",
                                     "func_2",
                                 ]
@@ -267,7 +243,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                 [
                                     "parent_function_call_id_123",
                                     "previous_awaitable_id_456",
-                                    "2",
+                                    "4",
                                     "FunctionCall",
                                     "func_3",
                                     _sha256_hash_strings(
@@ -277,12 +253,12 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                             "3",
                                             "FunctionCall",
                                             "func_4",
-                                            # "a" kwarg key first due to alphabetical order
+                                            # "a" kwarg key is before "c" due alphabetical traversal order
                                             _sha256_hash_strings(
                                                 [
                                                     "parent_function_call_id_123",
                                                     "previous_awaitable_id_456",
-                                                    "4",
+                                                    "1",
                                                     "FunctionCall",
                                                     "func_6",
                                                 ]
@@ -291,7 +267,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                                 [
                                                     "parent_function_call_id_123",
                                                     "previous_awaitable_id_456",
-                                                    "5",
+                                                    "2",
                                                     "FunctionCall",
                                                     "func_5",
                                                 ]
@@ -311,12 +287,12 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                             "3",
                                             "FunctionCall",
                                             "func_4",
-                                            # "a" kwarg key first due to alphabetical order
+                                            # "a" kwarg key is after "c" due to reverse alphabetical traversal order
                                             _sha256_hash_strings(
                                                 [
                                                     "parent_function_call_id_123",
                                                     "previous_awaitable_id_456",
-                                                    "4",
+                                                    "1",
                                                     "FunctionCall",
                                                     "func_6",
                                                 ]
@@ -325,7 +301,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                                 [
                                                     "parent_function_call_id_123",
                                                     "previous_awaitable_id_456",
-                                                    "5",
+                                                    "2",
                                                     "FunctionCall",
                                                     "func_5",
                                                 ]
@@ -335,12 +311,13 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                     function_name="func_4",
                                     args=[4],
                                     kwargs={
+                                        # "a" kwarg key is before "c" due alphabetical traversal order
                                         "c": FunctionCallAwaitable(
                                             id=_sha256_hash_strings(
                                                 [
                                                     "parent_function_call_id_123",
                                                     "previous_awaitable_id_456",
-                                                    "5",
+                                                    "2",
                                                     "FunctionCall",
                                                     "func_5",
                                                 ]
@@ -354,7 +331,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                                 [
                                                     "parent_function_call_id_123",
                                                     "previous_awaitable_id_456",
-                                                    "4",
+                                                    "1",
                                                     "FunctionCall",
                                                     "func_6",
                                                 ]
@@ -372,138 +349,23 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                 ),
             },
             {
-                "name": "Nested Reduce Operations",
-                "node": ReduceOperationAwaitable(
-                    id="reduce_op_1",
-                    function_name="reduce_func_1",
-                    inputs=[
-                        ReduceOperationAwaitable(
-                            id="reduce_op_2",
-                            function_name="reduce_func_2",
-                            inputs=[1, 2, 3],
-                        ),
-                        ReduceOperationAwaitable(
-                            id="reduce_op_3",
-                            function_name="reduce_func_3",
-                            inputs=[5, 6],
-                        ),
-                    ],
-                ),
-                "parent_function_call_id": "parent_function_call_id_327",
-                "previous_awaitable_id": "previous_awaitable_id_456",
-                "expected_node": FunctionCallAwaitable(
-                    id=_sha256_hash_strings(
-                        [
-                            "parent_function_call_id_327",
-                            "previous_awaitable_id_456",
-                            "0",
-                            "FunctionCall",
-                            "reduce_func_1",
-                            _sha256_hash_strings(
-                                [
-                                    "parent_function_call_id_327",
-                                    "previous_awaitable_id_456",
-                                    "1",
-                                    "FunctionCall",
-                                    "reduce_func_2",
-                                    _sha256_hash_strings(
-                                        [
-                                            "parent_function_call_id_327",
-                                            "previous_awaitable_id_456",
-                                            "2",
-                                            "FunctionCall",
-                                            "reduce_func_2",
-                                        ]
-                                    ),
-                                ],
-                            ),
-                            _sha256_hash_strings(
-                                [
-                                    "parent_function_call_id_327",
-                                    "previous_awaitable_id_456",
-                                    "3",
-                                    "FunctionCall",
-                                    "reduce_func_3",
-                                ]
-                            ),
-                        ]
-                    ),
-                    function_name="reduce_func_1",
-                    args=[
-                        FunctionCallAwaitable(
-                            id=_sha256_hash_strings(
-                                [
-                                    "parent_function_call_id_327",
-                                    "previous_awaitable_id_456",
-                                    "1",
-                                    "FunctionCall",
-                                    "reduce_func_2",
-                                    _sha256_hash_strings(
-                                        [
-                                            "parent_function_call_id_327",
-                                            "previous_awaitable_id_456",
-                                            "2",
-                                            "FunctionCall",
-                                            "reduce_func_2",
-                                        ]
-                                    ),
-                                ],
-                            ),
-                            function_name="reduce_func_2",
-                            args=[
-                                FunctionCallAwaitable(
-                                    id=_sha256_hash_strings(
-                                        [
-                                            "parent_function_call_id_327",
-                                            "previous_awaitable_id_456",
-                                            "2",
-                                            "FunctionCall",
-                                            "reduce_func_2",
-                                        ]
-                                    ),
-                                    function_name="reduce_func_2",
-                                    args=[1, 2],
-                                    kwargs={},
-                                ),
-                                3,
-                            ],
-                            kwargs={},
-                        ),
-                        FunctionCallAwaitable(
-                            id=_sha256_hash_strings(
-                                [
-                                    "parent_function_call_id_327",
-                                    "previous_awaitable_id_456",
-                                    "3",
-                                    "FunctionCall",
-                                    "reduce_func_3",
-                                ]
-                            ),
-                            function_name="reduce_func_3",
-                            args=[5, 6],
-                            kwargs={},
-                        ),
-                    ],
-                    kwargs={},
-                ),
-            },
-            {
                 "name": "Mixed Awaitable Tree",
                 "node": AwaitableList(
                     id="1",
                     items=[
-                        ReduceOperationAwaitable(
+                        FunctionCallAwaitable(
                             id="2",
                             function_name="reduce_func_1",
-                            inputs=["123", "125"],
+                            args=["123", "125"],
+                            kwargs={},
                         ),
                         AwaitableList(
                             id="3",
                             items=[
-                                ReduceOperationAwaitable(
+                                FunctionCallAwaitable(
                                     id="4",
                                     function_name="reduce_func_2",
-                                    inputs=[
+                                    args=[
                                         FunctionCallAwaitable(
                                             id="5",
                                             function_name="func_map_1",
@@ -512,6 +374,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                         ),
                                         100500,
                                     ],
+                                    kwargs={},
                                 ),
                             ],
                             metadata=_AwaitableListMetadata(
@@ -531,13 +394,13 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                         [
                             "parent_function_call_id_111",
                             "previous_awaitable_id_456",
-                            "0",
+                            "4",
                             "MAP_OPERATION:func_map2",
                             _sha256_hash_strings(
                                 [
                                     "parent_function_call_id_111",
                                     "previous_awaitable_id_456",
-                                    "1",
+                                    "0",
                                     "FunctionCall",
                                     "reduce_func_1",
                                 ]
@@ -546,20 +409,20 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                 [
                                     "parent_function_call_id_111",
                                     "previous_awaitable_id_456",
-                                    "2",
+                                    "3",
                                     "MAP_OPERATION:func_map_1",
                                     _sha256_hash_strings(
                                         [
                                             "parent_function_call_id_111",
                                             "previous_awaitable_id_456",
-                                            "3",
+                                            "2",
                                             "FunctionCall",
                                             "reduce_func_2",
                                             _sha256_hash_strings(
                                                 [
                                                     "parent_function_call_id_111",
                                                     "previous_awaitable_id_456",
-                                                    "4",
+                                                    "1",
                                                     "FunctionCall",
                                                     "func_map_1",
                                                 ]
@@ -576,7 +439,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                 [
                                     "parent_function_call_id_111",
                                     "previous_awaitable_id_456",
-                                    "1",
+                                    "0",
                                     "FunctionCall",
                                     "reduce_func_1",
                                 ]
@@ -590,20 +453,20 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                 [
                                     "parent_function_call_id_111",
                                     "previous_awaitable_id_456",
-                                    "2",
+                                    "3",
                                     "MAP_OPERATION:func_map_1",
                                     _sha256_hash_strings(
                                         [
                                             "parent_function_call_id_111",
                                             "previous_awaitable_id_456",
-                                            "3",
+                                            "2",
                                             "FunctionCall",
                                             "reduce_func_2",
                                             _sha256_hash_strings(
                                                 [
                                                     "parent_function_call_id_111",
                                                     "previous_awaitable_id_456",
-                                                    "4",
+                                                    "1",
                                                     "FunctionCall",
                                                     "func_map_1",
                                                 ]
@@ -618,14 +481,14 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                         [
                                             "parent_function_call_id_111",
                                             "previous_awaitable_id_456",
-                                            "3",
+                                            "2",
                                             "FunctionCall",
                                             "reduce_func_2",
                                             _sha256_hash_strings(
                                                 [
                                                     "parent_function_call_id_111",
                                                     "previous_awaitable_id_456",
-                                                    "4",
+                                                    "1",
                                                     "FunctionCall",
                                                     "func_map_1",
                                                 ]
@@ -639,7 +502,7 @@ class TestToDurableAwaitableTree(unittest.TestCase):
                                                 [
                                                     "parent_function_call_id_111",
                                                     "previous_awaitable_id_456",
-                                                    "4",
+                                                    "1",
                                                     "FunctionCall",
                                                     "func_map_1",
                                                 ]


### PR DESCRIPTION
This is because Python has default recursion limit of 1000 which is pretty easy to break with i.e. a reduce operation of 1000 items list.

There are no functioncal changes. The semantic of all operations is the same.