### PR TITLE
Replace multi-round-trip sandbox exec with streaming POST

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,17 @@
 name: Tests
 
 on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to run the sandbox tests against"
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+          - prod
+
   push:
     branches:
       - 'main'
@@ -12,9 +23,6 @@ on:
 permissions:
   id-token: write
   contents: read
-
-env:
-  TENSORLAKE_API_URL: http://localhost:8900
 
 jobs:
   rust_tests:
@@ -194,8 +202,9 @@ jobs:
 
   test_sandbox:
     name: Sandbox integration tests
-    runs-on: ubuntu-latest-xlarge
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -221,116 +230,8 @@ jobs:
       - name: Build tensorlake
         run: make build
 
-      - name: Set up Docker
-        uses: docker/setup-docker-action@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          role-session-name: github-actions-sandbox-tests
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Install Indexify Dataplane
-        run: |
-          docker pull ${{ steps.login-ecr.outputs.registry }}/platform-dataplane:latest
-          container_id=$(docker create ${{ steps.login-ecr.outputs.registry }}/platform-dataplane:latest)
-          docker cp $container_id:/indexify/platform-dataplane /usr/local/bin/platform-dataplane
-          docker rm $container_id
-          chmod +x /usr/local/bin/platform-dataplane
-
-      - name: Start Background Indexify Server in Docker container
-        uses: JarvusInnovations/background-action@v1
-        with:
-          run: |
-            mkdir -p /tmp/indexify-server-storage/indexify_storage/blobs
-            docker run -i -a stdout -a stderr --rm \
-              --network host \
-              --user "$(id -u):$(id -g)" \
-              --name indexify-server \
-              -v /tmp/indexify-server-storage:/tmp/indexify-server-storage \
-              -w /tmp/indexify-server-storage \
-              ${{ steps.login-ecr.outputs.registry }}/indexify-server:latest  &
-          wait-on: |
-            tcp:localhost:8900
-          tail: true
-          wait-for: 30s
-          log-output: true
-          log-output-if: true
-
-      - name: Create Dataplane config
-        run: |
-          mkdir -p /tmp/dataplane
-          cat > /tmp/dataplane/config.yaml <<'YAML'
-          env: local
-          server_addr: "http://localhost:8901"
-          default_sandbox_image: "docker.io/library/alpine:latest"
-          sandbox_driver:
-            type: docker
-            snapshot_local_dir: "/tmp/dataplane/snapshots"
-          http_proxy:
-            port: 8902
-            listen_addr: "0.0.0.0"
-            advertise_address: "127.0.0.1:8902"
-          monitoring:
-            port: 8903
-          state_dir: "/tmp/dataplane/state"
-          YAML
-
-      - name: Start Background Indexify Dataplane
-        uses: JarvusInnovations/background-action@v1
-        with:
-          run: |
-            /usr/local/bin/platform-dataplane --config /tmp/dataplane/config.yaml &
-          wait-on: |
-            tcp:localhost:8902
-          tail: true
-          wait-for: 30s
-          log-output: true
-          log-output-if: true
-
-      - name: Wait for readiness
-        run: |
-          serverReady=false
-          counter=0
-          while [ "$serverReady" != true ]; do
-            output=$(curl --silent --fail http://localhost:8900/internal/executors | jq '. | length' 2>/dev/null)
-            if [[ $? -eq 0 && "$output" -ge 1 ]]; then
-                echo "Server ready with executors."
-                serverReady=true
-            else
-                echo 'Waiting for dataplane to join server...'
-                counter=$((counter+1))
-                if [ $counter -gt 6 ]; then
-                    echo "Timeout waiting for dataplane to join server."
-                    exit 1
-                fi
-                sleep 5
-            fi
-          done
-
       - name: Run Sandbox integration tests
+        run: make test_sandbox
         env:
-          TENSORLAKE_API_URL: http://127.0.0.1:8900
-        run: |
-          set -o pipefail
-          make test_sandbox 2>&1 | tee /tmp/sandbox-tests.log
-
-      - name: Dump logs on failure
-        if: failure()
-        run: |
-          echo "=== Docker containers at failure ==="
-          docker ps -a --format 'table {{.ID}}\t{{.Image}}\t{{.Status}}\t{{.Names}}'
-          echo ""
-          echo "=== Network connections to server ==="
-          ss -tnp 'sport = :8900 or dport = :8900' 2>/dev/null || netstat -tnp 2>/dev/null | grep 8900 || true
-          echo ""
-          echo "=== Sandbox test logs ==="
-          cat /tmp/sandbox-tests.log 2>/dev/null || echo "No test logs available"
-          echo ""
-          echo "=== dmesg OOM check ==="
-          sudo dmesg | grep -i "oom\|killed process" | tail -20 || true
+          TENSORLAKE_API_URL: ${{ secrets.TENSORLAKE_API_URL }}
+          TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -6,7 +6,7 @@ on:
       environment:
         description: "Environment to run the tests against"
         required: true
-        default: prod
+        default: dev
         type: choice
         options:
           - dev
@@ -57,7 +57,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'prod' }}
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ cython_debug/
 .envrc.secrets
 .vscode
 .tensorlake/
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cloud-sdk"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "bytes",
  "chrono",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.45"
+version = "0.4.46"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -120,8 +120,13 @@ async fn stream_run_events(resp: reqwest::Response) -> Result<i32> {
 }
 
 enum RunEvent {
-    Output { line: String, stream: Option<String> },
-    Exited { code: i32 },
+    Output {
+        line: String,
+        stream: Option<String>,
+    },
+    Exited {
+        code: i32,
+    },
     Other,
 }
 
@@ -184,7 +189,11 @@ mod tests {
 
     #[test]
     fn parse_run_event_skips_heartbeat_payloads() {
-        assert!(parse_run_event(r#"{"type":"heartbeat"}"#).unwrap().is_none());
+        assert!(
+            parse_run_event(r#"{"type":"heartbeat"}"#)
+                .unwrap()
+                .is_none()
+        );
         assert!(
             parse_run_event(r#"{"event":"keepalive"}"#)
                 .unwrap()

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -1,5 +1,3 @@
-use std::future::pending;
-
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::header::ACCEPT;
@@ -44,7 +42,7 @@ pub async fn run(
         .build()
         .map_err(|e| CliError::Other(anyhow::anyhow!("{}", e)))?;
 
-    // Start process
+    // Build request body
     let mut body = serde_json::json!({
         "command": command,
     });
@@ -57,9 +55,14 @@ pub async fn run(
     if let Some(wd) = workdir {
         body["working_dir"] = serde_json::Value::String(wd.to_string());
     }
+    if let Some(t) = timeout {
+        body["timeout"] = serde_json::json!(t);
+    }
 
+    // Single streaming POST: start process + stream output + get exit code
     let resp = client
-        .post(format!("{}/api/v1/processes", proxy_base))
+        .post(format!("{}/api/v1/processes/run", proxy_base))
+        .header(ACCEPT, "text/event-stream")
         .json(&body)
         .send()
         .await
@@ -69,181 +72,60 @@ pub async fn run(
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         return Err(CliError::Other(anyhow::anyhow!(
-            "failed to start process (HTTP {}): {}",
+            "failed to run process (HTTP {}): {}",
             status,
             body
         )));
     }
 
-    let proc_result: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
-    let pid = proc_result
-        .get("pid")
-        .map(|v| match v {
-            serde_json::Value::String(s) => s.clone(),
-            serde_json::Value::Number(n) => n.to_string(),
-            _ => v.to_string(),
-        })
-        .unwrap_or_default();
-
-    let exit_code = stream_and_wait(&client, &proxy_base, &pid, timeout).await?;
+    let exit_code = stream_run_events(resp).await?;
     if exit_code != 0 {
         return Err(CliError::ExitCode(exit_code));
     }
     Ok(())
 }
 
-async fn stream_and_wait(
-    client: &reqwest::Client,
-    proxy_base: &str,
-    pid: &str,
-    timeout: Option<f64>,
-) -> Result<i32> {
-    let follow_resp = client
-        .get(format!(
-            "{}/api/v1/processes/{}/output/follow",
-            proxy_base, pid
-        ))
-        .header(ACCEPT, "text/event-stream")
-        .send()
-        .await
-        .map_err(CliError::Http)?;
+/// Read a streaming `POST /api/v1/processes/run` SSE response, print output
+/// lines to stdout/stderr, and return the exit code from the final event.
+async fn stream_run_events(resp: reqwest::Response) -> Result<i32> {
+    let mut stream = Box::pin(resp.bytes_stream().eventsource());
+    let mut exit_code: Option<i32> = None;
 
-    if !follow_resp.status().is_success() {
-        let status = follow_resp.status();
-        let body = follow_resp.text().await.unwrap_or_default();
-        return Err(CliError::Other(anyhow::anyhow!(
-            "failed to stream process output (HTTP {}): {}",
-            status,
-            body
-        )));
-    }
-
-    let deadline =
-        timeout.map(|t| tokio::time::Instant::now() + std::time::Duration::from_secs_f64(t));
-    let mut stream = Box::pin(follow_resp.bytes_stream().eventsource());
-
-    loop {
-        let timeout_future = async {
-            if let Some(deadline) = deadline {
-                tokio::time::sleep_until(deadline).await;
-            } else {
-                pending::<()>().await;
-            }
-        };
-        tokio::pin!(timeout_future);
-
-        tokio::select! {
-            _ = &mut timeout_future => {
-                let _ = client
-                    .delete(format!("{}/api/v1/processes/{}", proxy_base, pid))
-                    .send()
-                    .await;
-                return Err(CliError::Other(anyhow::anyhow!(
-                    "Command timed out after {}s",
-                    timeout.unwrap_or(0.0)
-                )));
-            }
-            maybe_event = stream.next() => {
-                match maybe_event {
-                    Some(Ok(msg)) => {
-                        if let Some(event) = parse_output_event(&msg.data)? {
-                            print_output_event(&event);
+    while let Some(event) = stream.next().await {
+        match event {
+            Ok(msg) => {
+                if let Some(parsed) = parse_run_event(&msg.data)? {
+                    match parsed {
+                        RunEvent::Output { line, stream } => match stream.as_deref() {
+                            Some("stderr") => eprintln!("{}", line),
+                            _ => println!("{}", line),
+                        },
+                        RunEvent::Exited { code } => {
+                            exit_code = Some(code);
                         }
+                        RunEvent::Other => {}
                     }
-                    Some(Err(error)) => {
-                        return Err(CliError::Other(anyhow::anyhow!(
-                            "failed to stream process output: {}",
-                            error
-                        )));
-                    }
-                    None => break,
                 }
             }
+            Err(error) => {
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "failed to stream process output: {}",
+                    error
+                )));
+            }
         }
     }
 
-    let info = process_info(client, proxy_base, pid).await?;
-    let status = info.get("status").and_then(|v| v.as_str()).unwrap_or("");
-    if status == "running" {
-        return wait_for_exit_code(client, proxy_base, pid, deadline, timeout).await;
-    }
-
-    exit_code_from_info(&info)
+    Ok(exit_code.unwrap_or(1))
 }
 
-async fn wait_for_exit_code(
-    client: &reqwest::Client,
-    proxy_base: &str,
-    pid: &str,
-    deadline: Option<tokio::time::Instant>,
-    timeout: Option<f64>,
-) -> Result<i32> {
-    loop {
-        if let Some(deadline) = deadline
-            && tokio::time::Instant::now() > deadline
-        {
-            let _ = client
-                .delete(format!("{}/api/v1/processes/{}", proxy_base, pid))
-                .send()
-                .await;
-            return Err(CliError::Other(anyhow::anyhow!(
-                "Command timed out after {}s",
-                timeout.unwrap_or(0.0)
-            )));
-        }
-
-        let info = process_info(client, proxy_base, pid).await?;
-        let status = info.get("status").and_then(|v| v.as_str()).unwrap_or("");
-        if status != "running" {
-            return exit_code_from_info(&info);
-        }
-
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
+enum RunEvent {
+    Output { line: String, stream: Option<String> },
+    Exited { code: i32 },
+    Other,
 }
 
-async fn process_info(
-    client: &reqwest::Client,
-    proxy_base: &str,
-    pid: &str,
-) -> Result<serde_json::Value> {
-    let info_resp = client
-        .get(format!("{}/api/v1/processes/{}", proxy_base, pid))
-        .send()
-        .await
-        .map_err(CliError::Http)?;
-
-    if !info_resp.status().is_success() {
-        let status = info_resp.status();
-        let body = info_resp.text().await.unwrap_or_default();
-        return Err(CliError::Other(anyhow::anyhow!(
-            "failed to get process status (HTTP {}): {}",
-            status,
-            body
-        )));
-    }
-
-    info_resp.json().await.map_err(CliError::Http)
-}
-
-fn exit_code_from_info(info: &serde_json::Value) -> Result<i32> {
-    if let Some(code) = info.get("exit_code").and_then(|v| v.as_i64()) {
-        return Ok(code as i32);
-    }
-    if let Some(signal) = info.get("signal").and_then(|v| v.as_i64()) {
-        return Ok(128 + signal as i32);
-    }
-    Ok(1)
-}
-
-fn print_output_event(event: &StreamOutputEvent) {
-    match event.stream.as_deref() {
-        Some("stderr") => eprintln!("{}", event.line),
-        _ => println!("{}", event.line),
-    }
-}
-
-fn parse_output_event(data: &str) -> Result<Option<StreamOutputEvent>> {
+fn parse_run_event(data: &str) -> Result<Option<RunEvent>> {
     let trimmed = data.trim();
     if trimmed.is_empty() {
         return Ok(None);
@@ -254,19 +136,29 @@ fn parse_output_event(data: &str) -> Result<Option<StreamOutputEvent>> {
         return Ok(None);
     }
 
-    let Some(line) = value.get("line").and_then(|value| value.as_str()) else {
-        return Ok(None);
-    };
+    // Output line event
+    if let Some(line) = value.get("line").and_then(|v| v.as_str()) {
+        let stream = value
+            .get("stream")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        return Ok(Some(RunEvent::Output {
+            line: line.to_string(),
+            stream,
+        }));
+    }
 
-    let stream = value
-        .get("stream")
-        .and_then(|value| value.as_str())
-        .map(str::to_string);
+    // Exit event
+    if let Some(code) = value.get("exit_code").and_then(|v| v.as_i64()) {
+        return Ok(Some(RunEvent::Exited { code: code as i32 }));
+    }
+    if let Some(signal) = value.get("signal").and_then(|v| v.as_i64()) {
+        return Ok(Some(RunEvent::Exited {
+            code: 128 + signal as i32,
+        }));
+    }
 
-    Ok(Some(StreamOutputEvent {
-        line: line.to_string(),
-        stream,
-    }))
+    Ok(Some(RunEvent::Other))
 }
 
 fn should_skip_event(value: &serde_json::Value) -> bool {
@@ -280,52 +172,56 @@ fn should_skip_event(value: &serde_json::Value) -> bool {
         .any(|kind| matches!(kind, "heartbeat" | "keepalive"))
 }
 
-#[derive(Debug)]
-struct StreamOutputEvent {
-    line: String,
-    stream: Option<String>,
-}
-
 #[cfg(test)]
 mod tests {
-    use super::parse_output_event;
+    use super::parse_run_event;
 
     #[test]
-    fn parse_output_event_skips_empty_payloads() {
-        assert!(parse_output_event("").unwrap().is_none());
-        assert!(parse_output_event("   ").unwrap().is_none());
+    fn parse_run_event_skips_empty_payloads() {
+        assert!(parse_run_event("").unwrap().is_none());
+        assert!(parse_run_event("   ").unwrap().is_none());
     }
 
     #[test]
-    fn parse_output_event_skips_heartbeat_payloads() {
+    fn parse_run_event_skips_heartbeat_payloads() {
+        assert!(parse_run_event(r#"{"type":"heartbeat"}"#).unwrap().is_none());
         assert!(
-            parse_output_event(r#"{"type":"heartbeat"}"#)
-                .unwrap()
-                .is_none()
-        );
-        assert!(
-            parse_output_event(r#"{"event":"keepalive"}"#)
+            parse_run_event(r#"{"event":"keepalive"}"#)
                 .unwrap()
                 .is_none()
         );
     }
 
     #[test]
-    fn parse_output_event_skips_unknown_json_frames() {
-        assert!(
-            parse_output_event(r#"{"status":"done"}"#)
-                .unwrap()
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn parse_output_event_parses_output_lines() {
-        let event = parse_output_event(r#"{"line":"hello","stream":"stdout"}"#)
+    fn parse_run_event_parses_output_lines() {
+        let event = parse_run_event(r#"{"line":"hello","stream":"stdout"}"#)
             .unwrap()
             .unwrap();
 
-        assert_eq!(event.line, "hello");
-        assert_eq!(event.stream.as_deref(), Some("stdout"));
+        match event {
+            super::RunEvent::Output { line, stream } => {
+                assert_eq!(line, "hello");
+                assert_eq!(stream.as_deref(), Some("stdout"));
+            }
+            _ => panic!("expected Output"),
+        }
+    }
+
+    #[test]
+    fn parse_run_event_parses_exit_code() {
+        let event = parse_run_event(r#"{"exit_code":0}"#).unwrap().unwrap();
+        match event {
+            super::RunEvent::Exited { code } => assert_eq!(code, 0),
+            _ => panic!("expected Exited"),
+        }
+    }
+
+    #[test]
+    fn parse_run_event_parses_signal_as_exit_code() {
+        let event = parse_run_event(r#"{"signal":9}"#).unwrap().unwrap();
+        match event {
+            super::RunEvent::Exited { code } => assert_eq!(code, 128 + 9),
+            _ => panic!("expected Exited"),
+        }
     }
 }

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -15,8 +15,9 @@ use models::{
     CreateSandboxPoolResponse, CreateSandboxRequest, CreateSandboxResponse, CreateSnapshotRequest,
     CreateSnapshotResponse, DaemonInfo, HealthResponse, ListDirectoryResponse,
     ListProcessesResponse, ListSandboxPoolsResponse, ListSandboxesResponse, ListSnapshotsResponse,
-    OutputEvent, OutputResponse, ProcessInfo, SandboxInfo, SandboxPoolInfo, SandboxPoolRequest,
-    SendSignalResponse, SnapshotContentMode, SnapshotInfo, UpdateSandboxRequest,
+    OutputEvent, OutputResponse, ProcessInfo, RunProcessEvent, SandboxInfo, SandboxPoolInfo,
+    SandboxPoolRequest, SendSignalResponse, SnapshotContentMode, SnapshotInfo,
+    UpdateSandboxRequest,
 };
 
 /// A client for managing sandbox lifecycle, pool, and snapshot APIs.
@@ -345,6 +346,44 @@ impl SandboxProxyClient {
     pub async fn follow_output(&self, pid: i64) -> Result<Vec<OutputEvent>, SdkError> {
         self.follow_stream(&format!("/api/v1/processes/{pid}/output/follow"))
             .await
+    }
+
+    pub async fn run_process(&self, payload: &Value) -> Result<Vec<RunProcessEvent>, SdkError> {
+        let req = self
+            .request(Method::POST, "/api/v1/processes/run")
+            .header(ACCEPT, "text/event-stream")
+            .json(payload)
+            .build()?;
+        let response = self.client.execute_raw(req).await?;
+        let stream = response
+            .bytes_stream()
+            .eventsource()
+            .filter_map(move |event| async move {
+                match event {
+                    Ok(msg) => {
+                        // Single parse: try typed deserialization directly.
+                        // The Exited variant has all-optional fields so it acts
+                        // as a catch-all for unrecognised JSON (heartbeats, etc.).
+                        // Discard Exited{None, None} — a real exit always has at
+                        // least one of exit_code or signal.
+                        match serde_json::from_str::<RunProcessEvent>(&msg.data) {
+                            Ok(RunProcessEvent::Exited {
+                                exit_code: None,
+                                signal: None,
+                            }) => None,
+                            Ok(evt) => Some(Ok(evt)),
+                            Err(_) => None,
+                        }
+                    }
+                    Err(error) => Some(Err(SdkError::EventSourceError(error.to_string()))),
+                }
+            });
+        futures::pin_mut!(stream);
+        let mut events = Vec::new();
+        while let Some(event) = stream.next().await {
+            events.push(event?);
+        }
+        Ok(events)
     }
 
     async fn follow_stream(&self, path: &str) -> Result<Vec<OutputEvent>, SdkError> {

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -249,6 +249,26 @@ pub struct OutputEvent {
     pub stream: Option<String>,
 }
 
+/// Events returned by the streaming `POST /api/v1/processes/run` endpoint.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RunProcessEvent {
+    /// First event: process was created.
+    Started {
+        pid: i64,
+        started_at: serde_json::Value,
+    },
+    /// Intermediate events: output lines (stdout/stderr).
+    Output(OutputEvent),
+    /// Final event: process exited.
+    Exited {
+        #[serde(default)]
+        exit_code: Option<i64>,
+        #[serde(default)]
+        signal: Option<i64>,
+    },
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DaemonInfo {
     pub version: String,
@@ -300,6 +320,52 @@ mod tests {
             snapshot_content_mode: None,
         };
         assert_eq!(serde_json::to_string(&body).unwrap(), "{}");
+    }
+
+    #[test]
+    fn run_process_event_deserializes_started() {
+        let json = r#"{"pid": 42, "started_at": 1234567890.123}"#;
+        let event: RunProcessEvent = serde_json::from_str(json).unwrap();
+        assert!(matches!(event, RunProcessEvent::Started { pid: 42, .. }));
+    }
+
+    #[test]
+    fn run_process_event_deserializes_output() {
+        let json = r#"{"line": "hello", "timestamp": 1234567890.456, "stream": "stdout"}"#;
+        let event: RunProcessEvent = serde_json::from_str(json).unwrap();
+        match event {
+            RunProcessEvent::Output(evt) => {
+                assert_eq!(evt.line, "hello");
+                assert_eq!(evt.stream.as_deref(), Some("stdout"));
+            }
+            _ => panic!("expected Output variant"),
+        }
+    }
+
+    #[test]
+    fn run_process_event_deserializes_exited() {
+        let json = r#"{"exit_code": 0}"#;
+        let event: RunProcessEvent = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            event,
+            RunProcessEvent::Exited {
+                exit_code: Some(0),
+                signal: None,
+            }
+        ));
+    }
+
+    #[test]
+    fn run_process_event_deserializes_signaled() {
+        let json = r#"{"signal": 9}"#;
+        let event: RunProcessEvent = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            event,
+            RunProcessEvent::Exited {
+                exit_code: None,
+                signal: Some(9),
+            }
+        ));
     }
 
     #[test]

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.4.45"
+version = "0.4.46"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -979,6 +979,20 @@ impl CloudSandboxProxyClient {
         })
     }
 
+    fn run_process_json(&self, payload_json: String) -> PyResult<Vec<String>> {
+        let payload: Value = parse_json_payload(&payload_json)?;
+        self.run_with_retry(5, move |client| {
+            let payload = payload.clone();
+            async move {
+                let events = client.run_process(&payload).await?;
+                events
+                    .into_iter()
+                    .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
+                    .collect()
+            }
+        })
+    }
+
     fn health_json(&self) -> PyResult<String> {
         self.run_with_retry(5, move |client| async move {
             let response = client.health().await?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.4.45"
+version = "0.4.46"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -266,13 +266,15 @@ class Sandbox:
             CommandResult with exit_code, stdout, and stderr
         """
         payload = self._build_command_payload(
-            command, args, env, working_dir, timeout=timeout,
+            command,
+            args,
+            env,
+            working_dir,
+            timeout=timeout,
         )
 
         try:
-            events_json = self._rust_client.run_process_json(
-                json.dumps(payload)
-            )
+            events_json = self._rust_client.run_process_json(json.dumps(payload))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -326,7 +328,10 @@ class Sandbox:
             ProcessInfo with pid and status
         """
         payload = self._build_command_payload(
-            command, args, env, working_dir,
+            command,
+            args,
+            env,
+            working_dir,
             stdin_mode=stdin_mode if stdin_mode != StdinMode.CLOSED else None,
             stdout_mode=stdout_mode if stdout_mode != OutputMode.CAPTURE else None,
             stderr_mode=stderr_mode if stderr_mode != OutputMode.CAPTURE else None,

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import time
 from typing import TYPE_CHECKING, Iterator
 from urllib.parse import urlparse
 
@@ -25,7 +24,6 @@ from .models import (
     OutputMode,
     OutputResponse,
     ProcessInfo,
-    ProcessStatus,
     SandboxInfo,
     SendSignalResponse,
     StdinMode,
@@ -220,6 +218,27 @@ class Sandbox:
         if lifecycle_client is not None:
             lifecycle_client.delete(self._identifier)
 
+    @staticmethod
+    def _build_command_payload(
+        command: str,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        working_dir: str | None = None,
+        **extra: object,
+    ) -> dict:
+        """Build a process command payload dict with common fields."""
+        payload: dict = {"command": command}
+        if args is not None:
+            payload["args"] = args
+        if env is not None:
+            payload["env"] = env
+        if working_dir is not None:
+            payload["working_dir"] = working_dir
+        for key, value in extra.items():
+            if value is not None:
+                payload[key] = value
+        return payload
+
     # --- High-level convenience ---
 
     def run(
@@ -232,49 +251,52 @@ class Sandbox:
     ) -> CommandResult:
         """Run a command to completion and return its output.
 
+        Uses a single streaming ``POST /api/v1/processes/run`` request that
+        starts the process, streams output, and delivers the exit code — all
+        over one HTTP connection.
+
         Args:
             command: Command to execute
             args: Command arguments
             env: Environment variables
             working_dir: Working directory
-            timeout: Maximum seconds to wait (None = no limit)
+            timeout: Maximum seconds to wait (enforced server-side; None = no limit)
 
         Returns:
             CommandResult with exit_code, stdout, and stderr
         """
-        proc = self.start_process(
-            command=command,
-            args=args,
-            env=env,
-            working_dir=working_dir,
+        payload = self._build_command_payload(
+            command, args, env, working_dir, timeout=timeout,
         )
 
-        deadline = time.time() + timeout if timeout else None
-        while True:
-            info = self.get_process(proc.pid)
-            if info.status != ProcessStatus.RUNNING:
-                break
-            if deadline and time.time() > deadline:
-                self.kill_process(proc.pid)
-                raise SandboxError(f"Command timed out after {timeout}s")
-            # Poll at 100ms — fast enough for interactive commands while
-            # keeping overhead low for longer-running processes.
-            time.sleep(0.1)
+        try:
+            events_json = self._rust_client.run_process_json(
+                json.dumps(payload)
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
 
-        stdout_resp = self.get_stdout(proc.pid)
-        stderr_resp = self.get_stderr(proc.pid)
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+        exit_code = -1
 
-        if info.exit_code is not None:
-            exit_code = info.exit_code
-        elif info.signal is not None:
-            exit_code = -info.signal
-        else:
-            exit_code = -1
+        for event_json in events_json:
+            event = json.loads(event_json)
+            if "line" in event:
+                if event.get("stream") == "stderr":
+                    stderr_lines.append(event["line"])
+                else:
+                    stdout_lines.append(event["line"])
+            elif "exit_code" in event or "signal" in event:
+                if event.get("exit_code") is not None:
+                    exit_code = event["exit_code"]
+                elif event.get("signal") is not None:
+                    exit_code = -event["signal"]
 
         return CommandResult(
             exit_code=exit_code,
-            stdout="\n".join(stdout_resp.lines),
-            stderr="\n".join(stderr_resp.lines),
+            stdout="\n".join(stdout_lines),
+            stderr="\n".join(stderr_lines),
         )
 
     # --- Process management ---
@@ -303,19 +325,12 @@ class Sandbox:
         Returns:
             ProcessInfo with pid and status
         """
-        payload: dict = {"command": command}
-        if args is not None:
-            payload["args"] = args
-        if env is not None:
-            payload["env"] = env
-        if working_dir is not None:
-            payload["working_dir"] = working_dir
-        if stdin_mode != StdinMode.CLOSED:
-            payload["stdin_mode"] = stdin_mode
-        if stdout_mode != OutputMode.CAPTURE:
-            payload["stdout_mode"] = stdout_mode
-        if stderr_mode != OutputMode.CAPTURE:
-            payload["stderr_mode"] = stderr_mode
+        payload = self._build_command_payload(
+            command, args, env, working_dir,
+            stdin_mode=stdin_mode if stdin_mode != StdinMode.CLOSED else None,
+            stdout_mode=stdout_mode if stdout_mode != OutputMode.CAPTURE else None,
+            stderr_mode=stderr_mode if stderr_mode != OutputMode.CAPTURE else None,
+        )
 
         try:
             response_json = self._rust_client.start_process_json(json.dumps(payload))

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -230,11 +230,11 @@ class TestPoolLifecycle(BaseSandboxTest):
             pool_id=self.__class__.pool_id,
             image=_SANDBOX_IMAGE,
             cpus=_SANDBOX_CPUS,
-            memory_mb=768,
+            memory_mb=2048,
             ephemeral_disk_mb=_SANDBOX_DISK_MB,
             warm_containers=1,
         )
-        self.assertEqual(updated.resources.memory_mb, 768)
+        self.assertEqual(updated.resources.memory_mb, 2048)
         self.assertEqual(updated.warm_containers, 1)
 
     def test_5_delete_pool(self):

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -1,11 +1,11 @@
 """Integration tests for sandbox lifecycle management APIs.
 
-Requires a running Indexify server (localhost:8900/8901) and a running
-indexify-dataplane process.
+Runs against the Tensorlake cloud API (or the URL in TENSORLAKE_API_URL).
+Requires TENSORLAKE_API_KEY to be set.
 
 Usage:
-    export TENSORLAKE_API_URL=http://localhost:8900
-    poetry run python tests/sandbox/test_lifecycle.py
+    TENSORLAKE_API_KEY=... poetry run python tests/sandbox/test_lifecycle.py
+    TENSORLAKE_API_URL=https://api.tensorlake.ai TENSORLAKE_API_KEY=... poetry run python tests/sandbox/test_lifecycle.py
 """
 
 import os
@@ -22,9 +22,9 @@ from tensorlake.sandbox import (
     SandboxStatus,
 )
 
-_SANDBOX_IMAGE = "docker.io/library/alpine:latest"
-_SANDBOX_CPUS = 0.2
-_SANDBOX_MEMORY_MB = 512
+_SANDBOX_IMAGE = "tensorlake/ubuntu-minimal"
+_SANDBOX_CPUS = 1.0
+_SANDBOX_MEMORY_MB = 1024
 _SANDBOX_DISK_MB = 1024
 
 
@@ -105,7 +105,7 @@ class BaseSandboxTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        api_url = os.environ.get("TENSORLAKE_API_URL", "http://localhost:8900")
+        api_url = os.environ.get("TENSORLAKE_API_URL", "https://api.tensorlake.ai")
         cls.client = SandboxClient(api_url=api_url)
 
     @classmethod
@@ -870,7 +870,9 @@ class TestSandboxRun(BaseSandboxTest):
             entrypoint=["sleep", "300"],
         )
         cls.sandbox_id = resp.sandbox_id
-        _poll_sandbox_status(cls.client, cls.sandbox_id, SandboxStatus.RUNNING, timeout=60)
+        _poll_sandbox_status(
+            cls.client, cls.sandbox_id, SandboxStatus.RUNNING, timeout=60
+        )
         cls.sandbox = cls.client.connect(identifier=cls.sandbox_id)
 
     @classmethod
@@ -888,13 +890,19 @@ class TestSandboxRun(BaseSandboxTest):
     def test_captures_stdout(self):
         result = self.sandbox.run("echo", args=["hello world"])
         self.assertEqual(result.exit_code, 0, f"sandbox {self.sandbox_id}: exit_code")
-        self.assertIn("hello world", result.stdout, f"sandbox {self.sandbox_id}: stdout")
+        self.assertIn(
+            "hello world", result.stdout, f"sandbox {self.sandbox_id}: stdout"
+        )
 
     def test_captures_stderr(self):
         result = self.sandbox.run("sh", args=["-c", "echo error-output >&2"])
         self.assertEqual(result.exit_code, 0, f"sandbox {self.sandbox_id}: exit_code")
-        self.assertIn("error-output", result.stderr, f"sandbox {self.sandbox_id}: stderr")
-        self.assertEqual(result.stdout, "", f"sandbox {self.sandbox_id}: stdout should be empty")
+        self.assertIn(
+            "error-output", result.stderr, f"sandbox {self.sandbox_id}: stderr"
+        )
+        self.assertEqual(
+            result.stdout, "", f"sandbox {self.sandbox_id}: stdout should be empty"
+        )
 
     def test_nonzero_exit_code(self):
         result = self.sandbox.run("sh", args=["-c", "exit 42"])
@@ -922,7 +930,9 @@ class TestSandboxRun(BaseSandboxTest):
         result = self.sandbox.run("sh", args=["-c", "printf 'a\\nb\\nc\\n'"])
         self.assertEqual(result.exit_code, 0, f"sandbox {self.sandbox_id}: exit_code")
         lines = result.stdout.splitlines()
-        self.assertEqual(lines, ["a", "b", "c"], f"sandbox {self.sandbox_id}: stdout lines")
+        self.assertEqual(
+            lines, ["a", "b", "c"], f"sandbox {self.sandbox_id}: stdout lines"
+        )
 
     def test_stdout_and_stderr_independent(self):
         """Lines written to stdout and stderr must be routed to the correct field."""
@@ -933,7 +943,11 @@ class TestSandboxRun(BaseSandboxTest):
         self.assertIn("out-line", result.stdout, f"sandbox {self.sandbox_id}: stdout")
         self.assertIn("out-line2", result.stdout, f"sandbox {self.sandbox_id}: stdout")
         self.assertIn("err-line", result.stderr, f"sandbox {self.sandbox_id}: stderr")
-        self.assertNotIn("err-line", result.stdout, f"sandbox {self.sandbox_id}: stdout should not contain stderr")
+        self.assertNotIn(
+            "err-line",
+            result.stdout,
+            f"sandbox {self.sandbox_id}: stdout should not contain stderr",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -16,6 +16,7 @@ from tensorlake.sandbox import (
     PoolContainerInfo,
     PoolInUseError,
     PoolNotFoundError,
+    Sandbox,
     SandboxClient,
     SandboxNotFoundError,
     SandboxStatus,
@@ -844,6 +845,98 @@ class TestNamedSandboxIdentifier(BaseSandboxTest):
 
 
 # ---------------------------------------------------------------------------
+# TestSandboxRun
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxRun(BaseSandboxTest):
+    """Integration tests for Sandbox.run() — the streaming process execution endpoint.
+
+    A single Alpine sandbox is created for the whole class and shared across
+    all test methods.  Each test is independent (no ordering dependencies).
+    """
+
+    sandbox_id: str | None = None
+    sandbox: Sandbox | None = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        resp = cls.client.create(
+            image=_SANDBOX_IMAGE,
+            cpus=_SANDBOX_CPUS,
+            memory_mb=_SANDBOX_MEMORY_MB,
+            ephemeral_disk_mb=_SANDBOX_DISK_MB,
+            entrypoint=["sleep", "300"],
+        )
+        cls.sandbox_id = resp.sandbox_id
+        _poll_sandbox_status(cls.client, cls.sandbox_id, SandboxStatus.RUNNING, timeout=60)
+        cls.sandbox = cls.client.connect(identifier=cls.sandbox_id)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.sandbox is not None:
+            cls.sandbox.close()
+            cls.sandbox = None
+        if cls.sandbox_id:
+            try:
+                cls.client.delete(cls.sandbox_id)
+            except Exception:
+                pass
+        super().tearDownClass()
+
+    def test_captures_stdout(self):
+        result = self.sandbox.run("echo", args=["hello world"])
+        self.assertEqual(result.exit_code, 0, f"sandbox {self.sandbox_id}: exit_code")
+        self.assertIn("hello world", result.stdout, f"sandbox {self.sandbox_id}: stdout")
+
+    def test_captures_stderr(self):
+        result = self.sandbox.run("sh", args=["-c", "echo error-output >&2"])
+        self.assertEqual(result.exit_code, 0, f"sandbox {self.sandbox_id}: exit_code")
+        self.assertIn("error-output", result.stderr, f"sandbox {self.sandbox_id}: stderr")
+        self.assertEqual(result.stdout, "", f"sandbox {self.sandbox_id}: stdout should be empty")
+
+    def test_nonzero_exit_code(self):
+        result = self.sandbox.run("sh", args=["-c", "exit 42"])
+        self.assertEqual(result.exit_code, 42, f"sandbox {self.sandbox_id}: exit_code")
+
+    def test_env_vars(self):
+        result = self.sandbox.run(
+            "sh",
+            args=["-c", "echo $MY_VAR"],
+            env={"MY_VAR": "streaming-test-value"},
+        )
+        self.assertEqual(result.exit_code, 0, f"sandbox {self.sandbox_id}: exit_code")
+        self.assertIn(
+            "streaming-test-value",
+            result.stdout,
+            f"sandbox {self.sandbox_id}: stdout",
+        )
+
+    def test_working_directory(self):
+        result = self.sandbox.run("pwd", working_dir="/tmp")
+        self.assertEqual(result.exit_code, 0, f"sandbox {self.sandbox_id}: exit_code")
+        self.assertIn("/tmp", result.stdout, f"sandbox {self.sandbox_id}: stdout")
+
+    def test_multiline_output(self):
+        result = self.sandbox.run("sh", args=["-c", "printf 'a\\nb\\nc\\n'"])
+        self.assertEqual(result.exit_code, 0, f"sandbox {self.sandbox_id}: exit_code")
+        lines = result.stdout.splitlines()
+        self.assertEqual(lines, ["a", "b", "c"], f"sandbox {self.sandbox_id}: stdout lines")
+
+    def test_stdout_and_stderr_independent(self):
+        """Lines written to stdout and stderr must be routed to the correct field."""
+        result = self.sandbox.run(
+            "sh", args=["-c", "echo out-line; echo err-line >&2; echo out-line2"]
+        )
+        self.assertEqual(result.exit_code, 0, f"sandbox {self.sandbox_id}: exit_code")
+        self.assertIn("out-line", result.stdout, f"sandbox {self.sandbox_id}: stdout")
+        self.assertIn("out-line2", result.stdout, f"sandbox {self.sandbox_id}: stdout")
+        self.assertIn("err-line", result.stderr, f"sandbox {self.sandbox_id}: stderr")
+        self.assertNotIn("err-line", result.stdout, f"sandbox {self.sandbox_id}: stdout should not contain stderr")
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -862,6 +955,7 @@ if __name__ == "__main__":
         TestPoolDeletion,
         TestSandboxTimeout,
         TestNamedSandboxIdentifier,
+        TestSandboxRun,
     ]:
         suite.addTests(loader.loadTestsFromTestCase(cls))
     runner = unittest.TextTestRunner(verbosity=2 if "-v" in sys.argv else 1)

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -8,6 +8,7 @@ from tensorlake.sandbox.models import StdinMode
 class _FakeRustProxyClient:
     def __init__(self):
         self.start_payload_json = None
+        self.run_payload_json = None
 
     def close(self):
         return None
@@ -54,6 +55,15 @@ class _FakeRustProxyClient:
                     "stream": "stdout",
                 }
             )
+        ]
+
+    def run_process_json(self, payload_json):
+        self.run_payload_json = payload_json
+        return [
+            json.dumps({"line": "out1", "stream": "stdout", "timestamp": 1_700_000_001}),
+            json.dumps({"line": "err1", "stream": "stderr", "timestamp": 1_700_000_002}),
+            json.dumps({"line": "out2", "stream": "stdout", "timestamp": 1_700_000_003}),
+            json.dumps({"exit_code": 0}),
         ]
 
     def health_json(self):
@@ -113,6 +123,40 @@ class TestSandboxRustBackend(unittest.TestCase):
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].line, "hello")
         self.assertEqual(events[0].stream, "stdout")
+
+    def test_run_uses_streaming_endpoint(self):
+        sandbox = Sandbox(
+            sandbox_id="sbx-1", proxy_url="http://localhost:9443", api_key="k"
+        )
+        fake = _FakeRustProxyClient()
+        sandbox._rust_client = fake
+
+        result = sandbox.run("echo", args=["hello"])
+
+        # Verify the payload sent to the Rust client.
+        payload = json.loads(fake.run_payload_json)
+        self.assertEqual(payload["command"], "echo")
+        self.assertEqual(payload["args"], ["hello"])
+
+        # Verify stdout/stderr lines are collected from streaming events.
+        self.assertEqual(result.stdout, "out1\nout2")
+        self.assertEqual(result.stderr, "err1")
+        self.assertEqual(result.exit_code, 0)
+
+    def test_run_signal_maps_to_negative_exit_code(self):
+        sandbox = Sandbox(
+            sandbox_id="sbx-1", proxy_url="http://localhost:9443", api_key="k"
+        )
+
+        class _SignaledFakeClient(_FakeRustProxyClient):
+            def run_process_json(self, payload_json):
+                return [json.dumps({"signal": 9})]
+
+        sandbox._rust_client = _SignaledFakeClient()
+
+        result = sandbox.run("sleep", args=["100"])
+
+        self.assertEqual(result.exit_code, -9)
 
     def test_health_maps_connection_error(self):
         class FakeRustError(Exception):

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -60,9 +60,15 @@ class _FakeRustProxyClient:
     def run_process_json(self, payload_json):
         self.run_payload_json = payload_json
         return [
-            json.dumps({"line": "out1", "stream": "stdout", "timestamp": 1_700_000_001}),
-            json.dumps({"line": "err1", "stream": "stderr", "timestamp": 1_700_000_002}),
-            json.dumps({"line": "out2", "stream": "stdout", "timestamp": 1_700_000_003}),
+            json.dumps(
+                {"line": "out1", "stream": "stdout", "timestamp": 1_700_000_001}
+            ),
+            json.dumps(
+                {"line": "err1", "stream": "stderr", "timestamp": 1_700_000_002}
+            ),
+            json.dumps(
+                {"line": "out2", "stream": "stdout", "timestamp": 1_700_000_003}
+            ),
             json.dumps({"exit_code": 0}),
         ]
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.4.45",
+  "version": "0.4.46",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1,0 +1,2138 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.39
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.9)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.39)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4)':
+    dependencies:
+      eslint: 9.39.4
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.14.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@20.19.39':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.39
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.39))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.39)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  any-promise@1.3.0: {}
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  callsites@3.1.0: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  check-error@2.1.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@4.1.1: {}
+
+  concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  deep-is@0.1.4: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.39.4:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.1
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  joycon@3.1.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.11: {}
+
+  natural-compare@1.4.0: {}
+
+  object-assign@4.1.1: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.9):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.9
+
+  postcss@8.5.9:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  readdirp@4.1.2: {}
+
+  resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
+
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(postcss@8.5.9)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.9)
+      resolve-from: 5.0.0
+      rollup: 4.60.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.9
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  undici-types@6.21.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  vite-node@2.1.9(@types/node@20.19.39):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.39)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.39):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.9
+      rollup: 4.60.1
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@20.19.39):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.39))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.39)
+      vite-node: 2.1.9(@types/node@20.19.39)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
+
+  ws@8.20.0: {}
+
+  yocto-queue@0.1.0: {}

--- a/typescript/src/http.ts
+++ b/typescript/src/http.ts
@@ -118,16 +118,17 @@ export class HttpClient {
     return new Uint8Array(buffer);
   }
 
-  /** Make a request and return the raw Response (for SSE streaming). */
+  /** Make a request and return the response body as an SSE stream. */
   async requestStream(
     method: string,
     path: string,
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; json?: unknown },
   ): Promise<ReadableStream<Uint8Array>> {
     const response = await this.requestResponse(
       method,
       path,
       {
+        json: options?.json,
         headers: { Accept: "text/event-stream" },
         signal: options?.signal,
       },

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -4,7 +4,7 @@ import {
   Desktop,
 } from "./desktop.js";
 import * as defaults from "./defaults.js";
-import { RemoteAPIError, SandboxError } from "./errors.js";
+import { SandboxError } from "./errors.js";
 import { HttpClient } from "./http.js";
 import {
   type CommandResult,
@@ -352,24 +352,12 @@ export class Sandbox {
     if (options?.workingDir) body.working_dir = options.workingDir;
     if (options?.timeout != null) body.timeout = options.timeout;
 
-    try {
-      const sseStream = await this.http.requestStream(
-        "POST",
-        "/api/v1/processes/run",
-        { json: body },
-      );
-      return await this._collectRunStream(sseStream);
-    } catch (e) {
-      if (e instanceof RemoteAPIError && e.statusCode === 405) {
-        return this._runLegacy(command, options);
-      }
-      throw e;
-    }
-  }
+    const sseStream = await this.http.requestStream(
+      "POST",
+      "/api/v1/processes/run",
+      { json: body },
+    );
 
-  private async _collectRunStream(
-    sseStream: ReadableStream<Uint8Array>,
-  ): Promise<CommandResult> {
     const stdoutLines: string[] = [];
     const stderrLines: string[] = [];
     let exitCode = -1;
@@ -389,65 +377,6 @@ export class Sandbox {
         }
       }
     }
-
-    return {
-      exitCode,
-      stdout: stdoutLines.join("\n"),
-      stderr: stderrLines.join("\n"),
-    };
-  }
-
-  private async _runLegacy(
-    command: string,
-    options?: RunOptions,
-  ): Promise<CommandResult> {
-    const proc = await this.startProcess(command, {
-      args: options?.args,
-      env: options?.env,
-      workingDir: options?.workingDir,
-    });
-
-    const stdoutLines: string[] = [];
-    const stderrLines: string[] = [];
-
-    // Use AbortController so we can cancel the SSE stream on timeout.
-    const ac = new AbortController();
-    let timedOut = false;
-    const timeoutId =
-      options?.timeout != null
-        ? setTimeout(() => {
-            timedOut = true;
-            ac.abort();
-          }, options.timeout * 1000)
-        : null;
-
-    try {
-      for await (const event of this.followOutput(proc.pid, {
-        signal: ac.signal,
-      })) {
-        if (typeof event.line === "string") {
-          if (event.stream === "stderr") {
-            stderrLines.push(event.line);
-          } else {
-            stdoutLines.push(event.line);
-          }
-        }
-      }
-    } finally {
-      if (timeoutId != null) clearTimeout(timeoutId);
-    }
-
-    if (timedOut) {
-      await this.killProcess(proc.pid).catch(() => {});
-    }
-
-    const info = await this.getProcess(proc.pid);
-    const exitCode =
-      info.exitCode != null
-        ? info.exitCode
-        : info.signal != null
-          ? -info.signal
-          : -1;
 
     return {
       exitCode,

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -17,7 +17,6 @@ import {
   type OutputEvent,
   type OutputResponse,
   type ProcessInfo,
-  ProcessStatus,
   type PtySessionInfo,
   type RunOptions,
   type SandboxOptions,
@@ -340,44 +339,49 @@ export class Sandbox {
 
   // --- High-level convenience ---
 
+  /**
+   * Run a command to completion and return its output.
+   *
+   * Uses a single streaming `POST /api/v1/processes/run` request that starts
+   * the process, streams output, and delivers the exit code over one connection.
+   */
   async run(command: string, options?: RunOptions): Promise<CommandResult> {
-    const proc = await this.startProcess(command, {
-      args: options?.args,
-      env: options?.env,
-      workingDir: options?.workingDir,
-    });
+    const body: Record<string, unknown> = { command };
+    if (options?.args) body.args = options.args;
+    if (options?.env) body.env = options.env;
+    if (options?.workingDir) body.working_dir = options.workingDir;
+    if (options?.timeout != null) body.timeout = options.timeout;
 
-    const deadline = options?.timeout
-      ? Date.now() + options.timeout * 1000
-      : null;
+    const sseStream = await this.http.requestStream(
+      "POST",
+      "/api/v1/processes/run",
+      { json: body },
+    );
 
-    let info: ProcessInfo;
-    while (true) {
-      info = await this.getProcess(proc.pid);
-      if (info.status !== ProcessStatus.RUNNING) break;
-      if (deadline && Date.now() > deadline) {
-        await this.killProcess(proc.pid);
-        throw new SandboxError(`Command timed out after ${options!.timeout}s`);
+    const stdoutLines: string[] = [];
+    const stderrLines: string[] = [];
+    let exitCode = -1;
+
+    for await (const raw of parseSSEStream<Record<string, unknown>>(sseStream)) {
+      if (typeof raw.line === "string") {
+        if (raw.stream === "stderr") {
+          stderrLines.push(raw.line);
+        } else {
+          stdoutLines.push(raw.line);
+        }
+      } else if ("exit_code" in raw || "signal" in raw) {
+        if (typeof raw.exit_code === "number") {
+          exitCode = raw.exit_code;
+        } else if (typeof raw.signal === "number") {
+          exitCode = -raw.signal;
+        }
       }
-      await sleep(100);
-    }
-
-    const stdoutResp = await this.getStdout(proc.pid);
-    const stderrResp = await this.getStderr(proc.pid);
-
-    let exitCode: number;
-    if (info.exitCode != null) {
-      exitCode = info.exitCode;
-    } else if (info.signal != null) {
-      exitCode = -info.signal;
-    } else {
-      exitCode = -1;
     }
 
     return {
       exitCode,
-      stdout: stdoutResp.lines.join("\n"),
-      stderr: stderrResp.lines.join("\n"),
+      stdout: stdoutLines.join("\n"),
+      stderr: stderrLines.join("\n"),
     };
   }
 
@@ -681,8 +685,4 @@ export class Sandbox {
     );
     return fromSnakeKeys(raw) as DaemonInfo;
   }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -4,7 +4,7 @@ import {
   Desktop,
 } from "./desktop.js";
 import * as defaults from "./defaults.js";
-import { SandboxError } from "./errors.js";
+import { RemoteAPIError, SandboxError } from "./errors.js";
 import { HttpClient } from "./http.js";
 import {
   type CommandResult,
@@ -352,12 +352,24 @@ export class Sandbox {
     if (options?.workingDir) body.working_dir = options.workingDir;
     if (options?.timeout != null) body.timeout = options.timeout;
 
-    const sseStream = await this.http.requestStream(
-      "POST",
-      "/api/v1/processes/run",
-      { json: body },
-    );
+    try {
+      const sseStream = await this.http.requestStream(
+        "POST",
+        "/api/v1/processes/run",
+        { json: body },
+      );
+      return await this._collectRunStream(sseStream);
+    } catch (e) {
+      if (e instanceof RemoteAPIError && e.statusCode === 405) {
+        return this._runLegacy(command, options);
+      }
+      throw e;
+    }
+  }
 
+  private async _collectRunStream(
+    sseStream: ReadableStream<Uint8Array>,
+  ): Promise<CommandResult> {
     const stdoutLines: string[] = [];
     const stderrLines: string[] = [];
     let exitCode = -1;
@@ -377,6 +389,65 @@ export class Sandbox {
         }
       }
     }
+
+    return {
+      exitCode,
+      stdout: stdoutLines.join("\n"),
+      stderr: stderrLines.join("\n"),
+    };
+  }
+
+  private async _runLegacy(
+    command: string,
+    options?: RunOptions,
+  ): Promise<CommandResult> {
+    const proc = await this.startProcess(command, {
+      args: options?.args,
+      env: options?.env,
+      workingDir: options?.workingDir,
+    });
+
+    const stdoutLines: string[] = [];
+    const stderrLines: string[] = [];
+
+    // Use AbortController so we can cancel the SSE stream on timeout.
+    const ac = new AbortController();
+    let timedOut = false;
+    const timeoutId =
+      options?.timeout != null
+        ? setTimeout(() => {
+            timedOut = true;
+            ac.abort();
+          }, options.timeout * 1000)
+        : null;
+
+    try {
+      for await (const event of this.followOutput(proc.pid, {
+        signal: ac.signal,
+      })) {
+        if (typeof event.line === "string") {
+          if (event.stream === "stderr") {
+            stderrLines.push(event.line);
+          } else {
+            stdoutLines.push(event.line);
+          }
+        }
+      }
+    } finally {
+      if (timeoutId != null) clearTimeout(timeoutId);
+    }
+
+    if (timedOut) {
+      await this.killProcess(proc.pid).catch(() => {});
+    }
+
+    const info = await this.getProcess(proc.pid);
+    const exitCode =
+      info.exitCode != null
+        ? info.exitCode
+        : info.signal != null
+          ? -info.signal
+          : -1;
 
     return {
       exitCode,

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -145,28 +145,26 @@ describe(
         entrypoint: ["sleep", "300"],
       });
       expect(resp.sandboxId).toBeTruthy();
-      expect([
-        SandboxStatus.PENDING,
-        SandboxStatus.RUNNING,
-        SandboxStatus.TERMINATED,
-      ]).toContain(resp.status);
+      expect(
+        [SandboxStatus.PENDING, SandboxStatus.RUNNING, SandboxStatus.TERMINATED],
+        `sandbox ${resp.sandboxId}`,
+      ).toContain(resp.status);
       sandboxId = resp.sandboxId;
     });
 
     it("gets a sandbox", async () => {
       const info = await client.get(sandboxId);
-      expect(info.sandboxId).toBe(sandboxId);
-      expect([
-        SandboxStatus.PENDING,
-        SandboxStatus.RUNNING,
-        SandboxStatus.TERMINATED,
-      ]).toContain(info.status);
+      expect(info.sandboxId, `sandbox ${sandboxId}`).toBe(sandboxId);
+      expect(
+        [SandboxStatus.PENDING, SandboxStatus.RUNNING, SandboxStatus.TERMINATED],
+        `sandbox ${sandboxId}`,
+      ).toContain(info.status);
     });
 
     it("lists sandboxes", async () => {
       const list = await client.list();
       const ids = list.map((s) => s.sandboxId);
-      expect(ids).toContain(sandboxId);
+      expect(ids, `sandbox ${sandboxId} not found in list`).toContain(sandboxId);
     });
 
     it("transitions out of pending", async () => {
@@ -175,7 +173,10 @@ describe(
         sandboxId,
         [SandboxStatus.RUNNING, SandboxStatus.TERMINATED],
       );
-      expect([SandboxStatus.RUNNING, SandboxStatus.TERMINATED]).toContain(status);
+      expect(
+        [SandboxStatus.RUNNING, SandboxStatus.TERMINATED],
+        `sandbox ${sandboxId}`,
+      ).toContain(status);
     });
 
     it("deletes a sandbox", async () => {
@@ -189,7 +190,7 @@ describe(
         SandboxStatus.TERMINATED,
         30,
       );
-      expect(status).toBe(SandboxStatus.TERMINATED);
+      expect(status, `sandbox ${sandboxId}`).toBe(SandboxStatus.TERMINATED);
       sandboxId = undefined!;
     });
 
@@ -249,21 +250,21 @@ describe(
 
     it("runs a command and captures stdout", async () => {
       const result = await sandbox.run("echo", { args: ["hello world"] });
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("hello world");
+      expect(result.exitCode, `sandbox ${sandbox.sandboxId}: exitCode`).toBe(0);
+      expect(result.stdout, `sandbox ${sandbox.sandboxId}: stdout`).toContain("hello world");
     });
 
     it("captures stderr", async () => {
       const result = await sandbox.run("sh", {
         args: ["-c", "echo error >&2"],
       });
-      expect(result.exitCode).toBe(0);
-      expect(result.stderr).toContain("error");
+      expect(result.exitCode, `sandbox ${sandbox.sandboxId}: exitCode`).toBe(0);
+      expect(result.stderr, `sandbox ${sandbox.sandboxId}: stderr`).toContain("error");
     });
 
     it("returns non-zero exit code", async () => {
       const result = await sandbox.run("sh", { args: ["-c", "exit 42"] });
-      expect(result.exitCode).toBe(42);
+      expect(result.exitCode, `sandbox ${sandbox.sandboxId}`).toBe(42);
     });
 
     it("runs command with env vars", async () => {
@@ -271,14 +272,14 @@ describe(
         args: ["-c", "echo $MY_VAR"],
         env: { MY_VAR: "test-value" },
       });
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("test-value");
+      expect(result.exitCode, `sandbox ${sandbox.sandboxId}: exitCode`).toBe(0);
+      expect(result.stdout, `sandbox ${sandbox.sandboxId}: stdout`).toContain("test-value");
     });
 
     it("runs command with working directory", async () => {
       const result = await sandbox.run("pwd", { workingDir: "/tmp" });
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("/tmp");
+      expect(result.exitCode, `sandbox ${sandbox.sandboxId}: exitCode`).toBe(0);
+      expect(result.stdout, `sandbox ${sandbox.sandboxId}: stdout`).toContain("/tmp");
     });
 
     it("writes and reads a file", async () => {
@@ -287,7 +288,7 @@ describe(
 
       const data = await sandbox.readFile("/tmp/test-ts-sdk.txt");
       const text = new TextDecoder().decode(data);
-      expect(text).toBe("hello from typescript sdk");
+      expect(text, `sandbox ${sandbox.sandboxId}`).toBe("hello from typescript sdk");
     });
 
     it("lists a directory", async () => {
@@ -298,10 +299,10 @@ describe(
       );
 
       const listing = await sandbox.listDirectory("/tmp");
-      expect(listing.path).toBe("/tmp");
-      expect(listing.entries.length).toBeGreaterThan(0);
+      expect(listing.path, `sandbox ${sandbox.sandboxId}: path`).toBe("/tmp");
+      expect(listing.entries.length, `sandbox ${sandbox.sandboxId}: entries`).toBeGreaterThan(0);
       const names = listing.entries.map((e) => e.name);
-      expect(names).toContain("list-test.txt");
+      expect(names, `sandbox ${sandbox.sandboxId}: list-test.txt not found`).toContain("list-test.txt");
     });
 
     it("deletes a file", async () => {
@@ -314,35 +315,35 @@ describe(
       // Verify the file is gone by listing the directory
       const listing = await sandbox.listDirectory("/tmp");
       const names = listing.entries.map((e) => e.name);
-      expect(names).not.toContain("to-delete.txt");
+      expect(names, `sandbox ${sandbox.sandboxId}: to-delete.txt still present`).not.toContain("to-delete.txt");
     });
 
     it("starts and manages processes", async () => {
       const proc = await sandbox.startProcess("sleep", { args: ["10"] });
-      expect(proc.pid).toBeGreaterThan(0);
-      expect(proc.status).toBe("running");
+      expect(proc.pid, `sandbox ${sandbox.sandboxId}: pid`).toBeGreaterThan(0);
+      expect(proc.status, `sandbox ${sandbox.sandboxId}: status`).toBe("running");
 
       const processes = await sandbox.listProcesses();
       const pids = processes.map((p) => p.pid);
-      expect(pids).toContain(proc.pid);
+      expect(pids, `sandbox ${sandbox.sandboxId}: pid ${proc.pid} not in list`).toContain(proc.pid);
 
       await sandbox.killProcess(proc.pid);
 
       // Wait for process to exit
       await sleep(500);
       const info = await sandbox.getProcess(proc.pid);
-      expect(info.status).not.toBe("running");
+      expect(info.status, `sandbox ${sandbox.sandboxId}: process ${proc.pid} still running`).not.toBe("running");
     });
 
     it("checks health", async () => {
       const health = await sandbox.health();
-      expect(health.healthy).toBe(true);
+      expect(health.healthy, `sandbox ${sandbox.sandboxId}`).toBe(true);
     });
 
     it("gets daemon info", async () => {
       const info = await sandbox.info();
-      expect(info.version).toBeTruthy();
-      expect(info.uptimeSecs).toBeGreaterThanOrEqual(0);
+      expect(info.version, `sandbox ${sandbox.sandboxId}: version`).toBeTruthy();
+      expect(info.uptimeSecs, `sandbox ${sandbox.sandboxId}: uptimeSecs`).toBeGreaterThanOrEqual(0);
     });
   },
   { timeout: 180_000 },
@@ -465,13 +466,16 @@ describe(
     it("claims a sandbox from pool", async () => {
       const resp = await client.claim(poolId);
       expect(resp.sandboxId).toBeTruthy();
-      expect([SandboxStatus.PENDING, SandboxStatus.RUNNING]).toContain(resp.status);
+      expect(
+        [SandboxStatus.PENDING, SandboxStatus.RUNNING],
+        `sandbox ${resp.sandboxId}`,
+      ).toContain(resp.status);
       sandboxId = resp.sandboxId;
     });
 
     it("sandbox from pool reaches running", async () => {
       const status = await pollSandboxStatus(client, sandboxId, SandboxStatus.RUNNING);
-      expect(status).toBe(SandboxStatus.RUNNING);
+      expect(status, `sandbox ${sandboxId}`).toBe(SandboxStatus.RUNNING);
     });
 
     it("cannot delete pool with active sandbox", async () => {
@@ -549,15 +553,15 @@ describe(
       const claimed = (detail.containers ?? []).filter(
         (c) => c.id === warmContainerId,
       );
-      expect(claimed).toHaveLength(1);
-      expect(claimed[0].sandboxId).toBe(sandboxId);
+      expect(claimed, `sandbox ${sandboxId}: warm container not claimed`).toHaveLength(1);
+      expect(claimed[0].sandboxId, `sandbox ${sandboxId}`).toBe(sandboxId);
     });
 
     it("replacement warm container is created", async () => {
       const containers = await pollPoolContainers(client, poolId, 2);
       const warm = warmContainers(containers);
-      expect(warm.length).toBeGreaterThanOrEqual(1);
-      expect(warm[0].id).not.toBe(warmContainerId);
+      expect(warm.length, `sandbox ${sandboxId}: no replacement warm container`).toBeGreaterThanOrEqual(1);
+      expect(warm[0].id, `sandbox ${sandboxId}: replacement has same id`).not.toBe(warmContainerId);
     });
 
     it("deleting sandbox removes claimed container", async () => {
@@ -646,7 +650,7 @@ describe(
 
     it("sandbox reaches running", async () => {
       const status = await pollSandboxStatus(client, sandboxId, SandboxStatus.RUNNING);
-      expect(status).toBe(SandboxStatus.RUNNING);
+      expect(status, `sandbox ${sandboxId}`).toBe(SandboxStatus.RUNNING);
     });
 
     it("sandbox suspended after timeout", async () => {
@@ -661,14 +665,17 @@ describe(
         [SandboxStatus.TERMINATED, SandboxStatus.SUSPENDED],
         30,
       );
-      expect([SandboxStatus.TERMINATED, SandboxStatus.SUSPENDED]).toContain(status);
+      expect(
+        [SandboxStatus.TERMINATED, SandboxStatus.SUSPENDED],
+        `sandbox ${sandboxId}`,
+      ).toContain(status);
 
       const info = await client.get(sandboxId);
       if (status === SandboxStatus.TERMINATED) {
-        expect(info.outcome).toBe("Success(Timeout)");
+        expect(info.outcome, `sandbox ${sandboxId}`).toBe("Success(Timeout)");
         sandboxId = undefined!;
       } else {
-        expect(info.outcome).toBeUndefined();
+        expect(info.outcome, `sandbox ${sandboxId}`).toBeUndefined();
       }
     });
 

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -36,59 +36,24 @@ describe("Sandbox", () => {
   });
 
   describe("run", () => {
+    /** Build an SSE-formatted response body from an array of JSON events. */
+    function sseResponse(events: unknown[]): Response {
+      const body = events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("");
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }
+
     it("runs a command and returns result", async () => {
-      let callIndex = 0;
       mockFetch((url, init) => {
-        callIndex++;
-
-        // 1: start_process
-        if (url.endsWith("/api/v1/processes") && init?.method === "POST") {
-          return new Response(
-            JSON.stringify({
-              pid: 42,
-              status: "running",
-              command: "echo",
-              args: ["hello"],
-              stdin_writable: false,
-              started_at: 1700000000,
-            }),
-            { status: 200 },
-          );
+        if (url.includes("/api/v1/processes/run") && init?.method === "POST") {
+          return sseResponse([
+            { pid: 42, started_at: 1700000000 },
+            { line: "hello", timestamp: 1700000000.1, stream: "stdout" },
+            { exit_code: 0 },
+          ]);
         }
-
-        // 2: get_process (poll returns exited)
-        if (url.includes("/api/v1/processes/42") && init?.method === "GET" && !url.includes("stdout") && !url.includes("stderr")) {
-          return new Response(
-            JSON.stringify({
-              pid: 42,
-              status: "exited",
-              exit_code: 0,
-              command: "echo",
-              args: ["hello"],
-              stdin_writable: false,
-              started_at: 1700000000,
-              ended_at: 1700000001,
-            }),
-            { status: 200 },
-          );
-        }
-
-        // 3: get_stdout
-        if (url.includes("/stdout")) {
-          return new Response(
-            JSON.stringify({ pid: 42, lines: ["hello"], line_count: 1 }),
-            { status: 200 },
-          );
-        }
-
-        // 4: get_stderr
-        if (url.includes("/stderr")) {
-          return new Response(
-            JSON.stringify({ pid: 42, lines: [], line_count: 0 }),
-            { status: 200 },
-          );
-        }
-
         return new Response("", { status: 404 });
       });
 


### PR DESCRIPTION
## Summary

- Replace the multi-round-trip `Sandbox.run()` flow (start + poll + fetch stdout + fetch stderr = 4+N requests) with a single streaming `POST /api/v1/processes/run` that returns SSE events for output lines and exit code
- Updated across all client SDKs (Rust, Python, TypeScript) and CLI
- Extracted `_build_command_payload()` helper in Python to deduplicate payload construction between `run()` and `start_process()`
- Added `RunProcessEvent` enum to Rust SDK with `Started`, `Output`, and `Exited` variants
- Timeout is now passed server-side in the request body instead of enforced client-side

### Before vs After

| | Before | After |
|---|---|---|
| Python/TS SDK | 4+N HTTP requests (start + N polls + stdout + stderr) | 1 streaming POST |
| CLI | 2 HTTP requests (start + SSE follow) | 1 streaming POST |
| Latency to first output | ~100ms (poll interval) | ~0 (streaming) |
| Exit code latency | ~100ms after exit | Immediate (in stream) |

## Test plan

- [x] Rust SDK unit tests pass (31 tests including 4 new `RunProcessEvent` deser tests)
- [x] CLI unit tests pass (89 tests including 5 new `parse_run_event` tests)
- [x] TypeScript tests pass (113 tests, mock updated for SSE stream)
- [x] PyO3 crate compiles clean
- [x] Python syntax verified
- [x] No compiler warnings
- [x] Integration test with sandbox daemon supporting the new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)