### PR TITLE
Stream output for `sbx exec` and `sbx run` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,6 +2408,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "docker-credentials-config",
+ "eventsource-stream",
  "futures",
  "http-body-util",
  "indicatif",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,6 +22,7 @@ rustls = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+eventsource-stream = { workspace = true }
 toml = { workspace = true }
 dirs = { workspace = true }
 comfy-table = { workspace = true }

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -1,3 +1,9 @@
+use std::future::pending;
+
+use eventsource_stream::Eventsource;
+use futures::StreamExt;
+use reqwest::header::ACCEPT;
+
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{parse_env_vars, sandbox_proxy_base};
 use crate::error::{CliError, Result};
@@ -79,30 +85,103 @@ pub async fn run(
         })
         .unwrap_or_default();
 
-    // Poll process until done
-    let exit_code = wait_and_print(&client, &proxy_base, &pid, timeout).await?;
-
+    let exit_code = stream_and_wait(&client, &proxy_base, &pid, timeout).await?;
     if exit_code != 0 {
         return Err(CliError::ExitCode(exit_code));
     }
     Ok(())
 }
 
-async fn wait_and_print(
+async fn stream_and_wait(
     client: &reqwest::Client,
     proxy_base: &str,
     pid: &str,
     timeout: Option<f64>,
 ) -> Result<i32> {
+    let follow_resp = client
+        .get(format!(
+            "{}/api/v1/processes/{}/output/follow",
+            proxy_base, pid
+        ))
+        .header(ACCEPT, "text/event-stream")
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !follow_resp.status().is_success() {
+        let status = follow_resp.status();
+        let body = follow_resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to stream process output (HTTP {}): {}",
+            status,
+            body
+        )));
+    }
+
     let deadline =
         timeout.map(|t| tokio::time::Instant::now() + std::time::Duration::from_secs_f64(t));
+    let mut stream = Box::pin(follow_resp.bytes_stream().eventsource());
 
     loop {
-        // Check timeout
-        if let Some(dl) = deadline
-            && tokio::time::Instant::now() > dl
+        let timeout_future = async {
+            if let Some(deadline) = deadline {
+                tokio::time::sleep_until(deadline).await;
+            } else {
+                pending::<()>().await;
+            }
+        };
+        tokio::pin!(timeout_future);
+
+        tokio::select! {
+            _ = &mut timeout_future => {
+                let _ = client
+                    .delete(format!("{}/api/v1/processes/{}", proxy_base, pid))
+                    .send()
+                    .await;
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "Command timed out after {}s",
+                    timeout.unwrap_or(0.0)
+                )));
+            }
+            maybe_event = stream.next() => {
+                match maybe_event {
+                    Some(Ok(msg)) => {
+                        if let Some(event) = parse_output_event(&msg.data)? {
+                            print_output_event(&event);
+                        }
+                    }
+                    Some(Err(error)) => {
+                        return Err(CliError::Other(anyhow::anyhow!(
+                            "failed to stream process output: {}",
+                            error
+                        )));
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+
+    let info = process_info(client, proxy_base, pid).await?;
+    let status = info.get("status").and_then(|v| v.as_str()).unwrap_or("");
+    if status == "running" {
+        return wait_for_exit_code(client, proxy_base, pid, deadline, timeout).await;
+    }
+
+    exit_code_from_info(&info)
+}
+
+async fn wait_for_exit_code(
+    client: &reqwest::Client,
+    proxy_base: &str,
+    pid: &str,
+    deadline: Option<tokio::time::Instant>,
+    timeout: Option<f64>,
+) -> Result<i32> {
+    loop {
+        if let Some(deadline) = deadline
+            && tokio::time::Instant::now() > deadline
         {
-            // Kill process
             let _ = client
                 .delete(format!("{}/api/v1/processes/{}", proxy_base, pid))
                 .send()
@@ -113,67 +192,140 @@ async fn wait_and_print(
             )));
         }
 
-        let info_resp = client
-            .get(format!("{}/api/v1/processes/{}", proxy_base, pid))
-            .send()
-            .await
-            .map_err(CliError::Http)?;
-
-        if !info_resp.status().is_success() {
-            return Err(CliError::Other(anyhow::anyhow!(
-                "failed to get process status"
-            )));
-        }
-
-        let info: serde_json::Value = info_resp.json().await.map_err(CliError::Http)?;
+        let info = process_info(client, proxy_base, pid).await?;
         let status = info.get("status").and_then(|v| v.as_str()).unwrap_or("");
-
         if status != "running" {
-            // Process done — fetch stdout/stderr
-            let stdout_resp = client
-                .get(format!("{}/api/v1/processes/{}/stdout", proxy_base, pid))
-                .send()
-                .await
-                .map_err(CliError::Http)?;
-
-            if stdout_resp.status().is_success() {
-                let stdout_body: serde_json::Value = stdout_resp.json().await.unwrap_or_default();
-                if let Some(lines) = stdout_body.get("lines").and_then(|v| v.as_array()) {
-                    for line in lines {
-                        if let Some(s) = line.as_str() {
-                            println!("{}", s);
-                        }
-                    }
-                }
-            }
-
-            let stderr_resp = client
-                .get(format!("{}/api/v1/processes/{}/stderr", proxy_base, pid))
-                .send()
-                .await
-                .map_err(CliError::Http)?;
-
-            if stderr_resp.status().is_success() {
-                let stderr_body: serde_json::Value = stderr_resp.json().await.unwrap_or_default();
-                if let Some(lines) = stderr_body.get("lines").and_then(|v| v.as_array()) {
-                    for line in lines {
-                        if let Some(s) = line.as_str() {
-                            eprintln!("{}", s);
-                        }
-                    }
-                }
-            }
-
-            // Determine exit code
-            if let Some(code) = info.get("exit_code").and_then(|v| v.as_i64()) {
-                return Ok(code as i32);
-            }
-            if let Some(signal) = info.get("signal").and_then(|v| v.as_i64()) {
-                return Ok(128 + signal as i32);
-            }
-            return Ok(1);
+            return exit_code_from_info(&info);
         }
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+async fn process_info(
+    client: &reqwest::Client,
+    proxy_base: &str,
+    pid: &str,
+) -> Result<serde_json::Value> {
+    let info_resp = client
+        .get(format!("{}/api/v1/processes/{}", proxy_base, pid))
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !info_resp.status().is_success() {
+        let status = info_resp.status();
+        let body = info_resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to get process status (HTTP {}): {}",
+            status,
+            body
+        )));
+    }
+
+    info_resp.json().await.map_err(CliError::Http)
+}
+
+fn exit_code_from_info(info: &serde_json::Value) -> Result<i32> {
+    if let Some(code) = info.get("exit_code").and_then(|v| v.as_i64()) {
+        return Ok(code as i32);
+    }
+    if let Some(signal) = info.get("signal").and_then(|v| v.as_i64()) {
+        return Ok(128 + signal as i32);
+    }
+    Ok(1)
+}
+
+fn print_output_event(event: &StreamOutputEvent) {
+    match event.stream.as_deref() {
+        Some("stderr") => eprintln!("{}", event.line),
+        _ => println!("{}", event.line),
+    }
+}
+
+fn parse_output_event(data: &str) -> Result<Option<StreamOutputEvent>> {
+    let trimmed = data.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let value: serde_json::Value = serde_json::from_str(trimmed)?;
+    if should_skip_event(&value) {
+        return Ok(None);
+    }
+
+    let Some(line) = value.get("line").and_then(|value| value.as_str()) else {
+        return Ok(None);
+    };
+
+    let stream = value
+        .get("stream")
+        .and_then(|value| value.as_str())
+        .map(str::to_string);
+
+    Ok(Some(StreamOutputEvent {
+        line: line.to_string(),
+        stream,
+    }))
+}
+
+fn should_skip_event(value: &serde_json::Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+
+    ["type", "event", "kind"]
+        .into_iter()
+        .filter_map(|key| obj.get(key).and_then(|value| value.as_str()))
+        .any(|kind| matches!(kind, "heartbeat" | "keepalive"))
+}
+
+#[derive(Debug)]
+struct StreamOutputEvent {
+    line: String,
+    stream: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_output_event;
+
+    #[test]
+    fn parse_output_event_skips_empty_payloads() {
+        assert!(parse_output_event("").unwrap().is_none());
+        assert!(parse_output_event("   ").unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_output_event_skips_heartbeat_payloads() {
+        assert!(
+            parse_output_event(r#"{"type":"heartbeat"}"#)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            parse_output_event(r#"{"event":"keepalive"}"#)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn parse_output_event_skips_unknown_json_frames() {
+        assert!(
+            parse_output_event(r#"{"status":"done"}"#)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn parse_output_event_parses_output_lines() {
+        let event = parse_output_event(r#"{"line":"hello","stream":"stdout"}"#)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.line, "hello");
+        assert_eq!(event.stream.as_deref(), Some("stdout"));
     }
 }


### PR DESCRIPTION
## Summary

This PR adds live output streaming to the sandbox CLI for both `tl sbx exec` and `tl sbx run`.

### Changes

- Updated `tl sbx exec` to stream process output live from the sandbox proxy SSE endpoint instead of waiting for the process to finish and fetching stdout/stderr afterward
- `tl sbx run` now also streams output live automatically, since it reuses the `exec` path
- Preserved existing timeout and exit-code behavior
- Added support for skipping non-output SSE frames such as heartbeat or terminal status events, so commands no longer fail on frames that do not contain a `line` field
- Kept invalid JSON as an error instead of silently swallowing malformed stream payloads