### PR TITLE
Use filesystem_only snapshots for sandbox image builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cloud-sdk"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "bytes",
  "chrono",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "futures",
  "pyo3",

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -12,11 +12,11 @@ use crate::{client::Client, error::SdkError};
 pub use desktop::SandboxDesktopClient;
 
 use models::{
-    CreateSandboxPoolResponse, CreateSandboxRequest, CreateSandboxResponse, CreateSnapshotResponse,
-    DaemonInfo, HealthResponse, ListDirectoryResponse, ListProcessesResponse,
-    ListSandboxPoolsResponse, ListSandboxesResponse, ListSnapshotsResponse, OutputEvent,
-    OutputResponse, ProcessInfo, SandboxInfo, SandboxPoolInfo, SandboxPoolRequest,
-    SendSignalResponse, SnapshotInfo, UpdateSandboxRequest,
+    CreateSandboxPoolResponse, CreateSandboxRequest, CreateSandboxResponse, CreateSnapshotRequest,
+    CreateSnapshotResponse, DaemonInfo, HealthResponse, ListDirectoryResponse,
+    ListProcessesResponse, ListSandboxPoolsResponse, ListSandboxesResponse, ListSnapshotsResponse,
+    OutputEvent, OutputResponse, ProcessInfo, SandboxInfo, SandboxPoolInfo, SandboxPoolRequest,
+    SendSignalResponse, SnapshotContentMode, SnapshotInfo, UpdateSandboxRequest,
 };
 
 /// A client for managing sandbox lifecycle, pool, and snapshot APIs.
@@ -113,9 +113,22 @@ impl SandboxesClient {
         Ok(())
     }
 
-    pub async fn snapshot(&self, sandbox_id: &str) -> Result<CreateSnapshotResponse, SdkError> {
+    pub async fn snapshot(
+        &self,
+        sandbox_id: &str,
+        content_mode: Option<SnapshotContentMode>,
+    ) -> Result<CreateSnapshotResponse, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/snapshot"));
-        let req = self.client.request(Method::POST, &uri).build()?;
+        let req = if content_mode.is_some() {
+            let body = CreateSnapshotRequest {
+                snapshot_content_mode: content_mode,
+            };
+            self.client
+                .build_post_json_request(Method::POST, &uri, &body)?
+        } else {
+            // Preserve today's wire shape (no body) for callers that don't set a content mode.
+            self.client.request(Method::POST, &uri).build()?
+        };
         let resp = self.client.execute(req).await?;
         Self::parse_json(resp).await
     }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -163,6 +163,19 @@ pub struct ListSandboxPoolsResponse {
     pub pools: Vec<SandboxPoolInfo>,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotContentMode {
+    Full,
+    FilesystemOnly,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CreateSnapshotRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_content_mode: Option<SnapshotContentMode>,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CreateSnapshotResponse {
     pub snapshot_id: String,
@@ -263,4 +276,40 @@ pub struct DirectoryEntry {
 pub struct ListDirectoryResponse {
     pub path: String,
     pub entries: Vec<DirectoryEntry>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_content_mode_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&SnapshotContentMode::Full).unwrap(),
+            "\"full\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SnapshotContentMode::FilesystemOnly).unwrap(),
+            "\"filesystem_only\""
+        );
+    }
+
+    #[test]
+    fn create_snapshot_request_skips_none_content_mode() {
+        let body = CreateSnapshotRequest {
+            snapshot_content_mode: None,
+        };
+        assert_eq!(serde_json::to_string(&body).unwrap(), "{}");
+    }
+
+    #[test]
+    fn create_snapshot_request_serializes_filesystem_only() {
+        let body = CreateSnapshotRequest {
+            snapshot_content_mode: Some(SnapshotContentMode::FilesystemOnly),
+        };
+        assert_eq!(
+            serde_json::to_string(&body).unwrap(),
+            r#"{"snapshot_content_mode":"filesystem_only"}"#
+        );
+    }
 }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -23,7 +23,7 @@ use tensorlake_cloud_sdk::images::models::{
     ApplicationBuildContext, CreateApplicationBuildRequest,
 };
 use tensorlake_cloud_sdk::sandboxes::models::{
-    CreateSandboxRequest, SandboxPoolRequest, UpdateSandboxRequest,
+    CreateSandboxRequest, SandboxPoolRequest, SnapshotContentMode, UpdateSandboxRequest,
 };
 use tensorlake_cloud_sdk::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
@@ -634,11 +634,26 @@ impl CloudSandboxClient {
         })
     }
 
-    fn create_snapshot(&self, sandbox_id: String) -> PyResult<String> {
+    #[pyo3(signature = (sandbox_id, content_mode=None))]
+    fn create_snapshot(
+        &self,
+        sandbox_id: String,
+        content_mode: Option<String>,
+    ) -> PyResult<String> {
+        let parsed_mode = match content_mode.as_deref() {
+            None => None,
+            Some("full") => Some(SnapshotContentMode::Full),
+            Some("filesystem_only") => Some(SnapshotContentMode::FilesystemOnly),
+            Some(other) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "invalid snapshot content_mode '{other}': expected 'full' or 'filesystem_only'"
+                )));
+            }
+        };
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
             async move {
-                let response = client.snapshot(&sandbox_id).await?;
+                let response = client.snapshot(&sandbox_id, parsed_mode).await?;
                 Ok(serde_json::to_string(&response)?)
             }
         })

--- a/src/tensorlake/cli/create_sandbox_image.py
+++ b/src/tensorlake/cli/create_sandbox_image.py
@@ -13,7 +13,7 @@ import httpx
 
 from tensorlake.cli._common import Context
 from tensorlake.sandbox import Sandbox, SandboxClient
-from tensorlake.sandbox.models import ProcessStatus
+from tensorlake.sandbox.models import ProcessStatus, SnapshotContentMode
 
 _BUILD_SANDBOX_PIP_ENV = {"PIP_BREAK_SYSTEM_PACKAGES": "1"}
 _IGNORED_DOCKERFILE_INSTRUCTIONS = {
@@ -646,7 +646,10 @@ def create_sandbox_image(
         _execute_dockerfile_plan(sandbox, plan)
 
         _emit({"type": "status", "message": "Creating snapshot..."})
-        snapshot = sandbox_client.snapshot_and_wait(sandbox.sandbox_id)
+        snapshot = sandbox_client.snapshot_and_wait(
+            sandbox.sandbox_id,
+            content_mode=SnapshotContentMode.FILESYSTEM_ONLY,
+        )
         _emit(
             {
                 "type": "snapshot_created",

--- a/src/tensorlake/sandbox/__init__.py
+++ b/src/tensorlake/sandbox/__init__.py
@@ -33,6 +33,7 @@ from .models import (
     SandboxPortAccess,
     SandboxStatus,
     SendSignalResponse,
+    SnapshotContentMode,
     SnapshotInfo,
     SnapshotStatus,
     StdinMode,
@@ -59,6 +60,7 @@ __all__ = [
     "NetworkConfig",
     # Snapshot models
     "SnapshotStatus",
+    "SnapshotContentMode",
     "SnapshotInfo",
     "CreateSnapshotResponse",
     # Command result

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -30,6 +30,7 @@ from .models import (
     SandboxPoolRequest,
     SandboxPortAccess,
     SandboxStatus,
+    SnapshotContentMode,
     SnapshotInfo,
     SnapshotStatus,
     UpdateSandboxRequest,
@@ -529,14 +530,23 @@ class SandboxClient:
 
     # --- Snapshot operations ---
 
-    def snapshot(self, sandbox_id: str) -> CreateSnapshotResponse:
+    def snapshot(
+        self,
+        sandbox_id: str,
+        content_mode: SnapshotContentMode | None = None,
+    ) -> CreateSnapshotResponse:
         """Create a snapshot of a running sandbox's filesystem.
 
         This is an asynchronous operation. Poll with :meth:`get_snapshot`
         until the status is ``completed`` or ``failed``.
 
         Args:
-            sandbox_id: ID of the running sandbox to snapshot
+            sandbox_id: ID of the running sandbox to snapshot.
+            content_mode: Optional content mode for the snapshot. When
+                ``None`` (default) the server picks its default. Use
+                :attr:`SnapshotContentMode.FILESYSTEM_ONLY` for snapshots
+                that should be cold-booted by sandboxes restoring from
+                them (e.g. sandbox image builds).
 
         Returns:
             CreateSnapshotResponse with snapshot_id and status
@@ -547,7 +557,10 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            response_json = self._rust_client.create_snapshot(sandbox_id=sandbox_id)
+            response_json = self._rust_client.create_snapshot(
+                sandbox_id=sandbox_id,
+                content_mode=content_mode.value if content_mode is not None else None,
+            )
             return CreateSnapshotResponse.model_validate_json(response_json)
         except Exception as e:
             if _rust_status_code(e) == 404:
@@ -610,6 +623,7 @@ class SandboxClient:
         sandbox_id: str,
         timeout: float = 300,
         poll_interval: float = 1.0,
+        content_mode: SnapshotContentMode | None = None,
     ) -> SnapshotInfo:
         """Create a snapshot and wait for it to complete.
 
@@ -617,6 +631,8 @@ class SandboxClient:
             sandbox_id: ID of the running sandbox to snapshot
             timeout: Max seconds to wait for completion (default 300)
             poll_interval: Seconds between status polls (default 1)
+            content_mode: Optional content mode for the snapshot. See
+                :meth:`snapshot` for details.
 
         Returns:
             SnapshotInfo with completed snapshot details
@@ -624,7 +640,7 @@ class SandboxClient:
         Raises:
             SandboxError: If snapshot fails or times out
         """
-        result = self.snapshot(sandbox_id)
+        result = self.snapshot(sandbox_id, content_mode=content_mode)
         deadline = time.time() + timeout
         while time.time() < deadline:
             info = self.get_snapshot(result.snapshot_id)

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -48,6 +48,21 @@ class SnapshotStatus(str, Enum):
     FAILED = "failed"
 
 
+class SnapshotContentMode(str, Enum):
+    """Content mode for snapshot creation.
+
+    - ``FULL``: Full VM snapshot (memory + filesystem state). Sandboxes
+      restored from this snapshot warm-restore VM memory.
+    - ``FILESYSTEM_ONLY``: Filesystem-only snapshot. Sandboxes restored
+      from this snapshot cold-boot from the snapshot tarball instead of
+      warm-restoring VM state. Use this for sandbox image builds so that
+      the restored sandbox bypasses Firecracker's overlay-path constraints.
+    """
+
+    FULL = "full"
+    FILESYSTEM_ONLY = "filesystem_only"
+
+
 class ContainerResourcesInfo(BaseModel):
     """Container resource configuration."""
 

--- a/tests/cli/test_create_sandbox_image.py
+++ b/tests/cli/test_create_sandbox_image.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from tensorlake.cli import create_sandbox_image as create_sandbox_image_module
+from tensorlake.sandbox.models import SnapshotContentMode
 
 BUILD_CPUS = 2.0
 BUILD_MEMORY_MB = 4096
@@ -143,6 +144,14 @@ class TestCreateSandboxImage(unittest.TestCase):
             False,
         )
         sandbox.terminate.assert_called_once_with()
+        # Regression: sandbox image builds MUST request a filesystem-only
+        # snapshot so the resulting image cold-boots on restore (see PR
+        # #583 for the original regression that produced Full snapshots
+        # and broke `tl sbx new --image`).
+        sandbox_client.snapshot_and_wait.assert_called_once_with(
+            "sbx-1",
+            content_mode=SnapshotContentMode.FILESYSTEM_ONLY,
+        )
 
     def test_create_sandbox_image_public(self):
         ctx = MagicMock()
@@ -198,6 +207,10 @@ class TestCreateSandboxImage(unittest.TestCase):
             "snap-1",
             "s3://snapshots/snap-1.tar.zst",
             True,
+        )
+        sandbox_client.snapshot_and_wait.assert_called_once_with(
+            "sbx-1",
+            content_mode=SnapshotContentMode.FILESYSTEM_ONLY,
         )
 
 

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -2,7 +2,11 @@ import json
 import unittest
 from unittest.mock import patch
 
-from tensorlake.sandbox import PoolInUseError, SandboxNotFoundError
+from tensorlake.sandbox import (
+    PoolInUseError,
+    SandboxNotFoundError,
+    SnapshotContentMode,
+)
 from tensorlake.sandbox.client import SandboxClient
 from tensorlake.sandbox.exceptions import SandboxError
 
@@ -12,9 +16,21 @@ class _FakeRustClient:
         self.create_request_json = None
         self.update_request_json = None
         self.last_get_sandbox_id = None
+        self.create_snapshot_calls: list[tuple[str, str | None]] = []
 
     def close(self):
         return None
+
+    def create_snapshot(self, sandbox_id, content_mode=None):
+        self.create_snapshot_calls.append((sandbox_id, content_mode))
+        return '{"snapshot_id":"snap-1","status":"in_progress"}'
+
+    def get_snapshot_json(self, snapshot_id):
+        return (
+            '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
+            '"base_image":"python:3.12","status":"completed",'
+            '"snapshot_uri":"s3://snap-1.tar.zst"}'
+        )
 
     def create_sandbox(self, request_json):
         self.create_request_json = request_json
@@ -237,6 +253,33 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                 client.delete_pool("pool-1")
         finally:
             sandbox_client_module.RustCloudSandboxClientError = previous
+
+    def test_snapshot_threads_content_mode_to_rust_backend(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        info = client.snapshot_and_wait(
+            "sbx-1",
+            content_mode=SnapshotContentMode.FILESYSTEM_ONLY,
+        )
+
+        self.assertEqual(len(fake.create_snapshot_calls), 1)
+        sandbox_id, content_mode = fake.create_snapshot_calls[0]
+        self.assertEqual(sandbox_id, "sbx-1")
+        self.assertEqual(content_mode, "filesystem_only")
+        self.assertEqual(info.snapshot_id, "snap-1")
+
+    def test_snapshot_omits_content_mode_when_none(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        client.snapshot_and_wait("sbx-1")
+
+        self.assertEqual(len(fake.create_snapshot_calls), 1)
+        _, content_mode = fake.create_snapshot_calls[0]
+        self.assertIsNone(content_mode)
 
 
 if __name__ == "__main__":

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.4.41",
+  "version": "0.4.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.4.41",
+      "version": "0.4.42",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.20.0"
@@ -1224,6 +1224,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1530,6 +1531,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1584,6 +1586,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2304,6 +2307,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2353,6 +2357,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2790,6 +2795,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2828,6 +2834,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -15,6 +15,7 @@ import {
   SandboxStatus,
   type SnapshotAndWaitOptions,
   type SnapshotInfo,
+  type SnapshotOptions,
   SnapshotStatus,
   type UpdatePoolOptions,
   type UpdateSandboxOptions,
@@ -244,10 +245,19 @@ export class SandboxClient {
 
   // --- Snapshots ---
 
-  async snapshot(sandboxId: string): Promise<CreateSnapshotResponse> {
+  async snapshot(
+    sandboxId: string,
+    options?: SnapshotOptions,
+  ): Promise<CreateSnapshotResponse> {
+    // Preserve today's wire shape (no body) when contentMode is not set.
+    const requestOptions =
+      options?.contentMode != null
+        ? { body: { snapshot_content_mode: options.contentMode } }
+        : undefined;
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "POST",
       this.path(`sandboxes/${sandboxId}/snapshot`),
+      requestOptions,
     );
     return fromSnakeKeys(raw, "snapshotId") as CreateSnapshotResponse;
   }
@@ -284,7 +294,9 @@ export class SandboxClient {
     const timeout = options?.timeout ?? 300;
     const pollInterval = options?.pollInterval ?? 1;
 
-    const result = await this.snapshot(sandboxId);
+    const result = await this.snapshot(sandboxId, {
+      contentMode: options?.contentMode,
+    });
     const deadline = Date.now() + timeout * 1000;
 
     while (Date.now() < deadline) {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -38,6 +38,8 @@ export {
   ContainerState,
 } from "./models.js";
 
+export type { SnapshotContentMode, SnapshotOptions } from "./models.js";
+
 export type {
   BinaryPayload,
   CloudClientOptions,

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -15,6 +15,18 @@ export enum SnapshotStatus {
   FAILED = "failed",
 }
 
+/**
+ * Content mode for snapshot creation.
+ *
+ * - `"full"`: Full VM snapshot (memory + filesystem state). Sandboxes
+ *   restored from this snapshot warm-restore VM memory.
+ * - `"filesystem_only"`: Filesystem-only snapshot. Sandboxes restored from
+ *   this snapshot cold-boot from the snapshot tarball instead of warm-
+ *   restoring VM state. Use this for sandbox image builds so that the
+ *   restored sandbox bypasses Firecracker's overlay-path constraints.
+ */
+export type SnapshotContentMode = "full" | "filesystem_only";
+
 export enum ProcessStatus {
   RUNNING = "running",
   EXITED = "exited",
@@ -129,7 +141,16 @@ export interface SnapshotInfo {
   createdAt?: Date;
 }
 
-export interface SnapshotAndWaitOptions {
+export interface SnapshotOptions {
+  /**
+   * Optional content mode for the snapshot. When omitted the server picks
+   * its default. Use `"filesystem_only"` for snapshots intended for sandbox
+   * image builds so that restored sandboxes cold-boot.
+   */
+  contentMode?: SnapshotContentMode;
+}
+
+export interface SnapshotAndWaitOptions extends SnapshotOptions {
   timeout?: number;
   pollInterval?: number;
 }

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -4,6 +4,7 @@ import { parseArgs } from "node:util";
 import {
   type CommandResult,
   type ProcessInfo,
+  type SnapshotContentMode,
   type SnapshotInfo,
 } from "./models.js";
 import { type OutputResponse, ProcessStatus } from "./models.js";
@@ -96,7 +97,11 @@ interface BuildClient {
   }): Promise<BuildSandbox>;
   snapshotAndWait(
     sandboxId: string,
-    options?: { timeout?: number; pollInterval?: number },
+    options?: {
+      timeout?: number;
+      pollInterval?: number;
+      contentMode?: SnapshotContentMode;
+    },
   ): Promise<SnapshotInfo>;
   close(): void;
 }
@@ -989,7 +994,9 @@ export async function createSandboxImage(
     await executeDockerfilePlan(sandbox, plan, emit, sleep);
 
     emit({ type: "status", message: "Creating snapshot..." });
-    const snapshot = await client.snapshotAndWait(sandbox.sandboxId);
+    const snapshot = await client.snapshotAndWait(sandbox.sandboxId, {
+      contentMode: "filesystem_only",
+    });
     emit({
       type: "snapshot_created",
       snapshot_id: snapshot.snapshotId,

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -500,6 +500,45 @@ describe("SandboxClient", () => {
       client.close();
     });
 
+    it("omits request body when no snapshot options are provided", async () => {
+      // Pins down backwards compatibility: when contentMode is unset we
+      // must not change the wire shape for existing callers.
+      mockFetch((_url, init) => {
+        expect(init?.method).toBe("POST");
+        expect(init?.body).toBeUndefined();
+        return new Response(
+          JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
+          { status: 200 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost();
+      await client.snapshot("sbx-1");
+      client.close();
+    });
+
+    it("sends snapshot_content_mode in body when contentMode is provided", async () => {
+      // Regression: sandbox image builds MUST pass `filesystem_only` so
+      // that restored sandboxes cold-boot (see PR #583 for the original
+      // regression that broke `tl sbx new --image`).
+      mockFetch((_url, init) => {
+        expect(init?.method).toBe("POST");
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        expect(body.snapshot_content_mode).toBe("filesystem_only");
+        return new Response(
+          JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
+          { status: 200 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost();
+      const result = await client.snapshot("sbx-1", {
+        contentMode: "filesystem_only",
+      });
+      expect(result.snapshotId).toBe("snap-1");
+      client.close();
+    });
+
     it("gets snapshot info", async () => {
       mockFetch(() =>
         new Response(

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -206,7 +206,12 @@ describe("sandbox image helpers", () => {
       cpus: 2.0,
       memoryMb: 4096,
     });
-    expect(client.snapshotAndWait).toHaveBeenCalledWith("sbx-1");
+    // Regression: sandbox image builds MUST request a filesystem-only
+    // snapshot so restored sandboxes cold-boot (see PR #583).
+    expect(client.snapshotAndWait).toHaveBeenCalledWith(
+      "sbx-1",
+      expect.objectContaining({ contentMode: "filesystem_only" }),
+    );
     expect(registerImage).toHaveBeenCalledWith(
       expect.objectContaining({
         organizationId: "org_123",
@@ -289,6 +294,10 @@ describe("sandbox image helpers", () => {
       cpus: 2.0,
       memoryMb: 4096,
     });
+    expect(client.snapshotAndWait).toHaveBeenCalledWith(
+      "sbx-1",
+      expect.objectContaining({ contentMode: "filesystem_only" }),
+    );
     expect(writeFileMock).toHaveBeenCalledWith(
       "/workspace/hello.txt",
       expect.any(Uint8Array),
@@ -372,6 +381,10 @@ describe("sandbox image helpers", () => {
       cpus: 2.0,
       memoryMb: 4096,
     });
+    expect(client.snapshotAndWait).toHaveBeenCalledWith(
+      "sbx-1",
+      expect.objectContaining({ contentMode: "filesystem_only" }),
+    );
     expect(registerImage).toHaveBeenCalledWith(
       expect.anything(),
       "default-build",


### PR DESCRIPTION
## Summary
- Thread `content_mode` / `contentMode` through the Rust cloud SDK, PyO3 binding, Python SDK, and TypeScript SDK as an optional parameter on `snapshot()` / `snapshotAndWait()`.
- Pass `FILESYSTEM_ONLY` at the `create_sandbox_image` call site in both the Python (`src/tensorlake/cli/create_sandbox_image.py:649`) and TypeScript (`typescript/src/sandbox-image.ts:992`) flows.
- Add regression tests at two layers per SDK so the same omission cannot recur.

## Background
`tensorlake sbx image create` was producing **Full VM snapshots**. When launching a new sandbox with `tensorlake sbx new -i <name>`, Firecracker rejected the restore with:

```
Failed to restore from snapshot: drive rootfs requires 1 frozen overlay paths
when remapping restored host paths (StartupFailedInternalError)
```

The pre-#583 native-Rust `sbx image create` path called `create_snapshot(ctx, sandbox_id, 300.0, Some("filesystem_only"))`. #583 replaced that path with a Python shim (`tensorlake-create-sandbox-image` -> `src/tensorlake/cli/create_sandbox_image.py`) and a parallel TypeScript shim, but `content_mode` was never threaded through the SDK layers. Both shims silently fell back to Full snapshots, which then fail the Firecracker restore path.

Filesystem-only snapshots cold-boot from the snapshot tarball and bypass the Firecracker overlay-path constraints entirely — which is what we need for reusable sandbox images.

## Changes
### Rust cloud SDK (`crates/cloud-sdk/src/sandboxes/`)
- Added `SnapshotContentMode { Full, FilesystemOnly }` enum with serde snake_case serialization.
- Added `CreateSnapshotRequest` with `skip_serializing_if` so `None` produces `{}`.
- Updated `SandboxesClient::snapshot()` to accept `Option<SnapshotContentMode>` and send a body only when set — preserves today's "no body" wire shape for existing callers.
- Added an inline serde round-trip test.

### PyO3 binding (`crates/rust-cloud-sdk-py/src/lib.rs`)
- `create_snapshot()` accepts an optional `content_mode: Option<String>`, parses to the Rust enum, raises `PyValueError` on invalid strings.

### Python SDK (`src/tensorlake/sandbox/`)
- Added `SnapshotContentMode` str Enum and exported it from `sandbox/__init__.py`.
- `SandboxClient.snapshot()` and `snapshot_and_wait()` accept `content_mode` (kwarg, at end of signature — positional callers untouched).
- `src/tensorlake/cli/create_sandbox_image.py:649` now passes `content_mode=SnapshotContentMode.FILESYSTEM_ONLY`.

### TypeScript SDK (`typescript/src/`)
- Added `SnapshotContentMode` string literal union and new `SnapshotOptions` interface; `SnapshotAndWaitOptions` extends it.
- `SandboxClient.snapshot()` accepts `SnapshotOptions`; sends `{snapshot_content_mode: options.contentMode}` body only when set.
- `SandboxClient.snapshotAndWait()` forwards `contentMode` to `snapshot()`.
- `typescript/src/sandbox-image.ts:992` now passes `{ contentMode: "filesystem_only" }`.
- Widened the local `BuildClient` interface in `sandbox-image.ts` so dependency-injected fakes carry the new field.

## Regression tests
Coverage at two layers per SDK so no single-file oversight can re-introduce the bug:

| Layer | File | What it catches |
|---|---|---|
| Python CLI | `tests/cli/test_create_sandbox_image.py` | `snapshot_and_wait` is called with `FILESYSTEM_ONLY` from both the default and `--public` image builds |
| Python plumbing | `tests/sandbox/test_client_rust_backend.py` | `SandboxClient` threads `content_mode` through to the Rust binding; `None` stays `None` |
| TS CLI | `typescript/tests/sandbox-image.test.ts` | `snapshotAndWait` is called with `contentMode: "filesystem_only"` from all 3 `createSandboxImage` tests |
| TS wire | `typescript/tests/client.test.ts` | HTTP body contains `snapshot_content_mode` when set; body is undefined when unset (backwards compat) |
| Rust serde | `crates/cloud-sdk/src/sandboxes/models.rs` | Enum serializes to snake_case; `CreateSnapshotRequest { None }` serializes to `{}` |

Reverting the two call-site fixes and re-running Python Test A + TS Test C reproduces the expected "expected snapshot_and_wait to be called with content_mode=FILESYSTEM_ONLY" failure on both sides.


## Test plan
- [x] Regression-catch verification: stashed the two one-line call-site fixes → Python Test A and TS Test C both failed with the expected `expected snapshot_and_wait to be called with content_mode=FILESYSTEM_ONLY` diagnostic → `git stash pop` restored green state.
- [x] End-to-end on prod, Python path: `tensorlake sbx image create /tmp/image.Dockerfile -n devscripts-build` → `tensorlake sbx new -i devscripts-build` → sandbox running (pre-fix: `StartupFailedInternalError`).
- [x] End-to-end on prod, TS path: `node typescript/bin/tensorlake-create-sandbox-image.cjs /tmp/image.Dockerfile --name devscripts-build-ts` → `tensorlake sbx new -i devscripts-build-ts` → sandbox running.
- [x] Full-snapshot backwards compat, Python: create sandbox → `snapshot_and_wait()` (no content_mode) → restore from snapshot → marker file persists. Snapshot: `benfdjwrvc8sahsjqda75`.
- [x] Full-snapshot backwards compat, TS: same flow via Node SDK. Snapshot: `2p87zygfrmckxcaajke3a`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)