### PR TITLE
Add sandbox suspend and resume to the Python SDK

### DIFF
--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -113,6 +113,20 @@ impl SandboxesClient {
         Ok(())
     }
 
+    pub async fn suspend(&self, sandbox_id: &str) -> Result<(), SdkError> {
+        let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/suspend"));
+        let req = self.client.request(Method::POST, &uri).build()?;
+        let _resp = self.client.execute(req).await?;
+        Ok(())
+    }
+
+    pub async fn resume(&self, sandbox_id: &str) -> Result<(), SdkError> {
+        let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/resume"));
+        let req = self.client.request(Method::POST, &uri).build()?;
+        let _resp = self.client.execute(req).await?;
+        Ok(())
+    }
+
     pub async fn snapshot(
         &self,
         sandbox_id: &str,

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -634,6 +634,20 @@ impl CloudSandboxClient {
         })
     }
 
+    fn suspend_sandbox(&self, sandbox_id: String) -> PyResult<()> {
+        self.run_with_retry(5, move |client| {
+            let sandbox_id = sandbox_id.clone();
+            async move { client.suspend(&sandbox_id).await }
+        })
+    }
+
+    fn resume_sandbox(&self, sandbox_id: String) -> PyResult<()> {
+        self.run_with_retry(5, move |client| {
+            let sandbox_id = sandbox_id.clone();
+            async move { client.resume(&sandbox_id).await }
+        })
+    }
+
     #[pyo3(signature = (sandbox_id, content_mode=None))]
     fn create_snapshot(
         &self,

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -528,6 +528,52 @@ class SandboxClient:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
 
+    def suspend(self, sandbox_id: str) -> None:
+        """Suspend a named sandbox.
+
+        Only sandboxes created with a ``name`` can be suspended; ephemeral
+        sandboxes cannot. The call returns as soon as the server accepts
+        the request; poll :meth:`get` until
+        :attr:`SandboxStatus.SUSPENDED` if you need to wait for the
+        transition to complete.
+
+        Args:
+            sandbox_id: ID or name of the sandbox to suspend
+
+        Raises:
+            SandboxNotFoundError: If sandbox doesn't exist
+            RemoteAPIError: If the API request fails
+            SandboxConnectionError: If the server is unreachable
+        """
+        try:
+            self._rust_client.suspend_sandbox(sandbox_id=sandbox_id)
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise SandboxNotFoundError(sandbox_id) from None
+            _raise_as_sandbox_error(e)
+
+    def resume(self, sandbox_id: str) -> None:
+        """Resume a suspended sandbox.
+
+        The call returns as soon as the server accepts the request; poll
+        :meth:`get` until :attr:`SandboxStatus.RUNNING` if you need to
+        wait for the transition to complete.
+
+        Args:
+            sandbox_id: ID or name of the sandbox to resume
+
+        Raises:
+            SandboxNotFoundError: If sandbox doesn't exist
+            RemoteAPIError: If the API request fails
+            SandboxConnectionError: If the server is unreachable
+        """
+        try:
+            self._rust_client.resume_sandbox(sandbox_id=sandbox_id)
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise SandboxNotFoundError(sandbox_id) from None
+            _raise_as_sandbox_error(e)
+
     # --- Snapshot operations ---
 
     def snapshot(

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -17,9 +17,17 @@ class _FakeRustClient:
         self.update_request_json = None
         self.last_get_sandbox_id = None
         self.create_snapshot_calls: list[tuple[str, str | None]] = []
+        self.suspend_calls: list[str] = []
+        self.resume_calls: list[str] = []
 
     def close(self):
         return None
+
+    def suspend_sandbox(self, sandbox_id):
+        self.suspend_calls.append(sandbox_id)
+
+    def resume_sandbox(self, sandbox_id):
+        self.resume_calls.append(sandbox_id)
 
     def create_snapshot(self, sandbox_id, content_mode=None):
         self.create_snapshot_calls.append((sandbox_id, content_mode))
@@ -203,6 +211,78 @@ class TestSandboxClientRustBackend(unittest.TestCase):
 
         with self.assertRaisesRegex(SandboxError, "reserved for sandbox management"):
             client.expose_ports("sbx-1", [9501])
+
+    def test_suspend_calls_rust_backend(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        client.suspend("my-env")
+
+        self.assertEqual(fake.suspend_calls, ["my-env"])
+        self.assertEqual(fake.resume_calls, [])
+
+    def test_resume_calls_rust_backend(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        client.resume("my-env")
+
+        self.assertEqual(fake.resume_calls, ["my-env"])
+        self.assertEqual(fake.suspend_calls, [])
+
+    def test_suspend_maps_404_to_sandbox_not_found(self):
+        class FakeRustError(Exception):
+            pass
+
+        class _NotFoundRustClient:
+            def close(self):
+                return None
+
+            def suspend_sandbox(self, sandbox_id):
+                raise FakeRustError(
+                    ("remote_api", 404, f"sandbox {sandbox_id} not found")
+                )
+
+        import tensorlake.sandbox.client as sandbox_client_module
+
+        previous = sandbox_client_module.RustCloudSandboxClientError
+        try:
+            sandbox_client_module.RustCloudSandboxClientError = FakeRustError
+            client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+            client._rust_client = _NotFoundRustClient()
+
+            with self.assertRaises(SandboxNotFoundError):
+                client.suspend("missing")
+        finally:
+            sandbox_client_module.RustCloudSandboxClientError = previous
+
+    def test_resume_maps_404_to_sandbox_not_found(self):
+        class FakeRustError(Exception):
+            pass
+
+        class _NotFoundRustClient:
+            def close(self):
+                return None
+
+            def resume_sandbox(self, sandbox_id):
+                raise FakeRustError(
+                    ("remote_api", 404, f"sandbox {sandbox_id} not found")
+                )
+
+        import tensorlake.sandbox.client as sandbox_client_module
+
+        previous = sandbox_client_module.RustCloudSandboxClientError
+        try:
+            sandbox_client_module.RustCloudSandboxClientError = FakeRustError
+            client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+            client._rust_client = _NotFoundRustClient()
+
+            with self.assertRaises(SandboxNotFoundError):
+                client.resume("missing")
+        finally:
+            sandbox_client_module.RustCloudSandboxClientError = previous
 
     def test_get_maps_404_to_sandbox_not_found(self):
         class FakeRustError(Exception):


### PR DESCRIPTION
Brings the Python SandboxClient to parity with the TypeScript client, which has had `suspend`/`resume` since the named-sandbox work. Wires the POST `sandboxes/{id}/{suspend,resume}` endpoints through the Rust cloud-sdk, its pyo3 bindings, and the Python client, with 404 mapping to SandboxNotFoundError and unit coverage mirroring the existing delete/404 patterns.

Addressed #629 