### PR TITLE
Add --disk flag to sbx new and sbx run

### DIFF
--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -63,6 +63,7 @@ pub struct CreateArgs<'a> {
     pub name: Option<&'a str>,
     pub cpus: Option<f64>,
     pub memory: Option<i64>,
+    pub disk: Option<i64>,
     pub timeout: Option<i64>,
     pub entrypoint: &'a [String],
     pub snapshot_id: Option<&'a str>,
@@ -80,6 +81,7 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         name,
         cpus,
         memory,
+        disk,
         timeout,
         entrypoint,
         snapshot_id,
@@ -93,7 +95,7 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
     } = args;
 
     let mut body =
-        build_create_request_body(cpus, memory, timeout, entrypoint, snapshot_id, image_name);
+        build_create_request_body(cpus, memory, disk, timeout, entrypoint, snapshot_id, image_name);
     if let Some(n) = name {
         body["name"] = serde_json::Value::String(n.to_string());
     }
@@ -197,6 +199,7 @@ fn print_post_create_tip(ctx: &CliContext, sandbox_id: &str, is_ephemeral: bool)
 fn build_create_request_body(
     cpus: Option<f64>,
     memory: Option<i64>,
+    disk: Option<i64>,
     timeout: Option<i64>,
     entrypoint: &[String],
     snapshot_id: Option<&str>,
@@ -212,15 +215,24 @@ fn build_create_request_body(
         if let Some(memory) = memory {
             resources.insert("memory_mb".to_string(), serde_json::json!(memory));
         }
+        // disk overrides are ignored by the server for snapshot restores,
+        // but we pass them through for forward compatibility.
+        if let Some(disk) = disk {
+            resources.insert("ephemeral_disk_mb".to_string(), serde_json::json!(disk));
+        }
         if !resources.is_empty() {
             body["resources"] = serde_json::Value::Object(resources);
         }
         body["snapshot_id"] = serde_json::Value::String(snapshot_id.to_string());
     } else {
-        body["resources"] = serde_json::json!({
+        let mut resources = serde_json::json!({
             "cpus": cpus.unwrap_or(DEFAULT_SANDBOX_CPUS),
             "memory_mb": memory.unwrap_or(DEFAULT_SANDBOX_MEMORY_MB),
         });
+        if let Some(disk) = disk {
+            resources["ephemeral_disk_mb"] = serde_json::json!(disk);
+        }
+        body["resources"] = resources;
     }
 
     if let Some(t) = timeout {
@@ -242,7 +254,7 @@ mod tests {
 
     #[test]
     fn create_body_uses_defaults_without_snapshot() {
-        let body = build_create_request_body(None, None, None, &[], None, None);
+        let body = build_create_request_body(None, None, None, None, &[], None, None);
 
         assert_eq!(body["resources"]["cpus"], 1.0);
         assert_eq!(body["resources"]["memory_mb"], 1024);
@@ -251,7 +263,7 @@ mod tests {
 
     #[test]
     fn create_body_omits_resources_for_snapshot_without_overrides() {
-        let body = build_create_request_body(None, None, None, &[], Some("snap-1"), None);
+        let body = build_create_request_body(None, None, None, None, &[], Some("snap-1"), None);
 
         assert_eq!(body["snapshot_id"], "snap-1");
         assert!(body.get("resources").is_none());
@@ -260,7 +272,7 @@ mod tests {
     #[test]
     fn create_body_includes_only_explicit_snapshot_overrides() {
         let body =
-            build_create_request_body(Some(2.5), None, None, &[], Some("snap-1"), None);
+            build_create_request_body(Some(2.5), None, None, None, &[], Some("snap-1"), None);
 
         assert_eq!(body["snapshot_id"], "snap-1");
         assert_eq!(body["resources"]["cpus"], 2.5);
@@ -269,9 +281,24 @@ mod tests {
 
     #[test]
     fn create_body_passes_image_name_through_to_server() {
-        let body = build_create_request_body(None, None, None, &[], None, Some("ubuntu-minimal"));
+        let body = build_create_request_body(None, None, None, None, &[], None, Some("ubuntu-minimal"));
 
         assert_eq!(body["image"], "ubuntu-minimal");
         assert!(body.get("snapshot_id").is_none());
+    }
+
+    #[test]
+    fn create_body_includes_disk_for_fresh_boot() {
+        let body = build_create_request_body(None, None, Some(4096), None, &[], None, None);
+
+        assert_eq!(body["resources"]["ephemeral_disk_mb"], 4096);
+    }
+
+    #[test]
+    fn create_body_includes_disk_for_snapshot_restore() {
+        let body = build_create_request_body(None, None, Some(8192), None, &[], Some("snap-1"), None);
+
+        assert_eq!(body["snapshot_id"], "snap-1");
+        assert_eq!(body["resources"]["ephemeral_disk_mb"], 8192);
     }
 }

--- a/crates/cli/src/commands/sbx/run.rs
+++ b/crates/cli/src/commands/sbx/run.rs
@@ -10,6 +10,7 @@ pub async fn run(
     image: Option<&str>,
     cpus: f64,
     memory: i64,
+    disk: Option<i64>,
     timeout: Option<f64>,
     workdir: Option<&str>,
     env: &[String],
@@ -28,11 +29,15 @@ pub async fn run(
         .unwrap_or_else(|| "default image".to_string());
     eprintln!("Creating sandbox with {}...", label);
 
+    let mut resources = serde_json::json!({
+        "cpus": cpus,
+        "memory_mb": memory,
+    });
+    if let Some(d) = disk {
+        resources["ephemeral_disk_mb"] = serde_json::json!(d);
+    }
     let mut create_body = serde_json::json!({
-        "resources": {
-            "cpus": cpus,
-            "memory_mb": memory,
-        },
+        "resources": resources,
     });
     if let Some(img) = image {
         create_body["image"] = serde_json::Value::String(img.to_string());

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -277,6 +277,10 @@ enum SbxCommands {
         #[arg(long)]
         memory: Option<i64>,
 
+        /// Root disk size in MB (default: 2048 for new sandboxes, ignored for snapshot restores)
+        #[arg(long)]
+        disk: Option<i64>,
+
         /// Timeout in seconds
         #[arg(long)]
         timeout: Option<i64>,
@@ -413,6 +417,10 @@ enum SbxCommands {
         /// Memory in MB
         #[arg(long, default_value = "1024")]
         memory: i64,
+
+        /// Root disk size in MB (default: 2048)
+        #[arg(long)]
+        disk: Option<i64>,
 
         /// Command timeout in seconds
         #[arg(short, long)]
@@ -730,6 +738,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     name,
                     cpus,
                     memory,
+                    disk,
                     timeout,
                     entrypoint,
                     snapshot,
@@ -747,6 +756,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             name: name.as_deref(),
                             cpus,
                             memory,
+                            disk,
                             timeout,
                             entrypoint: &entrypoint,
                             snapshot_id: snapshot.as_deref(),
@@ -827,6 +837,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     image,
                     cpus,
                     memory,
+                    disk,
                     timeout,
                     workdir,
                     env,
@@ -844,6 +855,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         image.as_deref(),
                         cpus,
                         memory,
+                        disk,
                         timeout,
                         workdir.as_deref(),
                         &env,


### PR DESCRIPTION
## Summary
- Add `--disk` flag to `tl sbx new` and `tl sbx run` commands, allowing users to specify root disk size in MB via `ephemeral_disk_mb`
- For fresh boots, the value is sent as `resources.ephemeral_disk_mb` in the create request
- For snapshot restores, the value is passed through for forward compatibility
- Adds test coverage for disk parameter in request body construction

## Context
The server-side now supports per-VM disk sizing (sparse copy + resize2fs). This CLI change exposes that capability to users via the `--disk` flag. Default disk size is 2 GiB; users who need more can request up to 100 GiB.

## Test plan
- [x] `cargo check` passes
- [x] All 89 unit tests pass (both binaries)
- [ ] Manual: `tl sbx new --disk 4096` creates a sandbox with 4 GiB disk
- [ ] Manual: `tl sbx run --disk 4096 -- echo hello` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)