### PR TITLE
Forward Ctrl+C to remote PTY instead of terminating local session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.4.48"
+version = "0.4.49"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2771,7 +2771,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cloud-sdk"
-version = "0.4.48"
+version = "0.4.49"
 dependencies = [
  "bytes",
  "chrono",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.4.48"
+version = "0.4.49"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.48"
+version = "0.4.49"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/ssh.rs
+++ b/crates/cli/src/commands/sbx/ssh.rs
@@ -304,18 +304,9 @@ pub async fn run(
                     match maybe_stdin {
                         Some(Ok(data)) if data.is_empty() => break,
                         Some(Ok(data)) => {
-                            // In raw mode the terminal driver does not generate SIGINT for
-                            // Ctrl+C; it sends 0x03 as a plain byte instead. Forward it to
-                            // the remote (aborting the foreground process there) and close
-                            // the session with exit code 130 (128 + SIGINT).
-                            let ctrl_c_pressed = data.contains(&0x03);
                             let mut msg = vec![OP_DATA];
                             msg.extend_from_slice(&data);
                             if ws_write.send(tungstenite::Message::Binary(msg.into())).await.is_err() {
-                                break;
-                            }
-                            if ctrl_c_pressed {
-                                server_exit_code = Some(130);
                                 break;
                             }
                         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.4.48"
+version = "0.4.49"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.4.48",
+  "version": "0.4.49",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Removes the special-case `break` that was firing when `0x03` (Ctrl+C) was detected in stdin data
- All stdin bytes — including control characters — are now forwarded to the remote PTY unconditionally
- The remote PTY's line discipline delivers SIGINT to the foreground process in the VM; the local session stays alive, matching the behavior of `docker exec -it` and `aws ssm`

## Behavior before

Pressing Ctrl+C forwarded `0x03` to the VM **and** immediately terminated the local session with exit code 130.

## Behavior after

Pressing Ctrl+C forwards `0x03` to the VM. The foreground process in the VM receives SIGINT. The session stays alive — only ends when the remote shell exits (user types `exit`, Ctrl+D, or the server sends an exit signal).

## Test plan

- [ ] `tl sbx ssh` into a sandbox, run `sleep 100`, press Ctrl+C — sleep is interrupted, shell prompt returns, session stays alive
- [ ] Verify `exit` and Ctrl+D still cleanly terminate the session
- [ ] Verify SIGHUP/SIGTERM on the CLI process still cleanly closes the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)