### PR TITLE
Fix sandbox SSE stream parsing and make pool image optional

### DIFF
--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -318,7 +318,7 @@ impl SandboxProxyClient {
                 match event {
                     Ok(msg) => match serde_json::from_str::<OutputEvent>(&msg.data) {
                         Ok(evt) => Some(Ok(evt)),
-                        Err(error) => Some(Err(SdkError::Json(error))),
+                        Err(_) => None, // Skip non-output events (e.g. heartbeats)
                     },
                     Err(error) => Some(Err(SdkError::EventSourceError(error.to_string()))),
                 }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -40,7 +40,8 @@ pub struct CreateSandboxRequest {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SandboxPoolRequest {
-    pub image: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
     pub resources: ContainerResourcesInfo,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_names: Option<Vec<String>>,

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -494,7 +494,7 @@ class SandboxClient:
 
     def create_pool(
         self,
-        image: str,
+        image: str | None = None,
         cpus: float = 1.0,
         memory_mb: int = 2048,
         ephemeral_disk_mb: int = 1024,


### PR DESCRIPTION
## Summary
- Fix `follow_output` / `follow_stdout` / `follow_stderr` crashing on non-output SSE events (e.g. heartbeats) with `missing field 'line'` error — now skips them instead
- Make `image` optional in `SandboxClient.create_pool()` and `SandboxPoolRequest` model
- Bump version to 0.4.19

## Test plan
- [ ] Verify `sandbox.follow_output(pid)` works without crashing on heartbeat events
- [ ] Verify `client.create_pool()` works without passing `image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)