### PR TITLE
Rename `sbx new --wait` flag to --no-wait

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -221,9 +221,9 @@ enum SbxCommands {
         #[arg(long)]
         snapshot: Option<String>,
 
-        /// Wait for sandbox to be running
-        #[arg(long, default_value = "true")]
-        wait: bool,
+        /// Return immediately after creation instead of waiting for the sandbox to be running
+        #[arg(long)]
+        no_wait: bool,
     },
 
     /// Execute a command in a sandbox
@@ -439,7 +439,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     timeout,
                     entrypoint,
                     snapshot,
-                    wait,
+                    no_wait,
                 } => {
                     commands::sbx::create::run(
                         ctx,
@@ -450,7 +450,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         timeout,
                         &entrypoint,
                         snapshot.as_deref(),
-                        wait,
+                        !no_wait,
                     )
                     .await
                 }


### PR DESCRIPTION
## Summary

This PR updates `tl sbx new` to use `--no-wait` instead of the previous `--wait` boolean behavior.

### Why

`--wait` was confusing because waiting was already the default behavior, and the `--wait` command doesn't do anything. But sometimes we actually don't want to wait.

### Changes

- Replaced the `--wait` flag with `--no-wait`
- Kept the default behavior the same:
  - `tl sbx new` still waits for the sandbox to reach `running`
- Added an explicit opt-out:
  - `tl sbx new --no-wait` returns immediately after creation and prints the sandbox ID
