### PR TITLE
Add grpcio-tools to package dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -252,7 +252,7 @@ version = "1.60.0"
 description = "Protobuf code generator for gRPC"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "grpcio-tools-1.60.0.tar.gz", hash = "sha256:ed30499340228d733ff69fcf4a66590ed7921f94eb5a2bf692258b1280b9dac7"},
     {file = "grpcio_tools-1.60.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:6807b7a3f3e6e594566100bd7fe04a2c42ce6d5792652677f1aaf5aa5adaef3d"},
@@ -615,7 +615,7 @@ version = "4.25.8"
 description = ""
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "protobuf-4.25.8-cp310-abi3-win32.whl", hash = "sha256:504435d831565f7cfac9f0714440028907f1975e4bed228e58e72ecfff58a1e0"},
     {file = "protobuf-4.25.8-cp310-abi3-win_amd64.whl", hash = "sha256:bd551eb1fe1d7e92c1af1d75bdfa572eff1ab0e5bf1736716814cdccdb2360f9"},
@@ -1026,7 +1026,7 @@ version = "69.5.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "setuptools-69.5.1-py3-none-any.whl", hash = "sha256:c636ac361bc47580504644275c9ad802c50415c7522212252c033bd15f301f32"},
     {file = "setuptools-69.5.1.tar.gz", hash = "sha256:6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"},
@@ -1160,4 +1160,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "62b86eda1da306e4229729c235aab626e24aa7afa139757d32b86ae7f3a50fbc"
+content-hash = "386c9b06f3b355da8b8b8e047bffaa7cb12b108f8451b750be456073f3304eeb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.3.10"
+version = "0.3.11"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
@@ -22,6 +22,7 @@ tomlkit = "^0.14.0"
 # when developing with poetry, the version
 # from dev.dependencies is used.
 grpcio = ">=1.40.0,<2.0.0"
+grpcio-tools = ">=1.40.0,<2.0.0"
 
 [tool.poetry.scripts]
 tensorlake = "tensorlake.cli:cli"


### PR DESCRIPTION
I though this is not needed, adding it back.
Didn't break CI because CI doesn't install from pypi.