### PR TITLE
Add future.coroutine() method, fix bug, add missing test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tensorlake"
-version = "0.4.2"
+version = "0.4.3"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]

--- a/src/tensorlake/applications/interface/futures.py
+++ b/src/tensorlake/applications/interface/futures.py
@@ -156,6 +156,35 @@ class Future:
         # This logic relies on runtime setting these fields as soon as the future is done.
         return self._result is not _FutureResultMissing or self._exception is not None
 
+    def coroutine(self) -> Coroutine[Any, Any, Any]:
+        """Returns an asyncio coroutine for the Future.
+
+        The coroutine can be used the same way as any coroutine returned by an async Tensorlake function call.
+        Returns the same coroutine object if called multiple times on the same Future.
+
+        Raises SDKUsageError if called from a sync function.
+        Raises SDKUsageError if called on an already started Future.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            raise SDKUsageError(
+                "Future.coroutine() can only be called from an async function. "
+                "Use Future.result() to get the result in a sync function."
+            )
+
+        # self._coroutine is set to None when the Future is done().
+        # We also can't recreate coroutines to not leak resources.
+        # So we have to limit the usage of coroutine().
+        if self._run_hook_was_called:
+            raise SDKUsageError(
+                f"Future.coroutine() cannot be called on a Future that is already running: {self}"
+            )
+
+        if self._coroutine is not None:
+            return self._coroutine
+        return _wrap_future_into_coroutine(self)
+
     def _done_result(self) -> Any:
         """Returns the result of the future if it's done, otherwise raises an error."""
         if not self.done():

--- a/src/tensorlake/applications/local/future_run/function_call_future_run.py
+++ b/src/tensorlake/applications/local/future_run/function_call_future_run.py
@@ -13,6 +13,8 @@ from ...interface.function import Function
 from ...interface.futures import (
     FunctionCallFuture,
     Future,
+    _TensorlakeFutureWrapper,
+    _unwrap_future,
 )
 from ...interface.request_context import RequestContext
 from ...interface.retries import Retries
@@ -86,16 +88,20 @@ class FunctionCallFutureRun(LocalFutureRun):
         while True:
             try:
                 if inspect.iscoroutinefunction(self._function):
-                    result: Any | Future = asyncio.run(
+                    result: Any | _TensorlakeFutureWrapper[Future] = asyncio.run(
                         self._function._original_function(
                             *self._arg_values, **self._kwarg_values
                         )
                     )
                 else:
-                    result: Any | Future = self._function._original_function(
-                        *self._arg_values, **self._kwarg_values
+                    result: Any | _TensorlakeFutureWrapper[Future] = (
+                        self._function._original_function(
+                            *self._arg_values, **self._kwarg_values
+                        )
                     )
-                return LocalFutureRunResult(id=future._id, output=result, error=None)
+                return LocalFutureRunResult(
+                    id=future._id, output=_unwrap_future(result), error=None
+                )
             except RequestError as e:
                 # Never retry on RequestError.
                 return LocalFutureRunResult(id=future._id, output=None, error=e)

--- a/tests/applications/test_async_output_propagation.py
+++ b/tests/applications/test_async_output_propagation.py
@@ -1,0 +1,150 @@
+import unittest
+
+import parameterized
+import validate_all_applications
+
+from tensorlake.applications import (
+    Request,
+    application,
+    function,
+)
+from tensorlake.applications.applications import run_application
+from tensorlake.applications.remote.deploy import deploy_applications
+
+ValidateAllApplicationsTest: unittest.TestCase = validate_all_applications.define_test()
+
+
+@function()
+async def async_identity(x: str) -> str:
+    return x
+
+
+@function()
+def sync_identity(x: str) -> str:
+    return x
+
+
+@application()
+@function()
+async def api_return_coroutine(payload: str) -> str:
+    return foo_coroutine(payload)
+
+
+@function()
+async def foo_coroutine(x: str) -> str:
+    return bar_coroutine(x)
+
+
+@function()
+async def bar_coroutine(x: str) -> str:
+    return async_identity(x)
+
+
+class TestReturnCoroutine(unittest.TestCase):
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_success(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(api_return_coroutine, is_remote, "coroutine")
+        self.assertEqual(request.output(), "coroutine")
+
+
+@application()
+@function()
+async def api_return_future(payload: str) -> str:
+    return foo_future(payload)
+
+
+@function()
+async def foo_future(x: str) -> str:
+    return bar_future.future(x)
+
+
+@function()
+async def bar_future(x: str) -> str:
+    return async_identity.future(x)
+
+
+class TestReturnFuture(unittest.TestCase):
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_success(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(api_return_future, is_remote, "future")
+        self.assertEqual(request.output(), "future")
+
+
+@application()
+@function()
+async def api_return_sync_future_coroutine(payload: str) -> str:
+    return foo_sync_future_coroutine(payload)
+
+
+@function()
+async def foo_sync_future_coroutine(x: str) -> str:
+    return sync_identity.future(x).coroutine()
+
+
+class TestReturnSyncFutureCoroutine(unittest.TestCase):
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_success(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            api_return_sync_future_coroutine, is_remote, "sync_future_coroutine"
+        )
+        self.assertEqual(request.output(), "sync_future_coroutine")
+
+
+@application()
+@function()
+async def api_return_async_future_coroutine(payload: str) -> str:
+    return foo_async_future_coroutine(payload)
+
+
+@function()
+async def foo_async_future_coroutine(x: str) -> str:
+    return async_identity.future(x).coroutine()
+
+
+class TestReturnAsyncFutureCoroutine(unittest.TestCase):
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_success(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            api_return_async_future_coroutine, is_remote, "async_future_coroutine"
+        )
+        self.assertEqual(request.output(), "async_future_coroutine")
+
+
+@application()
+@function()
+async def api_mixed_chain(payload: str) -> str:
+    # Tail call via coroutine (calling async function directly).
+    return mixed_step_future(payload)
+
+
+@function()
+async def mixed_step_future(x: str) -> str:
+    # Tail call via Future.
+    return mixed_step_sync_future_coroutine.future(x)
+
+
+@function()
+async def mixed_step_sync_future_coroutine(x: str) -> str:
+    # Tail call via sync .future().coroutine().
+    return sync_identity.future(x).coroutine()
+
+
+class TestMixedChain(unittest.TestCase):
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_success(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(api_mixed_chain, is_remote, "mixed")
+        self.assertEqual(request.output(), "mixed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/applications/test_futures_consume_futures.py
+++ b/tests/applications/test_futures_consume_futures.py
@@ -86,6 +86,43 @@ async def async_three_futures_consume_same_future_tail_call(x: int) -> int:
     return async_add.future(async_add(a, b), c)
 
 
+# Tail call returns a coroutine (calling async function directly).
+# This is distinct from async_three_futures_consume_same_future_tail_call which
+# returns a Future via .future(). Here the coroutine wraps the Future and needs
+# to be unwrapped by the runner.
+@application()
+@function()
+async def async_three_futures_consume_same_future_coroutine_tail_call(x: int) -> int:
+    doubled = async_double(x)
+    a = async_add(doubled, 1)
+    b = async_add(doubled, 2)
+    c = async_add(doubled, 3)
+    return async_add(async_add(a, b), c)
+
+
+# Tail call returns a coroutine from sync .future().coroutine().
+# Async app consumes sync function futures converted to coroutines.
+@application()
+@function()
+async def async_sync_futures_as_coroutines_tail_call(x: int) -> int:
+    doubled = sync_double.future(x).coroutine()
+    a = sync_add.future(doubled, 1).coroutine()
+    b = sync_add.future(doubled, 2).coroutine()
+    c = sync_add.future(doubled, 3).coroutine()
+    return sync_add.future(sync_add.future(a, b), c).coroutine()
+
+
+# Tail call returns a coroutine from async .future().coroutine().
+@application()
+@function()
+async def async_futures_as_coroutines_tail_call(x: int) -> int:
+    doubled = async_double.future(x).coroutine()
+    a = async_add.future(doubled, 1).coroutine()
+    b = async_add.future(doubled, 2).coroutine()
+    c = async_add.future(doubled, 3).coroutine()
+    return async_add.future(async_add.future(a, b), c).coroutine()
+
+
 class TestFuturesConsumeFutures(unittest.TestCase):
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync(self, _: str, is_remote: bool):
@@ -126,6 +163,39 @@ class TestFuturesConsumeFutures(unittest.TestCase):
             deploy_applications(__file__)
         request: Request = run_application(
             async_three_futures_consume_same_future_tail_call,
+            is_remote,
+            x=5,
+        )
+        self.assertEqual(request.output(), 36)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_async_coroutine_tail_call(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            async_three_futures_consume_same_future_coroutine_tail_call,
+            is_remote,
+            x=5,
+        )
+        self.assertEqual(request.output(), 36)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_async_sync_futures_as_coroutines_tail_call(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            async_sync_futures_as_coroutines_tail_call,
+            is_remote,
+            x=5,
+        )
+        self.assertEqual(request.output(), 36)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_async_futures_as_coroutines_tail_call(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            async_futures_as_coroutines_tail_call,
             is_remote,
             x=5,
         )

--- a/tests/applications/test_sync_async_calls.py
+++ b/tests/applications/test_sync_async_calls.py
@@ -7,6 +7,7 @@ import validate_all_applications
 from tensorlake.applications import (
     Future,
     Request,
+    SDKUsageError,
     application,
     function,
 )
@@ -207,6 +208,73 @@ def sync_app_chains_futures(x: int) -> int:
     a: Future = sync_double.future(x)
     b: Future = sync_double.future(x)
     return sync_add.future(a, b)
+
+
+@application()
+@function()
+async def async_app_await_sync_coroutine(x: int) -> int:
+    return await sync_double.future(x).coroutine()
+
+
+@application()
+@function()
+async def async_app_create_task_from_sync_coroutine(x: int) -> int:
+    task: asyncio.Task = asyncio.create_task(sync_double.future(x).coroutine())
+    return await task
+
+
+@application()
+@function()
+async def async_app_gather_sync_coroutines(x: int) -> int:
+    coroutines = [
+        sync_double.future(x).coroutine(),
+        sync_add.future(x, x).coroutine(),
+    ]
+    results: list[int] = await asyncio.gather(*coroutines)
+    return results[0] + results[1]
+
+
+@application()
+@function()
+async def async_app_coroutine_returns_same_object(x: int) -> int:
+    future: Future = sync_double.future(x)
+    coro1 = future.coroutine()
+    coro2 = future.coroutine()
+    assert coro1 is coro2
+    return await coro1
+
+
+@application()
+@function()
+async def async_app_pass_sync_coroutine_as_arg(x: int) -> int:
+    doubled_coroutine = sync_double.future(x).coroutine()
+    return async_add(x, doubled_coroutine)
+
+
+@application()
+@function()
+def sync_app_coroutine_raises(x: int) -> int:
+    try:
+        sync_double.future(x).coroutine()
+    except SDKUsageError as e:
+        assert str(e) == (
+            "Future.coroutine() can only be called from an async function. "
+            "Use Future.result() to get the result in a sync function."
+        )
+        return x
+    raise Exception("Expected SDKUsageError")
+
+
+@application()
+@function()
+async def async_app_coroutine_on_started_future_raises(x: int) -> int:
+    future: Future = sync_double.future(x)
+    future.run()
+    try:
+        future.coroutine()
+    except SDKUsageError:
+        return await future
+    raise Exception("Expected SDKUsageError")
 
 
 class TestSyncAsyncCalls(unittest.TestCase):
@@ -417,6 +485,67 @@ class TestSyncAsyncCalls(unittest.TestCase):
             deploy_applications(__file__)
         request: Request = run_application(sync_app_chains_futures, is_remote, 5)
         self.assertEqual(request.output(), 20)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_async_app_await_sync_coroutine(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(async_app_await_sync_coroutine, is_remote, 5)
+        self.assertEqual(request.output(), 10)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_async_app_create_task_from_sync_coroutine(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            async_app_create_task_from_sync_coroutine, is_remote, 5
+        )
+        self.assertEqual(request.output(), 10)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_async_app_gather_sync_coroutines(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            async_app_gather_sync_coroutines, is_remote, 5
+        )
+        self.assertEqual(request.output(), 20)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_async_app_coroutine_returns_same_object(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            async_app_coroutine_returns_same_object, is_remote, 5
+        )
+        self.assertEqual(request.output(), 10)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_async_app_pass_sync_coroutine_as_arg(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            async_app_pass_sync_coroutine_as_arg, is_remote, 5
+        )
+        self.assertEqual(request.output(), 15)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_sync_app_coroutine_raises(self, _: str, is_remote: bool):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(sync_app_coroutine_raises, is_remote, 5)
+        self.assertEqual(request.output(), 5)
+
+    @parameterized.parameterized.expand([("remote", True), ("local", False)])
+    def test_async_app_coroutine_on_started_future_raises(
+        self, _: str, is_remote: bool
+    ):
+        if is_remote:
+            deploy_applications(__file__)
+        request: Request = run_application(
+            async_app_coroutine_on_started_future_raises, is_remote, 5
+        )
+        self.assertEqual(request.output(), 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The method allows to create a Future for a sync function call and then convert it to a coroutine to use it completely natively in an async Tensorlake functions.

Also add output propagation tests that check Futures, asyncio coroutines and asyncio tasks returned as tail calls.

Also add missing test cases for futures consuming Futures, asyncio coroutines and asyncio tasks in test_futures_consume_futures.py.