### PR TITLE
Improve sbx new/run CLI: expose ports, network controls, and better UX

### DIFF
--- a/crates/cli/src/commands/build_images.rs
+++ b/crates/cli/src/commands/build_images.rs
@@ -19,6 +19,7 @@ struct ImageBuildContext {
     sdk_version: String,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     application_file_path: &str,
     repository: Option<&str>,

--- a/crates/cli/src/commands/cron.rs
+++ b/crates/cli/src/commands/cron.rs
@@ -15,12 +15,11 @@ fn cron_client(ctx: &CliContext) -> Result<CronClient> {
     let token = ctx.bearer_token()?;
     let mut builder = ClientBuilder::new(&ctx.api_url).bearer_token(&token);
     let use_scope_headers = ctx.personal_access_token.is_some() && ctx.api_key.is_none();
-    if use_scope_headers {
-        if let (Some(org), Some(proj)) =
+    if use_scope_headers
+        && let (Some(org), Some(proj)) =
             (ctx.effective_organization_id(), ctx.effective_project_id())
-        {
-            builder = builder.scope(&org, &proj);
-        }
+    {
+        builder = builder.scope(&org, &proj);
     }
     Ok(CronClient::new(builder.build().map_err(CliError::from)?))
 }

--- a/crates/cli/src/commands/parse.rs
+++ b/crates/cli/src/commands/parse.rs
@@ -42,11 +42,9 @@ pub async fn run(
     let cache_key = format!("{}|pages:{}", cache_identity, page_key);
     let cache = KvCache::new("parse");
 
-    if !ignore_cache {
-        if let Some(cached) = cache.get(&cache_key).await {
-            println!("{}", cached);
-            return Ok(());
-        }
+    if !ignore_cache && let Some(cached) = cache.get(&cache_key).await {
+        println!("{}", cached);
+        return Ok(());
     }
 
     // Resolve to file_id (upload) or keep as file_url.

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -1,6 +1,6 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
-    DEFAULT_SANDBOX_WAIT_TIMEOUT, sandbox_endpoint, wait_for_sandbox_status,
+    DEFAULT_SANDBOX_WAIT_TIMEOUT, sandbox_endpoint, sandbox_proxy_base, wait_for_sandbox_status,
 };
 use crate::error::{CliError, Result};
 
@@ -40,8 +40,6 @@ pub async fn create_with_request(
         .get("status")
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
-
-    eprintln!("Created sandbox {} ({})", sandbox_id, status);
 
     if wait && status != "running" {
         wait_for_sandbox_status(
@@ -110,6 +108,7 @@ async fn resolve_image(ctx: &CliContext, image_name: &str) -> Result<String> {
     )))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     ctx: &CliContext,
     cpus: f64,
@@ -119,6 +118,11 @@ pub async fn run(
     snapshot_id: Option<&str>,
     image_name: Option<&str>,
     wait: bool,
+    ports: &[u16],
+    allow_unauthenticated_access: bool,
+    no_internet: bool,
+    network_allow: &[String],
+    network_deny: &[String],
 ) -> Result<()> {
     // Resolve --image to a snapshot ID if provided.
     let resolved_snapshot = match image_name {
@@ -133,6 +137,7 @@ pub async fn run(
             "memory_mb": memory,
         },
     });
+
     if let Some(t) = timeout {
         body["timeout_secs"] = serde_json::Value::Number(t.into());
     }
@@ -142,8 +147,100 @@ pub async fn run(
     if let Some(snap) = effective_snapshot {
         body["snapshot_id"] = serde_json::Value::String(snap.to_string());
     }
+    if !ports.is_empty() {
+        body["exposed_ports"] = serde_json::json!(ports);
+    }
+    if allow_unauthenticated_access {
+        body["allow_unauthenticated_access"] = serde_json::Value::Bool(true);
+    }
+
+    let has_network = no_internet || !network_allow.is_empty() || !network_deny.is_empty();
+    if has_network {
+        let mut network = serde_json::json!({});
+        if no_internet {
+            network["allow_internet_access"] = serde_json::Value::Bool(false);
+        }
+        if !network_allow.is_empty() {
+            network["allow_out"] = serde_json::json!(network_allow);
+        }
+        if !network_deny.is_empty() {
+            network["deny_out"] = serde_json::json!(network_deny);
+        }
+        body["network"] = network;
+    }
 
     let sandbox_id = create_with_request(ctx, body, wait).await?;
-    println!("{}", sandbox_id);
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    if is_tty {
+        eprintln!("Sandbox {} is ready.", sandbox_id);
+    }
+    if !is_tty {
+        println!("{}", sandbox_id);
+    }
+    if is_tty {
+        print_post_create_tip(ctx, &sandbox_id);
+    }
     Ok(())
+}
+
+fn print_post_create_tip(ctx: &CliContext, sandbox_id: &str) {
+    let (proxy_url, host_header) = sandbox_proxy_base(ctx, sandbox_id);
+    let host_flag = host_header
+        .as_deref()
+        .map(|h| format!(" \\\n     -H \"Host: {}\"", h))
+        .unwrap_or_default();
+
+    eprintln!();
+    eprintln!("Get started:");
+    eprintln!("  tl sbx ssh {sandbox_id}");
+    eprintln!("  tl sbx exec {sandbox_id} -- bash -c \"echo Hello, World!\"");
+
+    let tips: Vec<(&str, String)> = vec![
+        (
+            "copy files into your sandbox?",
+            format!("  tl sbx cp ./myfile.py {sandbox_id}:/tmp/myfile.py"),
+        ),
+        (
+            "run a process via the HTTP API?",
+            format!(
+                "  curl -X POST {proxy_url}/api/v1/processes{host_flag} \\\n     -H \"Content-Type: application/json\" \\\n     -d '{{\"command\": \"echo\", \"args\": [\"Hello, World!\"]}}'"
+            ),
+        ),
+        (
+            "run a bash script via the HTTP API?",
+            format!(
+                "  curl -X POST {proxy_url}/api/v1/processes{host_flag} \\\n     -H \"Content-Type: application/json\" \\\n     -d '{{\"command\": \"bash\", \"args\": [\"-c\", \"for i in 1 2 3; do echo Line $i; sleep 1; done\"]}}'"
+            ),
+        ),
+        (
+            "follow process output in real-time?",
+            format!(
+                "  # Start a process:\n  curl -X POST {proxy_url}/api/v1/processes{host_flag} \\\n     -H \"Content-Type: application/json\" \\\n     -d '{{\"command\": \"bash\", \"args\": [\"-c\", \"for i in 1 2 3; do echo Line $i; sleep 1; done\"]}}'\n\n  # Then stream its output (replace <pid> with the returned pid):\n  curl {proxy_url}/api/v1/processes/<pid>/output/follow{host_flag}"
+            ),
+        ),
+        (
+            "write files into your sandbox via the HTTP API?",
+            format!(
+                "  curl -X PUT \"{proxy_url}/api/v1/files?path=/tmp/hello.txt\"{host_flag} \\\n     -H \"Content-Type: application/octet-stream\" \\\n     -d \"Hello from sandbox!\""
+            ),
+        ),
+        (
+            "read files from your sandbox via the HTTP API?",
+            format!("  curl \"{proxy_url}/api/v1/files?path=/tmp/hello.txt\"{host_flag}"),
+        ),
+    ];
+
+    let tip_index = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as usize)
+        .unwrap_or(0)
+        % tips.len();
+
+    let (title, body) = &tips[tip_index];
+    eprintln!();
+    eprintln!("Did you know that you can {title}");
+    eprintln!();
+    eprintln!("{body}");
+    eprintln!();
+    eprintln!("Docs: https://docs.tensorlake.ai/sandboxes");
 }

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -58,13 +58,20 @@ pub async fn wait_for_sandbox_status(
     timeout: Duration,
 ) -> Result<String> {
     let client = ctx.client()?;
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
 
-    let spinner = new_spinner(&format!("{}...", waiting_message));
+    let spinner = if is_tty {
+        Some(new_spinner(&format!("{}...", waiting_message)))
+    } else {
+        None
+    };
 
     let deadline = Instant::now() + timeout;
     loop {
         if Instant::now() > deadline {
-            spinner.finish_with_message(format!("{} timed out", waiting_message));
+            if let Some(ref s) = spinner {
+                s.finish_and_clear();
+            }
             return Err(CliError::Other(anyhow::anyhow!(
                 "Sandbox {} did not reach '{}' within {}s",
                 sandbox_id,
@@ -88,12 +95,16 @@ pub async fn wait_for_sandbox_status(
                 .to_string();
 
             if current_status == target_status {
-                spinner.finish_with_message(format!("{} {}", waiting_message, current_status));
+                if let Some(ref s) = spinner {
+                    s.finish_and_clear();
+                }
                 return Ok(current_status);
             }
 
             if current_status == "terminated" && target_status != "terminated" {
-                spinner.finish_with_message(format!("{} terminated", waiting_message));
+                if let Some(ref s) = spinner {
+                    s.finish_and_clear();
+                }
                 return Err(CliError::Other(anyhow::anyhow!(
                     "Sandbox terminated while waiting to reach '{}'",
                     target_status

--- a/crates/cli/src/commands/sbx/resume.rs
+++ b/crates/cli/src/commands/sbx/resume.rs
@@ -8,7 +8,10 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, wait: bool) -> Result<()> {
     let client = ctx.client()?;
     let url = sandbox_endpoint(ctx, &format!("sandboxes/{sandbox_id}/resume"));
 
-    eprintln!("Resuming sandbox {}...", sandbox_id);
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    if is_tty {
+        eprintln!("Resuming sandbox {}...", sandbox_id);
+    }
 
     let resp = client.post(&url).send().await.map_err(CliError::Http)?;
 
@@ -31,6 +34,9 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, wait: bool) -> Result<()> {
             DEFAULT_SANDBOX_WAIT_TIMEOUT,
         )
         .await?;
+        if is_tty {
+            eprintln!("Sandbox {} is running.", sandbox_id);
+        }
     }
 
     println!("{sandbox_id}");

--- a/crates/cli/src/commands/sbx/run.rs
+++ b/crates/cli/src/commands/sbx/run.rs
@@ -14,6 +14,11 @@ pub async fn run(
     workdir: Option<&str>,
     env: &[String],
     keep: bool,
+    ports: &[u16],
+    allow_unauthenticated_access: bool,
+    no_internet: bool,
+    network_allow: &[String],
+    network_deny: &[String],
 ) -> Result<()> {
     let client = ctx.client()?;
 
@@ -31,6 +36,26 @@ pub async fn run(
     });
     if let Some(img) = image {
         create_body["image"] = serde_json::Value::String(img.to_string());
+    }
+    if !ports.is_empty() {
+        create_body["exposed_ports"] = serde_json::json!(ports);
+    }
+    if allow_unauthenticated_access {
+        create_body["allow_unauthenticated_access"] = serde_json::Value::Bool(true);
+    }
+    let has_network = no_internet || !network_allow.is_empty() || !network_deny.is_empty();
+    if has_network {
+        let mut network = serde_json::json!({});
+        if no_internet {
+            network["allow_internet_access"] = serde_json::Value::Bool(false);
+        }
+        if !network_allow.is_empty() {
+            network["allow_out"] = serde_json::json!(network_allow);
+        }
+        if !network_deny.is_empty() {
+            network["deny_out"] = serde_json::json!(network_deny);
+        }
+        create_body["network"] = network;
     }
 
     let create_resp = client

--- a/crates/cli/src/commands/sbx/suspend.rs
+++ b/crates/cli/src/commands/sbx/suspend.rs
@@ -8,7 +8,10 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, wait: bool) -> Result<()> {
     let client = ctx.client()?;
     let url = sandbox_endpoint(ctx, &format!("sandboxes/{sandbox_id}/suspend"));
 
-    eprintln!("Suspending sandbox {}...", sandbox_id);
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    if is_tty {
+        eprintln!("Suspending sandbox {}...", sandbox_id);
+    }
 
     let resp = client.post(&url).send().await.map_err(CliError::Http)?;
 
@@ -31,6 +34,9 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, wait: bool) -> Result<()> {
             DEFAULT_SANDBOX_WAIT_TIMEOUT,
         )
         .await?;
+        if is_tty {
+            eprintln!("Sandbox {} suspended.", sandbox_id);
+        }
     }
 
     println!("{sandbox_id}");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -287,6 +287,26 @@ enum SbxCommands {
         /// Return immediately after creation instead of waiting for the sandbox to be running
         #[arg(long)]
         no_wait: bool,
+
+        /// Expose a port via the sandbox proxy (can be repeated)
+        #[arg(long = "expose", value_parser = parse_user_port)]
+        ports: Vec<u16>,
+
+        /// Allow unauthenticated proxy access to this sandbox
+        #[arg(long, hide = true)]
+        allow_unauthenticated_access: bool,
+
+        /// Block all outbound internet access
+        #[arg(long)]
+        no_internet: bool,
+
+        /// Allow outbound traffic to this IP or CIDR (can be repeated)
+        #[arg(long = "network-allow")]
+        network_allow: Vec<String>,
+
+        /// Deny outbound traffic to this IP or CIDR (can be repeated)
+        #[arg(long = "network-deny")]
+        network_deny: Vec<String>,
     },
 
     /// Suspend a running sandbox
@@ -400,6 +420,26 @@ enum SbxCommands {
         /// Keep sandbox after command exits
         #[arg(long)]
         keep: bool,
+
+        /// Expose a port via the sandbox proxy (can be repeated)
+        #[arg(long = "expose", value_parser = parse_user_port)]
+        ports: Vec<u16>,
+
+        /// Allow unauthenticated proxy access to this sandbox
+        #[arg(long, hide = true)]
+        allow_unauthenticated_access: bool,
+
+        /// Block all outbound internet access
+        #[arg(long)]
+        no_internet: bool,
+
+        /// Allow outbound traffic to this IP or CIDR (can be repeated)
+        #[arg(long = "network-allow")]
+        network_allow: Vec<String>,
+
+        /// Deny outbound traffic to this IP or CIDR (can be repeated)
+        #[arg(long = "network-deny")]
+        network_deny: Vec<String>,
     },
 
     /// Interactive shell in a sandbox
@@ -627,6 +667,11 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     snapshot,
                     image,
                     no_wait,
+                    ports,
+                    allow_unauthenticated_access,
+                    no_internet,
+                    network_allow,
+                    network_deny,
                 } => {
                     commands::sbx::create::run(
                         ctx,
@@ -637,6 +682,11 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         snapshot.as_deref(),
                         image.as_deref(),
                         !no_wait,
+                        &ports,
+                        allow_unauthenticated_access,
+                        no_internet,
+                        &network_allow,
+                        &network_deny,
                     )
                     .await
                 }
@@ -706,6 +756,11 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     workdir,
                     env,
                     keep,
+                    ports,
+                    allow_unauthenticated_access,
+                    no_internet,
+                    network_allow,
+                    network_deny,
                 } => {
                     commands::sbx::run::run(
                         ctx,
@@ -718,6 +773,11 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         workdir.as_deref(),
                         &env,
                         keep,
+                        &ports,
+                        allow_unauthenticated_access,
+                        no_internet,
+                        &network_allow,
+                        &network_deny,
                     )
                     .await
                 }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -1164,9 +1164,7 @@ fn into_py_error(error: SdkError) -> PyErr {
         }
         SdkError::Http(http_error) => {
             let message = format_error_chain(&http_error);
-            if http_error.is_timeout() {
-                CloudApiClientError::new_err(("connection", Option::<u16>::None, message))
-            } else if http_error.is_connect() {
+            if http_error.is_timeout() || http_error.is_connect() {
                 CloudApiClientError::new_err(("connection", Option::<u16>::None, message))
             } else {
                 CloudApiClientError::new_err(("internal", Option::<u16>::None, message))


### PR DESCRIPTION
Add missing flags to `sbx new` and `sbx run` based on the
CreateSandboxRequest
API schema: --expose (ports),
--allow-unauthenticated-access (hidden),
--no-internet, --network-allow, and --network-deny.

Improve post-creation output: show a spinner while
waiting, print a clean
"Sandbox X is ready." message on success, and display
always-on quick-start
commands (ssh, exec) alongside a rotating "Did you know?"
tip with curl
examples. All human-readable output is suppressed when
stdout is not a TTY
so that SBX=$(tl sbx new) captures only the sandbox ID.

Apply the same TTY-aware output to sbx suspend and sbx
resume. Fix two
pre-existing clippy warnings (too_many_arguments in
build_images, and
if_same_then_else in rust-cloud-sdk-py).
