### PR TITLE
Fix ssh panic when sandbox suspends after timeout

### DIFF
--- a/crates/cli/src/commands/sbx/ssh.rs
+++ b/crates/cli/src/commands/sbx/ssh.rs
@@ -335,7 +335,7 @@ pub async fn run(
         // If the reader hasn't finished yet, give it a short grace period to
         // receive a server-side exit signal or close frame. Abort afterwards so
         // local disconnects do not hang indefinitely on a broken close handshake.
-        if server_exit_code.is_none() {
+        if server_exit_code.is_none() && !terminated_by_remote {
             let (exit_code, reader_completed) = wait_for_reader_shutdown(&mut reader_handle).await?;
             server_exit_code = exit_code;
             terminated_by_remote = terminated_by_remote || reader_completed;


### PR DESCRIPTION
## Summary

- Fix `JoinHandle polled after completion` panic in `tl sbx ssh` when a sandbox is suspended after timeout
- The reader task's `JoinHandle` was polled twice: once in the `select!` loop when the WebSocket drops, then again in `wait_for_reader_shutdown` because `server_exit_code` was `None` (disconnect without exit code)
- Added `!terminated_by_remote` guard so `wait_for_reader_shutdown` is only called when the reader hasn't already been joined

## Test plan

- [x] Existing SSH unit tests pass (5/5)
- [ ] Manual: `tl sbx ssh <id>`, then suspend the sandbox from another terminal — should exit cleanly instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)