### PR TITLE
Add tensorlake CLI alias and sync CLI version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.1.0"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorlake-cli"
-version = "0.1.0"
+version = "0.4.6"
 edition = "2024"
 license = "Apache-2.0"
 description = "TensorLake CLI"
@@ -8,6 +8,10 @@ description = "TensorLake CLI"
 [[bin]]
 name = "tl"
 path = "src/main.rs"
+
+[[bin]]
+name = "tensorlake"
+path = "src/tensorlake.rs"
 
 [dependencies]
 tensorlake-cloud-sdk = { workspace = true }

--- a/crates/cli/src/tensorlake.rs
+++ b/crates/cli/src/tensorlake.rs
@@ -1,0 +1,2 @@
+// Alias binary for `tl`; both commands share the same implementation.
+include!("main.rs");


### PR DESCRIPTION
## Summary
- add a `tensorlake` CLI binary alias alongside existing `tl`
- keep both binaries using the same implementation via `src/tensorlake.rs`
- align `tensorlake-cli` crate version with `pyproject.toml` (`0.4.6`)

## Validation
- `cargo check -p tensorlake-cli --bin tl --bin tensorlake`
- `cargo run -p tensorlake-cli --bin tl -- --version` -> `tl 0.4.6`
- `cargo run -p tensorlake-cli --bin tensorlake -- --version` -> `tl 0.4.6`
- fresh venv install: `pip install .` exposes both `tl` and `tensorlake` executables
