### PR TITLE
Use routing hints to skip proxy placement lookup on first request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.46"
+version = "0.4.47"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -223,6 +223,7 @@ impl SandboxesClient {
 pub struct SandboxProxyClient {
     client: Client,
     host_override: Option<String>,
+    routing_hint: Option<String>,
 }
 
 impl SandboxProxyClient {
@@ -230,13 +231,22 @@ impl SandboxProxyClient {
         Self {
             client,
             host_override,
+            routing_hint: None,
         }
+    }
+
+    pub fn with_routing_hint(mut self, hint: Option<String>) -> Self {
+        self.routing_hint = hint;
+        self
     }
 
     fn request(&self, method: Method, path: &str) -> reqwest_middleware::RequestBuilder {
         let mut request_builder = self.client.request(method, path);
         if let Some(host) = self.host_override.as_deref() {
             request_builder = request_builder.header("Host", host);
+        }
+        if let Some(hint) = self.routing_hint.as_deref() {
+            request_builder = request_builder.header("X-Tensorlake-Route-Hint", hint);
         }
         request_builder
     }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -73,6 +73,8 @@ pub struct SandboxPoolRequest {
 pub struct CreateSandboxResponse {
     pub sandbox_id: String,
     pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing_hint: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -784,13 +784,14 @@ pub struct CloudSandboxProxyClient {
 #[pymethods]
 impl CloudSandboxProxyClient {
     #[new]
-    #[pyo3(signature = (proxy_url, sandbox_id, api_key=None, organization_id=None, project_id=None))]
+    #[pyo3(signature = (proxy_url, sandbox_id, api_key=None, organization_id=None, project_id=None, routing_hint=None))]
     fn new(
         proxy_url: String,
         sandbox_id: String,
         api_key: Option<String>,
         organization_id: Option<String>,
         project_id: Option<String>,
+        routing_hint: Option<String>,
     ) -> PyResult<Self> {
         let (base_url, host_override) = resolve_proxy_target(&proxy_url, &sandbox_id)?;
 
@@ -813,7 +814,8 @@ impl CloudSandboxProxyClient {
                 format!("failed to create tokio runtime: {e}"),
             ))
         })?;
-        let sandbox_proxy_client = SandboxProxyClient::new(client, host_override);
+        let sandbox_proxy_client =
+            SandboxProxyClient::new(client, host_override).with_routing_hint(routing_hint);
 
         Ok(Self {
             client: sandbox_proxy_client,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.4.46"
+version = "0.4.47"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Applications"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -884,6 +884,7 @@ class SandboxClient:
         *,
         proxy_url: str | None = None,
         sandbox_id: str | None = None,
+        routing_hint: str | None = None,
     ) -> "Sandbox":
         """Connect to a running sandbox for process and file operations.
 
@@ -914,6 +915,7 @@ class SandboxClient:
             api_key=self._api_key,
             organization_id=self._organization_id,
             project_id=self._project_id,
+            routing_hint=routing_hint,
         )
         sandbox._lifecycle_client = self
         return sandbox
@@ -991,6 +993,19 @@ class SandboxClient:
                 snapshot_id=snapshot_id,
                 name=name,
             )
+
+        # Fast path: the blocking create/claim response already carries Running status
+        # and a short-lived routing hint. Use it immediately to skip an extra poll RTT
+        # and let the proxy route the first request without a placement lookup.
+        if result.status == SandboxStatus.RUNNING:
+            sandbox = self.connect(
+                result.sandbox_id,
+                proxy_url=proxy_url,
+                routing_hint=result.routing_hint,
+            )
+            sandbox._owns_sandbox = True
+            sandbox._lifecycle_client = self
+            return sandbox
 
         deadline = time.time() + startup_timeout
         while time.time() < deadline:

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -151,6 +151,7 @@ class CreateSandboxResponse(BaseModel):
 
     sandbox_id: str
     status: SandboxStatus
+    routing_hint: str | None = None
 
 
 class SandboxInfo(BaseModel):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -118,6 +118,7 @@ class Sandbox:
         project_id: str | None = None,
         *,
         sandbox_id: str | None = None,
+        routing_hint: str | None = None,
     ):
         if identifier and sandbox_id and identifier != sandbox_id:
             raise SandboxError(
@@ -164,6 +165,7 @@ class Sandbox:
                 api_key=api_key,
                 organization_id=organization_id,
                 project_id=project_id,
+                routing_hint=routing_hint,
             )
             self._base_url = self._rust_client.base_url()
         except Exception as e:

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.4.46",
+  "version": "0.4.47",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -395,7 +395,7 @@ export class SandboxClient {
 
   // --- Connect ---
 
-  connect(identifier: string, proxyUrl?: string): Sandbox {
+  connect(identifier: string, proxyUrl?: string, routingHint?: string): Sandbox {
     const resolvedProxy = proxyUrl ?? resolveProxyUrl(this.apiUrl);
     return new Sandbox({
       sandboxId: identifier,
@@ -403,6 +403,7 @@ export class SandboxClient {
       apiKey: this.apiKey,
       organizationId: this.organizationId,
       projectId: this.projectId,
+      routingHint,
     });
   }
 
@@ -416,6 +417,15 @@ export class SandboxClient {
       result = await this.claim(options.poolId);
     } else {
       result = await this.create(options);
+    }
+
+    // Fast path: the blocking create/claim response already carries Running status
+    // and a short-lived routing hint. Use it immediately to skip an extra poll RTT
+    // and let the proxy route the first request without a placement lookup.
+    if (result.status === SandboxStatus.RUNNING) {
+      const sandbox = this.connect(result.sandboxId, options?.proxyUrl, result.routingHint);
+      sandbox._setOwner(this);
+      return sandbox;
     }
 
     const deadline = Date.now() + startupTimeout * 1000;

--- a/typescript/src/http.ts
+++ b/typescript/src/http.ts
@@ -13,6 +13,7 @@ export interface HttpClientOptions {
   organizationId?: string;
   projectId?: string;
   hostHeader?: string;
+  routingHint?: string;
   maxRetries?: number;
   retryBackoffMs?: number;
   timeoutMs?: number;
@@ -61,6 +62,9 @@ export class HttpClient {
     }
     if (options.hostHeader) {
       this.headers["Host"] = options.hostHeader;
+    }
+    if (options.routingHint) {
+      this.headers["X-Tensorlake-Route-Hint"] = options.routingHint;
     }
   }
 

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -93,6 +93,7 @@ export interface UpdateSandboxOptions {
 export interface CreateSandboxResponse {
   sandboxId: string;
   status: SandboxStatus;
+  routingHint?: string;
 }
 
 export interface SandboxInfo {
@@ -326,6 +327,7 @@ export interface SandboxOptions {
   apiKey?: string;
   organizationId?: string;
   projectId?: string;
+  routingHint?: string;
 }
 
 export interface CreateAndConnectOptions extends CreateSandboxOptions {

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -314,6 +314,7 @@ export class Sandbox {
       organizationId: options.organizationId,
       projectId: options.projectId,
       hostHeader,
+      routingHint: options.routingHint,
     });
   }
 


### PR DESCRIPTION
## Summary

Client-side implementation of [compute-engine-internal#680](https://github.com/tensorlakeai/compute-engine-internal/pull/680).

When the server is configured with a hint signing key, the sandbox create/claim response now carries a short-lived `routing_hint` HMAC-SHA256 token. This PR threads that token through to the first proxy request as `X-Tensorlake-Route-Hint`, letting the sandbox proxy route directly to the dataplane without an Indexify placement lookup.

- **Rust cloud-sdk** (`crates/cloud-sdk/`): adds `routing_hint` to `CreateSandboxResponse`, adds `with_routing_hint()` to `SandboxProxyClient`, includes `X-Tensorlake-Route-Hint` on all proxy requests when a hint is present
- **Rust Python bindings** (`crates/rust-cloud-sdk-py/`): exposes `routing_hint` param on `CloudSandboxProxyClient`
- **Python SDK** (`src/tensorlake/sandbox/`): parses `routing_hint` from create response, threads it through `connect()` into the proxy client; `create_and_connect()` fast-paths when status is already `running` (skips the redundant poll RTT)
- **TypeScript SDK** (`typescript/src/`): same pattern — `routingHint` on `CreateSandboxResponse`, `SandboxOptions`, and `HttpClientOptions`; `connect()` accepts the hint; `createAndConnect()` has the same fast path

The hint has a 5-second TTL and the proxy falls through silently on any failure, so no client-visible errors on expiry or misconfiguration.

## Test plan

- [ ] Rust: `cargo check -p tensorlake-cloud-sdk -p tensorlake-rust-cloud-sdk-py` passes
- [ ] TypeScript: `tsc --noEmit` passes
- [ ] Integration: create a sandbox, verify first proxy request includes `X-Tensorlake-Route-Hint` header when server is configured with signing key

🤖 Generated with [Claude Code](https://claude.com/claude-code)