### PR TITLE
Bump release versions to 0.4.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cloud-sdk"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "bytes",
  "chrono",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.42"
+version = "0.4.43"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.4.41"
+version = "0.4.43"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.4.42"
+version = "0.4.43"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.4.42",
+      "version": "0.4.43",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.20.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bumps Python (`tensorlake`), TypeScript (`tensorlake` npm), Rust workspace, and PyO3 binding (`tensorlake-rust-cloud-sdk`) packages from `0.4.42` to `0.4.43`.
- Ships the filesystem_only snapshot fix from #624 in the next release so that `tensorlake sbx image create` + `tensorlake sbx new --image <name>` works end-to-end for both Python and TS SDK users.

## Files bumped
- `Cargo.toml` (workspace)
- `Cargo.lock`
- `pyproject.toml` (`tensorlake`)
- `crates/rust-cloud-sdk-py/pyproject.toml` (`tensorlake-rust-cloud-sdk`)
- `typescript/package.json` (`tensorlake` npm)
- `typescript/package-lock.json`

## Test plan
- [x] `make bump_version VERSION=0.4.43` updated the three Python/Rust source files
- [x] `typescript/package.json` bumped manually
- [x] `cargo check -p tensorlake-cloud-sdk` syncs `Cargo.lock` to 0.4.43
- [x] `npm install --package-lock-only` (in `typescript/`) syncs `package-lock.json` to 0.4.43
- [x] All source and lock file version fields verified at 0.4.43

🤖 Generated with [Claude Code](https://claude.com/claude-code)