### PR TITLE
Publish standalone tensorlake CLI binaries via GitHub Releases

### DIFF
--- a/.github/workflows/publish_cli.yaml
+++ b/.github/workflows/publish_cli.yaml
@@ -1,0 +1,110 @@
+name: Release Tensorlake CLI binaries
+
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.target_id }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            target_id: linux-x86_64
+            archive: tar.gz
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            target_id: linux-aarch64
+            archive: tar.gz
+          - os: macos-14
+            target: aarch64-apple-darwin
+            target_id: darwin-aarch64
+            archive: tar.gz
+          - os: macos-13
+            target: x86_64-apple-darwin
+            target_id: darwin-x86_64
+            archive: tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            target_id: windows-x86_64
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build CLI
+        run: cargo build --release -p tensorlake-cli --bin tensorlake --target ${{ matrix.target }}
+
+      - name: Package (tar.gz)
+        if: matrix.archive == 'tar.gz'
+        shell: bash
+        run: |
+          mkdir -p dist
+          tar -C target/${{ matrix.target }}/release -czf dist/tensorlake-cli-${{ matrix.target_id }}.tar.gz tensorlake
+
+      - name: Package (zip)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Compress-Archive -Path target/${{ matrix.target }}/release/tensorlake.exe -DestinationPath dist/tensorlake-cli-${{ matrix.target_id }}.zip
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-${{ matrix.target_id }}
+          path: dist/*
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          version=$(grep -E '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "tag=cli-v$version" >> $GITHUB_OUTPUT
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cli-*
+          merge-multiple: true
+          path: dist
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd dist
+          sha256sum * > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "CLI v${{ steps.version.outputs.version }}" \
+            --notes "Standalone \`tl\` / \`tensorlake\` CLI binaries for v${{ steps.version.outputs.version }}. Install with \`curl https://tensorlake.ai/install | sh\`." \
+            dist/*


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` workflow that builds the standalone `tensorlake` binary from `crates/cli` (the single binary that backs both `tl` and `tensorlake` — `tensorlake.rs` is `include!(\"main.rs\")`) for five targets and publishes a GitHub Release:

- `linux-x86_64` / `linux-aarch64` (tar.gz)
- `darwin-x86_64` / `darwin-aarch64` (tar.gz)
- `windows-x86_64` (zip)

Each release also carries a `SHA256SUMS` file. Release tag is `cli-v<workspace-version>` read from `Cargo.toml`.

## Why

We ship the Rust CLI bundled inside the `tensorlake` Python wheel and `tensorlake` npm package today. For users who just want the CLI and don't want a Python or Node toolchain, we want `curl https://tensorlake.ai/install | sh`. That install script (in a separate PR on the website repo) reads from these releases.

## Test plan

- [ ] Run the workflow via "Run workflow" on `main` once merged
- [ ] Confirm five archives + `SHA256SUMS` appear on the release page
- [ ] Download one per platform locally, extract, confirm `tensorlake --version` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)