### PR TITLE
Use tensorlake/ prefix for built-in sandbox image names

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Create a sandbox, run a command, and clean up:
 
 ```bash
 # Create a sandbox
-tensorlake sbx create --image ubuntu-minimal
+tensorlake sbx create --image tensorlake/tensorlake/ubuntu-minimal
 
 # Run a command inside it
 tensorlake sbx exec <sandbox-id> -- sh -lc "printf 'Hello from the sandbox!\n'"
@@ -69,7 +69,7 @@ tensorlake sbx ssh <sandbox-id>
 tensorlake sbx terminate <sandbox-id>
 ```
 
-`--image` expects a sandbox image name such as `ubuntu-minimal` or a registered Sandbox Image name, not an arbitrary Docker image reference.
+`--image` expects a sandbox image name such as `tensorlake/ubuntu-minimal` or a registered Sandbox Image name, not an arbitrary Docker image reference.
 
 ### Create a Sandbox Programmatically
 
@@ -79,7 +79,7 @@ from tensorlake.sandbox import SandboxClient
 client = SandboxClient.for_cloud(api_key="your-api-key")
 
 # Create a sandbox and connect to it
-with client.create_and_connect(image="ubuntu-minimal") as sandbox:
+with client.create_and_connect(image="tensorlake/ubuntu-minimal") as sandbox:
     # Run a command
     result = sandbox.run("sh", ["-lc", "printf 'Hello from the sandbox!\\n'"])
     print(result.stdout)  # "Hello from the sandbox!"
@@ -117,7 +117,7 @@ Pre-warm containers for fast startup:
 ```python
 # Create a pool with warm containers
 pool = client.create_pool(
-    image="ubuntu-minimal",
+    image="tensorlake/ubuntu-minimal",
     warm_containers=3,
 )
 
@@ -126,7 +126,7 @@ resp = client.claim(pool.pool_id)
 sandbox = client.connect(resp.sandbox_id)
 
 # Named sandboxes can be reconnected later by name
-named = client.create(image="ubuntu-minimal", name="stable-name")
+named = client.create(image="tensorlake/ubuntu-minimal", name="stable-name")
 sandbox = client.connect("stable-name")
 ```
 

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -269,9 +269,9 @@ mod tests {
 
     #[test]
     fn create_body_passes_image_name_through_to_server() {
-        let body = build_create_request_body(None, None, None, &[], None, Some("ubuntu-minimal"));
+        let body = build_create_request_body(None, None, None, &[], None, Some("tensorlake/ubuntu-minimal"));
 
-        assert_eq!(body["image"], "ubuntu-minimal");
+        assert_eq!(body["image"], "tensorlake/ubuntu-minimal");
         assert!(body.get("snapshot_id").is_none());
     }
 }

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -282,7 +282,7 @@ class SandboxClient:
 
         Args:
             image: Sandbox image name to boot from, such as
-                ``ubuntu-minimal`` or a registered Sandbox Image name.
+                ``tensorlake/ubuntu-minimal`` or a registered Sandbox Image name.
                 When omitted, Tensorlake uses the default managed environment.
             cpus: Number of CPUs to allocate
             memory_mb: Memory in megabytes
@@ -673,7 +673,7 @@ class SandboxClient:
 
         Args:
             image: Sandbox image name to boot from, such as
-                ``ubuntu-minimal`` or a registered Sandbox Image name.
+                ``tensorlake/ubuntu-minimal`` or a registered Sandbox Image name.
             cpus: Number of CPUs to allocate
             memory_mb: Memory in megabytes
             ephemeral_disk_mb: Ephemeral disk space in megabytes
@@ -767,7 +767,7 @@ class SandboxClient:
         Args:
             pool_id: ID of the pool to update
             image: Sandbox image name to boot from, such as
-                ``ubuntu-minimal`` or a registered Sandbox Image name.
+                ``tensorlake/ubuntu-minimal`` or a registered Sandbox Image name.
             cpus: Number of CPUs to allocate
             memory_mb: Memory in megabytes
             ephemeral_disk_mb: Ephemeral disk space in megabytes
@@ -898,7 +898,7 @@ class SandboxClient:
 
         Args:
             image: Sandbox image name to boot from, such as
-                ``ubuntu-minimal`` or a registered Sandbox Image name
+                ``tensorlake/ubuntu-minimal`` or a registered Sandbox Image name
                 (optional if using pool).
             cpus: Number of CPUs to allocate
             memory_mb: Memory in megabytes

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -65,7 +65,7 @@ export interface NetworkConfig {
 // --- Sandbox lifecycle ---
 
 export interface CreateSandboxOptions {
-  /** Optional sandbox image name, such as `ubuntu-minimal` or a registered Sandbox Image. When omitted, Tensorlake uses the default managed environment. */
+  /** Optional sandbox image name, such as `tensorlake/ubuntu-minimal` or a registered Sandbox Image. When omitted, Tensorlake uses the default managed environment. */
   image?: string;
   cpus?: number;
   memoryMb?: number;
@@ -158,7 +158,7 @@ export interface SnapshotAndWaitOptions extends SnapshotOptions {
 // --- Pools ---
 
 export interface CreatePoolOptions {
-  /** Sandbox image name, such as `ubuntu-minimal` or a registered Sandbox Image. */
+  /** Sandbox image name, such as `tensorlake/ubuntu-minimal` or a registered Sandbox Image. */
   image: string;
   cpus?: number;
   memoryMb?: number;
@@ -171,7 +171,7 @@ export interface CreatePoolOptions {
 }
 
 export interface UpdatePoolOptions {
-  /** Sandbox image name, such as `ubuntu-minimal` or a registered Sandbox Image. */
+  /** Sandbox image name, such as `tensorlake/ubuntu-minimal` or a registered Sandbox Image. */
   image: string;
   cpus?: number;
   memoryMb?: number;

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../src/index.js";
 import { Sandbox } from "../src/sandbox.js";
 
-const SANDBOX_IMAGE = "ubuntu-minimal";
+const SANDBOX_IMAGE = "tensorlake/ubuntu-minimal";
 const SANDBOX_CPUS = 1.0;
 const SANDBOX_MEMORY_MB = 1024;
 const SANDBOX_DISK_MB = 1024;

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -69,7 +69,7 @@ describe("sandbox image helpers", () => {
   it("renders a Dockerfile from the Image DSL", () => {
     const image = new Image({
       name: "data-tools",
-      baseImage: "ubuntu-systemd",
+      baseImage: "tensorlake/ubuntu-systemd",
     })
       .workdir("/workspace")
       .env("APP_ENV", "prod")
@@ -77,7 +77,7 @@ describe("sandbox image helpers", () => {
       .run("python3 -m pip install --break-system-packages -r /tmp/requirements.txt");
 
     expect(dockerfileContent(image)).toBe([
-      "FROM ubuntu-systemd",
+      "FROM tensorlake/ubuntu-systemd",
       "WORKDIR /workspace",
       'ENV APP_ENV="prod"',
       "COPY requirements.txt /tmp/requirements.txt",
@@ -99,7 +99,7 @@ describe("sandbox image helpers", () => {
   it("loadImagePlan derives build plan from the Image DSL", () => {
     const image = new Image({
       name: "data-tools",
-      baseImage: "ubuntu-systemd",
+      baseImage: "tensorlake/ubuntu-systemd",
     })
       .workdir("/workspace")
       .copy("requirements.txt", "/tmp/requirements.txt")
@@ -109,7 +109,7 @@ describe("sandbox image helpers", () => {
       contextDir: "/tmp/project",
     });
 
-    expect(plan.baseImage).toBe("ubuntu-systemd");
+    expect(plan.baseImage).toBe("tensorlake/ubuntu-systemd");
     expect(plan.registeredName).toBe("data-tools");
     expect(plan.contextDir).toBe("/tmp/project");
     expect(plan.instructions).toEqual([
@@ -241,7 +241,7 @@ describe("sandbox image helpers", () => {
 
     const image = new Image({
       name: "dsl-image",
-      baseImage: "ubuntu-systemd",
+      baseImage: "tensorlake/ubuntu-systemd",
     })
       .workdir("/workspace")
       .copy("hello.txt", "/workspace/hello.txt")
@@ -290,7 +290,7 @@ describe("sandbox image helpers", () => {
     );
 
     expect(client.createAndConnect).toHaveBeenCalledWith({
-      image: "ubuntu-systemd",
+      image: "tensorlake/ubuntu-systemd",
       cpus: 2.0,
       memoryMb: 4096,
     });
@@ -309,7 +309,7 @@ describe("sandbox image helpers", () => {
       }),
       "dsl-image",
       [
-        "FROM ubuntu-systemd",
+        "FROM tensorlake/ubuntu-systemd",
         "WORKDIR /workspace",
         "COPY hello.txt /workspace/hello.txt",
         "RUN cat /workspace/hello.txt",
@@ -412,7 +412,7 @@ describe("sandbox image helpers", () => {
     await mkdir(contextDir, { recursive: true });
     await writeFile(path.join(rootDir, "secret.txt"), "top-secret", "utf8");
 
-    const image = new Image({ name: "escape-build", baseImage: "ubuntu-systemd" })
+    const image = new Image({ name: "escape-build", baseImage: "tensorlake/ubuntu-systemd" })
       .copy("../secret.txt", "/workspace/secret.txt");
 
     const sandbox = {


### PR DESCRIPTION
ubuntu-minimal and ubuntu-systemd are now referenced as
tensorlake/ubuntu-minimal and tensorlake/ubuntu-systemd everywhere in
the SDK, CLI, and documentation. The tensorlake/ namespace is reserved
for platform-managed global images; bare names are user-defined images.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
