### PR TITLE
Restore sbx new/run --expose behavior to match sbx port expose

### DIFF
--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -1,7 +1,8 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::image::resolve_image;
 use crate::commands::sbx::{
-    DEFAULT_SANDBOX_WAIT_TIMEOUT, sandbox_endpoint, sandbox_proxy_base, wait_for_sandbox_status,
+    DEFAULT_SANDBOX_WAIT_TIMEOUT, apply_proxy_access_settings, sandbox_endpoint,
+    sandbox_proxy_base, wait_for_sandbox_status,
 };
 use crate::error::{CliError, Result};
 
@@ -103,12 +104,7 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         body["name"] = serde_json::Value::String(n.to_string());
     }
 
-    if !ports.is_empty() {
-        body["exposed_ports"] = serde_json::json!(ports);
-    }
-    if allow_unauthenticated_access {
-        body["allow_unauthenticated_access"] = serde_json::Value::Bool(true);
-    }
+    apply_proxy_access_settings(&mut body, ports, allow_unauthenticated_access);
 
     let has_network = no_internet || !network_allow.is_empty() || !network_deny.is_empty();
     if has_network {

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -35,6 +35,20 @@ pub fn sandbox_endpoint(ctx: &CliContext, endpoint: &str) -> String {
     }
 }
 
+pub fn apply_proxy_access_settings(
+    body: &mut serde_json::Value,
+    ports: &[u16],
+    allow_unauthenticated_access: bool,
+) {
+    if !ports.is_empty() {
+        body["exposed_ports"] = serde_json::json!(ports);
+    }
+
+    if allow_unauthenticated_access || !ports.is_empty() {
+        body["allow_unauthenticated_access"] = serde_json::Value::Bool(true);
+    }
+}
+
 pub const DEFAULT_SANDBOX_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
 const SANDBOX_WAIT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -197,6 +211,47 @@ pub fn parse_env_vars(env: &[String]) -> Result<Option<serde_json::Value>> {
         );
     }
     Ok(Some(serde_json::Value::Object(map)))
+}
+
+#[cfg(test)]
+mod proxy_access_tests {
+    use super::apply_proxy_access_settings;
+
+    #[test]
+    fn exposed_ports_enable_unauthenticated_access() {
+        let mut body = serde_json::json!({});
+
+        apply_proxy_access_settings(&mut body, &[8000], false);
+
+        assert_eq!(body["exposed_ports"], serde_json::json!([8000]));
+        assert_eq!(
+            body["allow_unauthenticated_access"],
+            serde_json::Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn explicit_unauthenticated_access_without_ports_is_preserved() {
+        let mut body = serde_json::json!({});
+
+        apply_proxy_access_settings(&mut body, &[], true);
+
+        assert_eq!(
+            body["allow_unauthenticated_access"],
+            serde_json::Value::Bool(true)
+        );
+        assert!(body.get("exposed_ports").is_none());
+    }
+
+    #[test]
+    fn no_ports_and_no_unauthenticated_access_leave_body_unchanged() {
+        let mut body = serde_json::json!({});
+
+        apply_proxy_access_settings(&mut body, &[], false);
+
+        assert!(body.get("allow_unauthenticated_access").is_none());
+        assert!(body.get("exposed_ports").is_none());
+    }
 }
 
 pub fn format_created_at(value: Option<&serde_json::Value>) -> String {

--- a/crates/cli/src/commands/sbx/run.rs
+++ b/crates/cli/src/commands/sbx/run.rs
@@ -1,5 +1,5 @@
 use crate::auth::context::CliContext;
-use crate::commands::sbx::sandbox_endpoint;
+use crate::commands::sbx::{apply_proxy_access_settings, sandbox_endpoint};
 use crate::error::{CliError, Result};
 
 #[allow(clippy::too_many_arguments)]
@@ -37,12 +37,7 @@ pub async fn run(
     if let Some(img) = image {
         create_body["image"] = serde_json::Value::String(img.to_string());
     }
-    if !ports.is_empty() {
-        create_body["exposed_ports"] = serde_json::json!(ports);
-    }
-    if allow_unauthenticated_access {
-        create_body["allow_unauthenticated_access"] = serde_json::Value::Bool(true);
-    }
+    apply_proxy_access_settings(&mut create_body, ports, allow_unauthenticated_access);
     let has_network = no_internet || !network_allow.is_empty() || !network_deny.is_empty();
     if has_network {
         let mut network = serde_json::json!({});


### PR DESCRIPTION
## Summary

This fixes a regression in sandbox port exposure for the Rust CLI.

`tl sbx new --expose <port>` and `tl sbx run --expose <port>` were setting
`exposed_ports`, but they were not enabling
`allow_unauthenticated_access`. That meant the sandbox proxy would still
require auth for the exposed port, so a simple HTTP server inside the sandbox
was not reachable publicly even though the port appeared exposed.

This change restores the old behavior from `tl sbx port expose`:
when user ports are exposed through `sbx new` or `sbx run`, unauthenticated
proxy access is enabled automatically.

## What Changed

- Added shared helper logic for sandbox proxy exposure settings
- Updated `sbx new` to enable `allow_unauthenticated_access` when `--expose` is used
- Updated `sbx run` to do the same
- Added unit tests covering the new behavior

## Repro

Before this change:

```bash
tl sbx run --keep --expose 8000 \
  bash -lc 'python3 -m http.server 8000 --bind 0.0.0.0 &'

curl https://8000-<sandbox-id>.sandbox.tensorlake.ai/
# 401 Unauthorized
```
After this change:
```bash
curl https://8000-<sandbox-id>.sandbox.tensorlake.ai/
# 200 OK
```