### PR TITLE
WIP DO NOT MERGE: Non-deterministic sequential event loop in FE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/tensorlake/applications/interface/futures.py
+++ b/src/tensorlake/applications/interface/futures.py
@@ -9,7 +9,7 @@ from tensorlake.vendor.nanoid.nanoid import generate as nanoid_generate
 from ..runtime_hooks import await_future as runtime_hook_await_future
 from ..runtime_hooks import coroutine_to_future as runtime_hook_coroutine_to_future
 from ..runtime_hooks import register_coroutine as runtime_hook_register_coroutine
-from ..runtime_hooks import run_futures as runtime_hook_run_futures
+from ..runtime_hooks import run_future as runtime_hook_run_future
 from ..runtime_hooks import wait_futures as runtime_hook_wait_futures
 from .exceptions import InternalError, SDKUsageError, TensorlakeError
 
@@ -92,8 +92,13 @@ class Future:
                 f"Attempt to run Future that is already started: {self}"
             )
         self._run_hook_was_called = True
-        runtime_hook_run_futures(futures=[self])
-        return self
+
+        try:
+            runtime_hook_run_future(future=self)
+            return self
+        except TensorlakeError as e:
+            self._set_exception(e)
+            raise
 
     def run_later(self, start_delay: float) -> "Future":
         """Runs this Future after the given delay in seconds and returns it.
@@ -465,7 +470,10 @@ def _wrap_future_into_coroutine(future: Future) -> Coroutine[Any, Any, Any]:
 
 
 def _unwrap_future(value: Any | _TensorlakeFutureWrapper[Future]) -> Any | Future:
-    """Unwraps a Future from the given value if it's a future wrapper. Otherwise, returns the value itself."""
+    """Unwraps a Future from the given value if it's a future wrapper. Otherwise, returns the value itself.
+
+    Doesn't raise any exceptions.
+    """
     if isinstance(value, Future):
         return value
 

--- a/src/tensorlake/applications/local/runner.py
+++ b/src/tensorlake/applications/local/runner.py
@@ -82,12 +82,12 @@ from ..runtime_hooks import (
     clear_await_future_hook,
     clear_coroutine_to_future_hook,
     clear_register_coroutine_hook,
-    clear_run_futures_hook,
+    clear_run_future_hook,
     clear_wait_futures_hook,
     set_await_future_hook,
     set_coroutine_to_future_hook,
     set_register_coroutine_hook,
-    set_run_futures_hook,
+    set_run_future_hook,
     set_wait_futures_hook,
 )
 from ..user_data_serializer import (
@@ -304,7 +304,7 @@ class LocalRunner:
         """
         self._request_context_http_server_thread.start()
 
-        set_run_futures_hook(self._run_futures_runtime_hook)
+        set_run_future_hook(self._run_future_runtime_hook)
         set_await_future_hook(self._await_future_runtime_hook)
         set_wait_futures_hook(self._wait_futures_runtime_hook)
         set_register_coroutine_hook(self._register_coroutine_runtime_hook)
@@ -398,7 +398,7 @@ class LocalRunner:
 
         # Only clear runtime hooks at the very end when nothing can use them.
         clear_await_future_hook()
-        clear_run_futures_hook()
+        clear_run_future_hook()
         clear_wait_futures_hook()
         clear_register_coroutine_hook()
         clear_coroutine_to_future_hook()
@@ -447,7 +447,7 @@ class LocalRunner:
     def __coroutine_to_future_runtime_hook(self, coroutine: Coroutine) -> Future | None:
         return self._coroutine_to_future.get(coroutine, None)
 
-    def _run_futures_runtime_hook(self, futures: List[Future]) -> None:
+    def _run_future_runtime_hook(self, user_future: Future) -> None:
         # Don't catch any exceptions here because this is called from user code
         # and we want to propagate them to the user. We don't know what user gave
         # so it's easy to fail for any reason here.
@@ -459,21 +459,20 @@ class LocalRunner:
 
         try:
             self._user_code_cancellation_point()
-            for user_future in futures:
-                # SDK automatically starts user futures that are tail calls and
-                # function call or other operation inputs. This is why we walk
-                # the Futures tree, not just starting the user_future.
-                for future in dfs_bottom_up_unique_only(user_future):
-                    if future._id in self._future_runs:
-                        continue  # Future was already started by user.
+            # SDK automatically starts user futures that are tail calls and
+            # function call or other operation inputs. This is why we walk
+            # the Futures tree, not just starting the user_future.
+            for future in dfs_bottom_up_unique_only(user_future):
+                if future._id in self._future_runs:
+                    continue  # Future was already started by user.
 
-                    # Future is started by user code, cannot be a tail call.
-                    self._create_future_run(
-                        future=future,
-                        output_serializer_name_override=None,
-                        has_output_type_hint_override=False,
-                        output_type_hint_override=None,
-                    )
+                # Future is started by user code, cannot be a tail call.
+                self._create_future_run(
+                    future=future,
+                    output_serializer_name_override=None,
+                    has_output_type_hint_override=False,
+                    output_type_hint_override=None,
+                )
         except TensorlakeError:
             raise
         except Exception as e:

--- a/src/tensorlake/applications/runtime_hooks.py
+++ b/src/tensorlake/applications/runtime_hooks.py
@@ -93,36 +93,36 @@ def clear_await_future_hook() -> None:
     __await_future = None
 
 
-__run_futures: Callable[[List[Future]], None] = None
+__run_future: Callable[[Future], None] = None
 
 
-def run_futures(futures: List[Future]) -> None:
-    """Starts running the given futures in background.
+def run_future(future: Future) -> None:
+    """Starts running the given future in background.
 
-    Future results are set when the futures complete.
+    Future result is set when the future completes.
     """
-    global __run_futures
-    if __run_futures is None:
+    global __run_future
+    if __run_future is None:
         _raise_multiprocessing_usage_error()
 
-    return __run_futures(futures)
+    return __run_future(future)
 
 
-def set_run_futures_hook(hook: Any) -> None:
-    global __run_futures
-    if __run_futures is not None:
-        raise InternalError("__run_futures runtime hook already initialized")
+def set_run_future_hook(hook: Any) -> None:
+    global __run_future
+    if __run_future is not None:
+        raise InternalError("__run_future runtime hook already initialized")
 
-    __run_futures = hook
+    __run_future = hook
 
 
-def clear_run_futures_hook() -> None:
-    """Clears the __run_futures runtime hook if set.
+def clear_run_future_hook() -> None:
+    """Clears the __run_future runtime hook if set.
 
     Never raises.
     """
-    global __run_futures
-    __run_futures = None
+    global __run_future
+    __run_future = None
 
 
 __register_coroutine: Callable[[Coroutine, Future], None] = None

--- a/src/tensorlake/function_executor/allocation_runner/allocation_runner.py
+++ b/src/tensorlake/function_executor/allocation_runner/allocation_runner.py
@@ -1,37 +1,21 @@
-import asyncio
-import contextvars
 import datetime
-import inspect
+import queue
 import threading
-import time
-import weakref
-from collections.abc import Coroutine, Generator
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 
 import grpc
 from google.protobuf.timestamp_pb2 import Timestamp
 
 from tensorlake.applications import (
-    RETURN_WHEN,
     DeserializationError,
     Function,
-    Future,
     InternalError,
     RequestContext,
     RequestError,
-    SDKUsageError,
-    TensorlakeError,
-    TimeoutError,
-)
-from tensorlake.applications.algorithms import (
-    derived_function_call_future,
-    dfs_bottom_up_unique_only,
-    tail_call_output_future_ids,
-    validate_tail_call_user_future,
+    SerializationError,
 )
 from tensorlake.applications.blob_store import BLOBStore
-from tensorlake.applications.function.function_call import create_function_error
 from tensorlake.applications.function.type_hints import (
     function_signature,
     return_type_hint,
@@ -41,23 +25,11 @@ from tensorlake.applications.function.user_data_serializer import (
     function_output_serializer,
 )
 from tensorlake.applications.interface.futures import (
-    FunctionCallFuture,
-    ListFuture,
-    ReduceOperationFuture,
-    _FutureListKind,
-    _InitialMissing,
-    _InitialMissingType,
     _request_scoped_id,
-    _TensorlakeFutureWrapper,
-    _unwrap_future,
 )
 from tensorlake.applications.internal_logger import InternalLogger
 from tensorlake.applications.metadata import (
     FunctionCallMetadata,
-)
-from tensorlake.applications.registry import get_function
-from tensorlake.applications.request_context.contextvar import (
-    set_current_request_context,
 )
 from tensorlake.applications.request_context.http_server.handlers.progress_update import (
     FunctionProgressUpdateRequest,
@@ -99,20 +71,28 @@ from ..user_events import (
     log_user_event_allocations_started,
 )
 from .allocation_state_wrapper import AllocationStateWrapper
-from .contextvars import set_allocation_id_context_variable
 from .download import download_function_arguments, download_serialized_objects
+from .event_loop import (
+    AllocationEventLoop,
+    InputEventEmergencyShutdown,
+    InputEventFunctionCallCreated,
+    InputEventFunctionCallWatcherResult,
+    OutputEventBatch,
+    OutputEventCreateFunctionCall,
+    OutputEventCreateFunctionCallWatcher,
+    OutputEventFinishAllocation,
+    OutputEventType,
+)
 from .request_context.progress import AllocationProgress
 from .request_context.request_state import AllocationRequestState
 from .result_helper import ResultHelper
 from .sdk_algorithms import (
-    FutureInfo,
     deserialize_application_function_call_args,
     deserialize_sdk_function_call_args,
-    future_durable_id,
+    output_event_to_execution_plan_updates,
     reconstruct_sdk_function_call_args,
-    replace_user_values_with_serialized_values,
+    serialize_output_event_args,
     serialize_user_value,
-    to_execution_plan_updates,
     validate_and_deserialize_function_call_metadata,
 )
 from .upload import (
@@ -124,19 +104,25 @@ from .value import SerializedValue, Value
 
 
 @dataclass
-class FunctionCallCreationInfo:
-    # Not None when the function call creation is completed by Executor.
-    result: AllocationFunctionCallCreationResult | None
-    # Set only once after the function call creation result is set.
-    result_available: threading.Event
+class _ServerEventFunctionCallCreationResult:
+    result: AllocationFunctionCallCreationResult
 
 
 @dataclass
-class FunctionCallWatcherInfo:
-    # Not None when the function call result is delivered by Executor.
-    result: AllocationFunctionCallResult | None
-    # Set only once after the function call creation result is set.
-    result_available: threading.Event
+class _ServerEventFunctionCallResult:
+    result: AllocationFunctionCallResult
+
+
+@dataclass
+class _ServerEventStopProcessingThread:
+    pass  # A placeholder event just to stop the thread
+
+
+_ServerEvent = (
+    _ServerEventFunctionCallCreationResult
+    | _ServerEventFunctionCallResult
+    | _ServerEventStopProcessingThread
+)
 
 
 @dataclass
@@ -197,35 +183,37 @@ class AllocationRunner:
             function=function,
             logger=self._logger,
         )
-        self._allocation_thread: threading.Thread = threading.Thread(
-            target=self._run_allocation_thread,
+        self._run_allocation_thread: threading.Thread = threading.Thread(
+            target=self._run_allocation,
             daemon=True,
+        )
+        self._process_server_events_thread: threading.Thread = threading.Thread(
+            target=self._process_server_events, daemon=True
         )
         # Allocation function output related overrides.
         self._output_value_serializer_name_override: str | None = None
         self._has_output_value_type_hint_override: bool = False
         self._output_value_type_hint_override: Any = None
+        self._allocation_function_args: list[Any] | None = None
+        self._allocation_function_kwargs: dict[str, Any] | None = None
 
-        # Allocation Execution state.
-        #
-        # Coroutine -> Future, use weakref so once a coroutine is no longer used
-        # it's deleted from the mapping automatically. This is required because coroutine
-        # objects are owned by user code and so is their lifecycle.
-        self._coroutine_to_future: weakref.WeakKeyDictionary = (
-            weakref.WeakKeyDictionary()
-        )
-        # Futures that were created (started) during this allocation.
-        # Future ID -> FutureInfo.
-        self._future_infos: Dict[str, FutureInfo] = {}
-        # Durable ID of the previous future started by this allocation.
-        self._previous_future_durable_id: str = allocation.function_call_id
-        # Allocation Function Call ID -> FunctionCallCreationInfo.
-        # Allocation Function Call ID is different from Function Call ID in ExecutionPlanUpdates.
-        self._function_call_creations: Dict[str, FunctionCallCreationInfo] = {}
-        # Watcher ID -> FunctionCallWatcherInfo.
-        self._function_call_watchers: Dict[str, FunctionCallWatcherInfo] = {}
         # BLOB ID -> _OutputBLOBRequestInfo.
-        self._output_blob_requests: Dict[str, _OutputBLOBRequestInfo] = {}
+        self._output_blob_requests: dict[str, _OutputBLOBRequestInfo] = {}
+        # Queue for events coming from Server.
+        self._server_event_queue: queue.Queue[_ServerEvent] = queue.Queue()
+
+        # Event loop for running user code and managing Futures.
+        self._event_loop: AllocationEventLoop = AllocationEventLoop(
+            function=function,
+            function_call_id=allocation.function_call_id,
+            allocation_id=allocation.allocation_id,
+            request_context=request_context,
+            logger=logger,
+        )
+
+    @property
+    def event_loop(self) -> AllocationEventLoop:
+        return self._event_loop
 
     def wait_allocation_state_update(
         self, last_seen_hash: str | None
@@ -238,7 +226,7 @@ class AllocationRunner:
 
         When the allocation is finished, sets it .result field.
         """
-        self._allocation_thread.start()
+        self._run_allocation_thread.start()
 
     # finished() and is_terminal_state() need to be consistent with each other.
     # So once we return a terminal state to client and it calls delete_allocation,
@@ -254,41 +242,17 @@ class AllocationRunner:
     def deliver_allocation_update(self, update: AllocationUpdate) -> None:
         # No need for any locks because we never block here so we hold GIL non stop.
         if update.HasField("function_call_creation_result"):
-            alloc_function_call_id: str = (
-                update.function_call_creation_result.allocation_function_call_id
-                if update.function_call_creation_result.HasField(
-                    "allocation_function_call_id"
+            self._server_event_queue.put(
+                _ServerEventFunctionCallCreationResult(
+                    result=update.function_call_creation_result,
                 )
-                else update.function_call_creation_result.function_call_id
             )
-            if alloc_function_call_id not in self._function_call_creations:
-                self._logger.error(
-                    "received function call creation result for unknown allocation function call",
-                    alloc_fn_call_id=alloc_function_call_id,
-                )
-                return
-            function_call_creation_info: FunctionCallCreationInfo = (
-                self._function_call_creations[alloc_function_call_id]
-            )
-            function_call_creation_info.result = update.function_call_creation_result
-            function_call_creation_info.result_available.set()
         elif update.HasField("function_call_result"):
-            watcher_id: str = (
-                update.function_call_result.watcher_id
-                if update.function_call_result.HasField("watcher_id")
-                else update.function_call_result.function_call_id
-            )
-            if watcher_id not in self._function_call_watchers:
-                self._logger.error(
-                    "received function call result for unknown watcher",
-                    watcher_id=watcher_id,
+            self._server_event_queue.put(
+                _ServerEventFunctionCallResult(
+                    result=update.function_call_result,
                 )
-                return
-            watcher_info: FunctionCallWatcherInfo = self._function_call_watchers[
-                watcher_id
-            ]
-            watcher_info.result = update.function_call_result
-            watcher_info.result_available.set()
+            )
         elif update.HasField("output_blob_deprecated") or update.HasField(
             "output_blob"
         ):
@@ -355,528 +319,36 @@ class AllocationRunner:
                 f"Unknown request context operation type: {type(operation)}"
             )
 
-    def register_coroutine_runtime_hook(
-        self, coroutine: Coroutine, future: Future
+    def _process_event_loop_output_event_call_function(
+        self, output_event: OutputEventCreateFunctionCall
     ) -> None:
-        self._coroutine_to_future[coroutine] = future
+        """Processes an OutputEventCreateFunctionCall: serialize, upload, create on server.
 
-    def coroutine_to_future_runtime_hook(self, coroutine: Coroutine) -> Future | None:
-        return self._coroutine_to_future.get(coroutine, None)
-
-    def run_futures_runtime_hook(self, futures: List[Future]) -> None:
-        # NB: This code is called from user function thread. User function code is blocked.
-        # Right now we can only be called from the function thread, not any child threads that user
-        # code might have created because contextvars are not propagated to child threads.
-        # All exceptions raised here will be propagated to user code by design.
-        #
-        # NB: all exceptions raised here must be derived from TensorlakeError.
-        # NB: this hook must block the calling thread until all the Futures are fully started.
-        # If we do any asyncio await/yield operation here then this will result in concurrent
-        # hooks running with non-deterministic completion order.
+        Raises Exception on internal error.
+        """
+        # This is user code.
         try:
-            return self._run_futures_runtime_hook(futures)
-        except TensorlakeError:
-            raise
-        except Exception as e:
-            self._logger.error(
-                "Unexpected exception in run_futures_runtime_hook",
-                exc_info=e,
-            )
-            raise InternalError(f"Unexpected error while running futures")
-
-    def _run_futures_runtime_hook(self, futures: List[Future]) -> None:
-        # NB: To support durability, ordering of running the Futures must be deterministic.
-        for user_future in futures:
-            # SDK automatically starts user futures that are function call
-            # or other operation inputs. This is why we walk the Futures tree,
-            # not just starting the user_future.
-            for future in dfs_bottom_up_unique_only(user_future):
-                if future._id in self._future_infos:
-                    continue  # Future was already started by user.
-
-                # Future is started by user code, cannot be a tail call.
-                self._run_future(future, tail_call=False)
-
-    def _run_future(self, future: Future, tail_call: bool) -> None:
-        """Registers the future in _future_infos and starts it.
-
-        Raises InternalError on error.
-        """
-        if future._coroutine is not None and not future._run_hook_was_called:
-            # We're starting the future for the user.
-            # Close the coroutine to prevent "RuntimeWarning: coroutine '...' was never awaited" warning
-            # because user code is not expected to await the coroutine and it's a user code bug if it does.
-            future._run_hook_was_called = True
-            future._coroutine.close()
-            future._coroutine = None
-
-        if future._id in self._future_infos:
-            raise InternalError(
-                f"Future with ID {future._id} is already registered in AllocationRunner."
-            )
-
-        durable_id: str = future_durable_id(
-            future=future,
-            parent_function_call_id=self._allocation.function_call_id,
-            previous_future_durable_id=self._previous_future_durable_id,
-            future_infos=self._future_infos,
-        )
-        self._previous_future_durable_id = durable_id
-        future_info: FutureInfo = FutureInfo(
-            future=future,
-            durable_id=durable_id,
-            map_future_output=None,
-            reduce_future_output=None,
-        )
-        self._future_infos[future._id] = future_info
-
-        if isinstance(future, ListFuture):
-            self._run_list_future(future_info)
-        elif isinstance(future, ReduceOperationFuture):
-            self._run_reduce_opearation_future(future_info, tail_call)
-        elif isinstance(future, FunctionCallFuture):
-            self._run_function_call_future(future_info, tail_call)
-        else:
-            raise InternalError(
-                f"Unsupported Future type: {type(future)} with ID {future._id}"
-            )
-
-    def _run_list_future(self, future_info: FutureInfo) -> None:
-        # Server can't run ListFuture, we need to run each list item separately as a new
-        # internal (not user visible) Future. All child Futures of user_future are already running.
-        # FIXME: This is not efficient. When we change to log oriented protocol, all the function calls need
-        # to come in a single batch of ordered events instead sending one function call to Server at a time.
-        user_future: ListFuture = future_info.future
-
-        if user_future._metadata.kind != _FutureListKind.MAP_OPERATION:
-            raise InternalError(
-                f"Unsupported ListFuture kind: {user_future._metadata.kind}"
-            )
-        function: Function = get_function(user_future._metadata.function_name)
-
-        map_inputs: list[_TensorlakeFutureWrapper[Future] | Any]
-        items: list[_TensorlakeFutureWrapper[Future] | Any] | ListFuture = (
-            _unwrap_future(user_future._items)
-        )
-        if isinstance(items, ListFuture):
-            inputs_future_info: FutureInfo = self._future_infos[items._id]
-            map_inputs = inputs_future_info.map_future_output
-        else:
-            map_inputs = items
-
-        map_outputs: list[FunctionCallFuture] = []
-        for input in map_inputs:
-            mapped_input: FunctionCallFuture = derived_function_call_future(
-                user_future, function, input
-            )
-            # No output override for list future because it can't be returned from tail call.
-            # Strictly one level of recursion per mapped item, so it's okay.
-            self._run_future(mapped_input, tail_call=False)
-            map_outputs.append(mapped_input)
-
-        future_info.map_future_output = map_outputs
-
-    def _run_reduce_opearation_future(
-        self, future_info: FutureInfo, tail_call: bool
-    ) -> None:
-        # Server can't run ReduceOperationFuture, we need to run each list item separately as a new
-        # internal (not user visible) Future. All child Futures of user_future are already running.
-        # FIXME: This is not efficient. When we change to log oriented protocol, all the function calls need
-        # to come in a single batch of ordered events instead sending one function call to Server at a time.
-        user_future: ReduceOperationFuture = future_info.future
-        function: Function = get_function(user_future._function_name)
-
-        inputs: list[_TensorlakeFutureWrapper[Future] | Any] = []
-        initial: Future | Any | _InitialMissingType = _unwrap_future(
-            user_future._initial
-        )
-        if initial is not _InitialMissing:
-            inputs.append(initial)
-
-        items: list[_TensorlakeFutureWrapper[Future] | Any] | ListFuture = (
-            _unwrap_future(user_future._items)
-        )
-        if isinstance(items, ListFuture):
-            inputs_future_info: FutureInfo = self._future_infos[items._id]
-            inputs.extend(inputs_future_info.map_future_output)
-        else:
-            inputs.extend(items)
-
-        if len(inputs) == 0:
-            raise SDKUsageError("reduce of empty iterable with no initial value")
-
-        if len(inputs) == 1:
-            # Child future inputs[0] is already running due to DFS bottom up traversal.
-            future_info.reduce_future_output = _unwrap_future(inputs[0])
-            return
-
-        # Create a chain of function calls to reduce all args one by one.
-        # Ordering of calls is important here. We should reduce ["a", "b", "c", "d"]
-        # using string concat function into "abcd".
-
-        # inputs now contain at least two items.
-        last_future: Future = derived_function_call_future(
-            user_future, function, inputs[0], inputs[1]
-        )
-        for input in inputs[2:]:
-            # Strictly one level of recursion per reduced item, so it's okay.
-            self._run_future(last_future, tail_call=False)
-            last_future = derived_function_call_future(
-                user_future, function, last_future, input
-            )
-        reduce_operation_output: Future = last_future
-        self._run_future(reduce_operation_output, tail_call=tail_call)
-
-        future_info.reduce_future_output = reduce_operation_output
-
-    def wait_futures_runtime_hook(
-        self, futures: List[Future], timeout: float | None, return_when: RETURN_WHEN
-    ) -> tuple[List[Future], List[Future]]:
-        # NB: This code is called from user function thread. User function code is blocked.
-        # Right now we can only be called from the function thread, not any child threads that user
-        # code might have created because contextvars are not propagated to child threads.
-        # All exceptions raise here will be propagated to user code by design.
-        #
-        # NB: all exceptions raised here must be derived from TensorlakeError.
-        try:
-            return self._wait_futures_runtime_hook(futures, timeout, return_when)
-        except TensorlakeError:
-            raise
-        except Exception as e:
-            self._logger.error(
-                "Unexpected exception in wait_futures_runtime_hook",
-                exc_info=e,
-            )
-            raise InternalError(f"Unexpected error while waiting for futures")
-
-    def _wait_futures_runtime_hook(
-        self, futures: List[Future], timeout: float | None, return_when: RETURN_WHEN
-    ) -> tuple[List[Future], List[Future]]:
-        if return_when not in (
-            RETURN_WHEN.ALL_COMPLETED,
-            RETURN_WHEN.FIRST_COMPLETED,
-            RETURN_WHEN.FIRST_FAILURE,
-        ):
-            raise SDKUsageError(f"Not supported return_when value: '{return_when}'")
-
-        deadline: float | None = (
-            time.monotonic() + timeout if timeout is not None else None
-        )
-        # NB: The futures order in these lists should be the original order (like stable sort).
-        done: List[Future] = []
-        not_done: List[Future] = []
-
-        # FIXME: When FIRST_COMPLETED or FIRST_FAILURE is used we have to wait for all the
-        # future in parallel instead of serially. Without this, if the first future takes
-        # a long time to complete, but the second one completes quickly, we still wait
-        # for the first one to complete before checking the second one. This is not what customers expect.
-        for future in futures:
-            try:
-                self._wait_future_completion(future=future, deadline=deadline)
-            except BaseException as e:
-                # Something went wrong while waiting for the future.
-                self._logger.error(
-                    "Unexpected error while waiting for child future completion",
-                    future_id=future._id,
-                    exc_info=e,
+            serialized_args, serialized_kwargs, serialized_values = (
+                serialize_output_event_args(
+                    args=output_event.args,
+                    kwargs=output_event.kwargs,
+                    function_name=output_event.function_name,
                 )
-                future._set_exception(
-                    InternalError(
-                        f"Unexpected error while waiting for child future completion: {e}"
-                    )
+            )
+        except SerializationError as e:
+            # FIXME: This is not going via Server event log, so not replayable.
+            # Fix this by serializing inside event loop so the exception is raised there immediately.
+            self._event_loop.add_input_event(
+                InputEventFunctionCallCreated(
+                    durable_id=output_event.durable_id,
+                    exception=e,
                 )
-
-            if future.done():
-                done.append(future)
-            else:
-                not_done.append(future)
-
-            if return_when == RETURN_WHEN.FIRST_COMPLETED:
-                if len(done) > 0:
-                    break
-            elif return_when == RETURN_WHEN.FIRST_FAILURE:
-                if future.exception is not None:
-                    break
-            # else ALL_COMPLETED
-
-        for future in futures:
-            if future not in done and future not in not_done:
-                not_done.append(future)
-
-        return done, not_done
-
-    def await_future_runtime_hook(self, future: Future) -> Generator[None, None, Any]:
-        # NB: This code is called from user async function thread.
-        # All exceptions raised here will be propagated to user code by design.
-        #
-        # NB: all exceptions raised here must be derived from TensorlakeError.
-        try:
-            return self._await_future_runtime_hook(future)
-        except TensorlakeError:
-            raise
-        except Exception as e:
-            self._logger.error(
-                "Unexpected exception in await_future_runtime_hook",
-                exc_info=e,
-            )
-            raise InternalError("Unexpected error while awaiting future")
-
-    def _await_future_runtime_hook(self, future: Future) -> Generator[None, None, Any]:
-        user_aio_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
-        # Result is set to None because the actual result is stored in the
-        # Tensorlake SDK Future. This asyncio Future is only used for waiting
-        # in user code, not for getting the result.
-        user_aio_loop_future: asyncio.Future = user_aio_loop.create_future()
-
-        def background_wait():
-            # Required for pretty_print called when converting Future to str.
-            set_allocation_id_context_variable(self._allocation.allocation_id)
-            try:
-                self._wait_future_completion(future=future, deadline=None)
-            except BaseException as e:
-                self._logger.error(
-                    "Unexpected error while waiting for child future completion",
-                    future_id=future._id,
-                    exc_info=e,
-                )
-                future._set_exception(
-                    InternalError(
-                        f"Unexpected error while waiting for child future completion: {e}"
-                    )
-                )
-            user_aio_loop.call_soon_threadsafe(user_aio_loop_future.set_result, None)
-
-        threading.Thread(target=background_wait, daemon=True).start()
-        yield from user_aio_loop_future.__await__()
-        # The coroutine is done running. It can't be started again by user code.
-        # Clear the hard reference.
-        future._coroutine = None
-
-    def _wait_future_completion(self, future: Future, deadline: float | None) -> None:
-        """Waits for the completion of the future and sets its result or exception if didn't timeout.
-
-        Raises Exception on unexpected internal error. Normally all exceptions are set on the future itself.
-        """
-        if future.done():
-            # Short circuit just for performance optimization
-            # so we don't call Server to get the result again.
-            return
-
-        future_info: FutureInfo = self._future_infos.get(future._id)
-        if future_info is None:
-            raise InternalError(
-                f"Unknown Future with ID {future._id} is not tracked in AllocationRunner."
-            )
-
-        if isinstance(future, ListFuture):
-            self._wait_future_list_completion(future_info, deadline)
-        elif isinstance(future, ReduceOperationFuture):
-            self._wait_reduce_operation_future_completion(future_info, deadline)
-        elif isinstance(future, FunctionCallFuture):
-            self._wait_function_call_future_completion(future_info, deadline)
-        else:
-            raise InternalError(
-                f"Unsupported Future type: {type(future)} with ID {future._id}"
-            )
-
-    def _wait_function_call_future_completion(
-        self, future_info: FutureInfo, deadline: float | None
-    ) -> None:
-        future: FunctionCallFuture = future_info.future
-        start_time: float = time.monotonic()
-
-        if future_info.durable_id is None:
-            self._logger.error(
-                "Durable Future ID is not set for FutureInfo.",
-                future_id=future_info.future._id,
-            )
-            future._set_exception(
-                InternalError("Durable Future ID is not set for FutureInfo.")
             )
             return
 
-        function_call_watcher_id: str = _request_scoped_id()
-        self._logger.info(
-            "waiting for child future completion",
-            future_id=future._id,
-            future_fn_call_id=future_info.durable_id,
-            future_watcher_id=function_call_watcher_id,
-        )
-        watcher_info: FunctionCallWatcherInfo = FunctionCallWatcherInfo(
-            result=None,
-            result_available=threading.Event(),
-        )
-        self._function_call_watchers[function_call_watcher_id] = watcher_info
-        # FIXME: Temorary workaround for missing watcher_id coming from Executor.
-        # Remove once Executor is updated.
-        self._function_call_watchers[future_info.durable_id] = watcher_info
-        self._allocation_state.add_function_call_watcher(
-            id=function_call_watcher_id,
-            root_function_call_id=future_info.durable_id,
-        )
-
-        result_wait_timeout: float | None = (
-            deadline - time.monotonic() if deadline is not None else None
-        )
-        result_available: bool = watcher_info.result_available.wait(
-            timeout=result_wait_timeout
-        )
-
-        self._allocation_state.delete_function_call_watcher(id=function_call_watcher_id)
-        del self._function_call_watchers[function_call_watcher_id]
-        # FIXME: Temorary workaround for missing watcher_id coming from Executor.
-        # Remove once Executor is updated.
-        del self._function_call_watchers[future_info.durable_id]
-
-        if result_available:
-            result: AllocationFunctionCallResult = watcher_info.result
-            if (
-                result.outcome_code
-                == AllocationOutcomeCode.ALLOCATION_OUTCOME_CODE_SUCCESS
-            ):
-                serialized_output: SerializedValue = download_serialized_objects(
-                    serialized_objects=[result.value_output],
-                    serialized_object_blobs=[result.value_blob],
-                    blob_store=self._blob_store,
-                    logger=self._logger,
-                )[0]
-                if serialized_output.metadata is None:
-                    future._set_exception(
-                        InternalError(
-                            "Function Call output SerializedValue is missing metadata."
-                        )
-                    )
-                    return
-                output: Any = deserialize_value_with_metadata(
-                    serialized_output.data, serialized_output.metadata
-                )
-                future._set_result(output)
-            elif (
-                result.outcome_code
-                == AllocationOutcomeCode.ALLOCATION_OUTCOME_CODE_FAILURE
-            ):
-                if result.HasField("request_error_output"):
-                    serialized_request_error: SerializedValue = (
-                        download_serialized_objects(
-                            serialized_objects=[result.request_error_output],
-                            serialized_object_blobs=[result.request_error_blob],
-                            blob_store=self._blob_store,
-                            logger=self._logger,
-                        )[0]
-                    )
-                    future._set_exception(
-                        RequestError(
-                            message=serialized_request_error.data.decode("utf-8")
-                        )
-                    )
-                else:
-                    # We don't have a user visible cause of failure.
-                    future._set_exception(create_function_error(future, cause=None))
-            else:
-                self._logger.error(
-                    f"Unexpected outcome code in function call result: {result.outcome_code}"
-                )
-                future._set_exception(
-                    InternalError(
-                        f"Unexpected outcome code in function call result: {result.outcome_code}"
-                    )
-                )
-        else:
-            # timeout and no result or error are available.
-            future._set_exception(TimeoutError())
-
-        # Future result is set, we can remove the Future from tracking.
-        del self._future_infos[future._id]
-        self._logger.info(
-            "child future completed",
-            future_id=future._id,
-            future_fn_call_id=future_info.durable_id,
-            future_watcher_id=function_call_watcher_id,
-            duration_sec=f"{time.monotonic() - start_time:.3f}",
-            success=future.exception is None,
-        )
-
-    def _wait_future_list_completion(
-        self, future_info: FutureInfo, deadline: float | None
-    ) -> None:
-        """Wait for the completion of the future representing a ListFuture and sets its result or exception.
-
-        Raises Exception on unexpected internal error. Normally all exceptions are set on the future itself.
-        """
-        # Reconstruct the original collection out of individual futures.
-        future: ListFuture = future_info.future
-        collection: List[Any] = []
-        exception: TensorlakeError | None = None
-        is_timeout: bool = False
-
-        for item in future_info.map_future_output:
-            if deadline is not None and deadline - time.monotonic() <= 0:
-                is_timeout = True
-                break
-
-            self._wait_future_completion(future=item, deadline=deadline)
-            if item.exception is None:
-                collection.append(item.result())
-            else:
-                exception = item.exception
-                break
-
-        if is_timeout:
-            future._set_exception(TimeoutError())
-        elif exception is not None:
-            future._set_exception(exception)
-        else:
-            future._set_result(collection)
-
-    def _wait_reduce_operation_future_completion(
-        self, future_info: FutureInfo, deadline: float | None
-    ) -> None:
-        """Wait for the completion of the future representing a ReduceOperationFuture and sets its result or exception.
-
-        Raises Exception on unexpected internal error. Normally all exceptions are set on the future itself.
-        """
-        future: ReduceOperationFuture = future_info.future
-        reduce_future_output: Future | Any | None = future_info.reduce_future_output
-
-        if reduce_future_output is None:
-            future._set_exception(
-                InternalError("Reduce operation future is missing the output future.")
-            )
-            return
-
-        if isinstance(reduce_future_output, Future):
-            # FIXME: Recursive call. Max 1000 recursion depth is allowed in Python by default.
-            self._wait_future_completion(future=reduce_future_output, deadline=deadline)
-            if reduce_future_output.exception is not None:
-                future._set_exception(reduce_future_output.exception)
-            else:
-                future._set_result(reduce_future_output.result())
-        else:
-            # This can happen when we have only one item to reduce, in that case we shortcut and set the output directly without creating a Future for it.
-            future._set_result(reduce_future_output)
-
-    def _run_function_call_future(
-        self, future_info: FutureInfo, tail_call: bool
-    ) -> None:
-        future: FunctionCallFuture = future_info.future
-
-        # Copy the user's future to not pollute user Future by the modifications coming next.
-        future_copy: FunctionCallFuture = FunctionCallFuture(
-            id=future_info.durable_id,
-            function_name=future._function_name,
-            args=list(future._args),
-            kwargs=dict(future._kwargs),
-        )
-
-        serialized_values: Dict[str, SerializedValue] = (
-            replace_user_values_with_serialized_values(
-                future=future_copy,
-                future_infos=self._future_infos,
-            )
-        )
-        serialized_objects: Dict[str, SerializedObjectInsideBLOB] = {}
+        # This is our code.
+        serialized_objects: dict[str, SerializedObjectInsideBLOB] = {}
         uploaded_args_blob: BLOB | None = None
-        # Only request args blob and upload to it if there are any actual function arguments in the call tree.
         if len(serialized_values) > 0:
             serialized_objects, blob_data = serialized_values_to_serialized_objects(
                 serialized_values=serialized_values
@@ -892,49 +364,43 @@ class AllocationRunner:
                 logger=self._logger,
             )
 
-        execution_plan_pb: ExecutionPlanUpdates = to_execution_plan_updates(
-            future=future_copy,
-            uploaded_serialized_objects=serialized_objects,
-            output_serializer_name_override=(
-                self._output_value_serializer_name_override if tail_call else None
-            ),
-            output_type_hint_override=(
-                self._output_value_type_hint_override if tail_call else None
-            ),
-            has_output_type_hint_override=(
-                self._has_output_value_type_hint_override if tail_call else False
-            ),
-            function_ref=self._function_ref,
-            future_infos=self._future_infos,
+        execution_plan_pb: ExecutionPlanUpdates = (
+            output_event_to_execution_plan_updates(
+                output_event=output_event,
+                serialized_args=serialized_args,
+                serialized_kwargs=serialized_kwargs,
+                uploaded_serialized_objects=serialized_objects,
+                output_serializer_name_override=(
+                    self._output_value_serializer_name_override
+                    if output_event.is_tail_call
+                    else None
+                ),
+                has_output_type_hint_override=(
+                    self._has_output_value_type_hint_override
+                    if output_event.is_tail_call
+                    else False
+                ),
+                output_type_hint_override=(
+                    self._output_value_type_hint_override
+                    if output_event.is_tail_call
+                    else None
+                ),
+                function_ref=self._function_ref,
+            )
         )
-        if future._start_delay is not None:
+        if output_event.start_delay is not None:
             start_at: Timestamp = Timestamp()
             start_at.FromDatetime(
                 datetime.datetime.now(datetime.timezone.utc)
-                + datetime.timedelta(seconds=future._start_delay)
+                + datetime.timedelta(seconds=output_event.start_delay)
             )
             execution_plan_pb.start_at.CopyFrom(start_at)
 
-        function_call_creation_info: FunctionCallCreationInfo = (
-            FunctionCallCreationInfo(
-                result=None,
-                result_available=threading.Event(),
-            )
-        )
         alloc_function_call_id: str = _request_scoped_id()
         self._logger.info(
             "starting child future",
-            future_id=future_info.future._id,
-            future_fn_call_id=future_info.durable_id,
+            future_fn_call_id=output_event.durable_id,
             future_alloc_fn_call_id=alloc_function_call_id,
-        )
-        self._function_call_creations[alloc_function_call_id] = (
-            function_call_creation_info
-        )
-        # Temporary workaround for missing allocation_function_call_id coming from Executor.
-        # TODO: Remove once Executor is updated.
-        self._function_call_creations[future_info.durable_id] = (
-            function_call_creation_info
         )
         self._allocation_state.add_function_call(
             id=alloc_function_call_id,
@@ -942,34 +408,257 @@ class AllocationRunner:
             args_blob=uploaded_args_blob,
         )
 
-        function_call_creation_info.result_available.wait()
+    def _process_event_loop_output_event_add_watcher(
+        self, output_event: OutputEventCreateFunctionCallWatcher
+    ) -> None:
+        """Processes an OutputEventCreateFunctionCallWatcher: register watcher.
 
-        del self._function_call_creations[alloc_function_call_id]
-        # TODO: Remove once Executor is updated.
-        del self._function_call_creations[future_info.durable_id]
-        self._allocation_state.delete_function_call(id=alloc_function_call_id)
+        Raises Exception on internal error.
+        """
+        function_call_watcher_id: str = _request_scoped_id()
+        self._allocation_state.add_function_call_watcher(
+            id=function_call_watcher_id,
+            root_function_call_id=output_event.function_call_durable_id,
+        )
+        self._logger.info(
+            "waiting for child future completion",
+            future_fn_call_id=output_event.function_call_durable_id,
+            future_watcher_id=function_call_watcher_id,
+        )
 
-        if (
-            function_call_creation_info.result.status.code
-            != grpc.StatusCode.OK.value[0]
-        ):
+    def _process_server_events(self) -> None:
+        """Processes Server events from server event queue.
+
+        Doesn't raise any exceptions.
+        """
+        while True:
+            event: _ServerEvent = self._server_event_queue.get()
+            try:
+                if self._process_server_event(event):
+                    break
+            except BaseException as e:
+                # NB: If an exception is raised in an event handler then we should not report
+                # it back to event loop as an input event because the exception is an internal error
+                # which is not replayable because it's not in the input event log. Instead, we must
+                # stop the allocation immediately and set the allocation result to internal error.
+                # This ensures that the allocation is not progressint past the point of internal failure
+                # so when we replay it with input events it starts where it left.
+                self._logger.error(
+                    "Error while processing server event, sending emergency shutdown to event loop",
+                    event=str(event),
+                    exc_info=e,
+                )
+                self._event_loop.add_input_event(
+                    InputEventEmergencyShutdown(internal_exception=e)
+                )
+
+        self._logger.info("stopping server event processing thread")
+
+    def _process_server_event(self, event: _ServerEvent) -> bool:
+        if isinstance(event, _ServerEventFunctionCallCreationResult):
+            self._process_server_event_function_call_creation_result(event)
+        elif isinstance(event, _ServerEventFunctionCallResult):
+            self._process_server_event_function_call_result(event)
+        elif isinstance(event, _ServerEventStopProcessingThread):
+            return True
+        else:
+            self._logger.error(
+                "received unknown server event type",
+                event_type=str(type(event)),
+                event=str(event),
+            )
+        return False
+
+    def _process_server_event_function_call_creation_result(
+        self, event: _ServerEventFunctionCallCreationResult
+    ) -> None:
+        """Processes function call creation result event from Server.
+
+        Raises Exception on internal error while processing the event.
+        """
+        fc_creation_result: AllocationFunctionCallCreationResult = event.result
+        self._allocation_state.delete_function_call(
+            id=fc_creation_result.allocation_function_call_id
+        )
+
+        exception: InternalError | None = None
+        if fc_creation_result.status.code != grpc.StatusCode.OK.value[0]:
             self._logger.error(
                 "child future function call creation failed",
-                future_id=future_info.future._id,
-                future_fn_call_id=future_info.durable_id,
-                future_alloc_fn_call_id=alloc_function_call_id,
-                status=function_call_creation_info.result.status,
+                future_fn_call_id=fc_creation_result.function_call_id,
+                future_alloc_fn_call_id=fc_creation_result.allocation_function_call_id,
+                status=fc_creation_result.status,
             )
-            exception: InternalError = InternalError("Failed to start function call")
-            future_info.future._set_exception(exception)
-            raise exception
+            exception = InternalError("Failed to start function call")
         else:
             self._logger.info(
                 "started child function call future",
-                future_id=future_info.future._id,
-                future_fn_call_id=future_info.durable_id,
-                future_alloc_fn_call_id=alloc_function_call_id,
+                future_fn_call_id=fc_creation_result.function_call_id,
+                future_alloc_fn_call_id=fc_creation_result.allocation_function_call_id,
             )
+
+        self._event_loop.add_input_event(
+            InputEventFunctionCallCreated(
+                durable_id=fc_creation_result.function_call_id,
+                exception=exception,
+            )
+        )
+
+    def _process_server_event_function_call_result(
+        self, event: _ServerEventFunctionCallResult
+    ) -> None:
+        """Processes function call result event from Server.
+
+        Raises Exception on internal error while processing the event.
+        """
+        self._allocation_state.delete_function_call_watcher(id=event.result.watcher_id)
+
+        output: Any = None
+        exception = None
+        fc_result: AllocationFunctionCallResult = event.result
+        if (
+            fc_result.outcome_code
+            == AllocationOutcomeCode.ALLOCATION_OUTCOME_CODE_SUCCESS
+        ):
+            serialized_output: SerializedValue = download_serialized_objects(
+                serialized_objects=[fc_result.value_output],
+                serialized_object_blobs=[fc_result.value_blob],
+                blob_store=self._blob_store,
+                logger=self._logger,
+            )[0]
+            if serialized_output.metadata is None:
+                raise InternalError(
+                    "Function Call output SerializedValue is missing metadata."
+                )
+            else:
+                output = deserialize_value_with_metadata(
+                    serialized_output.data, serialized_output.metadata
+                )
+        elif (
+            fc_result.outcome_code
+            == AllocationOutcomeCode.ALLOCATION_OUTCOME_CODE_FAILURE
+        ):
+            if fc_result.HasField("request_error_output"):
+                serialized_request_error: SerializedValue = download_serialized_objects(
+                    serialized_objects=[fc_result.request_error_output],
+                    serialized_object_blobs=[fc_result.request_error_blob],
+                    blob_store=self._blob_store,
+                    logger=self._logger,
+                )[0]
+                exception = RequestError(
+                    message=serialized_request_error.data.decode("utf-8")
+                )
+            else:
+                exception = InternalError("Function call failed")
+        else:
+            self._logger.error(
+                f"Unexpected outcome code in function call result: {fc_result.outcome_code}"
+            )
+            raise InternalError(
+                f"Unexpected outcome code in function call result: "
+                f"{fc_result.outcome_code}"
+            )
+
+        self._logger.info(
+            "child future completed",
+            future_fn_call_id=fc_result.function_call_id,
+            future_watcher_id=fc_result.watcher_id,
+            success=exception is None,
+        )
+
+        self._event_loop.add_input_event(
+            InputEventFunctionCallWatcherResult(
+                function_call_durable_id=fc_result.function_call_id,
+                output=output,
+                exception=exception,
+            )
+        )
+
+    def _process_event_loop_output_event_finish_allocation(
+        self, output_event: OutputEventFinishAllocation
+    ) -> AllocationResult:
+        if output_event.internal_exception is not None:
+            raise output_event.internal_exception
+
+        if output_event.user_exception is not None:
+            if isinstance(output_event.user_exception, RequestError):
+                # This is user code.
+                try:
+                    utf8_message: bytes = output_event.user_exception.message.encode(
+                        "utf-8"
+                    )
+                except BaseException:
+                    return self._result_helper.from_user_exception(
+                        self._allocation_event_details, output_event.user_exception
+                    )
+
+                # This is internal FE code.
+                request_error_so, uploaded_output_blob = upload_request_error(
+                    utf8_message=utf8_message,
+                    destination_blob=self._allocation.inputs.request_error_blob,
+                    blob_store=self._blob_store,
+                    logger=self._logger,
+                )
+                return self._result_helper.from_request_error(
+                    details=self._allocation_event_details,
+                    request_error=output_event.user_exception,
+                    request_error_output=request_error_so,
+                    uploaded_request_error_blob=uploaded_output_blob,
+                )
+            else:
+                return self._result_helper.from_user_exception(
+                    self._allocation_event_details, output_event.user_exception
+                )
+
+        if output_event.tail_call is not None:
+            output_pb: ExecutionPlanUpdates = ExecutionPlanUpdates(
+                root_function_call_id=output_event.tail_call.durable_id,
+            )
+            return self._result_helper.from_function_output(
+                output=output_pb, uploaded_outputs_blob=None
+            )
+
+        # Regular value output. This is user code (serialization).
+        output_value_serializer: UserDataSerializer = function_output_serializer(
+            function=self._function,
+            output_serializer_override=self._output_value_serializer_name_override,
+        )
+        try:
+            serialized_output_value: SerializedValue = serialize_user_value(
+                value=output_event.value,
+                serializer=output_value_serializer,
+                type_hint=(
+                    self._output_value_type_hint_override
+                    if self._has_output_value_type_hint_override
+                    else type(output_event.value)
+                ),
+            )
+        except BaseException as e:
+            return self._result_helper.from_user_exception(
+                self._allocation_event_details, e
+            )
+
+        # This is internal FE code.
+        serialized_objects, blob_data = serialized_values_to_serialized_objects(
+            serialized_values={
+                serialized_output_value.metadata.id: serialized_output_value
+            }
+        )
+        serialized_output = serialized_objects[serialized_output_value.metadata.id]
+        outputs_blob: BLOB = self._get_new_output_blob(
+            size=sum(len(data) for data in blob_data)
+        )
+        uploaded_output_blob = upload_serialized_objects_to_blob(
+            serialized_objects=serialized_objects,
+            blob_data=blob_data,
+            destination_blob=outputs_blob,
+            blob_store=self._blob_store,
+            logger=self._logger,
+        )
+
+        return self._result_helper.from_function_output(
+            output=serialized_output, uploaded_outputs_blob=uploaded_output_blob
+        )
 
     def _get_new_output_blob(self, size: int) -> BLOB:
         """Returns new BLOB to upload function outputs to.
@@ -1003,47 +692,148 @@ class AllocationRunner:
         else:
             return blob_request_info.blob
 
-    def _run_allocation_thread(self) -> None:
-        alloc_result: AllocationResult | None = None
+    def _run_allocation(self) -> None:
+        alloc_result: AllocationResult = self._result_helper.internal_error()
         try:
             log_user_event_allocations_started([self._allocation_event_details])
-            alloc_result = self._run_allocation()
+            alloc_result = self.__run_allocation()
         except BaseException as e:
+            # This leaks event loop resources because we don't properly cleanup event loop in this case.
             self._logger.error(
-                "allocation failed due to exception in function executor code",
+                "Unexpected exception in function executor code while running allocation",
                 exc_info=e,
             )
         finally:
-            log_user_event_allocations_finished([self._allocation_event_details])
-            if alloc_result is None:
-                # alloc_result is None only if an exception was raised.
-                alloc_result = self._result_helper.internal_error()
-
             self._allocation.result.CopyFrom(alloc_result)
             # This must be the last thing we do. Immeditately after this the allocation can be deleted.
             self._allocation_state.set_result(alloc_result)
+            log_user_event_allocations_finished([self._allocation_event_details])
 
-    def _run_allocation(self) -> AllocationResult:
+    def __run_allocation(self) -> AllocationResult:
+        """Runs the allocation to completion.
+
+        Doesn't raise any exceptions.
+        """
+        alloc_result: AllocationResult | None = self._prepare_allocation_run()
+        if alloc_result is not None:
+            return alloc_result
+
+        self._event_loop.start(
+            self._allocation_function_args, self._allocation_function_kwargs
+        )
+        self._process_server_events_thread.start()
+        # Blocks here until event loop finishes and cleans up its resources.
+        alloc_result = self._process_event_loop_output_events()
+
+        self._server_event_queue.put(_ServerEventStopProcessingThread())
+        if self._process_server_events_thread.is_alive():
+            try:
+                self._logger.info(
+                    "waiting for server event processing thread to finish"
+                )
+                self._process_server_events_thread.join()
+            except RuntimeError as e:
+                self._logger.error(
+                    "error while waiting for server event processing thread to finish",
+                    exc_info=e,
+                )
+
+        return alloc_result
+
+    def _prepare_allocation_run(self) -> AllocationResult | None:
+        """Prepares allocation for running.
+
+        Sets up allocation state, parses function call metadata and arguments, and sets up output overrides.
+        Doesn't raise any exceptions.
+        """
         # We need to be very careful who's code we're running here. Exceptions raised in customer
         # code should be caught here and converted into proper AllocationResult indicating customer code failure.
         # Exceptions in our internal FE code are just raised here and handled by caller.
 
         # This is internal FE code.
-        serialized_args: List[SerializedValue] = download_function_arguments(
-            self._allocation, self._blob_store, self._logger
-        )
-        function_call_metadata: FunctionCallMetadata | None = (
-            validate_and_deserialize_function_call_metadata(
-                serialized_function_call_metadata=self._allocation.inputs.function_call_metadata,
-                serialized_args=serialized_args,
-                function=self._function,
-                logger=self._logger,
+        try:
+            serialized_args: list[SerializedValue] = download_function_arguments(
+                self._allocation, self._blob_store, self._logger
             )
-        )
+            function_call_metadata: FunctionCallMetadata | None = (
+                validate_and_deserialize_function_call_metadata(
+                    serialized_function_call_metadata=self._allocation.inputs.function_call_metadata,
+                    serialized_args=serialized_args,
+                    function=self._function,
+                    logger=self._logger,
+                )
+            )
 
+            self._parse_output_overrides(function_call_metadata)
+            return self._parse_function_call_args(
+                function_call_metadata, serialized_args
+            )
+        except BaseException as e:
+            self._logger.error(
+                "error while preparing allocation run",
+                exc_info=e,
+            )
+            return self._result_helper.internal_error()
+
+    def _process_event_loop_output_events(self) -> AllocationResult:
+        """Processes output events from the event loop until allocation completes.
+
+        Doesn't raise any exceptions.
+        """
+        while True:
+            batch: OutputEventBatch = self._event_loop.wait_for_output_event_batch()
+            for output_event in batch.events:
+                try:
+                    alloc_result: AllocationResult | None = (
+                        self._process_event_loop_output_event(output_event)
+                    )
+                except BaseException as e:
+                    # NB: If an exception is raised in an event handler then we should not report
+                    # it back to event loop as an input event because the exception is an internal error
+                    # which is not replayable because it's not in the input event log. Instead, we must
+                    # stop the allocation immediately and set the allocation result to internal error.
+                    # This ensures that the allocation is not progressint past the point of internal failure
+                    # so when we replay it with input events it starts where it left.
+                    self._logger.error(
+                        "Error while processing event loop output event, sending emergency shutdown to event loop",
+                        event=str(output_event),
+                        exc_info=e,
+                    )
+                    self._event_loop.add_input_event(
+                        InputEventEmergencyShutdown(internal_exception=e)
+                    )
+                    alloc_result = self._result_helper.internal_error()
+
+                if alloc_result is not None:
+                    break
+
+            self._event_loop.join()
+
+    def _process_event_loop_output_event(
+        self, output_event: OutputEventType
+    ) -> AllocationResult | None:
+        if isinstance(output_event, OutputEventFinishAllocation):
+            return self._process_event_loop_output_event_finish_allocation(output_event)
+        elif isinstance(output_event, OutputEventCreateFunctionCall):
+            self._process_event_loop_output_event_call_function(output_event)
+        elif isinstance(output_event, OutputEventCreateFunctionCallWatcher):
+            self._process_event_loop_output_event_add_watcher(output_event)
+        else:
+            self._logger.error(
+                "received unknown output event from event loop",
+                event_type=str(type(output_event)),
+                event=str(output_event),
+            )
+
+    def _parse_output_overrides(
+        self, function_call_metadata: FunctionCallMetadata | None
+    ) -> None:
+        """Parses output serializer/type hint overrides from function call metadata.
+
+        Raises exception on internal error.
+        """
         if function_call_metadata is None:
             # Application function call created by Server.
-            # This is our code.
             # Application function call doesn't have a parent call that can override output serializer.
             # Application function overrides output type hint and serializer for all its child tail call futures.
             self._output_value_serializer_name_override = function_output_serializer(
@@ -1054,10 +844,35 @@ class AllocationRunner:
                 function_signature(self._function).return_annotation
             )
             self._has_output_value_type_hint_override = True
+        else:
+            # Regular function call created by SDK. Uses function call metadata.
+            self._output_value_serializer_name_override = (
+                function_call_metadata.output_serializer_name_override
+            )
+            if function_call_metadata.has_output_type_hint_override:
+                self._output_value_type_hint_override = (
+                    function_call_metadata.output_type_hint_override
+                )
+                self._has_output_value_type_hint_override = True
+
+    def _parse_function_call_args(
+        self,
+        function_call_metadata: FunctionCallMetadata | None,
+        serialized_args: list[SerializedValue],
+    ) -> AllocationResult | None:
+        """Parses allocation function call arguments.
+
+        Raises exception on internal error.
+        Returns AllocationResult on user code error.
+        """
+        args: list[Any]
+        kwargs: dict[str, Any]
+        if function_call_metadata is None:
+            # Application function call created by Server.
             if len(serialized_args) == 0:
-                # We expect exactly one argument but support more for any future FE protocol migrations.
                 raise InternalError(
-                    f"Application function call must have at least one argument, got {len(serialized_args)}."
+                    f"Application function call must have at least one argument, "
+                    f"got {len(serialized_args)}."
                 )
             # This is user code.
             try:
@@ -1067,29 +882,17 @@ class AllocationRunner:
                     function_instance_arg=self._function_instance_arg,
                 )
             except DeserializationError as e:
-                # Failed due to user error. All other exceptions are out internal FE errors.
                 return self._result_helper.from_user_exception(
                     self._allocation_event_details, e
                 )
         else:
-            # Regular function call created by SDK. Uses function call metadata.
-            #
-            # This is our code.
-            self._output_value_serializer_name_override = (
-                function_call_metadata.output_serializer_name_override
-            )
-            if function_call_metadata.has_output_type_hint_override:
-                self._output_value_type_hint_override = (
-                    function_call_metadata.output_type_hint_override
-                )
-                self._has_output_value_type_hint_override = True
+            # Regular function call created by SDK.
             # This is user code.
             try:
-                arg_values: Dict[str, Value] = deserialize_sdk_function_call_args(
+                arg_values: dict[str, Value] = deserialize_sdk_function_call_args(
                     serialized_args
                 )
             except BaseException as e:
-                # This is internal FE code.
                 return self._result_helper.from_user_exception(
                     self._allocation_event_details, e
                 )
@@ -1101,171 +904,6 @@ class AllocationRunner:
                 function_instance_arg=self._function_instance_arg,
             )
 
-        # This is user code.
-        try:
-            output: Any | _TensorlakeFutureWrapper[Future] = self._call_user_function(
-                args, kwargs
-            )
-        except RequestError as e:
-            # This is user code.
-            try:
-                utf8_message: bytes = e.message.encode("utf-8")
-            except BaseException:
-                return self._result_helper.from_user_exception(
-                    self._allocation_event_details, e
-                )
-
-            # This is internal FE code.
-            request_error_so, uploaded_output_blob = upload_request_error(
-                utf8_message=utf8_message,
-                destination_blob=self._allocation.inputs.request_error_blob,
-                blob_store=self._blob_store,
-                logger=self._logger,
-            )
-            return self._result_helper.from_request_error(
-                details=self._allocation_event_details,
-                request_error=e,
-                request_error_output=request_error_so,
-                uploaded_request_error_blob=uploaded_output_blob,
-            )
-        except BaseException as e:
-            # This is internal FE code.
-            return self._result_helper.from_user_exception(
-                self._allocation_event_details, e
-            )
-
-        # Required for _unwrap_future calls done by various algorithms below.
-        set_allocation_id_context_variable(self._allocation.allocation_id)
-
-        tail_call_output_future: Future | None = None
-        output: Any | Future = _unwrap_future(output)
-        if isinstance(output, Future):
-            # Function returned tail call. This is user code.
-            try:
-                validate_tail_call_user_future(
-                    function_name=self._function_ref.function_name,
-                    tail_call_user_future=output,
-                )
-            except BaseException as e:
-                # This is internal FE code.
-                return self._result_helper.from_user_exception(
-                    self._allocation_event_details, e
-                )
-
-            # SDK automatically starts tail call futures and their inputs.
-            # This is why we walk the Futures tree, not just starting the output.
-            # This is our code.
-            output_future_ids: set[str] = tail_call_output_future_ids(output)
-            for future in dfs_bottom_up_unique_only(output):
-                if future._id in self._future_infos:
-                    return self._result_helper.from_user_exception(
-                        self._allocation_event_details,
-                        SDKUsageError(
-                            f"A tail call Future {future} returned from function '{self._function_ref.function_name}' is already running, "
-                            "a tail call Future should not be started."
-                        ),
-                    )
-
-                self._run_future(
-                    future,
-                    tail_call=(future._id in output_future_ids),
-                )
-
-            if isinstance(output, ReduceOperationFuture):
-                output_future_info: FutureInfo = self._future_infos[output._id]
-                if isinstance(output_future_info.reduce_future_output, Future):
-                    tail_call_output_future = output_future_info.reduce_future_output
-                else:
-                    output = output_future_info.reduce_future_output
-            else:
-                tail_call_output_future = output
-
-        serialized_output: SerializedObjectInsideBLOB | None = None
-        uploaded_output_blob: BLOB | None = None
-        if tail_call_output_future is None:
-            # Function returned regular value. This is user code.
-            output_value_serializer: UserDataSerializer = function_output_serializer(
-                function=self._function,
-                output_serializer_override=self._output_value_serializer_name_override,
-            )
-            try:
-                serialized_output_value: SerializedValue = serialize_user_value(
-                    value=output,
-                    serializer=output_value_serializer,
-                    type_hint=(
-                        self._output_value_type_hint_override
-                        if self._has_output_value_type_hint_override
-                        else type(output)
-                    ),
-                )
-            except BaseException as e:
-                # This is internal FE code.
-                return self._result_helper.from_user_exception(
-                    self._allocation_event_details, e
-                )
-
-            # This is internal FE code.
-            serialized_objects, blob_data = serialized_values_to_serialized_objects(
-                serialized_values={
-                    serialized_output_value.metadata.id: serialized_output_value
-                }
-            )
-            serialized_output = serialized_objects[serialized_output_value.metadata.id]
-            outputs_blob: BLOB = self._get_new_output_blob(
-                size=sum(len(data) for data in blob_data)
-            )
-            uploaded_output_blob = upload_serialized_objects_to_blob(
-                serialized_objects=serialized_objects,
-                blob_data=blob_data,
-                destination_blob=outputs_blob,
-                blob_store=self._blob_store,
-                logger=self._logger,
-            )
-
-        output_pb: SerializedObjectInsideBLOB | ExecutionPlanUpdates
-        # This is user code.
-        try:
-            if tail_call_output_future is None:
-                output_pb = serialized_output
-            else:
-                tail_call_output_future_info: FutureInfo = self._future_infos[
-                    tail_call_output_future._id
-                ]
-                output_pb = ExecutionPlanUpdates(
-                    root_function_call_id=tail_call_output_future_info.durable_id,
-                )
-
-        except BaseException as e:
-            return self._result_helper.from_user_exception(
-                self._allocation_event_details, e
-            )
-
-        return self._result_helper.from_function_output(
-            output=output_pb, uploaded_outputs_blob=uploaded_output_blob
-        )
-
-    def _call_user_function(self, args: List[Any], kwargs: Dict[str, Any]) -> Any:
-        """Runs user function and returns its output."""
-        context: contextvars.Context = contextvars.Context()
-        return context.run(self._call_user_function_in_new_context, args, kwargs)
-
-    def _call_user_function_in_new_context(
-        self, args: List[Any], kwargs: Dict[str, Any]
-    ) -> Any:
-        # This function is executed in contextvars.Context of the Tensorlake Function call.
-        set_current_request_context(self._request_context)
-        set_allocation_id_context_variable(self._allocation.allocation_id)
-
-        self._logger.info("running function")
-        start_time = time.monotonic()
-
-        try:
-            if inspect.iscoroutinefunction(self._function):
-                return asyncio.run(self._function._original_function(*args, **kwargs))
-            else:
-                return self._function._original_function(*args, **kwargs)
-        finally:
-            self._logger.info(
-                "function finished",
-                duration_sec=f"{time.monotonic() - start_time:.3f}",
-            )
+        self._allocation_function_args = args
+        self._allocation_function_kwargs = kwargs
+        return None

--- a/src/tensorlake/function_executor/allocation_runner/event_loop/__init__.py
+++ b/src/tensorlake/function_executor/allocation_runner/event_loop/__init__.py
@@ -1,0 +1,33 @@
+from .event_loop import (
+    AllocationEventLoop,
+)
+from .input_events import (
+    InputEventEmergencyShutdown,
+    InputEventFunctionCallCreated,
+    InputEventFunctionCallWatcherResult,
+    InputEventType,
+)
+from .output_events import (
+    FunctionCallCollectionRef,
+    FunctionCallRef,
+    OutputEventBatch,
+    OutputEventCreateFunctionCall,
+    OutputEventCreateFunctionCallWatcher,
+    OutputEventFinishAllocation,
+    OutputEventType,
+)
+
+__all__ = [
+    "OutputEventCreateFunctionCallWatcher",
+    "AllocationEventLoop",
+    "OutputEventCreateFunctionCall",
+    "InputEventFunctionCallCreated",
+    "OutputEventType",
+    "OutputEventBatch",
+    "InputEventType",
+    "InputEventEmergencyShutdown",
+    "OutputEventFinishAllocation",
+    "FunctionCallCollectionRef",
+    "FunctionCallRef",
+    "InputEventFunctionCallWatcherResult",
+]

--- a/src/tensorlake/function_executor/allocation_runner/event_loop/durable_id.py
+++ b/src/tensorlake/function_executor/allocation_runner/event_loop/durable_id.py
@@ -1,0 +1,169 @@
+import hashlib
+from typing import Any
+
+from tensorlake.applications import InternalError
+from tensorlake.applications.interface.futures import (
+    FunctionCallFuture,
+    Future,
+    ListFuture,
+    ReduceOperationFuture,
+    _TensorlakeFutureWrapper,
+    _unwrap_future,
+)
+
+from .future_info import FutureInfo
+
+
+def future_durable_id(
+    future: Future,
+    parent_function_call_id: str,
+    previous_future_durable_id: str,
+    future_infos: dict[str, FutureInfo],
+) -> str:
+    """Return durable ID for the supplied Future.
+
+    parent_function_call_id is durable ID of the function call that created the Future.
+    previous_durable_id is durable ID of the previous Future created by the parent function call.
+    future_infos is a mapping from Future IDs to their FutureInfo.
+
+    Durable Future IDs are the same across different executions (allocations) of the same parent function call
+    if the parent function call is deterministic, i.e. it creates the same Futures in the same order each
+    time it's executed. If this is not the case then the durable Future IDs will differ between executions, which may
+    lead to re-execution of some function calls even if their inputs are the same as in a previous execution.
+
+    To produce a durable Future ID, we compute it as a hash of:
+    - parent_function_call_id, this scopes each durable ID to its parent function call and allows to generate them locally while running
+      the parent function call.
+    - previous_durable_id, this ties each Future durable ID to the previous Future created by the parent function call.
+      If while replaying the parent function call it follows a different execution path (i.e. running a different function call) then this new
+      function call and all next function calls won't be replayed because their durable IDs will be different due to different previous_durable_id
+      in their durable ID hash. This ensures that any drift in the execution path gets detected and gets handled according to the replay mode used.
+    - Future-specific metadata. This ensures that we detect changes inside each Future, i.e. a change of called function name.
+    - Deterministically ordered durable IDs of all immediate child Futures.
+      This ensures that changes in the structure of the Future tree leads to different durable IDs of its nodes
+      starting from root so it's easy to detect a drift on Server side just by comparing durable ID of root.
+
+    We're deliberately not hashing entire user values (i.e. function call args) to produce their durable IDs. This is because hashing entire user values
+    is an expensive operation (i.e. hashing gigabytes of arbitrary user supplied objects which are function call parameters).
+    This also results in better UX, i.e. this allows:
+    - Seamless Schema Evolution: Users may want to change the schema of function parameters (e.g. add a new field with a default value
+      to a pydantic model).
+    - Use of non-deterministic functions: Users may want to use non-deterministic functions (e.g. functions that return current time or random values)
+      inside otherwise deterministic function call trees.
+    - To avoid "Serialization Flakiness": Strict equality checks on serialized data are fragile and can lead to false positive
+      re-executions due to minor, non-semantic changes in serialization (e.g. different field ordering in protobufs, or insertion order in dicts).
+    - To decouple Logic from Data. We adhere to a philosophy of being Strict on Control Flow but Lenient on Data. "The History is the Source of Truth."
+
+    Raises TensorlakeError on error.
+    """
+    # Warning: any change of ordering of operations in this function may lead to different durable IDs being generated
+    # which may lead to re-execution of function calls on Server side even if nothing changed in the future tree.
+    durable_id_attrs: list[str] = [
+        parent_function_call_id,
+        previous_future_durable_id,
+    ]
+
+    if isinstance(future, FunctionCallFuture):
+        # Future specific metadata, part of durable ID.
+        durable_id_attrs.extend(["FunctionCall", future._function_name])
+        for arg in future._args:
+            _add_future_durable_id(
+                value=arg,
+                future_infos=future_infos,
+                durable_id_attrs=durable_id_attrs,
+            )
+
+        # Iterate over sorted dict keys to ensure deterministic hash key order.
+        sorted_kwarg_keys: list[str] = sorted(future._kwargs.keys())
+        for kwarg_name in sorted_kwarg_keys:
+            kwarg_value: _TensorlakeFutureWrapper[Future] | Any = future._kwargs[
+                kwarg_name
+            ]
+            _add_future_durable_id(
+                value=kwarg_value,
+                future_infos=future_infos,
+                durable_id_attrs=durable_id_attrs,
+            )
+    elif isinstance(future, ListFuture):
+        # Future specific metadata, part of durable ID.
+        durable_id_attrs.append(future._metadata.durability_key)
+        items: ListFuture | list[_TensorlakeFutureWrapper[Future] | Any] = (
+            _unwrap_future(future._items)
+        )
+        if isinstance(items, ListFuture):
+            _add_future_durable_id(
+                value=items,
+                future_infos=future_infos,
+                durable_id_attrs=durable_id_attrs,
+            )
+        else:
+            for item in items:
+                _add_future_durable_id(
+                    value=item,
+                    future_infos=future_infos,
+                    durable_id_attrs=durable_id_attrs,
+                )
+
+    elif isinstance(future, ReduceOperationFuture):
+        # Future specific metadata, part of durable ID.
+        durable_id_attrs.extend(["ReduceOperation", future._function_name])
+
+        _add_future_durable_id(
+            value=future._initial,
+            future_infos=future_infos,
+            durable_id_attrs=durable_id_attrs,
+        )
+
+        items: ListFuture | list[_TensorlakeFutureWrapper[Future] | Any] = (
+            _unwrap_future(future._items)
+        )
+        if isinstance(items, ListFuture):
+            _add_future_durable_id(
+                value=items,
+                future_infos=future_infos,
+                durable_id_attrs=durable_id_attrs,
+            )
+        else:
+            for item in items:
+                _add_future_durable_id(
+                    value=item,
+                    future_infos=future_infos,
+                    durable_id_attrs=durable_id_attrs,
+                )
+    else:
+        raise InternalError(f"Unexpected Future type: {type(future)}")
+
+    return _sha256_hash_strings(durable_id_attrs)
+
+
+def _add_future_durable_id(
+    value: _TensorlakeFutureWrapper[Future] | Any,
+    future_infos: dict[str, FutureInfo],
+    durable_id_attrs: list[str],
+) -> None:
+    """Adds durable ID of the given Future to durable_attrs if the value is a Future. Does nothing otherwise.
+
+    Raises InternalError if the value is a Future but its durable ID is not found in future_durable_ids.
+    """
+    # We don't hash user provided values. Only hash Futures to verify tree structure.
+    value: Future | Any = _unwrap_future(value)
+    if isinstance(value, Future):
+        value_future_info: FutureInfo | None = future_infos.get(value._id, None)
+        if value_future_info is None:
+            raise InternalError(
+                f"FutureInfo for Future with id {value._id} not found in future_infos."
+            )
+        durable_id_attrs.append(value_future_info.durable_id)
+
+
+def _sha256_hash_strings(strings: list[str]) -> str:
+    """Returns sha256 hash of the concatenation of strings in the given list.
+
+    If the strings are sha256 hashes, the result is also a high quality sha256 hash
+    of the original hashed values. See https://en.wikipedia.org/wiki/Merkle_tree.
+    """
+    sha256 = hashlib.sha256()
+    for s in strings:
+        sha256.update(s.encode("utf-8"))
+        sha256.update(b"|")  # Separator to avoid collisions of neighbouring strings.
+    return sha256.hexdigest()

--- a/src/tensorlake/function_executor/allocation_runner/event_loop/event_loop.py
+++ b/src/tensorlake/function_executor/allocation_runner/event_loop/event_loop.py
@@ -1,0 +1,921 @@
+import asyncio
+import inspect
+import queue
+import threading
+import time
+import weakref
+from collections.abc import Coroutine, Generator
+from typing import Any
+
+from tensorlake.applications import (
+    RETURN_WHEN,
+    Function,
+    Future,
+    InternalError,
+    RequestContext,
+    SDKUsageError,
+    SerializationError,
+    TensorlakeError,
+    TimeoutError,
+)
+from tensorlake.applications.algorithms import (
+    derived_function_call_future,
+    dfs_bottom_up_unique_only,
+    tail_call_output_future_ids,
+    validate_tail_call_user_future,
+)
+from tensorlake.applications.interface.futures import (
+    FunctionCallFuture,
+    ListFuture,
+    ReduceOperationFuture,
+    _FutureListKind,
+    _InitialMissing,
+    _TensorlakeFutureWrapper,
+    _unwrap_future,
+)
+from tensorlake.applications.internal_logger import InternalLogger
+from tensorlake.applications.registry import get_function
+from tensorlake.applications.request_context.contextvar import (
+    set_current_request_context,
+)
+
+from ..contextvars import set_allocation_id_context_variable
+from .durable_id import future_durable_id
+from .future_info import FutureInfo
+from .input_events import (
+    InputEventEmergencyShutdown,
+    InputEventFunctionCallCreated,
+    InputEventFunctionCallWatcherResult,
+    InputEventType,
+    _InputEventShutdown,
+)
+from .output_events import (
+    FunctionCallCollectionRef,
+    FunctionCallRef,
+    OutputEventBatch,
+    OutputEventCreateFunctionCall,
+    OutputEventCreateFunctionCallWatcher,
+    OutputEventFinishAllocation,
+)
+
+
+class AllocationEventLoop:
+    """Deterministic event loop for running user code.
+
+    Runs user code in a thread. When user calls an SDK hook, generates strictly
+    ordered output events and blocks the hook (and user code) until input events required to
+    complete the current SDK hook are delivered by AllocationRunner. This ensures strict
+    step-by-step execution of user code and ensures its deterministic execution.
+    """
+
+    def __init__(
+        self,
+        function: Function,
+        function_call_id: str,
+        allocation_id: str,
+        request_context: RequestContext,
+        logger: InternalLogger,
+    ):
+        self._function: Function = function
+        self._function_call_id: str = function_call_id
+        self._allocation_id: str = allocation_id
+        self._request_context: RequestContext = request_context
+        self._logger: InternalLogger = logger.bind(module=__name__)
+
+        # Allocation Execution state.
+        #
+        # Durable ID of the previous future started by this allocation.
+        self._previous_future_durable_id: str = function_call_id
+        # Futures that were created (started) during this allocation.
+        # Future ID -> FutureInfo.
+        # Future Durable ID -> FutureInfo.
+        self._future_infos: dict[str, FutureInfo] = {}
+        # Coroutine -> Future, use weakref so once a coroutine is no longer used
+        # it's deleted from the mapping automatically. This is required because coroutine
+        # objects are owned by user code and so is their lifecycle.
+        self._coroutine_to_future: weakref.WeakKeyDictionary = (
+            weakref.WeakKeyDictionary()
+        )
+
+        # Lock taken on entry into every runtime hook. This is only to ensure no parallel execution
+        # is happening inside event loop due to customer code spinning up multiple threads.
+        # Customer code can currently spin up a new thread that can call a runtime hook. For this customer
+        # code can call asyncio.to_thread() because the thread automatically inherits a copy of the current
+        # contextvars.Context. Async Agentic frameworks use asyncio.to_thread() for running sync tool functions.
+        # Customer code doing this makes their application non-deterministic, we just ensure no race conditions
+        # inside event loop by putting this lock in place.
+        self._runtime_hook_lock: threading.Lock = threading.Lock()
+        self._output_event_queue: queue.Queue[OutputEventBatch] = queue.Queue()
+        self._input_event_queue: queue.Queue[InputEventType] = queue.Queue()
+        # Thread that runs user code and runtime hooks.
+        # Generates output events in deterministic, replayable order.
+        self._user_thread: threading.Thread | None = None
+        # Thread that processes input events.
+        # Applies input events one by one in deterministic way.
+        self._input_event_thread: threading.Thread | None = None
+
+    def start(self, args: list[Any], kwargs: dict[str, Any]) -> None:
+        """Starts user code in a thread. Non-blocking.
+
+        Doesn't raise any exceptions.
+        """
+        self._user_thread = threading.Thread(
+            target=self._run_user_function,
+            args=(args, kwargs),
+            daemon=True,
+        )
+        self._user_thread.start()
+
+    def join(self) -> None:
+        """Waits for event loop to exit.
+
+        Exit means stop running user code and other service threads.
+        Doesn't raise any exceptions. All exceptions should be delivered via output events and handled by AllocationRunner.
+        """
+        if self._user_thread is not None:
+            try:
+                self._user_thread.join()
+            except RuntimeError as e:
+                self._logger.error(
+                    "Error while waiting for user thread to finish",
+                    exc_info=e,
+                )
+        if self._input_event_thread is not None:
+            try:
+                self._input_event_thread.join()
+            except RuntimeError as e:
+                self._logger.error(
+                    "Error while waiting for input event processing thread to finish",
+                    exc_info=e,
+                )
+
+    def wait_for_output_event_batch(self) -> OutputEventBatch:
+        """Blocks until user code generates an output event batch."""
+        return self._output_event_queue.get()
+
+    def add_input_event(self, event: InputEventType) -> None:
+        """Delivers a single input event to event loop."""
+        self._input_event_queue.put(event)
+
+    def _run_user_function(self, args: list[Any], kwargs: dict[str, Any]) -> None:
+        """Runs user function to completion.
+
+        Doesn't raise any exceptions. All exceptions are caught and delivered via output events.
+        """
+        # The thread context should be empty, because we're running in a new thread.
+        #
+        # Request context is required for user function running in this thread.
+        # Allocation ID context variable is required for both user function, _unwrap_future
+        # and all its callers.
+        set_current_request_context(self._request_context)
+        set_allocation_id_context_variable(self._allocation_id)
+
+        try:
+            self._input_event_thread = threading.Thread(
+                target=self._process_input_events, daemon=True
+            )
+            self._input_event_thread.start()
+            self.__run_user_function(args, kwargs)
+        except BaseException as e:
+            # This can only be exception in our code.
+            self._output_event_queue.put(
+                OutputEventBatch(
+                    events=[OutputEventFinishAllocation(internal_exception=e)]
+                )
+            )
+        finally:
+            # Cleanup resources, no exceptions must be raised here.
+            self._input_event_queue.put(_InputEventShutdown())
+            if (
+                self._input_event_thread is not None
+                and self._input_event_thread.is_alive()
+            ):
+                try:
+                    self._logger.info(
+                        "Waiting for input event processing thread to finish"
+                    )
+                    self._input_event_thread.join()
+                except RuntimeError as e:
+                    self._logger.error(
+                        "Error while waiting for input event processing thread to finish",
+                        exc_info=e,
+                    )
+
+    def __run_user_function(self, args: list[Any], kwargs: dict[str, Any]) -> None:
+        """Runs user function to completion.
+
+        Raises an exception on internal error. All exceptions in user code are caught and delivered via output events.
+        """
+        # This is user code.
+        try:
+            output: Any | _TensorlakeFutureWrapper[Future] = self.__call_user_function(
+                args, kwargs
+            )
+        except BaseException as e:
+            self._output_event_queue.put(
+                OutputEventBatch(events=[OutputEventFinishAllocation(user_exception=e)])
+            )
+            return
+
+        # This is our code.
+        output: Any | Future = _unwrap_future(output)
+        output_events: list[OutputEventCreateFunctionCall] = []
+
+        if isinstance(output, Future):
+            # Function returned tail call. This is user code.
+            try:
+                validate_tail_call_user_future(
+                    function_name=self._function._function_config.function_name,
+                    tail_call_user_future=output,
+                )
+            except BaseException as e:
+                self._output_event_queue.put(
+                    OutputEventBatch(
+                        events=[OutputEventFinishAllocation(user_exception=e)]
+                    )
+                )
+                return
+
+            # This is our code.
+            #
+            # SDK automatically starts tail call futures and their inputs.
+            # This is why we walk the Futures tree, not just starting the output.
+            output_future_ids: set[str] = tail_call_output_future_ids(output)
+            for future in dfs_bottom_up_unique_only(output):
+                if future._id in self._future_infos:
+                    # This is user code.
+                    self._output_event_queue.put(
+                        OutputEventBatch(
+                            events=[
+                                OutputEventFinishAllocation(
+                                    user_exception=SDKUsageError(
+                                        f"A tail call Future {future} is already running, "
+                                        "a tail call Future should not be started."
+                                    )
+                                )
+                            ]
+                        )
+                    )
+                    return
+
+                cmds: list[OutputEventCreateFunctionCall] = self._register_future(
+                    future, tail_call=(future._id in output_future_ids)
+                )
+                output_events.extend(cmds)
+
+            if isinstance(output, ReduceOperationFuture):
+                output_future_info: FutureInfo = self._future_infos[output._id]
+                output = output_future_info.reduce_future_output
+
+        if isinstance(output, Future):
+            tail_call_output_info: FutureInfo = self._future_infos[output._id]
+            tail_call_ref: FunctionCallRef = FunctionCallRef(
+                durable_id=tail_call_output_info.durable_id
+            )
+
+            # Tail call: first output events batch creates function calls and waits
+            # for server to confirm creation. Second batch finishes the allocation.
+            self._create_function_calls(output_events)
+
+            # Check each command completion because tail_call_output_info.future might not create
+            # a function call for itself (i.e., it might be a composite future of other function calls).
+            for function_call in output_events:
+                function_call: OutputEventCreateFunctionCall
+                function_call_future_info: FutureInfo = self._future_infos[
+                    function_call.durable_id
+                ]
+                if function_call_future_info.future._exception is not None:
+                    exception: TensorlakeError = (
+                        function_call_future_info.future._exception
+                    )
+                    # TODO: Move serialization into event loop so we don't have to have this workaround.
+                    if isinstance(exception, SerializationError):
+                        event = OutputEventFinishAllocation(user_exception=exception)
+                    else:
+                        event = OutputEventFinishAllocation(
+                            internal_exception=exception
+                        )
+
+                    self._output_event_queue.put(OutputEventBatch(events=[event]))
+                    return
+
+            self._output_event_queue.put(
+                OutputEventBatch(
+                    events=[OutputEventFinishAllocation(tail_call=tail_call_ref)]
+                )
+            )
+        else:
+            output_events.append(OutputEventFinishAllocation(value=output))
+            self._output_event_queue.put(OutputEventBatch(events=output_events))
+
+    def __call_user_function(
+        self, args: list[Any], kwargs: dict[str, Any]
+    ) -> Any | _TensorlakeFutureWrapper[Future]:
+        self._logger.info("running function")
+        start_time: float = time.monotonic()
+
+        try:
+            if inspect.iscoroutinefunction(self._function):
+                return asyncio.run(self._function._original_function(*args, **kwargs))
+            else:
+                return self._function._original_function(*args, **kwargs)
+        finally:
+            self._logger.info(
+                "function finished",
+                duration_sec=f"{time.monotonic() - start_time:.3f}",
+            )
+
+    def run_future_runtime_hook(self, future: Future) -> None:
+        # NB: This code is called from user function thread. User function thread and aio event loop
+        # are blocked. This hook must block the calling thread until all the Futures are fully started.
+        # If we do any asyncio await/yield operation here then this will result in concurrent hooks running
+        # with non-deterministic completion order.
+        #
+        # NB: all exceptions raised here must be derived from TensorlakeError.
+        with self._runtime_hook_lock:
+            try:
+                self._run_future_runtime_hook(future)
+            except TensorlakeError:
+                raise
+            except Exception as e:
+                self._logger.error(
+                    "Unexpected exception in run_future_runtime_hook",
+                    exc_info=e,
+                )
+                raise InternalError("Unexpected error while running futures") from e
+
+    def _create_function_calls(
+        self, function_call_output_events: list[OutputEventCreateFunctionCall]
+    ) -> None:
+        """Creates function calls for the given output events.
+
+        If a function call creation failed, then sets the exception on its future.
+        (done by input event processor).
+        """
+        if len(function_call_output_events) == 0:
+            return
+
+        pending_durable_ids: list[str] = [
+            event.durable_id for event in function_call_output_events
+        ]
+        self._output_event_queue.put(
+            OutputEventBatch(events=function_call_output_events)
+        )
+
+        for durable_id in pending_durable_ids:
+            self._future_infos[durable_id].function_call_created.wait()
+
+    def _run_future_runtime_hook(self, user_future: Future) -> None:
+        output_events: list[OutputEventCreateFunctionCall] = []
+
+        # NB: To support durability, ordering of running the Futures must be deterministic.
+        # SDK automatically starts user futures that are function call
+        # or other operation inputs. This is why we walk the Futures tree,
+        # not just starting the user_future.
+        for future in dfs_bottom_up_unique_only(user_future):
+            if future._id in self._future_infos:
+                continue  # Future was already started by user.
+
+            # Future is started by user code, cannot be a tail call.
+            future_output_events: list[OutputEventCreateFunctionCall] = (
+                self._register_future(future, tail_call=False)
+            )
+            output_events.extend(future_output_events)
+
+        self._create_function_calls(output_events)
+        # Check each command completion because tail_call_output_info.future might not create
+        # a function call for itself (i.e., it might be a composite future of other function calls).
+        for function_call in output_events:
+            function_call: OutputEventCreateFunctionCall
+            function_call_future_info: FutureInfo = self._future_infos[
+                function_call.durable_id
+            ]
+            if function_call_future_info.future._exception is not None:
+                raise function_call_future_info.future._exception
+
+    def wait_futures_runtime_hook(
+        self, futures: list[Future], timeout: float | None, return_when: int
+    ) -> tuple[list[Future], list[Future]]:
+        # NB: This code is called from user function thread. User function code is blocked.
+        #
+        # NB: all exceptions raised here must be derived from TensorlakeError.
+        with self._runtime_hook_lock:
+            try:
+                return self._wait_futures_runtime_hook(futures, timeout, return_when)
+            except TensorlakeError:
+                raise
+            except Exception as e:
+                self._logger.error(
+                    "Unexpected exception in wait_futures_runtime_hook",
+                    exc_info=e,
+                )
+                raise InternalError("Unexpected error while waiting for futures")
+
+    def _wait_futures_runtime_hook(
+        self, futures: list[Future], timeout: float | None, return_when: int
+    ) -> tuple[list[Future], list[Future]]:
+        if return_when not in (
+            RETURN_WHEN.ALL_COMPLETED,
+            RETURN_WHEN.FIRST_COMPLETED,
+            RETURN_WHEN.FIRST_FAILURE,
+        ):
+            raise SDKUsageError(f"Not supported return_when value: '{return_when}'")
+
+        deadline: float | None = (
+            time.monotonic() + timeout if timeout is not None else None
+        )
+        # NB: The futures order in these lists should be the original order (like stable sort).
+        done: list[Future] = []
+        not_done: list[Future] = []
+
+        # FIXME: We have to keep track of input events timedout waiting.
+        # We have to add an event that this happened in SDK so we replay this on replay.
+        # Otherwise, if the input event is delivered after timeout, we will have it in
+        # the queue and the next call to _read_input_event will get this old event instead
+        # of what it expects.
+        #
+        # FIXME: When FIRST_COMPLETED or FIRST_FAILURE is used we have to wait for all the
+        # future in parallel instead of serially. Without this, if the first future takes
+        # a long time to complete, but the second one completes quickly, we still wait
+        # for the first one to complete before checking the second one. This is not what customers expect.
+        for future in futures:
+            try:
+                self._wait_future_completion(future, deadline)
+            except BaseException as e:
+                # Something went wrong while waiting for the future.
+                self._logger.error(
+                    "Unexpected error while waiting for child future completion",
+                    future_id=future._id,
+                    exc_info=e,
+                )
+                future._set_exception(
+                    InternalError(
+                        f"Unexpected error while waiting for child future completion: {e}"
+                    )
+                )
+
+            if future.done():
+                done.append(future)
+            else:
+                not_done.append(future)
+
+            if return_when == RETURN_WHEN.FIRST_COMPLETED:
+                if len(done) > 0:
+                    break
+            elif return_when == RETURN_WHEN.FIRST_FAILURE:
+                if future.exception is not None:
+                    break
+            # else ALL_COMPLETED
+
+        for future in futures:
+            if future not in done and future not in not_done:
+                not_done.append(future)
+
+        return done, not_done
+
+    def await_future_runtime_hook(self, future: Future) -> Generator[None, None, Any]:
+        # NB: This code is called from user async function thread.
+        # NB: all exceptions raised here must be derived from TensorlakeError.
+        with self._runtime_hook_lock:
+            try:
+                return self._await_future_runtime_hook(future)
+            except TensorlakeError:
+                raise
+            except Exception as e:
+                self._logger.error(
+                    "Unexpected exception in await_future_runtime_hook",
+                    exc_info=e,
+                )
+                raise InternalError("Unexpected error while awaiting future")
+
+    def _await_future_runtime_hook(self, future: Future) -> Generator[None, None, Any]:
+        user_aio_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        # Result is set to None because the actual result is stored in the
+        # Tensorlake SDK Future. This asyncio Future is only used for waiting
+        # in user code, not for getting the result.
+        user_aio_loop_future: asyncio.Future = user_aio_loop.create_future()
+
+        def background_wait():
+            # Required for pretty_print called when converting Future to str.
+            set_allocation_id_context_variable(self._allocation_id)
+            try:
+                self._wait_future_completion(future, deadline=None)
+            except BaseException as e:
+                self._logger.error(
+                    "Unexpected error while waiting for child future completion",
+                    future_id=future._id,
+                    exc_info=e,
+                )
+                future._set_exception(
+                    InternalError(
+                        f"Unexpected error while waiting for child future completion: {e}"
+                    )
+                )
+            user_aio_loop.call_soon_threadsafe(user_aio_loop_future.set_result, None)
+
+        threading.Thread(target=background_wait, daemon=True).start()
+        # FIXME: The order of self._wait_future_completion() calls depends on OS threading timings.
+        # This is not deterministic. We should block the current thread (event loop) until the thread actually
+        # starts.
+        yield from user_aio_loop_future.__await__()
+        # The coroutine is done running. It can't be started again by user code.
+        # Clear the hard reference.
+        future._coroutine = None
+
+    def register_coroutine_runtime_hook(
+        self, coroutine: Coroutine, future: Future
+    ) -> None:
+        with self._runtime_hook_lock:
+            self._coroutine_to_future[coroutine] = future
+
+    def coroutine_to_future_runtime_hook(self, coroutine: Coroutine) -> Future | None:
+        # Do not take self._runtime_hook_lock because this hook can be called from another hook
+        # via i.e. _unwrap_future() call and because this hook is trivial.
+        return self._coroutine_to_future.get(coroutine, None)
+
+    def _register_future(
+        self, future: Future, tail_call: bool
+    ) -> list[OutputEventCreateFunctionCall]:
+        """Register a future and return any OutputEventCreateFunctionCall generated.
+
+        Raises InternalError on error.
+        """
+        if future._coroutine is not None and not future._run_hook_was_called:
+            # We're starting the future for the user.
+            # Close the coroutine to prevent "RuntimeWarning: coroutine '...' was never awaited" warning
+            # because user code is not expected to await the coroutine and it's a user code bug if it does.
+            future._run_hook_was_called = True
+            future._coroutine.close()
+            future._coroutine = None
+
+        if future._id in self._future_infos:
+            raise InternalError(f"Future with ID {future._id} is already registered.")
+
+        durable_id: str = future_durable_id(
+            future=future,
+            parent_function_call_id=self._function_call_id,
+            previous_future_durable_id=self._previous_future_durable_id,
+            future_infos=self._future_infos,
+        )
+        self._previous_future_durable_id = durable_id
+
+        future_info: FutureInfo = FutureInfo(
+            future=future,
+            durable_id=durable_id,
+            map_future_output=None,
+            reduce_future_output=None,
+        )
+        self._future_infos[future._id] = future_info
+        self._future_infos[durable_id] = future_info
+
+        if isinstance(future, ListFuture):
+            return self._register_list_future(future_info)
+        elif isinstance(future, ReduceOperationFuture):
+            return self._register_reduce_operation_future(future_info, tail_call)
+        elif isinstance(future, FunctionCallFuture):
+            return [self._make_call_function_output_event(future_info, tail_call)]
+        else:
+            raise InternalError(
+                f"Unsupported Future type: {type(future)} with ID {future._id}"
+            )
+
+    def _register_list_future(
+        self, future_info: FutureInfo
+    ) -> list[OutputEventCreateFunctionCall]:
+        # Server can't run ListFuture, we need to run each list item separately as a new
+        # internal (not user visible) Future. All child Futures of user_future are already running.
+        user_future: ListFuture = future_info.future
+
+        if user_future._metadata.kind != _FutureListKind.MAP_OPERATION:
+            raise InternalError(
+                f"Unsupported ListFuture kind: {user_future._metadata.kind}"
+            )
+        function: Function = get_function(user_future._metadata.function_name)
+
+        items: list[_TensorlakeFutureWrapper[Future] | Any] | ListFuture = (
+            _unwrap_future(user_future._items)
+        )
+        map_inputs: list[_TensorlakeFutureWrapper[Future] | Any]
+        if isinstance(items, ListFuture):
+            inputs_future_info: FutureInfo = self._future_infos[items._id]
+            map_inputs = inputs_future_info.map_future_output
+        else:
+            map_inputs = items
+
+        output_events: list[OutputEventCreateFunctionCall] = []
+        map_outputs: list[FunctionCallFuture] = []
+        for input in map_inputs:
+            mapped_input: FunctionCallFuture = derived_function_call_future(
+                user_future, function, input
+            )
+            # No output override for list future because it can't be returned from tail call.
+            # Strictly one level of recursion per mapped item, so it's okay.
+            cmds: list[OutputEventCreateFunctionCall] = self._register_future(
+                mapped_input, tail_call=False
+            )
+            output_events.extend(cmds)
+            map_outputs.append(mapped_input)
+
+        future_info.map_future_output = map_outputs
+        return output_events
+
+    def _register_reduce_operation_future(
+        self, future_info: FutureInfo, tail_call: bool
+    ) -> list[OutputEventCreateFunctionCall]:
+        # Server can't run ReduceOperationFuture, we need to run each list item separately as a new
+        # internal (not user visible) Future. All child Futures of user_future are already running.
+        user_future: ReduceOperationFuture = future_info.future
+        function: Function = get_function(user_future._function_name)
+
+        inputs: list[_TensorlakeFutureWrapper[Future] | Any] = []
+        initial: Future | Any = _unwrap_future(user_future._initial)
+        if initial is not _InitialMissing:
+            inputs.append(initial)
+
+        items: list[_TensorlakeFutureWrapper[Future] | Any] | ListFuture = (
+            _unwrap_future(user_future._items)
+        )
+        if isinstance(items, ListFuture):
+            inputs_future_info: FutureInfo = self._future_infos[items._id]
+            inputs.extend(inputs_future_info.map_future_output)
+        else:
+            inputs.extend(items)
+
+        if len(inputs) == 0:
+            raise SDKUsageError("reduce of empty iterable with no initial value")
+
+        if len(inputs) == 1:
+            # Child future inputs[0] is already running due to DFS bottom up traversal.
+            future_info.reduce_future_output = _unwrap_future(inputs[0])
+            return []
+
+        # Create a chain of function calls to reduce all args one by one.
+        # Ordering of calls is important here. We should reduce ["a", "b", "c", "d"]
+        # using string concat function into "abcd".
+
+        # inputs now contain at least two items.
+        output_events: list[OutputEventCreateFunctionCall] = []
+        last_future: Future = derived_function_call_future(
+            user_future, function, inputs[0], inputs[1]
+        )
+        for input in inputs[2:]:
+            # Strictly one level of recursion per reduced item, so it's okay.
+            cmds: list[OutputEventCreateFunctionCall] = self._register_future(
+                last_future, tail_call=False
+            )
+            output_events.extend(cmds)
+            last_future = derived_function_call_future(
+                user_future, function, last_future, input
+            )
+        cmds: list[OutputEventCreateFunctionCall] = self._register_future(
+            last_future, tail_call=tail_call
+        )
+        output_events.extend(cmds)
+
+        future_info.reduce_future_output = last_future
+        return output_events
+
+    def _make_call_function_output_event(
+        self, future_info: FutureInfo, tail_call: bool
+    ) -> OutputEventCreateFunctionCall:
+        future: FunctionCallFuture = future_info.future
+
+        # Convert args: replace Future references with FunctionCallRef/FunctionCallCollectionRef.
+        args: list[Any | FunctionCallRef | FunctionCallCollectionRef] = [
+            self._resolve_arg(arg) for arg in future._args
+        ]
+        kwargs: dict[str, Any | FunctionCallRef | FunctionCallCollectionRef] = {
+            k: self._resolve_arg(v) for k, v in future._kwargs.items()
+        }
+
+        return OutputEventCreateFunctionCall(
+            durable_id=future_info.durable_id,
+            function_name=future._function_name,
+            args=args,
+            kwargs=kwargs,
+            is_tail_call=tail_call,
+            start_delay=future._start_delay,
+        )
+
+    def _resolve_arg(
+        self, value: Any | _TensorlakeFutureWrapper[Future]
+    ) -> Any | FunctionCallRef | FunctionCallCollectionRef:
+        """Resolve a Future arg to FunctionCallRef/FunctionCallCollectionRef, or keep as raw value."""
+        unwrapped: Any | Future = _unwrap_future(value)
+        if isinstance(unwrapped, FunctionCallFuture):
+            future_info: FutureInfo | None = self._future_infos.get(unwrapped._id)
+            if future_info is None:
+                raise InternalError(
+                    f"FunctionCallFuture arg with ID {unwrapped._id} is not registered."
+                )
+            return FunctionCallRef(durable_id=future_info.durable_id)
+        elif isinstance(unwrapped, ListFuture):
+            future_info: FutureInfo | None = self._future_infos.get(unwrapped._id)
+            if future_info is None:
+                raise InternalError(
+                    f"ListFuture arg with ID {unwrapped._id} is not registered."
+                )
+            durable_ids: list[str] = [
+                self._future_infos[item._id].durable_id
+                for item in future_info.map_future_output
+            ]
+            return FunctionCallCollectionRef(durable_ids=durable_ids)
+        elif isinstance(unwrapped, ReduceOperationFuture):
+            future_info: FutureInfo | None = self._future_infos.get(unwrapped._id)
+            if future_info is None:
+                raise InternalError(
+                    f"ReduceOperationFuture arg with ID {unwrapped._id} is not registered."
+                )
+            output = future_info.reduce_future_output
+            if isinstance(output, Future):
+                # Follow the chain to the final FunctionCallFuture.
+                return self._resolve_arg(output)
+            else:
+                # Single-item reduce with plain value output.
+                return output
+        elif isinstance(unwrapped, Future):
+            raise InternalError(
+                f"Unsupported Future type as argument: {type(unwrapped)} "
+                f"with ID {unwrapped._id}"
+            )
+        return value
+
+    def _wait_future_completion(self, future: Future, deadline: float | None) -> None:
+        """Waits for the completion of the future and sets its result.
+
+        Raises Exception on unexpected internal error. Normally all exceptions are set on the future itself.
+        """
+        if future.done():
+            # Short circuit just for performance optimization
+            # so we don't call Server to get the result again.
+            return
+
+        future_info: FutureInfo | None = self._future_infos.get(future._id)
+        if future_info is None:
+            raise InternalError(f"Unknown Future with ID {future._id} is not tracked.")
+
+        if isinstance(future, ListFuture):
+            self._wait_list_future_completion(future_info, deadline)
+        elif isinstance(future, ReduceOperationFuture):
+            self._wait_reduce_operation_future_completion(future_info, deadline)
+        elif isinstance(future, FunctionCallFuture):
+            self._wait_function_call_future_completion(future_info, deadline)
+        else:
+            raise InternalError(
+                f"Unsupported Future type: {type(future)} with ID {future._id}"
+            )
+
+    def _wait_function_call_future_completion(
+        self, future_info: FutureInfo, deadline: float | None
+    ) -> None:
+        cmd: OutputEventCreateFunctionCallWatcher = (
+            OutputEventCreateFunctionCallWatcher(
+                function_call_durable_id=future_info.durable_id,
+            )
+        )
+        self._output_event_queue.put(OutputEventBatch(events=[cmd]))
+
+        result_wait_timeout: float | None = (
+            deadline - time.monotonic() if deadline is not None else None
+        )
+        if not future_info.function_call_finished.wait(timeout=result_wait_timeout):
+            # FIXME: This timeout is not replayable, add an output event for this and then wait for its input event to arrive
+            # or the watcher result to arrive, whichever happens first.
+            future_info.future._set_exception(TimeoutError())
+
+    def _wait_list_future_completion(
+        self, future_info: FutureInfo, deadline: float | None
+    ) -> None:
+        """Wait for the completion of the future representing a ListFuture and sets its result or exception.
+
+        Raises Exception on unexpected internal error. Normally all exceptions are set on the future itself.
+        """
+        future: ListFuture = future_info.future
+        # Reconstruct the original collection out of individual futures.
+        collection: list[Any] = []
+        exception: TensorlakeError | None = None
+        is_timeout: bool = False
+
+        for item in future_info.map_future_output:
+            if deadline is not None and deadline - time.monotonic() <= 0:
+                is_timeout = True
+                break
+
+            self._wait_future_completion(item, deadline)
+            if item.exception is None:
+                collection.append(item.result())
+            else:
+                exception = item.exception
+                break
+
+        if is_timeout:
+            future._set_exception(TimeoutError())
+        elif exception is not None:
+            future._set_exception(exception)
+        else:
+            future._set_result(collection)
+
+    def _wait_reduce_operation_future_completion(
+        self, future_info: FutureInfo, deadline: float | None
+    ) -> None:
+        """Wait for the completion of the future representing a ReduceOperationFuture and sets its result or exception.
+
+        Raises Exception on unexpected internal error. Normally all exceptions are set on the future itself.
+        """
+        future: ReduceOperationFuture = future_info.future
+        reduce_output: Future | Any | None = future_info.reduce_future_output
+
+        if reduce_output is None:
+            future._set_exception(
+                InternalError("Reduce operation future is missing the output future.")
+            )
+            return
+
+        if isinstance(reduce_output, Future):
+            # FIXME: Recursive call. Max 1000 recursion depth is allowed in Python by default.
+            self._wait_future_completion(reduce_output, deadline)
+            if reduce_output.exception is not None:
+                future._set_exception(reduce_output.exception)
+            else:
+                future._set_result(reduce_output.result())
+        else:
+            # This can happen when we have only one item to reduce, in that case we shortcut
+            # and set the output directly without creating a Future for it.
+            future._set_result(reduce_output)
+
+    def _process_input_events(self) -> None:
+        while True:
+            input_event: InputEventType = self._input_event_queue.get()
+            if isinstance(input_event, _InputEventShutdown):
+                break
+            elif isinstance(input_event, InputEventEmergencyShutdown):
+                self._process_input_event_emergency_shutdown(input_event)
+            elif isinstance(input_event, InputEventFunctionCallCreated):
+                self._process_input_event_function_call_created(input_event)
+            elif isinstance(input_event, InputEventFunctionCallWatcherResult):
+                self._process_input_event_function_call_watcher_result(input_event)
+            else:
+                self._logger.error(
+                    "Unknown input event type received",
+                    input_event=input_event,
+                )
+
+    def _process_input_event_emergency_shutdown(
+        self, event: InputEventEmergencyShutdown
+    ) -> None:
+        # TODO: Implement.
+        self._output_event_queue.put(
+            OutputEventBatch(
+                events=[
+                    OutputEventFinishAllocation(
+                        internal_exception=event.internal_exception
+                    )
+                ]
+            )
+        )
+
+    def _process_input_event_function_call_created(
+        self, event: InputEventFunctionCallCreated
+    ) -> None:
+        # This event is used for both regular and tail call function calls.
+        future_info: FutureInfo | None = self._future_infos.get(event.durable_id)
+        if future_info is None:
+            # Info because this might be some stale event we're not interested about anymore.
+            self._logger.info(
+                "Function call created event received for unknown durable ID",
+                durable_id=event.durable_id,
+            )
+            return
+
+        if event.exception is not None:
+            future_info.future._set_exception(event.exception)
+        future_info.function_call_created.set()
+        # FIXME: We can only return once the runtime hook blocked on this returns and reads the current Future state,
+        # not some later state that we might update in i.e. the next event.
+
+    def _process_input_event_function_call_watcher_result(
+        self, event: InputEventFunctionCallWatcherResult
+    ) -> None:
+        future_info: FutureInfo | None = self._future_infos.get(
+            event.function_call_durable_id
+        )
+        if future_info is None:
+            # Info because this might be some stale event we're not interested about anymore.
+            self._logger.info(
+                "Function call watcher result event received for unknown durable ID",
+                durable_id=event.function_call_durable_id,
+            )
+            return
+
+        future: Future = future_info.future
+        if event.exception is None:
+            future._set_result(event.output)
+        else:
+            future._set_exception(event.exception)
+
+        # Future result is set, we can remove the Future from tracking.
+        del self._future_infos[future._id]
+        del self._future_infos[future_info.durable_id]
+        future_info.function_call_finished.set()
+        # FIXME: We can only return once the runtime hook blocked on this returns and reads the current Future state,
+        # not some later state that we might update in i.e. the next event.

--- a/src/tensorlake/function_executor/allocation_runner/event_loop/future_info.py
+++ b/src/tensorlake/function_executor/allocation_runner/event_loop/future_info.py
@@ -1,0 +1,29 @@
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+from tensorlake.applications.interface.futures import (
+    FunctionCallFuture,
+    Future,
+)
+
+
+@dataclass
+class FutureInfo:
+    # Original Future created by user code or internal Future created by SDK i.e.
+    # a future per map function call, or a future per reduce operation step.
+    future: Future
+    # The future's durable ID.
+    # ReduceOp and ListFuture are not visible to Server but we still
+    # compute durable IDs because this allows to detect changes not visible
+    # to Server and also avoids us using a recursive durable ID compute algorithm.
+    durable_id: str
+    # Set if this future is ListFuture.
+    map_future_output: list[FunctionCallFuture] | None
+    # Set if this is reduce operation future. None can be a valid output.
+    reduce_future_output: Future | Any | None
+
+    # Set when the function call creation is confirmed by the server.
+    function_call_created: threading.Event = field(default_factory=threading.Event)
+    # Set when the function call result is delivered by the server.
+    function_call_finished: threading.Event = field(default_factory=threading.Event)

--- a/src/tensorlake/function_executor/allocation_runner/event_loop/input_events.py
+++ b/src/tensorlake/function_executor/allocation_runner/event_loop/input_events.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from typing import Any
+
+from tensorlake.applications.interface.exceptions import TensorlakeError
+
+
+@dataclass(frozen=True)
+class InputEventFunctionCallCreated:
+    durable_id: str
+    # Not None if creating the function call failed.
+    exception: TensorlakeError | None
+
+
+@dataclass(frozen=True)
+class InputEventFunctionCallWatcherResult:
+    """Result of a CreateFunctionCallWatcherRequest.
+
+    Contains either the actual function call output (success) or an
+    internal error (watcher installation failed or function call failed).
+    AllocationRunner downloads blobs and deserializes the output before
+    delivering this result.
+    """
+
+    function_call_durable_id: str
+    output: Any
+    # Not None if the function call failed.
+    exception: TensorlakeError | None
+
+
+@dataclass(frozen=True)
+class InputEventEmergencyShutdown:
+    """Internal event used to stop the entire AllocationRunner immediately.
+
+    This is used when we detect an error which breaks durable execution if
+    user code proceeds further. We stop all user code execution immediately
+    in this case.
+    """
+
+    # Reason for the emergency shutdown.
+    internal_exception: BaseException
+
+
+@dataclass(frozen=True)
+class _InputEventShutdown:
+    """Internal event used to stop input envent processing thread."""
+
+    pass
+
+
+InputEventType = (
+    InputEventFunctionCallCreated
+    | InputEventFunctionCallWatcherResult
+    | InputEventEmergencyShutdown
+    | _InputEventShutdown
+)

--- a/src/tensorlake/function_executor/allocation_runner/event_loop/output_events.py
+++ b/src/tensorlake/function_executor/allocation_runner/event_loop/output_events.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class FunctionCallRef:
+    """Reference to a function call by its durable ID.
+
+    Used in CreateFunctionCallRequest args/kwargs to reference the output of
+    another function call as an input. The referenced function call can
+    be previously started or from the same batch of requests.
+    """
+
+    durable_id: str
+
+
+@dataclass(frozen=True)
+class FunctionCallCollectionRef:
+    """Reference to a collection of function call results (from map operations).
+
+    Used in CreateFunctionCallRequest args/kwargs when a map operation's output
+    is passed as an input to another function call.
+    """
+
+    durable_ids: list[str]
+
+
+@dataclass(frozen=True)
+class OutputEventCreateFunctionCall:
+    """Create a function call on the server.
+
+    AllocationRunner is responsible for serializing args, uploading blobs,
+    building ExecutionPlanUpdates proto, and sending to server.
+    """
+
+    durable_id: str
+    function_name: str
+    args: list[Any | FunctionCallRef | FunctionCallCollectionRef]
+    kwargs: dict[str, Any | FunctionCallRef | FunctionCallCollectionRef]
+    is_tail_call: bool
+    start_delay: float | None
+
+
+@dataclass(frozen=True)
+class OutputEventCreateFunctionCallWatcher:
+    """Watch for a function call result.
+
+    AllocationRunner is responsible for adding the watcher via
+    AllocationState/gRPC, waiting for the function call to complete,
+    deserializing the result, and delivering an InputEventFunctionCallWatcherCreated.
+    """
+
+    function_call_durable_id: str
+
+
+@dataclass(frozen=True)
+class OutputEventFinishAllocation:
+    """Signals that user code has completed.
+
+    This is the last command emitted by the event loop. No result
+    is expected for this command.
+    """
+
+    value: Any = None
+    # Not None if our code raised an exception (aka internal error).
+    internal_exception: BaseException | None = None
+    # Not None if user code raised an exception.
+    user_exception: BaseException | None = None
+    # Not None if tail call.
+    tail_call: FunctionCallRef | None = None
+
+
+OutputEventType = (
+    OutputEventCreateFunctionCall
+    | OutputEventCreateFunctionCallWatcher
+    | OutputEventFinishAllocation
+)
+
+
+@dataclass
+class OutputEventBatch:
+    """A batch of output events from a single user code operation.
+
+    Events are ordered deterministically.
+    A single event is a batch of size 1.
+    """
+
+    events: list[OutputEventType]

--- a/src/tensorlake/function_executor/allocation_runner/sdk_algorithms.py
+++ b/src/tensorlake/function_executor/allocation_runner/sdk_algorithms.py
@@ -1,5 +1,3 @@
-import hashlib
-from dataclasses import dataclass
 from typing import Any, Dict, List
 
 from tensorlake.applications import (
@@ -19,13 +17,7 @@ from tensorlake.applications.function.user_data_serializer import (
     serialize_value,
 )
 from tensorlake.applications.interface.futures import (
-    FunctionCallFuture,
-    Future,
-    ListFuture,
-    ReduceOperationFuture,
     _request_scoped_id,
-    _TensorlakeFutureWrapper,
-    _unwrap_future,
 )
 from tensorlake.applications.metadata import (
     CollectionItemMetadata,
@@ -50,183 +42,17 @@ from ..proto.function_executor_pb2 import (
     FunctionRef,
     SerializedObjectInsideBLOB,
 )
+from .event_loop.output_events import (
+    FunctionCallCollectionRef,
+    FunctionCallRef,
+    OutputEventCreateFunctionCall,
+)
 from .http_request_parse import (
     parse_application_function_call_arg_from_single_payload,
     parse_application_function_call_args_from_http_request,
     parse_application_function_call_args_from_multipart_form_data,
 )
 from .value import SerializedValue, Value
-
-
-@dataclass
-class FutureInfo:
-    # Original Future created by user code or internal Future created by SDK i.e.
-    # a future per map function call, or a future per reduce operation step.
-    future: Future
-    # The future's durable ID.
-    # ReduceOp and ListFuture are not visible to Server but we still
-    # compute durable IDs because this allows to detect changes not visible
-    # to Server and also avoids us using a recursive durable ID compute algorithm.
-    durable_id: str
-    # Set if this future is ListFuture.
-    map_future_output: List[FunctionCallFuture] | None
-    # Set if this is reduce operation future. None can be a valid output.
-    reduce_future_output: Future | Any | None
-
-
-def future_durable_id(
-    future: Future,
-    parent_function_call_id: str,
-    previous_future_durable_id: str,
-    future_infos: dict[str, FutureInfo],
-) -> str:
-    """Return durable ID for the supplied Future.
-
-    parent_function_call_id is durable ID of the function call that created the Future.
-    previous_durable_id is durable ID of the previous Future created by the parent function call.
-    future_infos is a mapping from Future IDs to their FutureInfo.
-
-    Durable Future IDs are the same across different executions (allocations) of the same parent function call
-    if the parent function call is deterministic, i.e. it creates the same Futures in the same order each
-    time it's executed. If this is not the case then the durable Future IDs will differ between executions, which may
-    lead to re-execution of some function calls even if their inputs are the same as in a previous execution.
-
-    To produce a durable Future ID, we compute it as a hash of:
-    - parent_function_call_id, this scopes each durable ID to its parent function call and allows to generate them locally while running
-      the parent function call.
-    - previous_durable_id, this ties each Future durable ID to the previous Future created by the parent function call.
-      If while replaying the parent function call it follows a different execution path (i.e. running a different function call) then this new
-      function call and all next function calls won't be replayed because their durable IDs will be different due to different previous_durable_id
-      in their durable ID hash. This ensures that any drift in the execution path gets detected and gets handled according to the replay mode used.
-    - Future-specific metadata. This ensures that we detect changes inside each Future, i.e. a change of called function name.
-    - Deterministically ordered durable IDs of all immediate child Futures.
-      This ensures that changes in the structure of the Future tree leads to different durable IDs of its nodes
-      starting from root so it's easy to detect a drift on Server side just by comparing durable ID of root.
-
-    We're deliberately not hashing entire user values (i.e. function call args) to produce their durable IDs. This is because hashing entire user values
-    is an expensive operation (i.e. hashing gigabytes of arbitrary user supplied objects which are function call parameters).
-    This also results in better UX, i.e. this allows:
-    - Seamless Schema Evolution: Users may want to change the schema of function parameters (e.g. add a new field with a default value
-      to a pydantic model).
-    - Use of non-deterministic functions: Users may want to use non-deterministic functions (e.g. functions that return current time or random values)
-      inside otherwise deterministic function call trees.
-    - To avoid "Serialization Flakiness": Strict equality checks on serialized data are fragile and can lead to false positive
-      re-executions due to minor, non-semantic changes in serialization (e.g. different field ordering in protobufs, or insertion order in dicts).
-    - To decouple Logic from Data. We adhere to a philosophy of being Strict on Control Flow but Lenient on Data. "The History is the Source of Truth."
-
-    Raises TensorlakeError on error.
-    """
-    # Warning: any change of ordering of operations in this function may lead to different durable IDs being generated
-    # which may lead to re-execution of function calls on Server side even if nothing changed in the future tree.
-    durable_id_attrs: list[str] = [
-        parent_function_call_id,
-        previous_future_durable_id,
-    ]
-
-    if isinstance(future, FunctionCallFuture):
-        # Future specific metadata, part of durable ID.
-        durable_id_attrs.extend(["FunctionCall", future._function_name])
-        for arg in future._args:
-            _add_future_durable_id(
-                value=arg,
-                future_infos=future_infos,
-                durable_id_attrs=durable_id_attrs,
-            )
-
-        # Iterate over sorted dict keys to ensure deterministic hash key order.
-        sorted_kwarg_keys: list[str] = sorted(future._kwargs.keys())
-        for kwarg_name in sorted_kwarg_keys:
-            kwarg_value: _TensorlakeFutureWrapper[Future] | Any = future._kwargs[
-                kwarg_name
-            ]
-            _add_future_durable_id(
-                value=kwarg_value,
-                future_infos=future_infos,
-                durable_id_attrs=durable_id_attrs,
-            )
-    elif isinstance(future, ListFuture):
-        # Future specific metadata, part of durable ID.
-        durable_id_attrs.append(future._metadata.durability_key)
-        items: ListFuture | list[_TensorlakeFutureWrapper[Future] | Any] = (
-            _unwrap_future(future._items)
-        )
-        if isinstance(items, ListFuture):
-            _add_future_durable_id(
-                value=items,
-                future_infos=future_infos,
-                durable_id_attrs=durable_id_attrs,
-            )
-        else:
-            for item in items:
-                _add_future_durable_id(
-                    value=item,
-                    future_infos=future_infos,
-                    durable_id_attrs=durable_id_attrs,
-                )
-
-    elif isinstance(future, ReduceOperationFuture):
-        # Future specific metadata, part of durable ID.
-        durable_id_attrs.extend(["ReduceOperation", future._function_name])
-
-        _add_future_durable_id(
-            value=future._initial,
-            future_infos=future_infos,
-            durable_id_attrs=durable_id_attrs,
-        )
-
-        items: ListFuture | list[_TensorlakeFutureWrapper[Future] | Any] = (
-            _unwrap_future(future._items)
-        )
-        if isinstance(items, ListFuture):
-            _add_future_durable_id(
-                value=items,
-                future_infos=future_infos,
-                durable_id_attrs=durable_id_attrs,
-            )
-        else:
-            for item in items:
-                _add_future_durable_id(
-                    value=item,
-                    future_infos=future_infos,
-                    durable_id_attrs=durable_id_attrs,
-                )
-    else:
-        raise InternalError(f"Unexpected Future type: {type(future)}")
-
-    return _sha256_hash_strings(durable_id_attrs)
-
-
-def _add_future_durable_id(
-    value: _TensorlakeFutureWrapper[Future] | Any,
-    future_infos: dict[str, FutureInfo],
-    durable_id_attrs: list[str],
-) -> None:
-    """Adds durable ID of the given Future to durable_attrs if the value is a Future. Does nothing otherwise.
-
-    Raises InternalError if the value is a Future but its durable ID is not found in future_durable_ids.
-    """
-    # We don't hash user provided values. Only hash Futures to verify tree structure.
-    value: Future | Any = _unwrap_future(value)
-    if isinstance(value, Future):
-        value_future_info: FutureInfo | None = future_infos.get(value._id, None)
-        if value_future_info is None:
-            raise InternalError(
-                f"FutureInfo for Future with id {value._id} not found in future_infos."
-            )
-        durable_id_attrs.append(value_future_info.durable_id)
-
-
-def _sha256_hash_strings(strings: list[str]) -> str:
-    """Returns sha256 hash of the concatenation of strings in the given list.
-
-    If the strings are sha256 hashes, the result is also a high quality sha256 hash
-    of the original hashed values. See https://en.wikipedia.org/wiki/Merkle_tree.
-    """
-    sha256 = hashlib.sha256()
-    for s in strings:
-        sha256.update(s.encode("utf-8"))
-        sha256.update(b"|")  # Separator to avoid collisions of neighbouring strings.
-    return sha256.hexdigest()
 
 
 def serialize_user_value(
@@ -246,223 +72,6 @@ def serialize_user_value(
         data=data,
         content_type=metadata.content_type,
     )
-
-
-def replace_user_values_with_serialized_values(
-    future: FunctionCallFuture,
-    future_infos: dict[str, FutureInfo],
-) -> Dict[str, SerializedValue]:
-    """Replaces user values in the given FunctionCallFuture with their SerializedValues.
-
-    The provided future is modified in-place with each user supplied value being
-    SerializedValue instead of the original user object.
-
-    Returns a mapping from value ID to SerializedValue for all serialized user values in the tree.
-
-    Raises SerializationError if serialization of any value fails.
-    Raises TensorlakeError for other errors.
-    """
-    serialized_values: Dict[str, SerializedValue] = {}
-
-    def to_serialized_value(
-        future_or_value: _TensorlakeFutureWrapper[Future] | Any,
-        value_serializer: UserDataSerializer,
-    ) -> Any | SerializedValue:
-        future_or_value: Future | Any = _unwrap_future(future_or_value)
-        if isinstance(future_or_value, ReduceOperationFuture):
-            future_info: FutureInfo = future_infos[future_or_value._id]
-            if not isinstance(future_info.reduce_future_output, Future):
-                # Replace the ReduceOperationFuture with its output value and upload.
-                # This simplifies execution plan update generation.
-                future_or_value = future_info.reduce_future_output
-            else:
-                return future_or_value
-        elif isinstance(future_or_value, Future):
-            return future_or_value
-
-        # This is user supplied value now, need to serialize it.
-        future_or_value: Any
-        serialized_value: SerializedValue = serialize_user_value(
-            value=future_or_value,
-            serializer=value_serializer,
-            type_hint=type(future_or_value),
-        )
-        serialized_values[serialized_value.metadata.id] = serialized_value
-        return serialized_value
-
-    args_serializer: UserDataSerializer = function_input_serializer(
-        get_function(future._function_name), app_call=False
-    )
-    # Iterating over list copy to allow modifying the original list.
-    for index, arg in enumerate(list(future._args)):
-        future._args[index] = to_serialized_value(
-            future_or_value=arg, value_serializer=args_serializer
-        )
-    # Iterating over dict copy to allow modifying the original list.
-    for kwarg_name, kwarg_value in dict(future._kwargs).items():
-        future._kwargs[kwarg_name] = to_serialized_value(
-            future_or_value=kwarg_value, value_serializer=args_serializer
-        )
-
-    return serialized_values
-
-
-def to_execution_plan_updates(
-    future: FunctionCallFuture,
-    uploaded_serialized_objects: Dict[str, SerializedObjectInsideBLOB],
-    output_serializer_name_override: str | None,
-    has_output_type_hint_override: bool,
-    output_type_hint_override: Any,
-    function_ref: FunctionRef,
-    future_infos: dict[str, FutureInfo],
-) -> ExecutionPlanUpdates:
-    """Constructs ExecutionPlanUpdates proto for the supplied function call future.
-
-    Each user supplied value in the args must be a SerializedValue present in uploaded_serialized_objects.
-    function_call_ids is a mapping from FunctionCallFuture IDs to their durable IDs for all FunctionCallFutures
-    in the tree rooted at function_call_future.
-
-    Raises TensorlakeError on error.
-    """
-    updates: List[ExecutionPlanUpdate] = []
-
-    updates.append(
-        _function_call_execution_plan_update(
-            function_call_future=future,
-            uploaded_serialized_objects=uploaded_serialized_objects,
-            output_serializer_name_override=output_serializer_name_override,
-            has_output_type_hint_override=has_output_type_hint_override,
-            output_type_hint_override=output_type_hint_override,
-            function_ref=function_ref,
-            future_infos=future_infos,
-        )
-    )
-
-    return ExecutionPlanUpdates(
-        updates=updates,
-        root_function_call_id=future._id,
-    )
-
-
-def _function_call_execution_plan_update(
-    function_call_future: FunctionCallFuture,
-    uploaded_serialized_objects: Dict[str, SerializedObjectInsideBLOB],
-    output_serializer_name_override: str | None,
-    has_output_type_hint_override: bool,
-    output_type_hint_override: Any,
-    function_ref: FunctionRef,
-    future_infos: dict[str, FutureInfo],
-) -> ExecutionPlanUpdate:
-    metadata: FunctionCallMetadata = FunctionCallMetadata(
-        id=function_call_future._id,
-        output_serializer_name_override=output_serializer_name_override,
-        output_type_hint_override=output_type_hint_override,
-        has_output_type_hint_override=has_output_type_hint_override,
-        args=[],
-        kwargs={},
-    )
-    function_pb_args: List[FunctionArg] = []
-
-    def process_function_call_argument(
-        arg: SerializedValue | _TensorlakeFutureWrapper[Future],
-    ) -> FunctionCallArgumentMetadata:
-        arg: SerializedValue | Future = _unwrap_future(arg)
-        if isinstance(arg, SerializedValue):
-            function_pb_args.append(
-                FunctionArg(
-                    value=uploaded_serialized_objects[arg.metadata.id],
-                )
-            )
-            return FunctionCallArgumentMetadata(
-                value_id=arg.metadata.id,
-                collection=None,
-            )
-        elif isinstance(arg, ListFuture):
-            _embed_collection_into_function_pb_args(
-                future=arg,
-                function_pb_args=function_pb_args,
-                future_infos=future_infos,
-            )
-            return FunctionCallArgumentMetadata(
-                value_id=None,
-                collection=_to_collection_metadata(arg, future_infos),
-            )
-        elif isinstance(arg, FunctionCallFuture):
-            arg_durable_id: str = future_infos[arg._id].durable_id
-            function_pb_args.append(
-                FunctionArg(
-                    function_call_id=arg_durable_id,
-                )
-            )
-            return FunctionCallArgumentMetadata(
-                value_id=arg_durable_id,
-                collection=None,
-            )
-        elif isinstance(arg, ReduceOperationFuture):
-            future_info: FutureInfo = future_infos[arg._id]
-            if isinstance(future_info.reduce_future_output, Future):
-                # FIXME: recursion, should be an iterative algorithm.
-                return process_function_call_argument(future_info.reduce_future_output)
-            else:
-                raise InternalError(
-                    "ReduceOperationFuture with value output should have been replaced by its output value by now."
-                )
-        else:
-            raise InternalError(
-                f"Unexpected type of function call argument: {type(arg)}"
-            )
-
-    for arg in function_call_future._args:
-        metadata.args.append(process_function_call_argument(arg))
-
-    for kwarg_name, kwarg_value in function_call_future._kwargs.items():
-        metadata.kwargs[kwarg_name] = process_function_call_argument(kwarg_value)
-
-    return ExecutionPlanUpdate(
-        function_call=FunctionCall(
-            id=function_call_future._id,
-            target=FunctionRef(
-                namespace=function_ref.namespace,
-                application_name=function_ref.application_name,
-                function_name=function_call_future._function_name,
-                application_version=function_ref.application_version,
-            ),
-            args=function_pb_args,
-            call_metadata=serialize_metadata(metadata),
-        )
-    )
-
-
-def _to_collection_metadata(
-    future: ListFuture, future_infos: dict[str, FutureInfo]
-) -> CollectionMetadata:
-    collection_metadata: CollectionMetadata = CollectionMetadata(items=[])
-    future_info: FutureInfo = future_infos[future._id]
-
-    for mapped_item in future_info.map_future_output:
-        mapped_item: FunctionCallFuture
-        collection_metadata.items.append(
-            CollectionItemMetadata(
-                value_id=future_infos[mapped_item._id].durable_id,
-                collection=None,
-            )
-        )
-
-    return collection_metadata
-
-
-def _embed_collection_into_function_pb_args(
-    future: ListFuture,
-    function_pb_args: List[FunctionArg],
-    future_infos: dict[str, FutureInfo],
-) -> None:
-    for output_item in future_infos[future._id].map_future_output:
-        output_item: FunctionCallFuture
-        function_pb_args.append(
-            FunctionArg(
-                function_call_id=future_infos[output_item._id].durable_id,
-            )
-        )
 
 
 def deserialize_application_function_call_args(
@@ -661,3 +270,135 @@ def _reconstruct_collection_value(
                 collection_values.append(item_collection)
 
     return result
+
+
+_OutputEventArgValueType = Any | FunctionCallRef | FunctionCallCollectionRef
+_OutputEventArgSerializedValueType = (
+    SerializedValue | FunctionCallRef | FunctionCallCollectionRef
+)
+
+
+def serialize_output_event_args(
+    args: List[_OutputEventArgValueType],
+    kwargs: Dict[str, _OutputEventArgValueType],
+    function_name: str,
+) -> tuple[
+    List[_OutputEventArgSerializedValueType],
+    Dict[str, _OutputEventArgSerializedValueType],
+    Dict[str, SerializedValue],
+]:
+    """Serializes raw values in output event args, passes refs through unchanged.
+
+    Returns (serialized_args, serialized_kwargs, serialized_values_for_blob_upload).
+
+    Raises SerializationError if serialization of any value fails.
+    """
+    serialized_values: Dict[str, SerializedValue] = {}
+    args_serializer: UserDataSerializer = function_input_serializer(
+        get_function(function_name), app_call=False
+    )
+
+    def serialize_arg(
+        arg: Any | FunctionCallRef | FunctionCallCollectionRef,
+    ) -> SerializedValue | FunctionCallRef | FunctionCallCollectionRef:
+        if isinstance(arg, (FunctionCallRef, FunctionCallCollectionRef)):
+            return arg
+        serialized_value: SerializedValue = serialize_user_value(
+            value=arg, serializer=args_serializer, type_hint=type(arg)
+        )
+        serialized_values[serialized_value.metadata.id] = serialized_value
+        return serialized_value
+
+    serialized_args = [serialize_arg(a) for a in args]
+    serialized_kwargs = {k: serialize_arg(v) for k, v in kwargs.items()}
+    return serialized_args, serialized_kwargs, serialized_values
+
+
+def output_event_to_execution_plan_updates(
+    output_event: OutputEventCreateFunctionCall,
+    serialized_args: List[
+        SerializedValue | FunctionCallRef | FunctionCallCollectionRef
+    ],
+    serialized_kwargs: Dict[
+        str, SerializedValue | FunctionCallRef | FunctionCallCollectionRef
+    ],
+    uploaded_serialized_objects: Dict[str, SerializedObjectInsideBLOB],
+    output_serializer_name_override: str | None,
+    has_output_type_hint_override: bool,
+    output_type_hint_override: Any,
+    function_ref: FunctionRef,
+) -> ExecutionPlanUpdates:
+    """Constructs ExecutionPlanUpdates proto from an OutputEventCreateFunctionCall and serialized args.
+
+    Raises TensorlakeError on error.
+    """
+    metadata: FunctionCallMetadata = FunctionCallMetadata(
+        id=output_event.durable_id,
+        output_serializer_name_override=output_serializer_name_override,
+        output_type_hint_override=output_type_hint_override,
+        has_output_type_hint_override=has_output_type_hint_override,
+        args=[],
+        kwargs={},
+    )
+    function_pb_args: List[FunctionArg] = []
+
+    def process_arg(
+        arg: SerializedValue | FunctionCallRef | FunctionCallCollectionRef,
+    ) -> FunctionCallArgumentMetadata:
+        if isinstance(arg, SerializedValue):
+            function_pb_args.append(
+                FunctionArg(value=uploaded_serialized_objects[arg.metadata.id])
+            )
+            return FunctionCallArgumentMetadata(
+                value_id=arg.metadata.id,
+                collection=None,
+            )
+        elif isinstance(arg, FunctionCallRef):
+            function_pb_args.append(FunctionArg(function_call_id=arg.durable_id))
+            return FunctionCallArgumentMetadata(
+                value_id=arg.durable_id,
+                collection=None,
+            )
+        elif isinstance(arg, FunctionCallCollectionRef):
+            for durable_id in arg.durable_ids:
+                function_pb_args.append(FunctionArg(function_call_id=durable_id))
+            return FunctionCallArgumentMetadata(
+                value_id=None,
+                collection=CollectionMetadata(
+                    items=[
+                        CollectionItemMetadata(
+                            value_id=durable_id,
+                            collection=None,
+                        )
+                        for durable_id in arg.durable_ids
+                    ]
+                ),
+            )
+        else:
+            raise InternalError(
+                f"Unexpected type of serialized output event argument: {type(arg)}"
+            )
+
+    for arg in serialized_args:
+        metadata.args.append(process_arg(arg))
+    for kwarg_name, kwarg_value in serialized_kwargs.items():
+        metadata.kwargs[kwarg_name] = process_arg(kwarg_value)
+
+    return ExecutionPlanUpdates(
+        updates=[
+            ExecutionPlanUpdate(
+                function_call=FunctionCall(
+                    id=output_event.durable_id,
+                    target=FunctionRef(
+                        namespace=function_ref.namespace,
+                        application_name=function_ref.application_name,
+                        function_name=output_event.function_name,
+                        application_version=function_ref.application_version,
+                    ),
+                    args=function_pb_args,
+                    call_metadata=serialize_metadata(metadata),
+                )
+            )
+        ],
+        root_function_call_id=output_event.durable_id,
+    )

--- a/src/tensorlake/function_executor/service.py
+++ b/src/tensorlake/function_executor/service.py
@@ -39,7 +39,7 @@ from tensorlake.applications.runtime_hooks import (
     set_await_future_hook,
     set_coroutine_to_future_hook,
     set_register_coroutine_hook,
-    set_run_futures_hook,
+    set_run_future_hook,
     set_wait_futures_hook,
 )
 
@@ -120,7 +120,7 @@ class Service(FunctionExecutorServicer):
             app_version=request.function.application_version,
             fn=request.function.function_name,
         )
-        set_run_futures_hook(self._run_futures_runtime_hook)
+        set_run_future_hook(self._run_future_runtime_hook)
         set_await_future_hook(self._await_future_runtime_hook)
         set_wait_futures_hook(self._wait_futures_runtime_hook)
         set_register_coroutine_hook(self._register_coroutine_runtime_hook)
@@ -261,7 +261,7 @@ class Service(FunctionExecutorServicer):
 
         allocation_logger: InternalLogger = self._logger.bind(
             request_id=allocation.request_id,
-            function_call_id=allocation.function_call_id,
+            fn_call_id=allocation.function_call_id,
             allocation_id=allocation.allocation_id,
         )
         allocation_runner: AllocationRunner = AllocationRunner(
@@ -379,24 +379,26 @@ class Service(FunctionExecutorServicer):
         return self._allocation_infos[allocation_id].runner
 
     def _await_future_runtime_hook(self, future: Future) -> Generator[None, None, Any]:
-        return self._thread_allocation_runner().await_future_runtime_hook(future)
+        return self._thread_allocation_runner().event_loop.await_future_runtime_hook(
+            future
+        )
 
-    def _run_futures_runtime_hook(self, futures: List[Future]) -> None:
-        self._thread_allocation_runner().run_futures_runtime_hook(futures)
+    def _run_future_runtime_hook(self, future: Future) -> None:
+        self._thread_allocation_runner().event_loop.run_future_runtime_hook(future)
 
     def _wait_futures_runtime_hook(
         self, futures: List[Future], timeout: float | None, return_when: RETURN_WHEN
     ) -> tuple[List[Future], List[Future]]:
-        return self._thread_allocation_runner().wait_futures_runtime_hook(
+        return self._thread_allocation_runner().event_loop.wait_futures_runtime_hook(
             futures, timeout, return_when
         )
 
     def _register_coroutine_runtime_hook(self, coroutine: Any, future: Future) -> None:
-        self._thread_allocation_runner().register_coroutine_runtime_hook(
+        self._thread_allocation_runner().event_loop.register_coroutine_runtime_hook(
             coroutine, future
         )
 
     def _coroutine_to_future_runtime_hook(self, coroutine: Any) -> Any:
-        return self._thread_allocation_runner().coroutine_to_future_runtime_hook(
+        return self._thread_allocation_runner().event_loop.coroutine_to_future_runtime_hook(
             coroutine
         )

--- a/tests/applications/autoscaling/test_container_scaling.py
+++ b/tests/applications/autoscaling/test_container_scaling.py
@@ -143,6 +143,10 @@ def burst_limited_function(x: int) -> int:
 class TestWarmContainerBehavior(unittest.TestCase):
     """Test warm_containers behavior: pre-allocated containers for low latency."""
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_warm_containers_provide_faster_cold_start(self):
         """Verify warm containers reduce initial allocation latency (remote only).
 
@@ -150,7 +154,6 @@ class TestWarmContainerBehavior(unittest.TestCase):
         - Function WITHOUT warm: Cold start latency for first request
         - Function WITH warm: Warm containers already allocated, faster start
         """
-        deploy_applications(__file__)
 
         # First request to function without warm - expect cold start
         cold_start_times = []
@@ -185,7 +188,6 @@ class TestWarmContainerBehavior(unittest.TestCase):
         - Function WITH warm=5: Can handle 5 concurrent requests immediately
         - Function WITHOUT warm: Must scale up on-demand, higher latency
         """
-        deploy_applications(__file__)
 
         # Test concurrent requests without warm containers
         start = time.time()
@@ -223,6 +225,10 @@ class TestWarmContainerBehavior(unittest.TestCase):
 class TestMinContainerBehavior(unittest.TestCase):
     """Test min_containers behavior: guaranteed minimum capacity."""
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_min_containers_always_available(self, _: str, is_remote: bool):
         """Verify min_containers are always available.
@@ -231,8 +237,6 @@ class TestMinContainerBehavior(unittest.TestCase):
         - Function with min=2: At least 2 containers always running
         - First requests should be fast (no cold start if within min)
         """
-        if is_remote:
-            deploy_applications(__file__)
 
         # Make requests that should hit pre-allocated min containers
         times = []
@@ -258,7 +262,6 @@ class TestMinContainerBehavior(unittest.TestCase):
         Only runs remote: concurrent local execution doesn't support shared
         runtime hooks from multiple threads.
         """
-        deploy_applications(__file__)
 
         # Should handle multiple concurrent requests immediately
         with ThreadPoolExecutor(max_workers=6) as executor:
@@ -280,6 +283,10 @@ class TestMinContainerBehavior(unittest.TestCase):
 class TestMaxContainerBehavior(unittest.TestCase):
     """Test max_containers behavior: scaling limits and backpressure."""
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_max_containers_limits_concurrent_execution(self):
         """Verify max_containers enforces scaling limit.
 
@@ -287,7 +294,6 @@ class TestMaxContainerBehavior(unittest.TestCase):
         - Function with max=3: Can handle at most 3 concurrent executions
         - Additional requests queue or experience higher latency
         """
-        deploy_applications(__file__)
 
         # Send 6 concurrent requests to function with max=3
         # Requests should queue due to max limit
@@ -321,7 +327,6 @@ class TestMaxContainerBehavior(unittest.TestCase):
         - Can scale up to 2 total
         - Burst of 4 requests should queue (only 2 can run concurrently)
         """
-        deploy_applications(__file__)
 
         start = time.time()
         with ThreadPoolExecutor(max_workers=4) as executor:
@@ -349,6 +354,10 @@ class TestMaxContainerBehavior(unittest.TestCase):
 class TestAutoscalingCombinations(unittest.TestCase):
     """Test combinations of min, max, and warm parameters."""
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_all_parameters_work_together(self):
         """Verify min + max + warm work together correctly.
 
@@ -360,7 +369,6 @@ class TestAutoscalingCombinations(unittest.TestCase):
         Only runs remote: concurrent local execution doesn't support shared
         runtime hooks from multiple threads.
         """
-        deploy_applications(__file__)
 
         # Should handle 5 concurrent requests immediately (min + warm)
         with ThreadPoolExecutor(max_workers=5) as executor:
@@ -388,7 +396,6 @@ class TestAutoscalingCombinations(unittest.TestCase):
         Only runs remote: concurrent local execution doesn't support shared
         runtime hooks from multiple threads.
         """
-        deploy_applications(__file__)
 
         # Test scaling up to max
         with ThreadPoolExecutor(max_workers=10) as executor:
@@ -406,6 +413,10 @@ class TestAutoscalingCombinations(unittest.TestCase):
 class TestScalingSemantics(unittest.TestCase):
     """Test the semantic difference between functions with and without warm."""
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_with_warm_maintains_buffer_above_demand(self):
         """Verify functions WITH warm maintain buffer above demand.
 
@@ -413,7 +424,6 @@ class TestScalingSemantics(unittest.TestCase):
         - Function WITH warm: System maintains (current_demand + warm) containers
         - Sequential requests remain fast (warm buffer maintained)
         """
-        deploy_applications(__file__)
 
         # Make sequential requests - warm buffer should be maintained
         times = []
@@ -437,8 +447,6 @@ class TestScalingSemantics(unittest.TestCase):
         - Function WITHOUT warm: Scales up on-demand, scales down when idle
         - May see cold starts between requests if scaled down
         """
-        deploy_applications(__file__)
-
         # Make requests with gaps to allow scale-down
         times = []
         for i in range(3):
@@ -459,6 +467,10 @@ class TestScalingSemantics(unittest.TestCase):
 class TestEdgeCases(unittest.TestCase):
     """Test edge cases and boundary conditions."""
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_warm_greater_than_max_is_bounded(self, _: str, is_remote: bool):
         """Verify warm is bounded by max_containers.
@@ -467,9 +479,6 @@ class TestEdgeCases(unittest.TestCase):
         - If warm > max, system creates at most max containers
         - max_warm_function: max=5, warm=2 → creates min(max, warm) = 2
         """
-        if is_remote:
-            deploy_applications(__file__)
-
         # Should work correctly with warm bounded by max
         request: Request = run_application(max_warm_function, is_remote, 5)
         self.assertEqual(request.output(), 40)
@@ -477,9 +486,6 @@ class TestEdgeCases(unittest.TestCase):
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_zero_values_handled_correctly(self, _: str, is_remote: bool):
         """Verify functions with None/default values work correctly."""
-        if is_remote:
-            deploy_applications(__file__)
-
         # Function with no autoscaling params should work
         request: Request = run_application(no_autoscaling_function, is_remote, 0)
         self.assertEqual(request.output(), 0)

--- a/tests/applications/exceptions/test_application_type_hints_mismatch.py
+++ b/tests/applications/exceptions/test_application_type_hints_mismatch.py
@@ -35,11 +35,12 @@ def application_returning_object_that_mismatch_return_type_hint() -> None:
 
 
 class TestApplicationTypeHintsMismatch(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_call_application_function_with_wrong_payload(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         # The request didn't start because its application payload couldn't be serialized.
         with self.assertRaises(SerializationError) as context:
             run_application(
@@ -56,9 +57,6 @@ class TestApplicationTypeHintsMismatch(unittest.TestCase):
     def test_call_application_function_that_returns_wrong_value(
         self, _, is_remote: bool
     ):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_returning_object_that_mismatch_return_type_hint,
             is_remote,

--- a/tests/applications/exceptions/test_mpt_call_sdk.py
+++ b/tests/applications/exceptions/test_mpt_call_sdk.py
@@ -105,11 +105,12 @@ def application_mt_wait_future(_: str) -> str:
 
 
 class TestCallSDKFromChildThread(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_error_on_get_context(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_mt_get_context,
             is_remote,
@@ -119,9 +120,6 @@ class TestCallSDKFromChildThread(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_error_on_run_future(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_mt_run_future,
             is_remote,
@@ -131,9 +129,6 @@ class TestCallSDKFromChildThread(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_error_on_wait_future(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_mt_wait_future,
             is_remote,
@@ -182,11 +177,12 @@ def application_mp_run_future(_: str) -> str:
 
 
 class TestCallSDKFromChildProcess(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_error_on_get_context(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_mp_get_context,
             is_remote,
@@ -196,9 +192,6 @@ class TestCallSDKFromChildProcess(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_error_on_run_future(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_mp_run_future,
             is_remote,

--- a/tests/applications/exceptions/test_pickle_serialization_errors.py
+++ b/tests/applications/exceptions/test_pickle_serialization_errors.py
@@ -59,11 +59,12 @@ def return_unpicklable_object() -> NotUnpicklableObject:
 
 
 class TestPickleSerializationErrors(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_call_function_passing_not_picklable_object(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_call_function_passing_not_picklable_object,
             is_remote,
@@ -76,9 +77,6 @@ class TestPickleSerializationErrors(unittest.TestCase):
         "Non-local error propagation logic is not working correctly yet in both modes."
     )
     def test_call_function_that_returns_unpicklable_object(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_call_function_that_returns_unpicklable_object,
             is_remote,

--- a/tests/applications/exceptions/test_request_error.py
+++ b/tests/applications/exceptions/test_request_error.py
@@ -30,11 +30,12 @@ def end_func(_: str) -> str:
 
 
 class TestRequestError(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_expected_exception(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             start_func,
             is_remote,

--- a/tests/applications/exceptions/test_request_failed_on_function_error.py
+++ b/tests/applications/exceptions/test_request_failed_on_function_error.py
@@ -25,11 +25,12 @@ def application_function(_: str) -> str:
 
 
 class TestRequestFailedRaisedOnFunctionError(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_expected_exception(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_function,
             is_remote,

--- a/tests/applications/exceptions/test_sdk_objects_usage_errors.py
+++ b/tests/applications/exceptions/test_sdk_objects_usage_errors.py
@@ -140,11 +140,12 @@ def other_function_reduce(arg1, arg2):
 
 
 class TestSDKObjectsUsageErrors(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_future_list_as_function_argument(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             function_call_future_list_as_function_argument,
             is_remote,
@@ -154,9 +155,6 @@ class TestSDKObjectsUsageErrors(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_return_list_of_futures_from_application(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_return_list_of_futures,
             is_remote,
@@ -171,9 +169,6 @@ class TestSDKObjectsUsageErrors(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_return_list_of_futures_from_regular_function(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_call_return_list_of_futures,
             is_remote,
@@ -188,9 +183,6 @@ class TestSDKObjectsUsageErrors(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_function_as_function_argument(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             function_as_function_argument,
             is_remote,
@@ -200,9 +192,6 @@ class TestSDKObjectsUsageErrors(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_return_function_from_application(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_return_function,
             is_remote,
@@ -218,9 +207,6 @@ class TestSDKObjectsUsageErrors(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_return_function_from_regular_function(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             application_call_return_function,
             is_remote,
@@ -236,9 +222,6 @@ class TestSDKObjectsUsageErrors(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_future_wait_wrong_return_when(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             future_wait_wrong_return_when,
             is_remote,
@@ -248,9 +231,6 @@ class TestSDKObjectsUsageErrors(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_return_map_future(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             return_map_future,
             is_remote,
@@ -263,9 +243,6 @@ class TestSDKObjectsUsageErrors(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_run_already_started_future(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             run_already_started_future,
             is_remote,
@@ -275,9 +252,6 @@ class TestSDKObjectsUsageErrors(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_tail_call_running_future(self, _, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             tail_call_running_future,
             is_remote,

--- a/tests/applications/request_context/test_metrics.py
+++ b/tests/applications/request_context/test_metrics.py
@@ -41,11 +41,12 @@ def func_emit_metrics(_: int) -> str:
 
 
 class TestUseMetricsFromFunction(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_emit_metrics(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(func_emit_metrics, is_remote, 1)
         self.assertEqual(request.output(), "success")
 
@@ -104,11 +105,12 @@ def mt_emit_metrics(_: int) -> str:
 
 
 class TestUseMetricsFromChildThread(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_emit_metrics(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(mt_emit_metrics, is_remote, 1)
         self.assertEqual(request.output(), "success")
 
@@ -128,11 +130,12 @@ def mp_emit_metrics(_: int) -> str:
 
 
 class TestUseMetricsFromChildProcess(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_emit_metrics(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(mp_emit_metrics, is_remote, 1)
         self.assertEqual(request.output(), "success")
 

--- a/tests/applications/request_context/test_mpt_progress.py
+++ b/tests/applications/request_context/test_mpt_progress.py
@@ -38,11 +38,12 @@ def func_update_progress(values: tuple[int, int]) -> str:
 
 
 class TestUseProgressFromFunction(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_update_progress(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(func_update_progress, is_remote, (10, 100))
         self.assertEqual(request.output(), "success")
 
@@ -61,11 +62,12 @@ def mt_update_progress(values: tuple[int, int]) -> str:
 
 
 class TestUseProgressFromChildThread(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_update_progress(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(mt_update_progress, is_remote, (10, 100))
         self.assertEqual(request.output(), "success")
 
@@ -84,11 +86,12 @@ def mp_update_progress(values: tuple[int, int]) -> str:
 
 
 class TestUseProgressFromChildProcess(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_update_progress(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(mp_update_progress, is_remote, (10, 100))
         self.assertEqual("success", request.output())
         self.assertEqual(request.output(), "success")

--- a/tests/applications/request_context/test_mpt_state.py
+++ b/tests/applications/request_context/test_mpt_state.py
@@ -70,11 +70,12 @@ def mt_get_after_set() -> str:
 
 
 class TestUseRequestStateFromChildThread(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_get_after_set(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(mt_get_after_set, is_remote)
 
         output: str = request.output()
@@ -110,11 +111,12 @@ def mp_get_after_set() -> str:
 
 
 class TestUseRequestStateFromChildProcess(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_get_after_set(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(mp_get_after_set, is_remote)
 
         output: str = request.output()

--- a/tests/applications/request_context/test_progress.py
+++ b/tests/applications/request_context/test_progress.py
@@ -43,6 +43,10 @@ def test_update_progress_with_parameters(
 
 
 class TestProgress(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def setUp(self):
         """Capture stdout before each test."""
         self.captured_output = io.StringIO()
@@ -54,9 +58,6 @@ class TestProgress(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_update_progress(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(test_update_progress, is_remote, (10, 100))
         self.assertEqual("success", request.output())
 
@@ -134,11 +135,12 @@ def test_update_progress_raises_expected_error(values: tuple[int, int]) -> str:
 
 
 class TestProgressRaisesError(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_update_progress(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_update_progress_raises_expected_error, is_remote, (10, 100)
         )

--- a/tests/applications/request_context/test_request_id.py
+++ b/tests/applications/request_context/test_request_id.py
@@ -38,11 +38,12 @@ def func_get_request_id(_: int) -> str:
 
 
 class TestUseRequestIdFromFunction(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_get_expected_request_id(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(func_get_request_id, is_remote, 11)
         self.assertEqual(request.id, request.output())
 
@@ -61,11 +62,12 @@ def mt_get_request_id(_: int) -> str:
 
 
 class TestUseRequestIdFromChildThread(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_get_expected_request_id(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(mt_get_request_id, is_remote, 11)
         self.assertEqual(request.id, request.output())
 
@@ -82,11 +84,12 @@ def mp_get_request_id(_: int) -> str:
 
 
 class TestUseRequestIdFromChildProcess(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_get_expected_request_id(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(mp_get_request_id, is_remote, 11)
         self.assertEqual(request.id, request.output())
 

--- a/tests/applications/request_context/test_state.py
+++ b/tests/applications/request_context/test_state.py
@@ -110,10 +110,12 @@ def test_request_context_state_set_get_pydantic_model_internal(model_name: str) 
 
 
 class TestRequestState(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_request_context_state_set_get_simple_value(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
 
         request: Request = run_application(
             test_request_context_state_set_get_simple_value_api, is_remote, 11
@@ -126,9 +128,6 @@ class TestRequestState(unittest.TestCase):
     def test_request_context_state_set_get_user_class_instance(
         self, _: str, is_remote: bool
     ):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_request_context_state_set_get_user_class_instance_api,
             is_remote,
@@ -142,9 +141,6 @@ class TestRequestState(unittest.TestCase):
     def test_request_context_state_set_get_pydantic_model(
         self, _: str, is_remote: bool
     ):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_request_context_state_set_get_pydantic_model_api,
             is_remote,
@@ -156,9 +152,6 @@ class TestRequestState(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_request_context_state_get_default_value(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_request_context_state_get_default_value_api,
             is_remote,
@@ -172,9 +165,6 @@ class TestRequestState(unittest.TestCase):
     def test_request_context_state_get_without_default_value_returns_none(
         self, _: str, is_remote: bool
     ):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_request_context_state_get_without_default_value_returns_none_api,
             is_remote,

--- a/tests/applications/test_async_complex_graph.py
+++ b/tests/applications/test_async_complex_graph.py
@@ -96,6 +96,10 @@ async def store_sum_as_file(total: int) -> File:
 
 
 class TestAsyncComplexGraph(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_local_api_call_of_complex_graph_produces_expected_outputs(self):
         for function in ["test_graph_api_reduce", "test_graph_api_fan_in"]:
             request = run_local_application(
@@ -108,7 +112,6 @@ class TestAsyncComplexGraph(unittest.TestCase):
             self.assertEqual(file.content, b"Total sum: 116")
 
     def test_remote_api_call_of_complex_graph_produces_expected_outputs(self):
-        deploy_applications(__file__)
         for function in ["test_graph_api_reduce", "test_graph_api_fan_in"]:
             request: Request = run_remote_application(
                 function,

--- a/tests/applications/test_async_output_propagation.py
+++ b/tests/applications/test_async_output_propagation.py
@@ -41,10 +41,12 @@ async def bar_coroutine(x: str) -> str:
 
 
 class TestReturnCoroutine(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(api_return_coroutine, is_remote, "coroutine")
         self.assertEqual(request.output(), "coroutine")
 
@@ -66,10 +68,12 @@ async def bar_future(x: str) -> str:
 
 
 class TestReturnFuture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(api_return_future, is_remote, "future")
         self.assertEqual(request.output(), "future")
 
@@ -86,10 +90,12 @@ async def foo_sync_future_coroutine(x: str) -> str:
 
 
 class TestReturnSyncFutureCoroutine(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_return_sync_future_coroutine, is_remote, "sync_future_coroutine"
         )
@@ -108,10 +114,12 @@ async def foo_async_future_coroutine(x: str) -> str:
 
 
 class TestReturnAsyncFutureCoroutine(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_return_async_future_coroutine, is_remote, "async_future_coroutine"
         )
@@ -138,10 +146,12 @@ async def mixed_step_sync_future_coroutine(x: str) -> str:
 
 
 class TestMixedChain(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(api_mixed_chain, is_remote, "mixed")
         self.assertEqual(request.output(), "mixed")
 

--- a/tests/applications/test_asyncio.py
+++ b/tests/applications/test_asyncio.py
@@ -138,10 +138,12 @@ async def await_coroutine_implicitly_started_by_sdk() -> str:
 
 
 class TestAsyncio(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_gather_all(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             gather_all,
             is_remote,
@@ -150,8 +152,6 @@ class TestAsyncio(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_gather_first_failure(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             gather_first_failure,
             is_remote,
@@ -166,29 +166,21 @@ class TestAsyncio(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_create_task(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(create_task, is_remote)
         self.assertEqual(request.output(), 10)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_ensure_future(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(ensure_future, is_remote)
         self.assertEqual(request.output(), 10)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_await_coroutine_twice(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(await_coroutine_twice, is_remote)
         self.assertEqual(request.output(), "success")
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_await_coroutine_implicitly_started_by_sdk(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             await_coroutine_implicitly_started_by_sdk, is_remote
         )

--- a/tests/applications/test_call_application_from_regular_function.py
+++ b/tests/applications/test_call_application_from_regular_function.py
@@ -35,11 +35,12 @@ def other_api_function(
 
 
 class TestCallApplicationFromRegularFunction(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             api_function, is_remote, 1, "test", (2, 3, "four"), {"five": [6, 7]}
         )

--- a/tests/applications/test_complex_graph.py
+++ b/tests/applications/test_complex_graph.py
@@ -96,6 +96,10 @@ def store_sum_as_file(total: int) -> File:
 
 
 class TestComplexGraph(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_local_api_call_of_complex_graph_produces_expected_outputs(self):
         for function in ["test_graph_api_reduce", "test_graph_api_fan_in"]:
             request = run_local_application(
@@ -108,7 +112,6 @@ class TestComplexGraph(unittest.TestCase):
             self.assertEqual(file.content, b"Total sum: 116")
 
     def test_remote_api_call_of_complex_graph_produces_expected_outputs(self):
-        deploy_applications(__file__)
         for function in ["test_graph_api_reduce", "test_graph_api_fan_in"]:
             request: Request = run_remote_application(
                 function,

--- a/tests/applications/test_fake_pdf_parse_workflow.py
+++ b/tests/applications/test_fake_pdf_parse_workflow.py
@@ -151,6 +151,10 @@ def watch_pdf_updates(url: str, page_range: str, iteration: int) -> None:
 
 
 class TestPDFParseDataWorkflow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_local_api_call(self):
         request: Request = run_local_application(
             parse_pdf_api,
@@ -160,7 +164,6 @@ class TestPDFParseDataWorkflow(unittest.TestCase):
         self.assertEqual(len(payload.chunks), 5)
 
     def test_remote_api_call(self):
-        deploy_applications(__file__)
         request: Request = run_remote_application(
             parse_pdf_api,
             RequestPayload(url="http://example.com/sample.pdf", page_range="1-5"),

--- a/tests/applications/test_function_call_signatures.py
+++ b/tests/applications/test_function_call_signatures.py
@@ -252,11 +252,12 @@ def test_tuple_arg_and_return_value_internal(
 
 
 class TestRegularFunctionCallSignatures(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_function_with_no_args(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_function_with_no_args_api, is_remote, None
         )
@@ -264,9 +265,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_function_returning_nothing(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_function_returning_nothing_api, is_remote, None
         )
@@ -274,9 +272,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_only_positional_args(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_only_positional_args_api,
             is_remote,
@@ -286,9 +281,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_only_kwargs(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_only_kwargs_api,
             is_remote,
@@ -298,9 +290,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_mixed_args(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request1: Request = run_application(
             test_mixed_args_api,
             is_remote,
@@ -310,9 +299,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_default_args(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_default_args_api,
             is_remote,
@@ -322,9 +308,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_file_args(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_file_args_api,
             is_remote,
@@ -334,9 +317,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_file_return_value(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_file_return_value_api,
             is_remote,
@@ -346,9 +326,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_pydantic_args(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_pydantic_args_api,
             is_remote,
@@ -358,9 +335,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_pydantic_return_value(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_pydantic_return_value_api,
             is_remote,
@@ -370,9 +344,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_set_arg_and_return_value(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_set_arg_and_return_value_api,
             is_remote,
@@ -381,9 +352,6 @@ class TestRegularFunctionCallSignatures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_tuple_arg_and_return_value(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             test_tuple_arg_and_return_value_api,
             is_remote,

--- a/tests/applications/test_function_resources.py
+++ b/tests/applications/test_function_resources.py
@@ -18,10 +18,12 @@ def function_with_custom_resources(x: int) -> str:
 
 
 class TestFunctionResources(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_function_with_custom_resources_succeeds(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(function_with_custom_resources, is_remote, 1)
         self.assertEqual(request.output(), "success")
 

--- a/tests/applications/test_function_retries.py
+++ b/tests/applications/test_function_retries.py
@@ -39,15 +39,16 @@ def function_that_always_fails(x: int) -> str:
 
 
 class TestFunctionRetries(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def setUp(self) -> None:
         global function_with_retry_policy_call_number
         function_with_retry_policy_call_number = 0
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_function_retries(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         start_time: float = time.monotonic()
         request: Request = run_application(
             function_that_succeeds_on_3rd_retry, is_remote, 1
@@ -61,9 +62,6 @@ class TestFunctionRetries(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_function_fails_with_retries_exhausted(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         start_time: float = time.monotonic()
         request: Request = run_application(function_that_always_fails, is_remote, 1)
         self.assertRaises(RequestFailed, request.output)

--- a/tests/applications/test_futures_consume_futures.py
+++ b/tests/applications/test_futures_consume_futures.py
@@ -124,10 +124,12 @@ async def async_futures_as_coroutines_tail_call(x: int) -> int:
 
 
 class TestFuturesConsumeFutures(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             sync_three_futures_consume_same_future,
             is_remote,
@@ -137,8 +139,6 @@ class TestFuturesConsumeFutures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_tail_call(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             sync_three_futures_consume_same_future_tail_call,
             is_remote,
@@ -148,8 +148,6 @@ class TestFuturesConsumeFutures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_sync_three_futures_consume_same_future,
             is_remote,
@@ -159,8 +157,6 @@ class TestFuturesConsumeFutures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_tail_call(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_three_futures_consume_same_future_tail_call,
             is_remote,
@@ -170,8 +166,6 @@ class TestFuturesConsumeFutures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_coroutine_tail_call(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_three_futures_consume_same_future_coroutine_tail_call,
             is_remote,
@@ -181,8 +175,6 @@ class TestFuturesConsumeFutures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_sync_futures_as_coroutines_tail_call(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_sync_futures_as_coroutines_tail_call,
             is_remote,
@@ -192,8 +184,6 @@ class TestFuturesConsumeFutures(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_futures_as_coroutines_tail_call(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_futures_as_coroutines_tail_call,
             is_remote,

--- a/tests/applications/test_futures_wait.py
+++ b/tests/applications/test_futures_wait.py
@@ -191,10 +191,12 @@ def app_wait_runs_not_running_futures() -> str:
 
 
 class TestFuturesWait(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_wait_all_completed(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             app_return_when_all_completed, is_remote, "foo"
         )
@@ -202,8 +204,6 @@ class TestFuturesWait(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_wait_first_completed(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             app_return_when_first_completed, is_remote, "foo"
         )
@@ -212,15 +212,11 @@ class TestFuturesWait(unittest.TestCase):
     # Timeouts are not implemented in local mode.
     @parameterized.parameterized.expand([("remote", True)])
     def test_wait_timeout(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(app_wait_timeout, is_remote, "foo")
         self.assertEqual(request.output(), "success")
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_wait_first_failure(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             app_return_when_first_failure, is_remote, "foo"
         )
@@ -234,15 +230,11 @@ class TestFuturesWait(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_future_result_caching(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(app_future_result_caching, is_remote, "foo")
         self.assertEqual(request.output(), "success")
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_wait_runs_not_running_futures(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             app_wait_runs_not_running_futures,
             is_remote,

--- a/tests/applications/test_map.py
+++ b/tests/applications/test_map.py
@@ -114,10 +114,12 @@ async def async_concat_strings(a: str, b: str) -> str:
 
 
 class TestRecursiveMaps(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_blocking(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_function_recursive_blocking_map, is_remote, [1, 2, 3, 4, 5]
         )
@@ -125,8 +127,6 @@ class TestRecursiveMaps(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_blocking(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_api_function_recursive_blocking_map, is_remote, [1, 2, 3, 4, 5]
         )
@@ -134,8 +134,6 @@ class TestRecursiveMaps(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_non_blocking(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_function_recursive_non_blocking_map, is_remote, [1, 2, 3, 4, 5]
         )
@@ -143,8 +141,6 @@ class TestRecursiveMaps(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_non_blocking_with_future(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_function_recursive_non_blocking_map_with_future,
             is_remote,
@@ -154,8 +150,6 @@ class TestRecursiveMaps(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_non_blocking_with_future_and_tail_call(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_function_recursive_non_blocking_map_with_future_and_tail_call,
             is_remote,
@@ -165,8 +159,6 @@ class TestRecursiveMaps(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_non_blocking(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_api_function_recursive_non_blocking_map, is_remote, [1, 2, 3, 4, 5]
         )
@@ -174,8 +166,6 @@ class TestRecursiveMaps(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_tail_call(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_function_recursive_tail_call_map, is_remote, [1, 2, 3, 4, 5]
         )
@@ -184,8 +174,6 @@ class TestRecursiveMaps(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_tail_call(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_api_function_recursive_tail_call_map, is_remote, [1, 2, 3, 4, 5]
         )
@@ -194,8 +182,6 @@ class TestRecursiveMaps(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_map_reduce_futures(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_function_map_reduce_futures, is_remote, [1, 2, 3, 4, 5]
         )

--- a/tests/applications/test_output_propagation.py
+++ b/tests/applications/test_output_propagation.py
@@ -46,10 +46,12 @@ def buzz() -> str:
 
 
 class TestFunctionOutputPropagation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_function_output_propagation, is_remote, "test"
         )
@@ -83,10 +85,12 @@ def concat_strings_value(a: str, b: str) -> str:
 
 
 class TestReducerValueOutputPropagation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_reducer_value_output_propagation, is_remote, "test"
         )
@@ -125,10 +129,12 @@ def concat_strings_actually(a: str, b: str) -> str:
 
 
 class TestReducerSubcallOutputPropagation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             "api_reducer_subcall_output_propagation", is_remote, "test"
         )

--- a/tests/applications/test_reduce.py
+++ b/tests/applications/test_reduce.py
@@ -274,11 +274,12 @@ async def async_int_to_str(x: int) -> str:
 
 
 class TestReduce(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success_function_call_collection(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             success_api_function_awaitable_collection, is_remote, 6
         )
@@ -287,9 +288,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_success_function_call_collection(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_success_api_function_awaitable_collection, is_remote, 6
         )
@@ -298,9 +296,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_success_value_collection(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             success_api_function_value_collection, is_remote, 6
         )
@@ -309,9 +304,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_success_value_collection(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_success_api_function_value_collection, is_remote, 6
         )
@@ -320,25 +312,16 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_failure(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(fail_api_function, is_remote, 6)
         self.assertRaises(RequestFailed, request.output)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_failure(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(async_fail_api_function, is_remote, 6)
         self.assertRaises(RequestFailed, request.output)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_reduce_nothing(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             api_reduce_no_items_no_initial, is_remote, None
         )
@@ -346,9 +329,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_reduce_nothing(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_api_reduce_no_items_no_initial, is_remote, None
         )
@@ -356,9 +336,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_reduce_initial(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             api_reduce_no_items_with_initial,
             is_remote,
@@ -369,9 +346,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_reduce_initial(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_api_reduce_no_items_with_initial,
             is_remote,
@@ -382,9 +356,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_reduce_one_value_item(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             api_reduce_one_value_item,
             is_remote,
@@ -395,9 +366,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_reduce_one_value_item(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_api_reduce_one_value_item,
             is_remote,
@@ -408,8 +376,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_reduce_one_function_call_item(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             api_reduce_one_future_item,
             is_remote,
@@ -420,9 +386,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_reduce_one_function_call_item(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_api_reduce_one_future_item,
             is_remote,
@@ -433,9 +396,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_reduce_mapped_collection_nonblocking(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             api_reduce_mapped_collection_nonblocking,
             is_remote,
@@ -446,9 +406,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_reduce_mapped_collection_nonblocking(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_api_reduce_mapped_collection_nonblocking,
             is_remote,
@@ -459,9 +416,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_reduce_mapped_collection_tailcall(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             api_reduce_mapped_collection_tailcall,
             is_remote,
@@ -472,9 +426,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_reduce_mapped_collection_tailcall(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_api_reduce_mapped_collection_tailcall,
             is_remote,
@@ -485,9 +436,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_reduce_of_reduced_list(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             api_reduce_of_reduced_list,
             is_remote,
@@ -500,9 +448,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_reduce_of_reduced_list(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_api_reduce_of_reduced_list,
             is_remote,
@@ -515,9 +460,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_reduce_of_mapped_collections(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             api_reduce_of_mapped_collections,
             is_remote,
@@ -530,9 +472,6 @@ class TestReduce(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_reduce_of_mapped_collections(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
-
         request: Request = run_application(
             async_api_reduce_of_mapped_collections,
             is_remote,

--- a/tests/applications/test_resource_caching.py
+++ b/tests/applications/test_resource_caching.py
@@ -44,7 +44,8 @@ def fd_caching_function(action: str) -> str:
 
 
 class TestFileDescriptorCaching(unittest.TestCase):
-    def setUp(self) -> None:
+    @classmethod
+    def setUpClass(cls) -> None:
         deploy_applications(__file__)
 
     def test_second_write_goes_to_cached_file_descriptor_if_same_func(self):
@@ -104,7 +105,8 @@ cached_function_class_instance: FunctionClass | None = None
 
 
 class TestFunctionClassInstanceCaching(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls) -> None:
         deploy_applications(__file__)
 
     def test_function_class_instance_caching(self):

--- a/tests/applications/test_sequential_async_workflow.py
+++ b/tests/applications/test_sequential_async_workflow.py
@@ -52,6 +52,10 @@ async def simple_workflow(payload: str) -> str:
 
 
 class TestSequentialAsyncWorkflow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_local_api_call(self):
         request: Request = run_local_application(
             simple_workflow,
@@ -60,7 +64,6 @@ class TestSequentialAsyncWorkflow(unittest.TestCase):
         self.assertEqual(request.output(), "[hello, foo! hello, foo!]")
 
     def test_remote_api_call(self):
-        deploy_applications(__file__)
         request: Request = run_remote_application(
             simple_workflow,
             payload="Bar",

--- a/tests/applications/test_sequential_sync_workflow.py
+++ b/tests/applications/test_sequential_sync_workflow.py
@@ -52,6 +52,10 @@ def simple_workflow(payload: str) -> str:
 
 
 class TestSequentialSyncWorkflow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_local_api_call(self):
         request: Request = run_local_application(
             simple_workflow,
@@ -60,7 +64,6 @@ class TestSequentialSyncWorkflow(unittest.TestCase):
         self.assertEqual(request.output(), "[hello, foo! hello, foo!]")
 
     def test_remote_api_call(self):
-        deploy_applications(__file__)
         request: Request = run_remote_application(
             simple_workflow,
             payload="Bar",

--- a/tests/applications/test_simple_graph.py
+++ b/tests/applications/test_simple_graph.py
@@ -48,6 +48,10 @@ async def print_and_return_value_async(value: str) -> str:
 
 
 class TestSimpleGraph(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_sync_local_api_call(self):
         request: Request = run_local_application(
             simple_graph_api_sync,
@@ -56,7 +60,6 @@ class TestSimpleGraph(unittest.TestCase):
         self.assertEqual(request.output(), "simple graph: 1, 2, 3, 4, 5")
 
     def test_sync_remote_api_call(self):
-        deploy_applications(__file__)
         request: Request = run_remote_application(
             simple_graph_api_sync,
             TestGraphRequestPayload(numbers=[str(i) for i in range(1, 6)]),
@@ -72,7 +75,6 @@ class TestSimpleGraph(unittest.TestCase):
         self.assertEqual(request.output(), "simple graph: 1, 2, 3, 4, 5")
 
     def test_async_remote_api_call(self):
-        deploy_applications(__file__)
         request: Request = run_remote_application(
             simple_graph_api_async,
             TestGraphRequestPayload(numbers=[str(i) for i in range(1, 6)]),

--- a/tests/applications/test_sync_async_calls.py
+++ b/tests/applications/test_sync_async_calls.py
@@ -284,87 +284,67 @@ class TestSyncAsyncCalls(unittest.TestCase):
     these calls are valid.
     """
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_calls_sync(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(sync_app_calls_sync, is_remote, 5)
         self.assertEqual(request.output(), 15)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_calls_async(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(async_app_calls_async, is_remote, 5)
         self.assertEqual(request.output(), 15)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_calls_sync(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(async_app_calls_sync, is_remote, 5)
         self.assertEqual(request.output(), 15)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_calls_async(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(sync_app_calls_async, is_remote, 5)
         self.assertEqual(request.output(), 15)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_calls_mixed(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(async_app_calls_mixed, is_remote, 5)
         self.assertEqual(request.output(), 15)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_calls_mixed_reversed(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(async_app_calls_mixed_reversed, is_remote, 5)
         self.assertEqual(request.output(), 15)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_calls_mixed(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(sync_app_calls_mixed, is_remote, 5)
         self.assertEqual(request.output(), 15)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_calls_mixed_reversed(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(sync_app_calls_mixed_reversed, is_remote, 5)
         self.assertEqual(request.output(), 15)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_async_map(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(async_app_async_map, is_remote, [1, 2, 3])
         self.assertEqual(request.output(), [2, 4, 6])
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_sync_map(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(async_app_sync_map, is_remote, [1, 2, 3])
         self.assertEqual(request.output(), [2, 4, 6])
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_async_map(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(sync_app_async_map, is_remote, [1, 2, 3])
         self.assertEqual(request.output(), [2, 4, 6])
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_async_reduce(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_async_reduce, is_remote, [1, 2, 3, 4]
         )
@@ -372,8 +352,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_sync_reduce(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_sync_reduce, is_remote, [1, 2, 3, 4]
         )
@@ -381,8 +359,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_async_reduce(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             sync_app_async_reduce, is_remote, [1, 2, 3, 4]
         )
@@ -390,8 +366,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_async_map_then_reduce(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_async_map_then_reduce, is_remote, [1, 2, 3, 4]
         )
@@ -399,8 +373,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_sync_map_then_async_reduce(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_sync_map_then_async_reduce, is_remote, [1, 2, 3, 4]
         )
@@ -408,8 +380,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_async_map_then_sync_reduce(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             sync_app_async_map_then_sync_reduce, is_remote, [1, 2, 3, 4]
         )
@@ -417,29 +387,21 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_returns_future(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(async_app_returns_future, is_remote, 5)
         self.assertEqual(request.output(), 10)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_returns_future(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(sync_app_returns_future, is_remote, 5)
         self.assertEqual(request.output(), 10)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_returns_sync_future(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(async_app_returns_sync_future, is_remote, 5)
         self.assertEqual(request.output(), 10)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_passes_coroutine_to_sync(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_passes_coroutine_to_sync, is_remote, 5
         )
@@ -447,8 +409,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_passes_coroutine_to_async(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_passes_coroutine_to_async, is_remote, 5
         )
@@ -456,15 +416,11 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_passes_future_to_sync(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(sync_app_passes_future_to_sync, is_remote, 5)
         self.assertEqual(request.output(), 15)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_passes_sync_future_to_async(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_passes_sync_future_to_async, is_remote, 5
         )
@@ -472,8 +428,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_chains_coroutines_and_futures(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_chains_coroutines_and_futures, is_remote, 5
         )
@@ -481,22 +435,16 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_chains_futures(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(sync_app_chains_futures, is_remote, 5)
         self.assertEqual(request.output(), 20)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_await_sync_coroutine(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(async_app_await_sync_coroutine, is_remote, 5)
         self.assertEqual(request.output(), 10)
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_create_task_from_sync_coroutine(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_create_task_from_sync_coroutine, is_remote, 5
         )
@@ -504,8 +452,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_gather_sync_coroutines(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_gather_sync_coroutines, is_remote, 5
         )
@@ -513,8 +459,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_coroutine_returns_same_object(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_coroutine_returns_same_object, is_remote, 5
         )
@@ -522,8 +466,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_async_app_pass_sync_coroutine_as_arg(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_pass_sync_coroutine_as_arg, is_remote, 5
         )
@@ -531,8 +473,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_sync_app_coroutine_raises(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(sync_app_coroutine_raises, is_remote, 5)
         self.assertEqual(request.output(), 5)
 
@@ -540,8 +480,6 @@ class TestSyncAsyncCalls(unittest.TestCase):
     def test_async_app_coroutine_on_started_future_raises(
         self, _: str, is_remote: bool
     ):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application(
             async_app_coroutine_on_started_future_raises, is_remote, 5
         )

--- a/tests/applications/validation/class/multiple_definitions/test_redefine_class_in_same_file.py
+++ b/tests/applications/validation/class/multiple_definitions/test_redefine_class_in_same_file.py
@@ -30,6 +30,10 @@ class Class1:
 
 
 class TestMultipleClassDefinitions(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_applications_are_valid(self):
         self.assertEqual(validate_loaded_applications(), [])
 
@@ -37,8 +41,6 @@ class TestMultipleClassDefinitions(unittest.TestCase):
     def test_redefine_same_class_in_the_same_file_succeeds(
         self, _: str, is_remote: bool
     ):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application("Class1.method", is_remote)
         self.assertEqual(request.output(), "Class1.method_redefined")
 

--- a/tests/applications/validation/function/multiple_definitions/test_redefine_function_in_same_file.py
+++ b/tests/applications/validation/function/multiple_definitions/test_redefine_function_in_same_file.py
@@ -25,13 +25,15 @@ def function_1(_: str) -> str:
 
 
 class TestRedefineFunctionInSameFile(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        deploy_applications(__file__)
+
     def test_applications_are_valid(self):
         self.assertEqual(validate_loaded_applications(), [])
 
     @parameterized.parameterized.expand([("remote", True), ("local", False)])
     def test_function_redefined_successfully(self, _: str, is_remote: bool):
-        if is_remote:
-            deploy_applications(__file__)
         request: Request = run_application("function_1", is_remote, "1")
         self.assertEqual(request.output(), "function_1_redefined")
 

--- a/tests/function_executor/test_event_loop.py
+++ b/tests/function_executor/test_event_loop.py
@@ -1,0 +1,1053 @@
+import unittest
+
+from tensorlake.applications import InternalError, RequestContext
+from tensorlake.applications.interface.exceptions import TensorlakeError
+from tensorlake.applications.interface.function import (
+    Function,
+    _FunctionConfiguration,
+)
+from tensorlake.applications.interface.image import Image
+from tensorlake.applications.internal_logger import InternalLogger
+from tensorlake.applications.registry import (
+    _function_registry,
+    register_function,
+)
+from tensorlake.applications.runtime_hooks import (
+    clear_await_future_hook,
+    clear_coroutine_to_future_hook,
+    clear_register_coroutine_hook,
+    clear_run_future_hook,
+    clear_wait_futures_hook,
+    set_await_future_hook,
+    set_coroutine_to_future_hook,
+    set_register_coroutine_hook,
+    set_run_future_hook,
+    set_wait_futures_hook,
+)
+from tensorlake.function_executor.allocation_runner.event_loop import (
+    AllocationEventLoop,
+    FunctionCallCollectionRef,
+    FunctionCallRef,
+    InputEventFunctionCallCreated,
+    InputEventFunctionCallWatcherResult,
+    OutputEventBatch,
+    OutputEventCreateFunctionCall,
+    OutputEventCreateFunctionCallWatcher,
+    OutputEventFinishAllocation,
+)
+
+
+def _make_test_function(name: str, fn) -> Function:
+    """Create a Function object with minimal config for testing."""
+    func = Function(fn)
+    func._function_config = _FunctionConfiguration(
+        class_name=None,
+        class_method_name=None,
+        class_init_timeout=None,
+        function_name=name,
+        description="",
+        image=Image(),
+        secrets=[],
+        retries=None,
+        timeout=300,
+        cpu=1.0,
+        memory=1.0,
+        ephemeral_disk=1.0,
+        gpu=None,
+        region=None,
+        cacheable=False,
+        max_concurrency=1,
+        warm_containers=None,
+        min_containers=None,
+        max_containers=None,
+    )
+    return func
+
+
+def _make_test_logger() -> InternalLogger:
+    return InternalLogger(
+        context={},
+        destination=InternalLogger.LOG_FILE.NULL,
+        as_cloud_event=False,
+    )
+
+
+def _make_test_event_loop(
+    func: Function, function_call_id: str = "fc_id_1"
+) -> AllocationEventLoop:
+    return AllocationEventLoop(
+        function=func,
+        function_call_id=function_call_id,
+        allocation_id="test_allocation_id",
+        request_context=RequestContext(),
+        logger=_make_test_logger(),
+    )
+
+
+class _EventLoopDriver:
+    """Helper that drives the AllocationEventLoop from the 'AllocationRunner' side.
+
+    Installs global runtime hooks that forward to the event loop (same as
+    service.py does for AllocationRunner), starts the event loop, and
+    processes commands by delivering pre-configured or callback-generated results.
+    """
+
+    def __init__(self, loop: AllocationEventLoop):
+        self.loop = loop
+        self.command_batches: list[OutputEventBatch] = []
+        # Callback: (command) -> result. If None, auto-generate success results.
+        self.result_callback = None
+
+    def run(self, args: list, kwargs: dict) -> OutputEventFinishAllocation:
+        """Run the event loop to completion, processing all commands."""
+        self._install_hooks()
+        try:
+            return self._run_loop(args, kwargs)
+        finally:
+            self._clear_hooks()
+
+    def _install_hooks(self) -> None:
+        set_run_future_hook(self.loop.run_future_runtime_hook)
+        set_wait_futures_hook(self.loop.wait_futures_runtime_hook)
+        set_await_future_hook(self.loop.await_future_runtime_hook)
+        set_register_coroutine_hook(self.loop.register_coroutine_runtime_hook)
+        set_coroutine_to_future_hook(self.loop.coroutine_to_future_runtime_hook)
+
+    def _clear_hooks(self) -> None:
+        clear_run_future_hook()
+        clear_wait_futures_hook()
+        clear_await_future_hook()
+        clear_register_coroutine_hook()
+        clear_coroutine_to_future_hook()
+
+    def _run_loop(self, args: list, kwargs: dict) -> OutputEventFinishAllocation:
+        self.loop.start(args, kwargs)
+
+        while True:
+            batch = self.loop.wait_for_output_event_batch()
+            self.command_batches.append(batch)
+            for cmd in batch.events:
+                if isinstance(cmd, OutputEventFinishAllocation):
+                    return cmd
+                result = self._make_result(cmd)
+                self.loop.add_input_event(result)
+
+    def _make_result(self, cmd):
+        if self.result_callback is not None:
+            return self.result_callback(cmd)
+
+        if isinstance(cmd, OutputEventCreateFunctionCall):
+            return InputEventFunctionCallCreated(
+                durable_id=cmd.durable_id,
+                exception=None,
+            )
+        elif isinstance(cmd, OutputEventCreateFunctionCallWatcher):
+            return InputEventFunctionCallWatcherResult(
+                function_call_durable_id=cmd.function_call_durable_id,
+                output=f"result_for_{cmd.function_call_durable_id}",
+                exception=None,
+            )
+
+
+class TestEventLoopBasic(unittest.TestCase):
+    def setUp(self):
+        # Save and restore function registry.
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_simple_return_value(self):
+        """User function returns a plain value (no futures)."""
+        func = _make_test_function("my_func", fn=lambda: 42)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertIsNone(output.tail_call)
+        self.assertEqual(output.value, 42)
+        # Only the finish batch (no IO commands).
+        self.assertEqual(len(driver.command_batches), 1)
+
+    def test_simple_return_value_with_args(self):
+        """User function receives and uses args/kwargs."""
+        func = _make_test_function("my_func", fn=lambda x, y=0: x + y)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([10], {"y": 5})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(output.value, 15)
+
+    def test_user_exception(self):
+        """User function raises an exception."""
+
+        def failing_func():
+            raise ValueError("user error")
+
+        func = _make_test_function("my_func", fn=failing_func)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsInstance(output.user_exception, ValueError)
+        self.assertEqual(str(output.user_exception), "user error")
+
+
+class TestEventLoopRunFutures(unittest.TestCase):
+    def setUp(self):
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_single_function_call_future(self):
+        """Future.run() generates a single OutputEventCreateFunctionCall."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            future = child_func.future(1, key="val")
+            future.run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(len(driver.command_batches), 2)
+
+        batch = driver.command_batches[0]
+        self.assertEqual(len(batch.events), 1)
+
+        cmd = batch.events[0]
+        self.assertIsInstance(cmd, OutputEventCreateFunctionCall)
+        self.assertEqual(cmd.function_name, "child_func")
+        self.assertEqual(cmd.args, [1])
+        self.assertEqual(cmd.kwargs, {"key": "val"})
+        self.assertFalse(cmd.is_tail_call)
+        self.assertIsNone(cmd.start_delay)
+
+    def test_function_call_with_future_arg(self):
+        """A function call with another future as argument generates FunctionCallRef."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            f1 = child_func.future(1)
+            f2 = child_func.future(f1, 2)
+            f1.run()
+            f2.run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        # f1.run() generates a batch, then f2.run() generates another batch,
+        # plus the finish batch.
+        self.assertEqual(len(driver.command_batches), 3)
+
+        # First batch: f1
+        cmd1 = driver.command_batches[0].events[0]
+        self.assertIsInstance(cmd1, OutputEventCreateFunctionCall)
+        self.assertEqual(cmd1.function_name, "child_func")
+        self.assertEqual(cmd1.args, [1])
+
+        # Second batch: f2 with f1 as FunctionCallRef
+        cmd2 = driver.command_batches[1].events[0]
+        self.assertIsInstance(cmd2, OutputEventCreateFunctionCall)
+        self.assertEqual(cmd2.function_name, "child_func")
+        self.assertEqual(len(cmd2.args), 2)
+        self.assertIsInstance(cmd2.args[0], FunctionCallRef)
+        self.assertEqual(cmd2.args[0].durable_id, cmd1.durable_id)
+        self.assertEqual(cmd2.args[1], 2)
+
+    def test_creation_failure_raises(self):
+        """Failed InputEventFunctionCallCreated raises InternalError."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            child_func.future(1).run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+
+        def fail_creation(cmd):
+            if isinstance(cmd, OutputEventCreateFunctionCall):
+                return InputEventFunctionCallCreated(
+                    durable_id=cmd.durable_id,
+                    exception=InternalError("server error"),
+                )
+
+        driver.result_callback = fail_creation
+        output = driver.run([], {})
+
+        self.assertIsInstance(output.user_exception, InternalError)
+        self.assertIn("server error", str(output.user_exception))
+
+    def test_map_creation_failure_raises(self):
+        """Failed creation of a map child function call raises InternalError."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            child_func.future.map([1, 2, 3]).run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+
+        def fail_creation(cmd):
+            if isinstance(cmd, OutputEventCreateFunctionCall):
+                return InputEventFunctionCallCreated(
+                    durable_id=cmd.durable_id,
+                    exception=InternalError("map creation failed"),
+                )
+
+        driver.result_callback = fail_creation
+        output = driver.run([], {})
+
+        self.assertIsInstance(output.user_exception, InternalError)
+        self.assertIn("map creation failed", str(output.user_exception))
+
+    def test_reduce_creation_failure_raises(self):
+        """Failed creation of a reduce child function call raises InternalError."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            child_func.future.reduce([10, 20]).run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+
+        def fail_creation(cmd):
+            if isinstance(cmd, OutputEventCreateFunctionCall):
+                return InputEventFunctionCallCreated(
+                    durable_id=cmd.durable_id,
+                    exception=InternalError("reduce creation failed"),
+                )
+
+        driver.result_callback = fail_creation
+        output = driver.run([], {})
+
+        self.assertIsInstance(output.user_exception, InternalError)
+        self.assertIn("reduce creation failed", str(output.user_exception))
+
+
+class TestEventLoopWaitFutures(unittest.TestCase):
+    def setUp(self):
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_wait_single_future(self):
+        """Future.result() generates OutputEventCreateFunctionCallWatcher and sets result."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        captured = {}
+
+        def user_code():
+            future = child_func.future(1)
+            future.run()
+            captured["result"] = future.result()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+
+        # Track the durable_id from the creation command for watcher result.
+        created_durable_ids = {}
+
+        def result_callback(cmd):
+            if isinstance(cmd, OutputEventCreateFunctionCall):
+                created_durable_ids[cmd.durable_id] = True
+                return InputEventFunctionCallCreated(
+                    durable_id=cmd.durable_id, exception=None
+                )
+            elif isinstance(cmd, OutputEventCreateFunctionCallWatcher):
+                return InputEventFunctionCallWatcherResult(
+                    function_call_durable_id=cmd.function_call_durable_id,
+                    output=99,
+                    exception=None,
+                )
+
+        driver.result_callback = result_callback
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(captured["result"], 99)
+
+        # Should have 3 batches: 1 for run, 1 for wait, 1 for finish.
+        self.assertEqual(len(driver.command_batches), 3)
+        watcher_cmd = driver.command_batches[1].events[0]
+        self.assertIsInstance(watcher_cmd, OutputEventCreateFunctionCallWatcher)
+
+    def test_wait_future_failure(self):
+        """InputEventFunctionCallWatcherCreated with failure sets exception on future."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        captured = {}
+
+        def user_code():
+            future = child_func.future(1)
+            future.run()
+            try:
+                future.result()
+            except TensorlakeError as e:
+                captured["exception"] = e
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+
+        def result_callback(cmd):
+            if isinstance(cmd, OutputEventCreateFunctionCall):
+                return InputEventFunctionCallCreated(
+                    durable_id=cmd.durable_id, exception=None
+                )
+            elif isinstance(cmd, OutputEventCreateFunctionCallWatcher):
+                return InputEventFunctionCallWatcherResult(
+                    function_call_durable_id=cmd.function_call_durable_id,
+                    output=None,
+                    exception=InternalError("child failed"),
+                )
+
+        driver.result_callback = result_callback
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertIn("exception", captured)
+        self.assertIsInstance(captured["exception"], InternalError)
+
+
+class TestEventLoopMapOperation(unittest.TestCase):
+    def setUp(self):
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_map_generates_batch_of_commands(self):
+        """map([1, 2, 3]) generates a batch of 3 OutputEventCreateFunctionCall."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            # Create a map future and run it.
+            map_future = child_func.future.map([10, 20, 30])
+            map_future.run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(len(driver.command_batches), 2)
+
+        batch = driver.command_batches[0]
+        # 3 items mapped = 3 OutputEventCreateFunctionCall.
+        call_cmds = [
+            c for c in batch.events if isinstance(c, OutputEventCreateFunctionCall)
+        ]
+        self.assertEqual(len(call_cmds), 3)
+        for cmd in call_cmds:
+            self.assertEqual(cmd.function_name, "child_func")
+
+    def test_map_result(self):
+        """map([1, 2, 3]).result() returns list of results in order."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        captured = {}
+
+        def user_code():
+            map_future = child_func.future.map([10, 20, 30])
+            map_future.run()
+            captured["result"] = map_future.result()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+
+        call_order = []
+
+        def result_callback(cmd):
+            if isinstance(cmd, OutputEventCreateFunctionCall):
+                call_order.append(cmd.durable_id)
+                return InputEventFunctionCallCreated(
+                    durable_id=cmd.durable_id, exception=None
+                )
+            elif isinstance(cmd, OutputEventCreateFunctionCallWatcher):
+                # Return result based on position.
+                idx = call_order.index(cmd.function_call_durable_id)
+                return InputEventFunctionCallWatcherResult(
+                    function_call_durable_id=cmd.function_call_durable_id,
+                    output=(idx + 1) * 100,
+                    exception=None,
+                )
+
+        driver.result_callback = result_callback
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(captured["result"], [100, 200, 300])
+
+
+class TestEventLoopResolveArg(unittest.TestCase):
+    """Tests for _resolve_arg handling of ListFuture and ReduceOperationFuture args."""
+
+    def setUp(self):
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_map_future_as_arg_generates_collection_ref(self):
+        """Passing a map future as arg to another function generates FunctionCallCollectionRef."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        consumer_func = _make_test_function("consumer_func", fn=lambda x: x)
+        register_function("consumer_func", consumer_func)
+
+        def user_code():
+            map_future = child_func.future.map([10, 20, 30])
+            consumer_func.future(map_future).run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        # Find the consumer_func command
+        consumer_cmds = []
+        map_cmds = []
+        for batch in driver.command_batches:
+            for cmd in batch.events:
+                if isinstance(cmd, OutputEventCreateFunctionCall):
+                    if cmd.function_name == "consumer_func":
+                        consumer_cmds.append(cmd)
+                    elif cmd.function_name == "child_func":
+                        map_cmds.append(cmd)
+
+        self.assertEqual(len(map_cmds), 3)
+        self.assertEqual(len(consumer_cmds), 1)
+
+        # The consumer's arg should be a FunctionCallCollectionRef
+        consumer_arg = consumer_cmds[0].args[0]
+        self.assertIsInstance(consumer_arg, FunctionCallCollectionRef)
+        self.assertEqual(len(consumer_arg.durable_ids), 3)
+        # The durable_ids should match the map command durable_ids
+        map_durable_ids = [cmd.durable_id for cmd in map_cmds]
+        self.assertEqual(consumer_arg.durable_ids, map_durable_ids)
+
+    def test_reduce_future_as_arg_generates_function_call_ref(self):
+        """Passing a reduce future as arg to another function generates FunctionCallRef."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        consumer_func = _make_test_function("consumer_func", fn=lambda x: x)
+        register_function("consumer_func", consumer_func)
+
+        def user_code():
+            reduce_future = child_func.future.reduce([10, 20])
+            consumer_func.future(reduce_future).run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        # Find the consumer_func command
+        consumer_cmds = []
+        reduce_chain_cmds = []
+        for batch in driver.command_batches:
+            for cmd in batch.events:
+                if isinstance(cmd, OutputEventCreateFunctionCall):
+                    if cmd.function_name == "consumer_func":
+                        consumer_cmds.append(cmd)
+                    elif cmd.function_name == "child_func":
+                        reduce_chain_cmds.append(cmd)
+
+        self.assertEqual(len(consumer_cmds), 1)
+        # reduce([10, 20]) creates 1 reduce call
+        self.assertEqual(len(reduce_chain_cmds), 1)
+
+        # The consumer's arg should be a FunctionCallRef pointing to the last reduce step
+        consumer_arg = consumer_cmds[0].args[0]
+        self.assertIsInstance(consumer_arg, FunctionCallRef)
+        self.assertEqual(consumer_arg.durable_id, reduce_chain_cmds[0].durable_id)
+
+    def test_single_item_reduce_as_arg_passes_value_through(self):
+        """Passing a single-item reduce future as arg passes the plain value through."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        consumer_func = _make_test_function("consumer_func", fn=lambda x: x)
+        register_function("consumer_func", consumer_func)
+
+        def user_code():
+            reduce_future = child_func.future.reduce([42])
+            consumer_func.future(reduce_future).run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        # Find the consumer_func command
+        consumer_cmds = [
+            cmd
+            for batch in driver.command_batches
+            for cmd in batch.events
+            if isinstance(cmd, OutputEventCreateFunctionCall)
+            and cmd.function_name == "consumer_func"
+        ]
+        self.assertEqual(len(consumer_cmds), 1)
+
+        # Single-item reduce with plain value: the arg should be the raw value 42
+        self.assertEqual(consumer_cmds[0].args[0], 42)
+
+
+class TestEventLoopReduceOperation(unittest.TestCase):
+    def setUp(self):
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_reduce_two_items(self):
+        """reduce([a, b]) generates a single OutputEventCreateFunctionCall (a, b)."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            reduce_future = child_func.future.reduce([10, 20])
+            reduce_future.run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(len(driver.command_batches), 2)
+
+        call_cmds = [
+            c
+            for c in driver.command_batches[0].events
+            if isinstance(c, OutputEventCreateFunctionCall)
+        ]
+        self.assertEqual(len(call_cmds), 1)
+        self.assertEqual(call_cmds[0].args, [10, 20])
+
+    def test_reduce_three_items(self):
+        """reduce([a, b, c]) generates a chain: reduce(a, b) -> reduce(result, c)."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            reduce_future = child_func.future.reduce([10, 20, 30])
+            reduce_future.run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(len(driver.command_batches), 2)
+
+        call_cmds = [
+            c
+            for c in driver.command_batches[0].events
+            if isinstance(c, OutputEventCreateFunctionCall)
+        ]
+        # reduce(a, b) and reduce(result_of_ab, c) = 2 commands.
+        self.assertEqual(len(call_cmds), 2)
+        # First: plain args.
+        self.assertEqual(call_cmds[0].args, [10, 20])
+        # Second: first arg is FunctionCallRef to first command.
+        self.assertIsInstance(call_cmds[1].args[0], FunctionCallRef)
+        self.assertEqual(call_cmds[1].args[0].durable_id, call_cmds[0].durable_id)
+        self.assertEqual(call_cmds[1].args[1], 30)
+
+    def test_reduce_with_initial(self):
+        """reduce([a, b], initial=init) generates chain: reduce(init, a) -> reduce(result, b)."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            reduce_future = child_func.future.reduce([10, 20], 0)
+            reduce_future.run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        call_cmds = [
+            c
+            for c in driver.command_batches[0].events
+            if isinstance(c, OutputEventCreateFunctionCall)
+        ]
+        # reduce(0, 10) and reduce(result, 20) = 2 commands.
+        self.assertEqual(len(call_cmds), 2)
+        self.assertEqual(call_cmds[0].args, [0, 10])
+
+    def test_reduce_single_item_no_initial(self):
+        """reduce([a]) with no initial skips to the single item."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        captured = {}
+
+        def user_code():
+            reduce_future = child_func.future.reduce([42])
+            reduce_future.run()
+            captured["result"] = reduce_future.result()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        # Single item reduce doesn't generate any IO commands, only the finish batch.
+        self.assertEqual(len(driver.command_batches), 1)
+        self.assertEqual(captured["result"], 42)
+
+    def test_reduce_result(self):
+        """reduce([a, b]).result() waits for chain and returns final result."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        captured = {}
+
+        def user_code():
+            reduce_future = child_func.future.reduce([10, 20])
+            reduce_future.run()
+            captured["result"] = reduce_future.result()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+
+        def result_callback(cmd):
+            if isinstance(cmd, OutputEventCreateFunctionCall):
+                return InputEventFunctionCallCreated(
+                    durable_id=cmd.durable_id, exception=None
+                )
+            elif isinstance(cmd, OutputEventCreateFunctionCallWatcher):
+                return InputEventFunctionCallWatcherResult(
+                    function_call_durable_id=cmd.function_call_durable_id,
+                    output=30,
+                    exception=None,
+                )
+
+        driver.result_callback = result_callback
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(captured["result"], 30)
+
+
+class TestEventLoopTailCall(unittest.TestCase):
+    def setUp(self):
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_tail_call_function_call(self):
+        """Returning a Future produces tail call output."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            return child_func.future(1)
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertIsNotNone(output.tail_call)
+
+        # Tail call is split into two batches: first creates function calls,
+        # second finishes the allocation with the tail call reference.
+        self.assertEqual(len(driver.command_batches), 2)
+        create_batch = driver.command_batches[0]
+        tail_call_cmds = [
+            c
+            for c in create_batch.events
+            if isinstance(c, OutputEventCreateFunctionCall)
+        ]
+        self.assertEqual(len(tail_call_cmds), 1)
+        self.assertEqual(tail_call_cmds[0].function_name, "child_func")
+        self.assertTrue(tail_call_cmds[0].is_tail_call)
+        self.assertEqual(output.tail_call.durable_id, tail_call_cmds[0].durable_id)
+
+    def test_tail_call_reduce_creation_failure(self):
+        """Tail call returning a reduce future with creation failure reports internal_exception."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            return child_func.future.reduce([10, 20])
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+
+        def fail_creation(cmd):
+            if isinstance(cmd, OutputEventCreateFunctionCall):
+                return InputEventFunctionCallCreated(
+                    durable_id=cmd.durable_id,
+                    exception=InternalError("tail call reduce failed"),
+                )
+
+        driver.result_callback = fail_creation
+        output = driver.run([], {})
+
+        self.assertIsInstance(output.internal_exception, InternalError)
+        self.assertIn("tail call reduce failed", str(output.internal_exception))
+
+    def test_tail_call_already_started_raises(self):
+        """Returning an already-started Future raises SDKUsageError."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            future = child_func.future(1)
+            future.run()
+            return future
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNotNone(output.user_exception)
+
+
+class TestEventLoopDeterminism(unittest.TestCase):
+    def setUp(self):
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_same_inputs_same_commands(self):
+        """Running the same function twice produces identical command sequences."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        def user_code():
+            f1 = child_func.future(1, key="a")
+            f2 = child_func.future(2, key="b")
+            f1.run()
+            f2.run()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        # Run 1
+        loop1 = _make_test_event_loop(func)
+        driver1 = _EventLoopDriver(loop1)
+        driver1.run([], {})
+
+        # Run 2
+        loop2 = _make_test_event_loop(func)
+        driver2 = _EventLoopDriver(loop2)
+        driver2.run([], {})
+
+        # Same number of batches.
+        self.assertEqual(len(driver1.command_batches), len(driver2.command_batches))
+
+        for b1, b2 in zip(driver1.command_batches, driver2.command_batches):
+            self.assertEqual(len(b1.events), len(b2.events))
+            for c1, c2 in zip(b1.events, b2.events):
+                self.assertEqual(type(c1), type(c2))
+                if isinstance(c1, OutputEventCreateFunctionCall):
+                    self.assertEqual(c1.durable_id, c2.durable_id)
+                    self.assertEqual(c1.function_name, c2.function_name)
+                    self.assertEqual(c1.is_tail_call, c2.is_tail_call)
+
+
+class TestEventLoopAsync(unittest.TestCase):
+    def setUp(self):
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_async_function_return_value(self):
+        """Async user function returning a plain value."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+
+        async def user_code():
+            return 42
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(output.value, 42)
+
+    def test_async_function_with_await(self):
+        """Async function that awaits a future."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        captured = {}
+
+        async def user_code():
+            result = await child_func.future(1)
+            captured["result"] = result
+            return result
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        driver = _EventLoopDriver(loop)
+
+        def result_callback(cmd):
+            if isinstance(cmd, OutputEventCreateFunctionCall):
+                return InputEventFunctionCallCreated(
+                    durable_id=cmd.durable_id, exception=None
+                )
+            elif isinstance(cmd, OutputEventCreateFunctionCallWatcher):
+                return InputEventFunctionCallWatcherResult(
+                    function_call_durable_id=cmd.function_call_durable_id,
+                    output=99,
+                    exception=None,
+                )
+
+        driver.result_callback = result_callback
+        output = driver.run([], {})
+
+        self.assertIsNone(output.user_exception)
+        self.assertEqual(output.value, 99)
+        self.assertEqual(captured["result"], 99)
+
+
+class TestEventLoopResultDeliveryOrder(unittest.TestCase):
+    def setUp(self):
+        self._saved_registry = dict(_function_registry)
+
+    def tearDown(self):
+        clear_run_future_hook()
+        clear_wait_futures_hook()
+        clear_await_future_hook()
+        clear_register_coroutine_hook()
+        clear_coroutine_to_future_hook()
+        _function_registry.clear()
+        _function_registry.update(self._saved_registry)
+
+    def test_results_delivered_in_reverse_order(self):
+        """Results can be delivered in any order; batch unblocks when all arrive."""
+        child_func = _make_test_function("child_func", fn=lambda x: x)
+        register_function("child_func", child_func)
+        captured = {}
+
+        def user_code():
+            map_future = child_func.future.map([1, 2, 3])
+            map_future.run()
+            captured["result"] = map_future.result()
+
+        func = _make_test_function("my_func", fn=user_code)
+
+        loop = _make_test_event_loop(func)
+        set_run_future_hook(loop.run_future_runtime_hook)
+        set_wait_futures_hook(loop.wait_futures_runtime_hook)
+        set_await_future_hook(loop.await_future_runtime_hook)
+        set_register_coroutine_hook(loop.register_coroutine_runtime_hook)
+        set_coroutine_to_future_hook(loop.coroutine_to_future_runtime_hook)
+
+        # Manually drive the event loop to deliver results in reverse order.
+        loop.start([], {})
+
+        # Batch 1: creation commands (from run).
+        batch1 = loop.wait_for_output_event_batch()
+        self.assertEqual(len(batch1.events), 3)
+
+        # Deliver creation results in order (required by durable ID ordering contract).
+        for cmd in batch1.events:
+            loop.add_input_event(
+                InputEventFunctionCallCreated(durable_id=cmd.durable_id, exception=None)
+            )
+
+        # Watcher batches: each map item is waited for sequentially
+        # (one watcher command per batch).
+        creation_durable_ids = [cmd.durable_id for cmd in batch1.events]
+        for i, expected_durable_id in enumerate(creation_durable_ids):
+            watcher_batch = loop.wait_for_output_event_batch()
+            self.assertEqual(len(watcher_batch.events), 1)
+            watcher_cmd = watcher_batch.events[0]
+            self.assertIsInstance(watcher_cmd, OutputEventCreateFunctionCallWatcher)
+            self.assertEqual(watcher_cmd.function_call_durable_id, expected_durable_id)
+            loop.add_input_event(
+                InputEventFunctionCallWatcherResult(
+                    function_call_durable_id=watcher_cmd.function_call_durable_id,
+                    output=(i + 1) * 10,
+                    exception=None,
+                )
+            )
+
+        # Wait for finish.
+        final_batch = loop.wait_for_output_event_batch()
+        self.assertEqual(len(final_batch.events), 1)
+        finish_cmd = final_batch.events[0]
+        self.assertIsInstance(finish_cmd, OutputEventFinishAllocation)
+
+        # Results should be in original command order.
+        self.assertIsNone(finish_cmd.user_exception)
+        self.assertEqual(captured["result"], [10, 20, 30])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/function_executor/test_future_durable_id.py
+++ b/tests/function_executor/test_future_durable_id.py
@@ -9,10 +9,12 @@ from tensorlake.applications.interface.futures import (
     _FutureListKind,
     _FutureListMetadata,
 )
-from tensorlake.function_executor.allocation_runner.sdk_algorithms import (
-    FutureInfo,
+from tensorlake.function_executor.allocation_runner.event_loop.durable_id import (
     _sha256_hash_strings,
     future_durable_id,
+)
+from tensorlake.function_executor.allocation_runner.event_loop.future_info import (
+    FutureInfo,
 )
 
 

--- a/tests/function_executor/test_run_allocation.py
+++ b/tests/function_executor/test_run_allocation.py
@@ -219,6 +219,7 @@ class TestRunAllocation(unittest.TestCase):
                                     function_call_creation_result=AllocationFunctionCallCreationResult(
                                         status=Status(code=grpc.StatusCode.OK.value[0]),
                                         allocation_function_call_id=allocation_function_call.id,
+                                        function_call_id=allocation_function_call.updates.root_function_call_id,
                                     ),
                                 )
                             )
@@ -402,6 +403,7 @@ class TestRunAllocation(unittest.TestCase):
                                     function_call_creation_result=AllocationFunctionCallCreationResult(
                                         status=Status(code=grpc.StatusCode.OK.value[0]),
                                         allocation_function_call_id=allocation_function_call.id,
+                                        function_call_id=allocation_function_call.updates.root_function_call_id,
                                     ),
                                 )
                             )
@@ -543,6 +545,7 @@ class TestRunAllocation(unittest.TestCase):
                     AllocationUpdate(
                         allocation_id=allocation_id,
                         function_call_result=AllocationFunctionCallResult(
+                            function_call_id=allocation_function_call_watcher.root_function_call_id,
                             watcher_id=allocation_function_call_watcher.id,
                             outcome_code=AllocationOutcomeCode.ALLOCATION_OUTCOME_CODE_SUCCESS,
                             value_output=SerializedObjectInsideBLOB(

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -7,13 +7,6 @@ if [[ -z "$TENSORLAKE_API_URL" ]]; then
     exit 1
 fi
 
-echo "Building Rust Cloud SDK Python bindings..."
-poetry run maturin develop --manifest-path ../crates/rust-cloud-sdk-py/Cargo.toml
-if [ $? -ne 0 ]; then
-  echo "Failed to build Rust Cloud SDK Python bindings." 1>&2
-  exit 1
-fi
-
 enable_fe_test_suite=false
 enable_applications_test_suite=false
 enable_cli_test_suite=false
@@ -56,6 +49,13 @@ run_test_suite() {
 
 # cd to the script's directory.
 cd "$(dirname "$0")"
+
+echo "Building Rust Cloud SDK Python bindings..."
+poetry run maturin develop --manifest-path ../crates/rust-cloud-sdk-py/Cargo.toml
+if [ $? -ne 0 ]; then
+  echo "Failed to build Rust Cloud SDK Python bindings." 1>&2
+  exit 1
+fi
 
 summary_file=".run_tests_summary.txt"
 rm -f $summary_file


### PR DESCRIPTION
A sequential strictly ordered input/output event stream is implemented. However, the event loop itself is not working with user code in a deterministic way yet. See the many FIXMEs I left. I'll address this in further commits. I'd like to merge this because all tests pass and it's a lot of changes already.

Now there're clearly defined responsibilities:

* Event Loop: running customer code deterministically, managing SDK objects like Futures, acting on input events from input event stream and producing output events in output event stream.
* AllocationRunner: serialization/deserialization, gRPC, replay (input/output events).

Also deduped application deployments in application tests because they otherwise makes the tests running very long which is wasting time.

map-reduce benchmark didn't change:

```
poetry run python ../indexify/benchmarks/map_reduce/main.py --num-requests 5 --maps-count 100
main:

Deploying benchmark application...
Starting map reduce benchmark with maps_count: 100, num_requests: 5
Started request zGIw2a5rn-vY6dbzlmg28 with 100 functions
Started request -xQed7iN6inQYMAma1Qp1 with 100 functions
Started request d_AqeMpEy1FDoW40i6YNS with 100 functions
Started request 7-36sH5Ef7j9HSxhHo-91 with 100 functions
Started request YXmCgx1ZJyGHqfIhEMOtE with 100 functions
All 5 requests started in 0.01 seconds
Waiting for all requests to complete...

Completed 5 requests in 84.60s

Test Configuration:
- Requests: 5
- Map calls per request: 100
- Total function calls: 1000

PR:

All 5 requests started in 0.01 seconds
Waiting for all requests to complete...

Completed 5 requests in 83.96s

Test Configuration:
- Requests: 5
- Map calls per request: 100
- Total function calls: 1000
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large refactor of core function-execution, future scheduling, and server interaction paths; subtle ordering/concurrency bugs could affect determinism, durability/replay, or result propagation.
> 
> **Overview**
> Refactors Function Executor allocation execution to use a new `AllocationEventLoop` that runs user code and manages `Future` lifecycles via a strictly ordered input/output event stream, while `AllocationRunner` now focuses on serialization, blob upload/download, and gRPC/state interactions.
> 
> Replaces the `run_futures` runtime hook with `run_future` (single future start), updating SDK `Future.run()` error handling and wiring in both local runner and function-executor service. Updates SDK-side algorithms to serialize output-event args and build `ExecutionPlanUpdates` from event-loop outputs, and adjusts many tests to deploy applications once per test class to reduce runtime. Also bumps `tensorlake-cli` to `0.4.7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e121b4958e20e6236652b2bef8d8fefa9348a68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->