### PR TITLE
Propagate routing hint header through Python, Rust, and TypeScript SDKs

### DIFF
--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         run: npm ci
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         run: npm ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.4.46"
+version = "0.4.48"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cloud-sdk"
-version = "0.4.46"
+version = "0.4.48"
 dependencies = [
  "bytes",
  "chrono",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.4.46"
+version = "0.4.48"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.47"
+version = "0.4.48"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,14 @@ install-dev-release:
 	@cp tensorlake.data/scripts/* $$(poetry env info --path)/bin/
 	@echo "Done. Activate the venv with 'poetry shell' or prefix commands with 'poetry run'."
 
-# Global install: builds the Rust CLI (release) and installs the Python package
-# into the user's Python environment (~/.local/) so that `tl`, `tensorlake`, and
-# all wrapper scripts work from any directory without activating a virtualenv.
-# Requires: pip and maturin available outside any virtualenv.
+# Global install: builds the Rust extension and the Python package and installs
+# both into the user's Python environment (~/.local/) so that `tl`, `tensorlake`,
+# and all wrapper scripts work from any directory without activating a virtualenv.
 # After running, ensure ~/.local/bin is on your PATH.
 install-global:
+	@rm -rf dist
+	@poetry run maturin build --release --manifest-path crates/rust-cloud-sdk-py/Cargo.toml --out dist
+	@pip3 install --user --break-system-packages --force-reinstall dist/*.whl
 	@pip3 install --user --break-system-packages -e .
 	@echo "Done. Make sure ~/.local/bin is on your PATH."
 	@echo "  fish: fish_add_path ~/.local/bin"
@@ -84,11 +86,11 @@ test_sandbox:
 # extension, bundles its native module into the main wheel, then installs into a
 # temporary venv and verifies imports — all without touching PyPI.
 build_release:
-	@rm -rf dist dist-cloud-sdk
+	@rm -rf dist
 	@echo "--- Building Cloud SDK extension ---"
-	@poetry run maturin build --manifest-path crates/rust-cloud-sdk-py/Cargo.toml --release --out dist-cloud-sdk
+	@poetry run maturin build --manifest-path crates/rust-cloud-sdk-py/Cargo.toml --release --out dist
 	@echo "--- Bundling native Cloud SDK extension into src/tensorlake/ ---"
-	@poetry run python .github/scripts/bundle_cloud_sdk_wheel.py "dist-cloud-sdk/tensorlake_rust_cloud_sdk-*.whl" src/tensorlake --require-abi3
+	@poetry run python .github/scripts/bundle_cloud_sdk_wheel.py "dist/tensorlake_rust_cloud_sdk-*.whl" src/tensorlake --require-abi3
 	@echo "--- Building main wheel ---"
 	@poetry run maturin build --release --out dist
 	@echo "--- Removing bundled native module from source tree ---"

--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -133,6 +133,20 @@ impl Client {
         self.default_headers.clone()
     }
 
+    /// Create a new client that shares the same underlying HTTP connection pool but uses a
+    /// different base URL. Cloning `reqwest::Client` shares its Arc-backed connection pool, so
+    /// HTTP/2 connections established for one base URL can be reused (via connection coalescing)
+    /// when talking to another host that resolves to the same IP with the same TLS certificate.
+    pub fn with_base_url(&self, new_url: &str) -> Self {
+        let client = ReqwestClientBuilder::new(self.base_client.clone()).build();
+        Self {
+            base_url: new_url.to_string(),
+            base_client: self.base_client.clone(),
+            client,
+            default_headers: self.default_headers.clone(),
+        }
+    }
+
     /// Execute an HTTP request.
     pub async fn execute(&self, request: Request) -> Result<Response, SdkError> {
         let response = self.client.execute(request).await?;

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -45,6 +45,10 @@ impl SandboxesClient {
         }
     }
 
+    pub fn http_client(&self) -> &Client {
+        &self.client
+    }
+
     fn endpoint(&self, endpoint: &str) -> String {
         if self.use_namespaced_endpoints {
             format!("/v1/namespaces/{}/{}", self.namespace, endpoint)

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.4.46"
+version = "0.4.48"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -745,6 +745,35 @@ impl CloudSandboxClient {
             async move { client.delete_pool(&pool_id).await }
         })
     }
+
+    /// Create a proxy client for the given sandbox that shares this client's HTTP connection
+    /// pool. All proxy clients created this way reuse the same underlying reqwest::Client,
+    /// so HTTP/2 connections can be coalesced: only the first sandbox in a session pays the
+    /// TCP+TLS handshake cost.
+    #[pyo3(signature = (proxy_url, sandbox_id, routing_hint=None))]
+    fn connect_proxy(
+        &self,
+        proxy_url: String,
+        sandbox_id: String,
+        routing_hint: Option<String>,
+    ) -> PyResult<CloudSandboxProxyClient> {
+        let (base_url, host_override) = resolve_proxy_target(&proxy_url, &sandbox_id)?;
+        let shared_client = self.client.http_client().with_base_url(&base_url);
+        let proxy = SandboxProxyClient::new(shared_client, host_override)
+            .with_routing_hint(routing_hint);
+        let runtime = Runtime::new().map_err(|e| {
+            CloudSandboxClientError::new_err((
+                "internal",
+                Option::<u16>::None,
+                format!("failed to create tokio runtime: {e}"),
+            ))
+        })?;
+        Ok(CloudSandboxProxyClient {
+            client: proxy,
+            runtime,
+            base_url,
+        })
+    }
 }
 
 impl CloudSandboxProxyClient {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.4.47"
+version = "0.4.48"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -176,8 +176,6 @@ class SandboxClient:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-
-
     @classmethod
     def for_cloud(
         cls,

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -176,6 +176,8 @@ class SandboxClient:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
+
+
     @classmethod
     def for_cloud(
         cls,
@@ -909,6 +911,12 @@ class SandboxClient:
         if proxy_url is None:
             proxy_url = self._resolve_proxy_url()
 
+        proxy_rust_client = self._rust_client.connect_proxy(
+            proxy_url=proxy_url,
+            sandbox_id=sandbox_identifier,
+            routing_hint=routing_hint,
+        )
+
         sandbox = Sandbox(
             identifier=sandbox_identifier,
             proxy_url=proxy_url,
@@ -916,6 +924,7 @@ class SandboxClient:
             organization_id=self._organization_id,
             project_id=self._project_id,
             routing_hint=routing_hint,
+            _proxy_rust_client=proxy_rust_client,
         )
         sandbox._lifecycle_client = self
         return sandbox
@@ -1003,6 +1012,9 @@ class SandboxClient:
                 proxy_url=proxy_url,
                 routing_hint=result.routing_hint,
             )
+            sandbox._sandbox_id = result.sandbox_id
+            sandbox._name = result.name
+            sandbox._name_loaded = True
             sandbox._owns_sandbox = True
             sandbox._lifecycle_client = self
             return sandbox
@@ -1011,7 +1023,15 @@ class SandboxClient:
         while time.time() < deadline:
             info = self.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
-                sandbox = self.connect(result.sandbox_id, proxy_url=proxy_url)
+                sandbox = self.connect(
+                    result.sandbox_id,
+                    proxy_url=proxy_url,
+                    routing_hint=info.routing_hint,
+                )
+                sandbox._sandbox_id = info.sandbox_id
+                sandbox._name = info.name
+                sandbox._name_loaded = True
+                sandbox._cached_info = info
                 sandbox._owns_sandbox = True
                 sandbox._lifecycle_client = self
                 return sandbox

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -152,6 +152,7 @@ class CreateSandboxResponse(BaseModel):
     sandbox_id: str
     status: SandboxStatus
     routing_hint: str | None = None
+    name: str | None = None
 
 
 class SandboxInfo(BaseModel):
@@ -174,6 +175,7 @@ class SandboxInfo(BaseModel):
     allow_unauthenticated_access: bool = False
     exposed_ports: list[int] | None = None
     sandbox_url: str | None = None
+    routing_hint: str | None = None
 
     model_config = {"populate_by_name": True}
 

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -6,6 +6,7 @@ import json
 from typing import TYPE_CHECKING, Iterator
 from urllib.parse import urlparse
 
+
 import httpx
 
 from . import _defaults
@@ -119,6 +120,7 @@ class Sandbox:
         *,
         sandbox_id: str | None = None,
         routing_hint: str | None = None,
+        _proxy_rust_client: object | None = None,
     ):
         if identifier and sandbox_id and identifier != sandbox_id:
             raise SandboxError(
@@ -131,6 +133,9 @@ class Sandbox:
             )
 
         self._identifier = sandbox_identifier
+        self._sandbox_id: str | None = None
+        self._name: str | None = None
+        self._name_loaded: bool = False
         self._cached_info: SandboxInfo | None = None
         self._owns_sandbox: bool = False
         self._lifecycle_client: SandboxClient | None = None
@@ -158,18 +163,22 @@ class Sandbox:
                 "Build/install it with `make build_rust_py_client`."
             )
 
-        try:
-            self._rust_client = RustCloudSandboxProxyClient(
-                proxy_url=proxy_url,
-                sandbox_id=sandbox_identifier,
-                api_key=api_key,
-                organization_id=organization_id,
-                project_id=project_id,
-                routing_hint=routing_hint,
-            )
+        if _proxy_rust_client is not None:
+            self._rust_client = _proxy_rust_client
             self._base_url = self._rust_client.base_url()
-        except Exception as e:
-            _raise_as_sandbox_error(e)
+        else:
+            try:
+                self._rust_client = RustCloudSandboxProxyClient(
+                    proxy_url=proxy_url,
+                    sandbox_id=sandbox_identifier,
+                    api_key=api_key,
+                    organization_id=organization_id,
+                    project_id=project_id,
+                    routing_hint=routing_hint,
+                )
+                self._base_url = self._rust_client.base_url()
+            except Exception as e:
+                _raise_as_sandbox_error(e)
 
     def _fetch_info(self) -> SandboxInfo:
         """Fetch and cache sandbox info from the server (lazy, once per instance)."""
@@ -185,12 +194,19 @@ class Sandbox:
     @property
     def sandbox_id(self) -> str:
         """The server-assigned UUID for this sandbox."""
-        return self._fetch_info().sandbox_id
+        if self._sandbox_id is not None:
+            return self._sandbox_id
+        self._sandbox_id = self._fetch_info().sandbox_id
+        return self._sandbox_id
 
     @property
     def name(self) -> str | None:
         """The human-readable name for this sandbox, or None if unnamed."""
-        return self._fetch_info().name
+        if self._name_loaded:
+            return self._name
+        self._name = self._fetch_info().name
+        self._name_loaded = True
+        return self._name
 
     def __enter__(self) -> Sandbox:
         return self

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -6,7 +6,6 @@ import json
 from typing import TYPE_CHECKING, Iterator
 from urllib.parse import urlparse
 
-
 import httpx
 
 from . import _defaults

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "tensorlake",
-  "version": "0.4.45",
+  "version": "0.4.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.4.45",
+      "version": "0.4.47",
       "license": "Apache-2.0",
       "dependencies": {
+        "undici": "^8.1.0",
         "ws": "^8.20.0"
       },
       "bin": {
@@ -2810,6 +2811,15 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.1.0.tgz",
+      "integrity": "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -42,7 +42,7 @@
     "prepack": "npm run build"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "keywords": [
     "tensorlake",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.4.47",
+  "version": "0.4.48",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -67,6 +67,7 @@
     "vitest": "^2.0.0"
   },
   "dependencies": {
+    "undici": "^8.1.0",
     "ws": "^8.20.0"
   }
 }

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -433,7 +433,7 @@ export class SandboxClient {
     while (Date.now() < deadline) {
       const info = await this.get(result.sandboxId);
       if (info.status === SandboxStatus.RUNNING) {
-        const sandbox = this.connect(result.sandboxId, options?.proxyUrl);
+        const sandbox = this.connect(result.sandboxId, options?.proxyUrl, info.routingHint);
         sandbox._setOwner(this);
         return sandbox;
       }

--- a/typescript/src/http.ts
+++ b/typescript/src/http.ts
@@ -1,4 +1,9 @@
-import { Agent, fetch as undiciFetch, setGlobalDispatcher } from "undici";
+import {
+  Agent,
+  fetch as undiciFetch,
+  setGlobalDispatcher,
+  type BodyInit as UndiciBodyInit,
+} from "undici";
 import * as defaults from "./defaults.js";
 import {
   PoolInUseError,
@@ -178,7 +183,7 @@ export class HttpClient {
   private async doFetch(
     method: string,
     path: string,
-    body: BodyInit | undefined,
+    body: UndiciBodyInit | undefined,
     headers: Record<string, string>,
     signal?: AbortSignal,
     allowHttpErrors = false,
@@ -207,7 +212,7 @@ export class HttpClient {
         const response = (await undiciFetch(url, {
           method,
           headers,
-          body: body ?? null,
+          body,
           signal: combinedSignal,
         })) as Response;
 
@@ -268,14 +273,16 @@ function hasHeader(headers: Record<string, string>, name: string): boolean {
   return Object.keys(headers).some((key) => key.toLowerCase() === lowered);
 }
 
-function normalizeRequestBody(body?: RequestBody | null): BodyInit | undefined {
+function normalizeRequestBody(
+  body?: RequestBody | null,
+): UndiciBodyInit | undefined {
   if (body == null) {
     return undefined;
   }
   if (body instanceof Uint8Array) {
-    return Uint8Array.from(body).buffer;
+    return Uint8Array.from(body).buffer as ArrayBuffer;
   }
-  return body;
+  return body as UndiciBodyInit;
 }
 
 /** Map HTTP status codes to specific error types. */

--- a/typescript/src/http.ts
+++ b/typescript/src/http.ts
@@ -1,3 +1,4 @@
+import { Agent, fetch as undiciFetch, setGlobalDispatcher } from "undici";
 import * as defaults from "./defaults.js";
 import {
   PoolInUseError,
@@ -18,6 +19,13 @@ export interface HttpClientOptions {
   retryBackoffMs?: number;
   timeoutMs?: number;
 }
+
+setGlobalDispatcher(
+  new Agent({
+    keepAliveTimeout: 60_000,
+    allowH2: true,
+  }),
+);
 
 type RequestBody = BodyInit | Uint8Array | ArrayBuffer;
 
@@ -109,15 +117,11 @@ export class HttpClient {
       headers["Content-Type"] = options.contentType;
     }
 
-    const response = await this.requestResponse(
-      method,
-      path,
-      {
-        body: options?.body,
-        headers,
-        signal: options?.signal,
-      },
-    );
+    const response = await this.requestResponse(method, path, {
+      body: options?.body,
+      headers,
+      signal: options?.signal,
+    });
     const buffer = await response.arrayBuffer();
     return new Uint8Array(buffer);
   }
@@ -128,17 +132,16 @@ export class HttpClient {
     path: string,
     options?: { signal?: AbortSignal; json?: unknown },
   ): Promise<ReadableStream<Uint8Array>> {
-    const response = await this.requestResponse(
-      method,
-      path,
-      {
-        json: options?.json,
-        headers: { Accept: "text/event-stream" },
-        signal: options?.signal,
-      },
-    );
+    const response = await this.requestResponse(method, path, {
+      json: options?.json,
+      headers: { Accept: "text/event-stream" },
+      signal: options?.signal,
+    });
     if (!response.body) {
-      throw new RemoteAPIError(response.status, "No response body for SSE stream");
+      throw new RemoteAPIError(
+        response.status,
+        "No response body for SSE stream",
+      );
     }
     return response.body;
   }
@@ -201,12 +204,12 @@ export class HttpClient {
         : this.abortController.signal;
 
       try {
-        const response = await fetch(url, {
+        const response = (await undiciFetch(url, {
           method,
           headers,
-          body,
+          body: body ?? null,
           signal: combinedSignal,
-        });
+        })) as Response;
 
         clearTimeout(timeoutId);
 
@@ -234,8 +237,12 @@ export class HttpClient {
       } catch (err) {
         clearTimeout(timeoutId);
 
-        if (err instanceof RemoteAPIError || err instanceof SandboxNotFoundError ||
-            err instanceof PoolNotFoundError || err instanceof PoolInUseError) {
+        if (
+          err instanceof RemoteAPIError ||
+          err instanceof SandboxNotFoundError ||
+          err instanceof PoolNotFoundError ||
+          err instanceof PoolInUseError
+        ) {
           throw err;
         }
 
@@ -244,8 +251,7 @@ export class HttpClient {
         }
 
         // Network / timeout error
-        lastError =
-          err instanceof Error ? err : new Error(String(err));
+        lastError = err instanceof Error ? err : new Error(String(err));
 
         if (attempt >= this.maxRetries) {
           throw new SandboxConnectionError(lastError.message);
@@ -273,11 +279,7 @@ function normalizeRequestBody(body?: RequestBody | null): BodyInit | undefined {
 }
 
 /** Map HTTP status codes to specific error types. */
-function throwMappedError(
-  status: number,
-  body: string,
-  path: string,
-): never {
+function throwMappedError(status: number, body: string, path: string): never {
   let message = body;
   try {
     const parsed = JSON.parse(body);

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -115,6 +115,7 @@ export interface SandboxInfo {
   allowUnauthenticatedAccess?: boolean;
   exposedPorts?: number[];
   sandboxUrl?: string;
+  routingHint?: string;
 }
 
 export interface SandboxPortAccess {

--- a/typescript/tests/api-client.test.ts
+++ b/typescript/tests/api-client.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as undici from "undici";
 import { APIClient } from "../src/api-client.js";
 import {
   RequestExecutionError,
@@ -6,22 +7,22 @@ import {
   RequestNotFinishedError,
 } from "../src/errors.js";
 
-describe("APIClient", () => {
-  let originalFetch: typeof globalThis.fetch;
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return { ...actual, fetch: vi.fn() };
+});
 
-  beforeEach(() => {
-    originalFetch = globalThis.fetch;
-  });
+describe("APIClient", () => {
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.mocked(undici.fetch).mockReset();
     vi.restoreAllMocks();
   });
 
   function mockFetch(
     handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
   ) {
-    globalThis.fetch = vi.fn(handler as typeof fetch);
+    vi.mocked(undici.fetch).mockImplementation(handler as typeof undici.fetch);
   }
 
   it("throws RequestNotFinishedError when output is requested too early", async () => {

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1,24 +1,25 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as undici from "undici";
 import { SandboxClient } from "../src/client.js";
 import { SandboxStatus, SnapshotStatus } from "../src/models.js";
 import { SandboxError, SandboxNotFoundError } from "../src/errors.js";
 
-describe("SandboxClient", () => {
-  let originalFetch: typeof globalThis.fetch;
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return { ...actual, fetch: vi.fn() };
+});
 
-  beforeEach(() => {
-    originalFetch = globalThis.fetch;
-  });
+describe("SandboxClient", () => {
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.mocked(undici.fetch).mockReset();
     vi.restoreAllMocks();
   });
 
   function mockFetch(
     handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
   ) {
-    globalThis.fetch = vi.fn(handler as typeof fetch);
+    vi.mocked(undici.fetch).mockImplementation(handler as typeof undici.fetch);
   }
 
   describe("construction", () => {
@@ -332,8 +333,7 @@ describe("SandboxClient", () => {
     });
 
     it("exposes ports by merging with existing ports", async () => {
-      const fetchMock = vi
-        .fn()
+      vi.mocked(undici.fetch)
         .mockResolvedValueOnce(
           new Response(
             JSON.stringify({
@@ -367,7 +367,7 @@ describe("SandboxClient", () => {
             ),
           );
         });
-      globalThis.fetch = fetchMock as typeof fetch;
+      
 
       const client = SandboxClient.forLocalhost();
       const info = await client.exposePorts("sbx-1", [8081, 8080], {
@@ -378,8 +378,7 @@ describe("SandboxClient", () => {
     });
 
     it("unexposes ports and disables unauthenticated access when none remain", async () => {
-      const fetchMock = vi
-        .fn()
+      vi.mocked(undici.fetch)
         .mockResolvedValueOnce(
           new Response(
             JSON.stringify({
@@ -413,7 +412,7 @@ describe("SandboxClient", () => {
             ),
           );
         });
-      globalThis.fetch = fetchMock as typeof fetch;
+      
 
       const client = SandboxClient.forLocalhost();
       const info = await client.unexposePorts("sbx-1", [8080]);

--- a/typescript/tests/cloud-client.test.ts
+++ b/typescript/tests/cloud-client.test.ts
@@ -1,22 +1,23 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as undici from "undici";
 import { CloudClient } from "../src/cloud-client.js";
 
-describe("CloudClient", () => {
-  let originalFetch: typeof globalThis.fetch;
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return { ...actual, fetch: vi.fn() };
+});
 
-  beforeEach(() => {
-    originalFetch = globalThis.fetch;
-  });
+describe("CloudClient", () => {
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.mocked(undici.fetch).mockReset();
     vi.restoreAllMocks();
   });
 
   function mockFetch(
     handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
   ) {
-    globalThis.fetch = vi.fn(handler as typeof fetch);
+    vi.mocked(undici.fetch).mockImplementation(handler as typeof undici.fetch);
   }
 
   it("runs single-part requests as raw bodies when the part name is 0", async () => {

--- a/typescript/tests/http.test.ts
+++ b/typescript/tests/http.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as undici from "undici";
 import { HttpClient } from "../src/http.js";
 import {
   PoolInUseError,
@@ -8,22 +9,22 @@ import {
   SandboxNotFoundError,
 } from "../src/errors.js";
 
-describe("HttpClient", () => {
-  let originalFetch: typeof globalThis.fetch;
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return { ...actual, fetch: vi.fn() };
+});
 
-  beforeEach(() => {
-    originalFetch = globalThis.fetch;
-  });
+describe("HttpClient", () => {
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.mocked(undici.fetch).mockReset();
     vi.restoreAllMocks();
   });
 
   function mockFetch(
     handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
   ) {
-    globalThis.fetch = vi.fn(handler as typeof fetch);
+    vi.mocked(undici.fetch).mockImplementation(handler as typeof undici.fetch);
   }
 
   it("makes successful JSON requests", async () => {

--- a/typescript/tests/pty.test.ts
+++ b/typescript/tests/pty.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as undici from "undici";
 
 class MockWebSocket {
   static readonly CONNECTING = 0;
@@ -65,12 +66,15 @@ vi.mock("ws", () => ({
   default: MockWebSocket,
 }));
 
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return { ...actual, fetch: vi.fn() };
+});
+
 describe("Sandbox PTY", () => {
-  let originalFetch: typeof globalThis.fetch;
   let Sandbox: typeof import("../src/sandbox.js").Sandbox;
 
   beforeEach(async () => {
-    originalFetch = globalThis.fetch;
     MockWebSocket.instances = [];
     MockWebSocket.failOnOpen = false;
     vi.resetModules();
@@ -78,14 +82,14 @@ describe("Sandbox PTY", () => {
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.mocked(undici.fetch).mockReset();
     vi.restoreAllMocks();
   });
 
   function mockFetch(
     handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
   ) {
-    globalThis.fetch = vi.fn(handler as typeof fetch);
+    vi.mocked(undici.fetch).mockImplementation(handler as typeof undici.fetch);
   }
 
   function makeSandbox() {
@@ -212,7 +216,7 @@ describe("Sandbox PTY", () => {
     const pty = await sandbox.createPty({ command: "/bin/bash" });
 
     await expect(pty.kill()).resolves.toBeUndefined();
-    expect(globalThis.fetch).toHaveBeenCalledWith(
+    expect(vi.mocked(undici.fetch)).toHaveBeenCalledWith(
       "https://sbx-1.sandbox.tensorlake.ai/api/v1/pty/sess-4",
       expect.objectContaining({
         method: "DELETE",
@@ -244,7 +248,7 @@ describe("Sandbox PTY", () => {
       sandbox.createPty({ command: "/bin/bash" }),
     ).rejects.toThrow(/mock websocket connect failure|READY completed/);
 
-    expect(globalThis.fetch).toHaveBeenCalledWith(
+    expect(vi.mocked(undici.fetch)).toHaveBeenCalledWith(
       "https://sbx-1.sandbox.tensorlake.ai/api/v1/pty/sess-fail",
       expect.objectContaining({
         method: "DELETE",

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -1,23 +1,24 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as undici from "undici";
 import { Sandbox } from "../src/sandbox.js";
 import { ProcessStatus } from "../src/models.js";
 
-describe("Sandbox", () => {
-  let originalFetch: typeof globalThis.fetch;
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  return { ...actual, fetch: vi.fn() };
+});
 
-  beforeEach(() => {
-    originalFetch = globalThis.fetch;
-  });
+describe("Sandbox", () => {
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    vi.mocked(undici.fetch).mockReset();
     vi.restoreAllMocks();
   });
 
   function mockFetch(
     handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
   ) {
-    globalThis.fetch = vi.fn(handler as typeof fetch);
+    vi.mocked(undici.fetch).mockImplementation(handler as typeof undici.fetch);
   }
 
   function makeSandbox(id = "sbx-test"): Sandbox {


### PR DESCRIPTION
## Summary

- **Routing hint propagation**: after sandbox creation returns a `routing_hint`, pass it through to the proxy client so every subsequent request carries `X-Tensorlake-Route-Hint` — not just the first one. Previously the hint was only threaded through the initial `connect()` call but not the poll loop.
- **Connection pool sharing (Python/Rust)**: the `SandboxClient` now calls `connect_proxy()` (new Rust method) which clones the same `reqwest::Client` for the proxy client. HTTP/2 connection coalescing means sandboxes in the same session reuse the existing TCP+TLS connection instead of opening a new one.
- **TypeScript: undici 8**: replaced `globalThis.fetch` with an explicit `undici` import (`fetch as undiciFetch`) and a global `Agent` dispatcher with keep-alive + H2. All unit test mocks updated from `globalThis.fetch` to `vi.mock("undici", ...)`.
- **Sandbox info caching (Python)**: `sandbox_id` and `name` are now cached immediately after creation/poll, avoiding a redundant GET on the first `.sandbox_id` or `.name` access.
- Version bumped to **0.4.48** across all packages.

## Test plan

- [ ] Run TypeScript unit tests: `cd typescript && npm test`
- [ ] Run Python sandbox tests
- [ ] Verify `X-Tensorlake-Route-Hint` header appears on proxy requests after sandbox creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)