### PR TITLE
Fix empty run responses on 502 errors.

### DIFF
--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -368,7 +368,20 @@ impl SandboxProxyClient {
             .header(ACCEPT, "text/event-stream")
             .json(payload)
             .build()?;
-        let response = self.client.execute_raw(req).await?;
+        let response = self.client.execute(req).await?;
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("");
+        if !content_type
+            .to_ascii_lowercase()
+            .contains("text/event-stream")
+        {
+            return Err(SdkError::ClientError(format!(
+                "expected text/event-stream response from /api/v1/processes/run, got content-type: {content_type}"
+            )));
+        }
         let stream = response
             .bytes_stream()
             .eventsource()

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -348,89 +348,108 @@ impl SandboxProxyClient {
     }
 
     pub async fn follow_stdout(&self, pid: i64) -> Result<Vec<OutputEvent>, SdkError> {
-        self.follow_stream(&format!("/api/v1/processes/{pid}/stdout/follow"))
-            .await
+        self.follow_stream(
+            Method::GET,
+            &format!("/api/v1/processes/{pid}/stdout/follow"),
+            None,
+            |data| -> Option<Result<OutputEvent, SdkError>> {
+                serde_json::from_str(data).ok().map(Ok)
+            },
+        )
+        .await
     }
 
     pub async fn follow_stderr(&self, pid: i64) -> Result<Vec<OutputEvent>, SdkError> {
-        self.follow_stream(&format!("/api/v1/processes/{pid}/stderr/follow"))
-            .await
+        self.follow_stream(
+            Method::GET,
+            &format!("/api/v1/processes/{pid}/stderr/follow"),
+            None,
+            |data| -> Option<Result<OutputEvent, SdkError>> {
+                serde_json::from_str(data).ok().map(Ok)
+            },
+        )
+        .await
     }
 
     pub async fn follow_output(&self, pid: i64) -> Result<Vec<OutputEvent>, SdkError> {
-        self.follow_stream(&format!("/api/v1/processes/{pid}/output/follow"))
-            .await
+        self.follow_stream(
+            Method::GET,
+            &format!("/api/v1/processes/{pid}/output/follow"),
+            None,
+            |data| -> Option<Result<OutputEvent, SdkError>> {
+                serde_json::from_str(data).ok().map(Ok)
+            },
+        )
+        .await
     }
 
     pub async fn run_process(&self, payload: &Value) -> Result<Vec<RunProcessEvent>, SdkError> {
-        let req = self
-            .request(Method::POST, "/api/v1/processes/run")
-            .header(ACCEPT, "text/event-stream")
-            .json(payload)
-            .build()?;
-        let response = self.client.execute(req).await?;
+        self.follow_stream(
+            Method::POST,
+            "/api/v1/processes/run",
+            Some(payload),
+            |data| -> Option<Result<RunProcessEvent, SdkError>> {
+                match serde_json::from_str(data) {
+                    Ok(RunProcessEvent::Exited {
+                        exit_code: None,
+                        signal: None,
+                    }) => None,
+                    Ok(evt) => Some(Ok(evt)),
+                    Err(_) => None,
+                }
+            },
+        )
+        .await
+    }
+
+    async fn follow_stream<T, E, F>(
+        &self,
+        method: Method,
+        path: &str,
+        payload: Option<&Value>,
+        filter_map: F,
+    ) -> Result<Vec<T>, SdkError>
+    where
+        E: Into<SdkError>,
+        F: Fn(&str) -> Option<Result<T, E>>,
+    {
+        let mut req = self
+            .request(method, path)
+            .header(ACCEPT, "text/event-stream");
+        if let Some(payload) = payload {
+            req = req.json(payload);
+        }
+
+        let response = self.client.execute(req.build()?).await?;
+
+        if !response.status().is_success() {
+            return Err(SdkError::ClientError(format!(
+                "expected success response from {path}, got status: {}",
+                response.status()
+            )));
+        }
+
         let content_type = response
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
             .and_then(|value| value.to_str().ok())
             .unwrap_or("");
+
         if !content_type
             .to_ascii_lowercase()
             .contains("text/event-stream")
         {
             return Err(SdkError::ClientError(format!(
-                "expected text/event-stream response from /api/v1/processes/run, got content-type: {content_type}"
+                "expected text/event-stream response from {path}, got content-type: {content_type}"
             )));
         }
-        let stream = response
-            .bytes_stream()
-            .eventsource()
-            .filter_map(move |event| async move {
-                match event {
-                    Ok(msg) => {
-                        // Single parse: try typed deserialization directly.
-                        // The Exited variant has all-optional fields so it acts
-                        // as a catch-all for unrecognised JSON (heartbeats, etc.).
-                        // Discard Exited{None, None} — a real exit always has at
-                        // least one of exit_code or signal.
-                        match serde_json::from_str::<RunProcessEvent>(&msg.data) {
-                            Ok(RunProcessEvent::Exited {
-                                exit_code: None,
-                                signal: None,
-                            }) => None,
-                            Ok(evt) => Some(Ok(evt)),
-                            Err(_) => None,
-                        }
-                    }
-                    Err(error) => Some(Err(SdkError::EventSourceError(error.to_string()))),
-                }
-            });
-        futures::pin_mut!(stream);
-        let mut events = Vec::new();
-        while let Some(event) = stream.next().await {
-            events.push(event?);
-        }
-        Ok(events)
-    }
-
-    async fn follow_stream(&self, path: &str) -> Result<Vec<OutputEvent>, SdkError> {
-        let req = self
-            .request(Method::GET, path)
-            .header(ACCEPT, "text/event-stream")
-            .build()?;
-        let response = self.client.execute(req).await?;
-        let stream = response
-            .bytes_stream()
-            .eventsource()
-            .filter_map(move |event| async move {
-                match event {
-                    Ok(msg) => match serde_json::from_str::<OutputEvent>(&msg.data) {
-                        Ok(evt) => Some(Ok(evt)),
-                        Err(_) => None, // Skip non-output events (e.g. heartbeats)
-                    },
-                    Err(error) => Some(Err(SdkError::EventSourceError(error.to_string()))),
-                }
-            });
+        let stream = response.bytes_stream().eventsource().filter_map(|event| {
+            let result = match event {
+                Ok(msg) => filter_map(&msg.data).map(|r| r.map_err(Into::into)),
+                Err(error) => Some(Err(SdkError::EventSourceError(error.to_string()))),
+            };
+            async move { result }
+        });
         futures::pin_mut!(stream);
         let mut events = Vec::new();
         while let Some(event) = stream.next().await {

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -793,9 +793,6 @@ impl CloudSandboxProxyClient {
 
                     retries += 1;
                     let sleep_time = calculate_sleep_time(retries);
-                    eprintln!(
-                        "Retrying rust sandbox proxy request after {sleep_time:.2} seconds. Retry count: {retries}. Retryable exception: {err}"
-                    );
                     std::thread::sleep(Duration::from_secs_f64(sleep_time));
                 }
             }
@@ -1019,7 +1016,7 @@ impl CloudSandboxProxyClient {
                 events
                     .into_iter()
                     .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
-                    .collect()
+                    .collect::<Result<Vec<_>, _>>()
             }
         })
     }

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -297,7 +297,7 @@ class Sandbox:
 
         stdout_lines: list[str] = []
         stderr_lines: list[str] = []
-        exit_code = -1
+        exit_code: int | None = None
 
         for event_json in events_json:
             event = json.loads(event_json)
@@ -311,6 +311,11 @@ class Sandbox:
                     exit_code = event["exit_code"]
                 elif event.get("signal") is not None:
                     exit_code = -event["signal"]
+
+        if exit_code is None:
+            raise SandboxConnectionError(
+                "sandbox process stream ended without an exit event"
+            )
 
         return CommandResult(
             exit_code=exit_code,

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -164,6 +164,22 @@ class TestSandboxRustBackend(unittest.TestCase):
 
         self.assertEqual(result.exit_code, -9)
 
+    def test_run_raises_when_stream_has_no_exit_event(self):
+        sandbox = Sandbox(
+            sandbox_id="sbx-1", proxy_url="http://localhost:9443", api_key="k"
+        )
+
+        class _MissingExitFakeClient(_FakeRustProxyClient):
+            def run_process_json(self, payload_json):
+                return []
+
+        sandbox._rust_client = _MissingExitFakeClient()
+
+        with self.assertRaisesRegex(
+            SandboxConnectionError, "stream ended without an exit event"
+        ):
+            sandbox.run("echo", args=["hello"])
+
     def test_health_maps_connection_error(self):
         class FakeRustError(Exception):
             pass


### PR DESCRIPTION
Correctly retry if the proxy returns a 502 error when we call /processes/run as we consider it retryable.