### PR TITLE
Add 60s delay between TestPyPI publish and integration test

### DIFF
--- a/.github/workflows/publish_test_pypi.yaml
+++ b/.github/workflows/publish_test_pypi.yaml
@@ -148,9 +148,17 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           attestations: false
 
+  wait-for-propagation:
+    name: Wait for TestPyPI propagation
+    needs: [publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sleep 60s for TestPyPI index propagation
+        run: sleep 60
+
   integration-test:
     name: Integration test against TestPyPI
-    needs: [publish, prepare]
+    needs: [wait-for-propagation, prepare]
     uses: ./.github/workflows/integration_test.yaml
     with:
       version: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
TestPyPI index propagation can lag after a push, causing the integration test to fail with a "version not found" error. A wait-for-propagation job sleeps 60 seconds before the test runs.