### PR TITLE
Fix PTY SSH client: resize, raw mode, token leak, cleanup

### DIFF
--- a/crates/cli/src/commands/sbx/ssh.rs
+++ b/crates/cli/src/commands/sbx/ssh.rs
@@ -19,17 +19,33 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, shell: &str) -> Result<()> 
     if let Ok(token) = ctx.bearer_token() {
         headers.insert(
             reqwest::header::AUTHORIZATION,
-            format!("Bearer {}", token).parse().unwrap(),
+            format!("Bearer {}", token)
+                .parse()
+                .map_err(|e| CliError::Other(anyhow::anyhow!("invalid bearer token header: {}", e)))?,
         );
     }
     if let Some(org_id) = ctx.effective_organization_id() {
-        headers.insert("X-Forwarded-Organization-Id", org_id.parse().unwrap());
+        headers.insert(
+            "X-Forwarded-Organization-Id",
+            org_id
+                .parse()
+                .map_err(|e| CliError::Other(anyhow::anyhow!("invalid organization id header: {}", e)))?,
+        );
     }
     if let Some(proj_id) = ctx.effective_project_id() {
-        headers.insert("X-Forwarded-Project-Id", proj_id.parse().unwrap());
+        headers.insert(
+            "X-Forwarded-Project-Id",
+            proj_id
+                .parse()
+                .map_err(|e| CliError::Other(anyhow::anyhow!("invalid project id header: {}", e)))?,
+        );
     }
     if let Some(ref host) = host_override {
-        headers.insert(reqwest::header::HOST, host.parse().unwrap());
+        headers.insert(
+            reqwest::header::HOST,
+            host.parse()
+                .map_err(|e| CliError::Other(anyhow::anyhow!("invalid host header: {}", e)))?,
+        );
     }
     let client = http::client_builder()
         .default_headers(headers.clone())
@@ -39,6 +55,10 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, shell: &str) -> Result<()> 
     // Get terminal size
     let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
 
+    // Forward the user's TERM value so applications inside the PTY see the
+    // correct terminal type (e.g. tmux-256color inside tmux).
+    let term_val = std::env::var("TERM").unwrap_or_else(|_| "xterm-256color".to_string());
+
     // Create PTY session via proxy API
     let pty_resp = client
         .post(format!("{}/api/v1/pty", proxy_base))
@@ -47,7 +67,7 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, shell: &str) -> Result<()> 
             "rows": rows,
             "cols": cols,
             "env": {
-                "TERM": "xterm-256color",
+                "TERM": term_val,
                 "COLORTERM": "truecolor",
             },
         }))
@@ -75,11 +95,12 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, shell: &str) -> Result<()> 
         .and_then(|v| v.as_str())
         .ok_or_else(|| CliError::Other(anyhow::anyhow!("missing token in PTY response")))?;
 
-    // Build WebSocket URL from proxy base
+    // Build WebSocket URL from proxy base (token sent via header, not query
+    // string, to avoid leaking it into proxy/CDN access logs).
     let ws_base = proxy_base
         .replace("https://", "wss://")
         .replace("http://", "ws://");
-    let ws_url = format!("{}/api/v1/pty/{}/ws?token={}", ws_base, session_id, token);
+    let ws_url = format!("{}/api/v1/pty/{}/ws", ws_base, session_id);
 
     // Connect WebSocket
     use tokio_tungstenite::tungstenite;
@@ -89,10 +110,16 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, shell: &str) -> Result<()> 
             CliError::Other(anyhow::anyhow!("failed to build WebSocket request: {}", e))
         })?;
 
-    // Add auth headers to WebSocket request
+    // Add auth headers and PTY token to WebSocket request
     for (key, value) in &headers {
         request.headers_mut().insert(key.clone(), value.clone());
     }
+    request.headers_mut().insert(
+        "X-PTY-Token",
+        token
+            .parse()
+            .map_err(|e| CliError::Other(anyhow::anyhow!("invalid pty token header: {}", e)))?,
+    );
 
     let (ws_stream, _) = tokio_tungstenite::connect_async(request)
         .await
@@ -100,7 +127,7 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, shell: &str) -> Result<()> 
 
     // PTY protocol opcodes
     const OP_DATA: u8 = 0x00;
-    const _OP_RESIZE: u8 = 0x01;
+    const OP_RESIZE: u8 = 0x01;
     const OP_READY: u8 = 0x02;
 
     use futures::sink::SinkExt;
@@ -109,14 +136,23 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, shell: &str) -> Result<()> 
 
     let (mut ws_write, mut ws_read) = ws_stream.split();
 
-    // Send READY
+    // Enter raw mode with a Drop guard so the terminal is restored even on
+    // panic or early return. Must happen before READY so output flushed by the
+    // server is received while already in raw mode (avoids staircase \n without \r).
+    struct RawModeGuard;
+    impl Drop for RawModeGuard {
+        fn drop(&mut self) {
+            let _ = crossterm::terminal::disable_raw_mode();
+        }
+    }
+    crossterm::terminal::enable_raw_mode()?;
+    let _raw_guard = RawModeGuard;
+
+    // Send READY to tell the server to flush buffered output.
     ws_write
         .send(tungstenite::Message::Binary(vec![OP_READY].into()))
         .await
         .map_err(|e| CliError::Other(anyhow::anyhow!("failed to send READY: {}", e)))?;
-
-    // Enter raw mode
-    crossterm::terminal::enable_raw_mode()?;
 
     let result = async {
         // Spawn reader task (WebSocket -> stdout)
@@ -148,9 +184,21 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, shell: &str) -> Result<()> 
             exit_code
         });
 
+        // Listen for terminal resize events (SIGWINCH) and SIGINT (in case it
+        // arrives from an external kill, since raw mode disables terminal ISIG).
+        let mut sigwinch = tokio::signal::unix::signal(
+            tokio::signal::unix::SignalKind::window_change(),
+        )
+        .expect("failed to register SIGWINCH handler");
+        let mut sigint = tokio::signal::unix::signal(
+            tokio::signal::unix::SignalKind::interrupt(),
+        )
+        .expect("failed to register SIGINT handler");
+
         // Main loop: stdin -> WebSocket
         let mut stdin = tokio::io::stdin();
         let mut buf = [0u8; 4096];
+        let mut server_exit_code: Option<i32> = None;
 
         loop {
             tokio::select! {
@@ -168,18 +216,44 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, shell: &str) -> Result<()> 
                     }
                 }
                 exit_code = &mut reader_handle => {
-                    return exit_code.unwrap_or(None::<i32>);
+                    server_exit_code = exit_code.unwrap_or(None);
+                    break;
+                }
+                _ = sigwinch.recv() => {
+                    let (new_cols, new_rows) = crossterm::terminal::size().unwrap_or((80, 24));
+                    let mut msg = vec![OP_RESIZE];
+                    msg.extend_from_slice(&new_cols.to_be_bytes());
+                    msg.extend_from_slice(&new_rows.to_be_bytes());
+                    if ws_write.send(tungstenite::Message::Binary(msg.into())).await.is_err() {
+                        break;
+                    }
+                }
+                _ = sigint.recv() => {
+                    break;
                 }
             }
         }
 
-        // Wait for reader to finish
-        reader_handle.await.unwrap_or(None)
+        // Send close frame so the server decrements client_count immediately
+        // instead of waiting for the ping/pong timeout.
+        let _ = ws_write
+            .send(tungstenite::Message::Close(None))
+            .await;
+
+        // If the reader hasn't finished yet, wait for it to get the exit code.
+        if server_exit_code.is_none() {
+            server_exit_code = reader_handle.await.unwrap_or(None);
+        }
+
+        server_exit_code
     }
     .await;
 
-    // Restore terminal
-    crossterm::terminal::disable_raw_mode()?;
+    // Terminal is restored by _raw_guard Drop.
+    drop(_raw_guard);
+
+    // Print a newline so the outer shell prompt starts on a clean line.
+    eprintln!();
 
     if let Some(code) = result
         && code != 0

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -456,7 +456,12 @@ class Sandbox:
             _raise_as_sandbox_error(e)
 
     def pty_ws_url(self, session_id: str, token: str) -> str:
-        """Construct the WebSocket URL for a PTY session."""
+        """Construct the WebSocket URL for a PTY session.
+
+        The token is NOT included in the URL query string to avoid leaking it
+        into proxy/CDN access logs. Callers should send the token via the
+        ``X-PTY-Token`` header on the WebSocket upgrade request instead.
+        """
         base = self._base_url.rstrip("/")
         if base.startswith("https://"):
             ws_base = "wss://" + base[8:]
@@ -464,7 +469,7 @@ class Sandbox:
             ws_base = "ws://" + base[7:]
         else:
             ws_base = base
-        return f"{ws_base}/api/v1/pty/{session_id}/ws?token={token}"
+        return f"{ws_base}/api/v1/pty/{session_id}/ws"
 
     # --- Health and info ---
 


### PR DESCRIPTION
## Summary
- **Resize forwarding**: Forward SIGWINCH to the remote PTY via the resize opcode — was defined (`_OP_RESIZE`) but never sent, causing garbled TUI layouts in tmux
- **Raw mode safety**: Add a `Drop` guard so the terminal is restored on panic/early return, and handle SIGINT gracefully instead of leaving the terminal broken
- **Token leak**: Move PTY session token from URL query string to `X-PTY-Token` header to avoid leaking it into proxy/CDN access logs
- **Session cleanup**: Send WebSocket close frame on all exit paths (including server-initiated close), print `\r\n` on exit so the outer shell prompt renders cleanly
- **Misc**: Forward user's `$TERM` instead of hardcoding `xterm-256color`, replace `.unwrap()` on header parsing with proper error handling

Companion server-side PR: tensorlakeai/indexify (accepts token from header, backwards-compatible with query string)

## Test plan
- [ ] `tl sbx ssh` into a sandbox, verify shell works
- [ ] Resize the terminal window while connected — remote shell should adapt
- [ ] Press Ctrl-C inside the session — should forward to remote, not hang
- [ ] Exit the shell — outer prompt should appear cleanly on a new line
- [ ] Verify proxy access logs no longer contain the PTY token

🤖 Generated with [Claude Code](https://claude.com/claude-code)