### PR TITLE
Fix Linux aarch64 wheel build failure in release workflows

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -54,6 +54,9 @@ jobs:
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
+        env:
+          # ring's AArch64 assembly requires __ARM_ARCH; manylinux2014 cross GCC 4.8 doesn't define it.
+          CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.platform.target == 'aarch64' && '-D__ARM_ARCH=8' || '' }}
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist

--- a/.github/workflows/publish_test_pypi.yaml
+++ b/.github/workflows/publish_test_pypi.yaml
@@ -54,6 +54,9 @@ jobs:
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
+        env:
+          # ring's AArch64 assembly requires __ARM_ARCH; manylinux2014 cross GCC 4.8 doesn't define it.
+          CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.platform.target == 'aarch64' && '-D__ARM_ARCH=8' || '' }}
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist


### PR DESCRIPTION
## Summary
- set `CFLAGS_aarch64_unknown_linux_gnu` to `-D__ARM_ARCH=8` for the Linux `aarch64` wheel matrix entry
- apply the change to both release workflows (`publish_pypi.yaml` and `publish_test_pypi.yaml`)

## Why
The `Build wheels on ubuntu-latest (aarch64)` job in run `22703066501` failed while compiling `ring` with:
`#error "ARM assembler must define __ARM_ARCH"`.

The manylinux2014 cross image used by maturin on this job provides `aarch64-unknown-linux-gnu-gcc 4.8.5`, which does not define `__ARM_ARCH` in assembler mode. Defining it via CFLAGS unblocks `ring` assembly compilation.
