### PR TITLE
Improve desktop session resilience and screenshot recovery in the TypeScript SDK

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.4.44",
+      "version": "0.4.45",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.20.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.4.44",
+  "version": "0.4.45",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/desktop.ts
+++ b/typescript/src/desktop.ts
@@ -82,6 +82,11 @@ export class DesktopSession<T extends DesktopTransport> {
   private pointerX = 0;
   private pointerY = 0;
   private buttonMask = 0;
+  private framebufferVersion = 0;
+  private closed = false;
+  private updateLoopError: Error | null = null;
+  private readonly updateSignal = createDeferredSignal();
+  private updateLoopPromise: Promise<void> | null = null;
 
   constructor(options: {
     transport: T;
@@ -120,56 +125,49 @@ export class DesktopSession<T extends DesktopTransport> {
     await sendSetPixelFormat(transport, pixelFormat);
     await sendSetEncodings(transport, [ENCODING_RAW, ENCODING_DESKTOP_SIZE]);
 
-    return new DesktopSession({
+    const session = new DesktopSession({
       transport,
       width: init.width,
       height: init.height,
       pixelFormat,
       framebuffer: allocateFramebuffer(init.width, init.height),
     });
+    session.startFramebufferUpdates();
+    return session;
   }
 
   async close(): Promise<void> {
+    this.closed = true;
+    this.updateSignal.resolve();
     await this.transport.close();
+    await this.updateLoopPromise;
   }
 
   async screenshot(timeoutSeconds = 5): Promise<Uint8Array> {
-    const timeoutMs = secondsToMillis(timeoutSeconds);
-    const deadline = Date.now() + timeoutMs;
-    let needsRefresh = true;
+    await this.waitForFramebufferVersion(
+      1,
+      timeoutSeconds,
+      `timed out waiting for initial desktop framebuffer after ${timeoutSeconds.toFixed(2)}s`,
+    );
+    return encodePng(this.width, this.height, this.framebuffer);
+  }
 
-    while (Date.now() < deadline) {
-      if (needsRefresh) {
-        await sendFramebufferUpdateRequest(
-          this.transport,
-          false,
-          0,
-          0,
-          this.width,
-          this.height,
-        );
-        needsRefresh = false;
-      }
+  getFrameVersion(): number {
+    return this.framebufferVersion;
+  }
 
-      const remainingMs = Math.max(0, deadline - Date.now());
-      const outcome = await withTimeout(
-        remainingMs,
-        () => this.readServerMessage(),
-        `timed out waiting for desktop screenshot after ${timeoutSeconds.toFixed(2)}s`,
+  async screenshotAfter(frameVersion: number, timeoutSeconds = 1): Promise<Uint8Array> {
+    const minimumVersion = validateNonNegativeInteger(frameVersion, "frame version") + 1;
+
+    if (this.framebufferVersion < minimumVersion) {
+      await this.waitForFramebufferVersion(
+        minimumVersion,
+        timeoutSeconds,
+        `timed out waiting for a fresher desktop framebuffer after ${timeoutSeconds.toFixed(2)}s`,
       );
-
-      if (outcome.kind === "framebufferUpdate") {
-        if (outcome.sawResize && !outcome.sawRaw) {
-          needsRefresh = true;
-          continue;
-        }
-        return encodePng(this.width, this.height, this.framebuffer);
-      }
     }
 
-    throw new SandboxError(
-      `timed out waiting for desktop screenshot after ${timeoutSeconds.toFixed(2)}s`,
-    );
+    return encodePng(this.width, this.height, this.framebuffer);
   }
 
   async moveMouse(x: number, y: number): Promise<void> {
@@ -316,6 +314,92 @@ export class DesktopSession<T extends DesktopTransport> {
     }
   }
 
+  private startFramebufferUpdates(): void {
+    if (this.updateLoopPromise) {
+      return;
+    }
+
+    this.updateLoopPromise = this.runFramebufferUpdateLoop().catch((error: unknown) => {
+      if (this.closed) {
+        return;
+      }
+      this.updateLoopError = normalizeError(error);
+      this.updateSignal.resolve();
+    });
+  }
+
+  private async runFramebufferUpdateLoop(): Promise<void> {
+    let incremental = false;
+
+    while (!this.closed) {
+      await sendFramebufferUpdateRequest(
+        this.transport,
+        incremental,
+        0,
+        0,
+        this.width,
+        this.height,
+      );
+
+      const outcome = await this.readUntilFramebufferUpdate();
+      if (outcome.sawResize && !outcome.sawRaw) {
+        incremental = false;
+        continue;
+      }
+
+      if (outcome.sawRaw) {
+        this.framebufferVersion += 1;
+        this.updateSignal.resolve();
+      }
+
+      incremental = true;
+    }
+  }
+
+  private async readUntilFramebufferUpdate(): Promise<FramebufferUpdateOutcome> {
+    while (true) {
+      const outcome = await this.readServerMessage();
+      if (outcome.kind === "framebufferUpdate") {
+        return outcome;
+      }
+    }
+  }
+
+  private async waitForFramebufferVersion(
+    minimumVersion: number,
+    timeoutSeconds: number,
+    timeoutMessage: string,
+  ): Promise<void> {
+    const timeoutMs = secondsToMillis(timeoutSeconds);
+    const deadline = Date.now() + timeoutMs;
+
+    while (this.framebufferVersion < minimumVersion) {
+      if (this.updateLoopError) {
+        throw this.updateLoopError;
+      }
+      if (this.closed) {
+        throw new SandboxError("desktop session is closed");
+      }
+
+      const observedVersion = this.framebufferVersion;
+      const waitForUpdate = this.updateSignal.wait();
+      if (this.framebufferVersion !== observedVersion) {
+        continue;
+      }
+
+      const remainingMs = Math.max(0, deadline - Date.now());
+      if (remainingMs === 0) {
+        break;
+      }
+
+      await withTimeout(remainingMs, () => waitForUpdate, timeoutMessage);
+    }
+
+    if (this.framebufferVersion < minimumVersion) {
+      throw new SandboxError(timeoutMessage);
+    }
+  }
+
   private async readServerMessage(): Promise<ServerMessageOutcome> {
     const messageType = await readU8(this.transport);
     if (messageType === 0) {
@@ -419,40 +503,32 @@ export class DesktopSession<T extends DesktopTransport> {
 }
 
 export class Desktop {
-  private readonly session: DesktopSession<TunnelByteStream>;
+  private session: DesktopSession<TunnelByteStream>;
+  private readonly connectRequest: DesktopConnectRequest & {
+    port: number;
+    shared: boolean;
+    connectTimeout: number;
+  };
   private operationChain: Promise<void> = Promise.resolve();
+  private reconnectPromise: Promise<void> | null = null;
+  private closed = false;
 
-  private constructor(session: DesktopSession<TunnelByteStream>) {
+  private constructor(
+    session: DesktopSession<TunnelByteStream>,
+    connectRequest: DesktopConnectRequest & {
+      port: number;
+      shared: boolean;
+      connectTimeout: number;
+    },
+  ) {
     this.session = session;
+    this.connectRequest = connectRequest;
   }
 
   static async connect(options: DesktopConnectRequest): Promise<Desktop> {
-    const port = validatePort(options.port ?? 5901, "desktop port");
-    const shared = options.shared ?? true;
-    const connectTimeout = options.connectTimeout ?? 10;
-    const connectTimeoutMs = secondsToMillis(connectTimeout);
-    const state: { transport?: TunnelByteStream } = {};
-    try {
-      const session = await withTimeout(
-        connectTimeoutMs,
-        async () => {
-          state.transport = await TunnelByteStream.connect({
-            baseUrl: options.baseUrl,
-            wsHeaders: options.wsHeaders,
-            remotePort: port,
-            connectTimeoutMs,
-          });
-          return DesktopSession.connect(state.transport, options.password, shared);
-        },
-        `timed out while connecting desktop session after ${connectTimeout.toFixed(2)}s`,
-      );
-      return new Desktop(session);
-    } catch (error) {
-      if (state.transport) {
-        await state.transport.close().catch(() => {});
-      }
-      throw error;
-    }
+    const connectRequest = normalizeDesktopConnectRequest(options);
+    const session = await openDesktopSession(connectRequest);
+    return new Desktop(session, connectRequest);
   }
 
   get width(): number {
@@ -464,11 +540,20 @@ export class Desktop {
   }
 
   async close(): Promise<void> {
+    this.closed = true;
     await this.enqueue(() => this.session.close());
   }
 
   async screenshot(timeout = 5): Promise<Uint8Array> {
-    return this.enqueue(() => this.session.screenshot(timeout));
+    return this.enqueue(() => this.captureScreenshot(timeout));
+  }
+
+  getFrameVersion(): number {
+    return this.session.getFrameVersion();
+  }
+
+  async screenshotAfter(frameVersion: number, timeout = 1): Promise<Uint8Array> {
+    return this.enqueue(() => this.captureScreenshotAfter(frameVersion, timeout));
   }
 
   async moveMouse(x: number, y: number): Promise<void> {
@@ -538,6 +623,52 @@ export class Desktop {
       () => undefined,
     );
     return run;
+  }
+
+  private async captureScreenshot(timeout: number): Promise<Uint8Array> {
+    try {
+      return await this.session.screenshot(timeout);
+    } catch (error) {
+      if (!isReconnectableDesktopScreenshotError(error) || this.closed) {
+        throw error;
+      }
+
+      await this.reconnect();
+      return this.session.screenshot(timeout);
+    }
+  }
+
+  private async captureScreenshotAfter(
+    frameVersion: number,
+    timeout: number,
+  ): Promise<Uint8Array> {
+    try {
+      return await this.session.screenshotAfter(frameVersion, timeout);
+    } catch (error) {
+      if (!isReconnectableDesktopScreenshotError(error) || this.closed) {
+        throw error;
+      }
+
+      await this.reconnect();
+      return this.session.screenshot(timeout);
+    }
+  }
+
+  private async reconnect(): Promise<void> {
+    if (this.reconnectPromise) {
+      return this.reconnectPromise;
+    }
+
+    this.reconnectPromise = this.performReconnect().finally(() => {
+      this.reconnectPromise = null;
+    });
+    return this.reconnectPromise;
+  }
+
+  private async performReconnect(): Promise<void> {
+    const previousSession = this.session;
+    await previousSession.close().catch(() => {});
+    this.session = await openDesktopSession(this.connectRequest);
   }
 }
 
@@ -916,6 +1047,101 @@ function allocateFramebuffer(width: number, height: number): Uint8Array {
   return new Uint8Array(width * height * 4);
 }
 
+function normalizeDesktopConnectRequest(
+  options: DesktopConnectRequest,
+): DesktopConnectRequest & {
+  port: number;
+  shared: boolean;
+  connectTimeout: number;
+} {
+  return {
+    ...options,
+    port: validatePort(options.port ?? 5901, "desktop port"),
+    shared: options.shared ?? true,
+    connectTimeout: options.connectTimeout ?? 10,
+  };
+}
+
+async function openDesktopSession(
+  options: DesktopConnectRequest & {
+    port: number;
+    shared: boolean;
+    connectTimeout: number;
+  },
+): Promise<DesktopSession<TunnelByteStream>> {
+  const connectTimeoutMs = secondsToMillis(options.connectTimeout);
+  const state: { transport?: TunnelByteStream } = {};
+
+  try {
+    return await withTimeout(
+      connectTimeoutMs,
+      async () => {
+        state.transport = await TunnelByteStream.connect({
+          baseUrl: options.baseUrl,
+          wsHeaders: options.wsHeaders,
+          remotePort: options.port,
+          connectTimeoutMs,
+        });
+        return DesktopSession.connect(
+          state.transport,
+          options.password,
+          options.shared,
+        );
+      },
+      `timed out while connecting desktop session after ${options.connectTimeout.toFixed(2)}s`,
+    );
+  } catch (error) {
+    if (state.transport) {
+      await state.transport.close().catch(() => {});
+    }
+    throw error;
+  }
+}
+
+function isReconnectableDesktopScreenshotError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("desktop tunnel closed unexpectedly") ||
+    message.includes("desktop tunnel is not connected") ||
+    message.includes("connection closed") ||
+    message.includes("econnreset") ||
+    message.includes("timed out waiting for initial desktop framebuffer") ||
+    message.includes("timed out while connecting tunnel websocket") ||
+    message.includes("tunnel websocket closed before opening") ||
+    message.includes("tunnel websocket handshake failed")
+  );
+}
+
+function createDeferredSignal(): {
+  resolve(): void;
+  wait(): Promise<void>;
+} {
+  let resolveCurrent!: () => void;
+  let promise = new Promise<void>((resolve) => {
+    resolveCurrent = resolve;
+  });
+
+  return {
+    resolve() {
+      resolveCurrent();
+      promise = new Promise<void>((resolve) => {
+        resolveCurrent = resolve;
+      });
+    },
+    wait() {
+      return promise;
+    },
+  };
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new SandboxError(String(error));
+}
+
 function buttonMask(button: MouseButton | string): number {
   const normalized = button.trim().toLowerCase();
   if (normalized === "left") return BUTTON_LEFT_MASK;
@@ -1078,6 +1304,8 @@ const SPECIAL_KEYSYMS = new Map<string, number>([
   ["right", 0xff53],
   ["home", 0xff50],
   ["end", 0xff57],
+  ["pageup", 0xff55],
+  ["pagedown", 0xff56],
   ["page_up", 0xff55],
   ["page_down", 0xff56],
   ["shift", 0xffe1],

--- a/typescript/src/tunnel.ts
+++ b/typescript/src/tunnel.ts
@@ -3,6 +3,7 @@ import { SandboxConnectionError, SandboxError } from "./errors.js";
 import WebSocket, { type RawData } from "ws";
 
 const DEFAULT_TUNNEL_CONNECT_TIMEOUT_MS = 10_000;
+const WEBSOCKET_KEEPALIVE_INTERVAL_MS = 15_000;
 
 export interface CreateTunnelOptions {
   /** Local host/interface to bind. Defaults to `127.0.0.1`. */
@@ -121,9 +122,16 @@ export class TunnelByteStream {
   private readonly pendingReads: PendingRead[] = [];
   private closeError: Error | null = null;
   private closePromise: Promise<void> | null = null;
+  private readonly keepAliveInterval: ReturnType<typeof setInterval>;
 
   constructor(socket: WebSocket) {
     this.socket = socket;
+    this.keepAliveInterval = setInterval(() => {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.ping();
+      }
+    }, WEBSOCKET_KEEPALIVE_INTERVAL_MS);
+    this.keepAliveInterval.unref?.();
 
     socket.on("message", (message: RawData, isBinary: boolean) => {
       if (!isBinary) {
@@ -142,12 +150,14 @@ export class TunnelByteStream {
     });
 
     socket.on("close", (_code: number, reason: Buffer) => {
+      clearInterval(this.keepAliveInterval);
       const closeReason =
         reason.length > 0 ? reason.toString("utf8") : "desktop tunnel closed unexpectedly";
       this.fail(new SandboxError(closeReason));
     });
 
     socket.on("error", (error: Error) => {
+      clearInterval(this.keepAliveInterval);
       this.fail(new SandboxConnectionError(error.message));
     });
   }
@@ -394,10 +404,17 @@ function normalizeWebSocketData(message: RawData): Buffer {
 async function relaySocket(localSocket: net.Socket, websocket: WebSocket): Promise<void> {
   return new Promise<void>((resolve) => {
     let settled = false;
+    const keepAliveInterval = setInterval(() => {
+      if (websocket.readyState === WebSocket.OPEN) {
+        websocket.ping();
+      }
+    }, WEBSOCKET_KEEPALIVE_INTERVAL_MS);
+    keepAliveInterval.unref?.();
 
     const finish = () => {
       if (settled) return;
       settled = true;
+      clearInterval(keepAliveInterval);
       cleanup();
       resolve();
     };

--- a/typescript/tests/desktop.test.ts
+++ b/typescript/tests/desktop.test.ts
@@ -9,6 +9,7 @@ class MockWebSocket {
 
   static instances: MockWebSocket[] = [];
   static nextIncomingFrames: Buffer[] = [];
+  static nextConnectionBehaviors: Array<(socket: MockWebSocket) => void> = [];
 
   readonly url: string;
   readonly options: { headers?: Record<string, string> } | undefined;
@@ -24,10 +25,15 @@ class MockWebSocket {
 
     queueMicrotask(() => {
       this.readyState = MockWebSocket.OPEN;
-      this.emit("open");
+      this.dispatch("open");
+      const behavior = MockWebSocket.nextConnectionBehaviors.shift();
+      if (behavior) {
+        behavior(this);
+        return;
+      }
       setTimeout(() => {
         for (const frame of MockWebSocket.nextIncomingFrames) {
-          this.emit("message", frame, true);
+          this.dispatch("message", frame, true);
         }
         MockWebSocket.nextIncomingFrames = [];
       }, 0);
@@ -54,14 +60,14 @@ class MockWebSocket {
 
   close(): void {
     this.readyState = MockWebSocket.CLOSED;
-    this.emit("close", 1000, Buffer.alloc(0));
+    this.dispatch("close", 1000, Buffer.alloc(0));
   }
 
   pong(_data?: Buffer, _mask?: boolean, cb?: () => void): void {
     cb?.();
   }
 
-  private emit(event: string, ...args: any[]): void {
+  dispatch(event: string, ...args: any[]): void {
     for (const handler of this.handlers[event] ?? []) {
       handler(...args);
     }
@@ -233,6 +239,7 @@ describe("DesktopSession", () => {
   beforeEach(async () => {
     MockWebSocket.instances = [];
     MockWebSocket.nextIncomingFrames = [];
+    MockWebSocket.nextConnectionBehaviors = [];
     vi.resetModules();
     ({ DesktopSession } = await import("../src/desktop.js"));
     ({ Sandbox } = await import("../src/sandbox.js"));
@@ -410,5 +417,48 @@ describe("DesktopSession", () => {
     expect(socket.options?.headers?.Authorization).toBe("Bearer test-api-key");
     expect(socket.sent[0].toString("ascii")).toBe("RFB 003.008\n");
     expect(parsePng(png).width).toBe(2);
+  });
+
+  it("reconnects screenshot operations after the desktop tunnel drops", async () => {
+    MockWebSocket.nextConnectionBehaviors = [
+      (socket) => {
+        setTimeout(() => {
+          socket.dispatch("message", Buffer.concat([
+            Buffer.from("RFB 003.008\n", "ascii"),
+            Buffer.from([1, 1]),
+            u32(0),
+            serverInitBytes(1, 1, true),
+          ]), true);
+        }, 0);
+      },
+      (socket) => {
+        setTimeout(() => {
+          socket.dispatch("message", Buffer.concat([
+            Buffer.from("RFB 003.008\n", "ascii"),
+            Buffer.from([1, 1]),
+            u32(0),
+            serverInitBytes(1, 1, true),
+            rawFramebufferUpdate(1, 1, [[7, 8, 9, 255]]),
+          ]), true);
+        }, 0);
+      },
+    ];
+
+    const sandbox = new Sandbox({
+      sandboxId: "sbx-reconnect",
+      proxyUrl: "https://sandbox.tensorlake.ai",
+      apiKey: "test-api-key",
+    });
+
+    const desktop = await sandbox.connectDesktop();
+    MockWebSocket.instances[0]?.dispatch(
+      "close",
+      1011,
+      Buffer.from("desktop tunnel closed unexpectedly"),
+    );
+    const png = await desktop.screenshot(1);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(parsePng(png).rgba).toEqual(Buffer.from([7, 8, 9, 255]));
   });
 });


### PR DESCRIPTION
### PR Summary
This PR improves desktop-session resilience in the TypeScript SDK.

- Keep the VNC framebuffer warm in the background instead of requesting a fresh screenshot round-trip for every capture.
- Add getFrameVersion() and screenshotAfter() so callers can wait for a newer frame when they need one.
- Reconnect screenshot operations automatically when the desktop tunnel drops.
- Add websocket keepalive pings for both desktop and TCP relay tunnels to reduce idle disconnects.
- Add pageup / pagedown key aliases.
- Add regression coverage for dropped-tunnel screenshot recovery.
