### PR TITLE
SDK v0.5.0: end-to-end observability and new sandbox lifecycle API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,6 +2797,7 @@ dependencies = [
  "toml",
  "url",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,6 +2805,7 @@ dependencies = [
  "indicatif",
  "minijinja",
  "open",
+ "rand 0.9.4",
  "reqwest",
  "rustls",
  "rustpython-parser",
@@ -2819,7 +2820,6 @@ dependencies = [
  "toml",
  "url",
  "urlencoding",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -57,15 +57,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -139,9 +139,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227aa051deec8d16bd9c34605e7aaf153f240e35483dd42f6f78903847934738"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "base64 0.22.1",
  "bollard-stubs",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -317,15 +317,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -350,13 +350,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
@@ -471,12 +470,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -495,11 +494,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -520,20 +518,20 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deranged"
@@ -787,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -1027,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1099,9 +1097,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1113,7 +1111,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1136,15 +1133,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1214,12 +1210,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1227,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1240,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1254,15 +1251,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1274,15 +1271,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1339,12 +1336,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1379,9 +1376,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1435,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -1448,7 +1445,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1457,9 +1454,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1473,10 +1492,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1495,9 +1516,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1507,14 +1528,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1531,9 +1552,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1621,6 +1642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,10 +1665,11 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.17.1"
+version = "2.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea5ea1e90055f200af6b8e52a4a34e05e77e7fee953a9fb40c631efdc43cab1"
+checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
 dependencies = [
+ "memo-map",
  "serde",
 ]
 
@@ -1663,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -1685,9 +1713,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1709,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1721,9 +1749,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",
@@ -1832,7 +1860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1851,16 +1879,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -1889,9 +1911,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1932,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
  "once_cell",
@@ -1946,18 +1968,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1965,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1977,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2011,9 +2033,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2022,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2079,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -2223,7 +2245,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2241,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "once_cell",
  "ring",
@@ -2267,9 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2303,9 +2325,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2392,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2454,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2525,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2546,15 +2568,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -2565,11 +2587,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2642,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -2666,12 +2688,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2731,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -2748,9 +2770,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -2761,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.4.50"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2802,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cloud-sdk"
-version = "0.4.50"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2815,7 +2837,7 @@ dependencies = [
  "hex",
  "pin-project-lite",
  "png",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest",
  "reqwest-middleware",
  "rustls",
@@ -2840,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.4.50"
+version = "0.5.0"
 dependencies = [
  "futures",
  "pyo3",
@@ -2933,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2943,9 +2965,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2959,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3013,13 +3035,13 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3033,18 +3055,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3127,7 +3149,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3137,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unic-char-property"
@@ -3207,9 +3229,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -3242,7 +3264,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3299,7 +3321,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -3318,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3361,11 +3383,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3374,14 +3396,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3392,23 +3414,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3416,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3429,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3453,7 +3471,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3479,15 +3497,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3505,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3518,14 +3536,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3649,11 +3667,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3704,28 +3722,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3747,12 +3748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3769,12 +3764,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3795,22 +3784,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3831,12 +3808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3853,12 +3824,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3879,12 +3844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3903,16 +3862,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wit-bindgen"
@@ -3922,6 +3881,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -3942,7 +3907,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3973,7 +3938,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -3992,7 +3957,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4004,9 +3969,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -4020,9 +3985,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4031,9 +3996,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4043,18 +4008,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4063,18 +4028,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4090,9 +4055,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4101,9 +4066,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4112,9 +4077,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3321,6 +3321,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.50"
+version = "0.5.0"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ minijinja = "2"
 # Data types
 bytes = "1.11.1"
 chrono = { version = "0.4.44", features = ["serde"] }
+rand = "0.9.2"
 uuid = { version = "1.22.0", features = ["serde", "v4"] }
 
 # Utilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2024"
 license = "Apache-2.0"
 
 [workspace.dependencies]
+async-trait = "0.1"
+
 # Internal crates
 tensorlake-cloud-sdk = { path = "crates/cloud-sdk" }
 
@@ -43,6 +45,7 @@ base64 = "0.22"
 # Docker
 bollard = "0.20"
 docker-credentials-config = "0.1.0"
+http = "1"
 http-body-util = "0.1"
 
 # Templating
@@ -51,7 +54,7 @@ minijinja = "2"
 # Data types
 bytes = "1.11.1"
 chrono = { version = "0.4.44", features = ["serde"] }
-uuid = { version = "1.22.0", features = ["serde"] }
+uuid = { version = "1.22.0", features = ["serde", "v4"] }
 
 # Utilities
 thiserror = "2.0.18"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -46,6 +46,7 @@ minijinja = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+uuid = { workspace = true }
 rustpython-parser = "0.3"
 
 [dev-dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -46,7 +46,7 @@ minijinja = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
-uuid = { workspace = true }
+rand = { workspace = true }
 rustpython-parser = "0.3"
 
 [dev-dependencies]

--- a/crates/cli/src/auth/context.rs
+++ b/crates/cli/src/auth/context.rs
@@ -1,5 +1,4 @@
 use reqwest::header::{HeaderMap, HeaderValue};
-use uuid::Uuid;
 
 use crate::config::resolver::ResolvedConfig;
 use crate::error::{CliError, Result};
@@ -41,7 +40,7 @@ impl CliContext {
             organization_id: config.organization_id,
             project_id: config.project_id,
             debug: config.debug,
-            trace_id: Uuid::new_v4().as_simple().to_string(),
+            trace_id: hex::encode(rand::random::<[u8; 16]>()),
             show_trace_id: config.show_trace_id,
             introspect_cache: None,
         }
@@ -61,7 +60,7 @@ impl CliContext {
         );
 
         // Inject W3C traceparent; share trace_id across all requests in this invocation.
-        let span_id = &Uuid::new_v4().as_simple().to_string()[..16];
+        let span_id = hex::encode(rand::random::<[u8; 8]>());
         headers.insert(
             "traceparent",
             HeaderValue::from_str(&format!("00-{}-{}-01", self.trace_id, span_id))

--- a/crates/cli/src/auth/context.rs
+++ b/crates/cli/src/auth/context.rs
@@ -1,4 +1,5 @@
 use reqwest::header::{HeaderMap, HeaderValue};
+use uuid::Uuid;
 
 use crate::config::resolver::ResolvedConfig;
 use crate::error::{CliError, Result};
@@ -15,6 +16,10 @@ pub struct CliContext {
     pub organization_id: Option<String>,
     pub project_id: Option<String>,
     pub debug: bool,
+    /// W3C trace ID for this CLI invocation (32 lowercase hex chars).
+    pub trace_id: String,
+    /// When true, print the trace ID to stderr after each command.
+    pub show_trace_id: bool,
     introspect_cache: Option<IntrospectResult>,
 }
 
@@ -36,6 +41,8 @@ impl CliContext {
             organization_id: config.organization_id,
             project_id: config.project_id,
             debug: config.debug,
+            trace_id: Uuid::new_v4().as_simple().to_string(),
+            show_trace_id: config.show_trace_id,
             introspect_cache: None,
         }
     }
@@ -51,6 +58,14 @@ impl CliContext {
                 env!("CARGO_PKG_VERSION")
             ))
             .unwrap_or_else(|_| HeaderValue::from_static("Tensorlake CLI")),
+        );
+
+        // Inject W3C traceparent; share trace_id across all requests in this invocation.
+        let span_id = &Uuid::new_v4().as_simple().to_string()[..16];
+        headers.insert(
+            "traceparent",
+            HeaderValue::from_str(&format!("00-{}-{}-01", self.trace_id, span_id))
+                .unwrap_or_else(|_| HeaderValue::from_static("00-0-0-01")),
         );
 
         if let Some(key) = &self.api_key {

--- a/crates/cli/src/auth/guard.rs
+++ b/crates/cli/src/auth/guard.rs
@@ -30,6 +30,7 @@ pub async fn ensure_auth_and_project(ctx: &mut CliContext) -> Result<()> {
             login_result.organization_id.as_deref(),
             login_result.project_id.as_deref(),
             ctx.debug,
+            ctx.show_trace_id,
         );
         *ctx = CliContext::from_resolved(resolved);
 
@@ -79,6 +80,7 @@ pub async fn ensure_auth_and_project(ctx: &mut CliContext) -> Result<()> {
         Some(&org_id),
         Some(&proj_id),
         ctx.debug,
+        ctx.show_trace_id,
     );
     *ctx = CliContext::from_resolved(resolved);
 

--- a/crates/cli/src/auth/login.rs
+++ b/crates/cli/src/auth/login.rs
@@ -205,6 +205,7 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
             ctx.organization_id.as_deref(),
             ctx.project_id.as_deref(),
             ctx.debug,
+            ctx.show_trace_id,
         );
         let updated_ctx = CliContext::from_resolved(resolved);
 

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -131,7 +131,9 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
 }
 
 fn print_post_create_tip(ctx: &CliContext, sandbox_id: &str, display_id: &str, is_ephemeral: bool) {
-    let (proxy_url, host_header) = sandbox_proxy_base(ctx, sandbox_id);
+    // Use the name as the proxy subdomain when available; it's a stable human-readable identifier.
+    let proxy_key = if is_ephemeral { sandbox_id } else { display_id };
+    let (proxy_url, host_header) = sandbox_proxy_base(ctx, proxy_key);
     let host_flag = host_header
         .as_deref()
         .map(|h| format!(" \\\n     -H \"Host: {}\"", h))

--- a/crates/cli/src/commands/secrets.rs
+++ b/crates/cli/src/commands/secrets.rs
@@ -271,6 +271,7 @@ mod tests {
             organization_id: organization_id.map(str::to_string),
             project_id: project_id.map(str::to_string),
             debug: false,
+            show_trace_id: false,
         })
     }
 

--- a/crates/cli/src/config/resolver.rs
+++ b/crates/cli/src/config/resolver.rs
@@ -14,6 +14,7 @@ pub struct ResolvedConfig {
     pub organization_id: Option<String>,
     pub project_id: Option<String>,
     pub debug: bool,
+    pub show_trace_id: bool,
 }
 
 /// Resolve all configuration from CLI args > env vars > local config > global config > defaults.
@@ -28,6 +29,7 @@ pub fn resolve(
     organization_id: Option<&str>,
     project_id: Option<&str>,
     debug: bool,
+    show_trace_id: bool,
 ) -> ResolvedConfig {
     let local_config = load_local_config();
     let global_config = load_global_config();
@@ -49,6 +51,7 @@ pub fn resolve(
         organization_id: org_id,
         project_id: proj_id,
         debug,
+        show_trace_id,
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -61,6 +61,10 @@ struct Cli {
     #[arg(long, env = "TENSORLAKE_PROJECT_ID")]
     project: Option<String>,
 
+    /// Print the trace ID for this command to stderr (for APM correlation)
+    #[arg(long, env = "TENSORLAKE_SHOW_TRACE_ID")]
+    show_trace_id: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -624,11 +628,16 @@ async fn main() {
         cli.organization.as_deref(),
         cli.project.as_deref(),
         cli.debug,
+        cli.show_trace_id,
     );
 
     let mut ctx = CliContext::from_resolved(resolved);
 
     let result = run_command(&mut ctx, cli.command).await;
+
+    if ctx.show_trace_id {
+        eprintln!("Trace-ID: {}", ctx.trace_id);
+    }
 
     if let Err(e) = result {
         match &e {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -269,7 +269,8 @@ enum SbxCommands {
     },
 
     /// Create a new sandbox
-    New {
+    #[command(alias = "new")]
+    Create {
         /// Optional name for the sandbox. Named sandboxes support suspend/resume.
         /// Omit to create an ephemeral sandbox (no suspend/resume). When provided, must start
         /// with a lowercase letter, contain only lowercase letters, digits, and hyphens, not end
@@ -753,7 +754,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                 SbxCommands::Terminate { sandbox_ids } => {
                     commands::sbx::terminate::run(ctx, &sandbox_ids).await
                 }
-                SbxCommands::New {
+                SbxCommands::Create {
                     name,
                     cpus,
                     memory,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -380,8 +380,9 @@ enum SbxCommands {
         dest: String,
     },
 
-    /// Create a snapshot or list snapshots
-    Snapshot(SnapshotArgs),
+    /// Create a checkpoint (snapshot) or list checkpoints
+    #[command(alias = "snapshot")]
+    Checkpoint(SnapshotArgs),
 
     /// Clone a running sandbox via snapshot
     Clone {
@@ -819,14 +820,14 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     .await
                 }
                 SbxCommands::Cp { src, dest } => commands::sbx::cp::run(ctx, &src, &dest).await,
-                SbxCommands::Snapshot(snapshot_args) => match snapshot_args.command {
+                SbxCommands::Checkpoint(snapshot_args) => match snapshot_args.command {
                     Some(SnapshotCommands::Ls) => commands::sbx::snapshot_ls::run(ctx).await,
                     Some(SnapshotCommands::Rm { snapshot_ids }) => {
                         commands::sbx::snapshot_rm::run(ctx, &snapshot_ids).await
                     }
                     None => {
                         let sandbox_id = snapshot_args.sandbox_id.ok_or_else(|| {
-                            CliError::usage("snapshot requires a sandbox ID or the 'ls' subcommand")
+                            CliError::usage("checkpoint requires a sandbox ID or the 'ls' subcommand")
                         })?;
                         commands::sbx::snapshot::run(ctx, &sandbox_id, snapshot_args.timeout).await
                     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -62,7 +62,7 @@ struct Cli {
     project: Option<String>,
 
     /// Print the trace ID for this command to stderr (for APM correlation)
-    #[arg(long, env = "TENSORLAKE_SHOW_TRACE_ID")]
+    #[arg(long, env = "TENSORLAKE_SHOW_TRACE_ID", global = true)]
     show_trace_id: bool,
 
     #[command(subcommand)]

--- a/crates/cloud-sdk/Cargo.toml
+++ b/crates/cloud-sdk/Cargo.toml
@@ -35,10 +35,10 @@ url = { workspace = true }
 urlencoding = { workspace = true }
 uuid = { workspace = true }
 des = { workspace = true }
+rand = "0.9.2"
 
 [dev-dependencies]
 data-encoding = "2.5"
-rand = "0.9.2"
 tempfile = "3"
 zip = "0.6"
 

--- a/crates/cloud-sdk/src/applications/mod.rs
+++ b/crates/cloud-sdk/src/applications/mod.rs
@@ -39,75 +39,27 @@ use reqwest::{
     multipart::{Form, Part},
 };
 
-use crate::{applications::models::RequestStateChangeEvent, client::Client, error::SdkError};
+use crate::{
+    applications::models::RequestStateChangeEvent,
+    client::{Client, Traced},
+    error::SdkError,
+};
 
 /// A client for interacting with Tensorlake Cloud applications.
-///
-/// This client provides high-level methods for managing applications, requests, and related operations.
-/// It wraps the raw API calls with a more ergonomic interface.
 #[derive(Clone)]
 pub struct ApplicationsClient {
     client: Client,
 }
 
 impl ApplicationsClient {
-    /// Create a new applications client.
-    ///
-    /// # Arguments
-    ///
-    /// * `client` - The base HTTP client configured with authentication
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::ApplicationsClient};
-    ///
-    /// fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    /// let apps_client = ApplicationsClient::new(client);
-    /// Ok(())
-    /// }
-    /// ```
     pub fn new(client: Client) -> Self {
         Self { client }
     }
 
-    /// List all applications in a namespace.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The list applications request
-    ///
-    /// # Returns
-    ///
-    /// Returns a list of applications in the specified namespace.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::ApplicationsClient};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let request = tensorlake_cloud_sdk::applications::models::ListApplicationsRequest {
-    ///         namespace: "default".to_string(),
-    ///         limit: Some(10),
-    ///         cursor: None,
-    ///         direction: None,
-    ///     };
-    ///     apps_client.list(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn list(
         &self,
         request: &models::ListApplicationsRequest,
-    ) -> Result<models::ApplicationsList, SdkError> {
+    ) -> Result<Traced<models::ApplicationsList>, SdkError> {
         let uri_str = format!("/v1/namespaces/{}/applications", request.namespace);
         let mut req_builder = self.client.request(Method::GET, &uri_str);
 
@@ -122,96 +74,25 @@ impl ApplicationsClient {
         }
 
         let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_slice(bytes.as_ref());
-        let list = serde_path_to_error::deserialize(jd)?;
-
-        Ok(list)
+        self.client.execute_json(req).await
     }
 
-    /// Get details of a specific application.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The get application request
-    ///
-    /// # Returns
-    ///
-    /// Returns the application details.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::GetApplicationRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let request = GetApplicationRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .build()?;
-    ///     apps_client.get(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn get(
         &self,
         request: &models::GetApplicationRequest,
-    ) -> Result<models::Application, SdkError> {
+    ) -> Result<Traced<models::Application>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}",
             request.namespace, request.application
         );
-        let req_builder = self.client.request(Method::GET, &uri_str);
-
-        let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_reader(bytes.as_ref());
-        let app = serde_path_to_error::deserialize(jd)?;
-
-        Ok(app)
+        let req = self.client.request(Method::GET, &uri_str).build()?;
+        self.client.execute_json(req).await
     }
 
-    /// Create or update an application.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The upsert application request
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::{UpsertApplicationRequest, ApplicationManifest}}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     // Note: Requires constructing a full ApplicationManifest model with all required fields
-    ///     // This is typically done by parsing from configuration files or build manifests
-    ///     let code_zip: Vec<u8> = vec![/* zip file bytes */];
-    ///     let app_data = ApplicationManifest::builder()
-    ///         .name("my-app")
-    ///         .version("1.0.0")
-    ///         .build()?;
-    ///     let request = UpsertApplicationRequest::builder()
-    ///         .namespace("default")
-    ///         .application_manifest(app_data)
-    ///         .code_zip(code_zip)
-    ///         .build()?;
-    ///     apps_client.upsert(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn upsert(&self, request: &models::UpsertApplicationRequest) -> Result<(), SdkError> {
+    pub async fn upsert(
+        &self,
+        request: &models::UpsertApplicationRequest,
+    ) -> Result<Traced<()>, SdkError> {
         let mut multipart_form = Form::new();
 
         let manifest_json = serde_json::to_string(&request.application_manifest)?;
@@ -224,144 +105,54 @@ impl ApplicationsClient {
         let req = self
             .client
             .build_multipart_request(Method::POST, &uri_str, multipart_form)?;
-        let _resp = self.client.execute(req).await?;
-
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    /// Delete an application.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The delete application request
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::DeleteApplicationRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let request = DeleteApplicationRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .build()?;
-    ///     apps_client.delete(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn delete(&self, request: &models::DeleteApplicationRequest) -> Result<(), SdkError> {
+    pub async fn delete(
+        &self,
+        request: &models::DeleteApplicationRequest,
+    ) -> Result<Traced<()>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}",
             request.namespace, request.application
         );
-        let req_builder = self.client.request(Method::DELETE, &uri_str);
-
-        let req = req_builder.build()?;
-        let _resp = self.client.execute(req).await?;
-
-        Ok(())
+        let req = self.client.request(Method::DELETE, &uri_str).build()?;
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    /// Invoke an application with object data.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The invoke application request
-    ///
-    /// # Returns
-    ///
-    /// If `stream` is false, returns the request ID. If `stream` is true, returns a stream of progress events.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::{InvokeApplicationRequest, InvokeResponse}}};
-    /// use serde_json;
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let data = serde_json::json!({"input": "hello world"});
-    ///     let request = InvokeApplicationRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .body(data)
-    ///         .build()?;
-    ///     let response = apps_client.invoke(&request).await?;
-    ///     match response {
-    ///         InvokeResponse::RequestId(id) => println!("Request ID: {}", id),
-    ///         InvokeResponse::Stream(_) => unreachable!(),
-    ///     }
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn invoke(
         &self,
         request: &models::InvokeApplicationRequest,
-    ) -> Result<models::InvokeResponse, SdkError> {
+    ) -> Result<Traced<models::InvokeResponse>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}",
             request.namespace, request.application
         );
-        let req_builder = self.client.request(Method::POST, &uri_str);
-        let req = req_builder
+        let req = self
+            .client
+            .request(Method::POST, &uri_str)
             .header(ACCEPT, "application/json")
             .json(&request.body)
             .build()?;
-        let resp = self.client.execute(req).await?;
-
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_slice(&bytes);
-        let request_id_resp: serde_json::Value = serde_path_to_error::deserialize(jd)?;
-        let request_id =
-            request_id_resp["request_id"]
-                .as_str()
-                .ok_or_else(|| SdkError::ServerError {
-                    status: reqwest::StatusCode::OK,
-                    message: "Missing request_id in response".to_string(),
-                })?;
-        Ok(models::InvokeResponse::RequestId(request_id.to_string()))
+        let resp = self.client.execute_json::<serde_json::Value>(req).await?;
+        let trace_id = resp.trace_id.clone();
+        let request_id = resp["request_id"]
+            .as_str()
+            .ok_or_else(|| SdkError::ServerError {
+                status: reqwest::StatusCode::OK,
+                message: "Missing request_id in response".to_string(),
+            })?
+            .to_string();
+        Ok(Traced::new(
+            trace_id,
+            models::InvokeResponse::RequestId(request_id),
+        ))
     }
 
-    /// List requests for an application.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The list requests request
-    ///
-    /// # Returns
-    ///
-    /// Returns the list of requests for the application.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::ListRequestsRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let request = ListRequestsRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .limit(10)
-    ///         .build()?;
-    ///     apps_client.list_requests(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn list_requests(
         &self,
         request: &models::ListRequestsRequest,
-    ) -> Result<models::ApplicationRequests, SdkError> {
+    ) -> Result<Traced<models::ApplicationRequests>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}/requests",
             request.namespace, request.application
@@ -379,48 +170,13 @@ impl ApplicationsClient {
         }
 
         let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_reader(bytes.as_ref());
-        let list = serde_path_to_error::deserialize(jd)?;
-
-        Ok(list)
+        self.client.execute_json(req).await
     }
 
-    /// Get details of a specific request.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The get request request
-    ///
-    /// # Returns
-    ///
-    /// Returns the request details including all function runs and their allocations.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::GetRequestRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let request = GetRequestRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .request_id("request-123")
-    ///         .build()?;
-    ///     let req_details = apps_client.get_request(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn get_request(
         &self,
         request: &models::GetRequestRequest,
-    ) -> Result<models::Request, SdkError> {
+    ) -> Result<Traced<models::Request>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}/requests/{}",
             request.namespace, request.application, request.request_id
@@ -429,255 +185,111 @@ impl ApplicationsClient {
         if let Some(token) = &request.updates_pagination_token {
             req_builder = req_builder.query(&["nextToken", token]);
         }
-
         let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_reader(bytes.as_ref());
-        let req_details = serde_path_to_error::deserialize(jd)?;
-
-        Ok(req_details)
+        self.client.execute_json(req).await
     }
 
-    /// Delete a request.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The delete request request
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::DeleteRequestRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let request = DeleteRequestRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .request_id("request-123")
-    ///         .build()?;
-    ///     apps_client.delete_request(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn delete_request(
         &self,
         request: &models::DeleteRequestRequest,
-    ) -> Result<(), SdkError> {
+    ) -> Result<Traced<()>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}/requests/{}",
             request.namespace, request.application, request.request_id
         );
-        let req_builder = self.client.request(Method::DELETE, &uri_str);
-
-        let req = req_builder.build()?;
-        let _resp = self.client.execute(req).await?;
-
-        Ok(())
+        let req = self.client.request(Method::DELETE, &uri_str).build()?;
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    /// Download the output of a specific function call within a request.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The download function output request
-    ///
-    /// # Returns
-    ///
-    /// Returns the function call output data.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::DownloadFunctionOutputRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let request = DownloadFunctionOutputRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .request_id("request-123")
-    ///         .function_call_id("func-456")
-    ///         .build()?;
-    ///     apps_client.download_function_output(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn download_function_output(
         &self,
         request: &models::DownloadFunctionOutputRequest,
-    ) -> Result<models::DownloadOutput, SdkError> {
+    ) -> Result<Traced<models::DownloadOutput>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}/requests/{}/output/{}",
             request.namespace, request.application, request.request_id, request.function_call_id
         );
-        let req_builder = self.client.request(reqwest::Method::GET, &uri_str);
-
-        let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
-        let mut output = models::DownloadOutput {
-            content_type: resp.headers().get(CONTENT_TYPE).cloned(),
-            content_length: resp.headers().get(CONTENT_LENGTH).cloned(),
-            content: Bytes::new(),
+        let req = self
+            .client
+            .request(reqwest::Method::GET, &uri_str)
+            .build()?;
+        let resp = self.client.execute_traced(req).await?;
+        let trace_id = resp.trace_id.clone();
+        let content_type = resp.headers().get(CONTENT_TYPE).cloned();
+        let content_length = resp.headers().get(CONTENT_LENGTH).cloned();
+        let is_success = resp.status().is_success();
+        let content = if is_success {
+            resp.into_inner().bytes().await?
+        } else {
+            Bytes::new()
         };
-
-        if resp.status().is_success() {
-            output.content = resp.bytes().await?;
-        }
-
-        Ok(output)
+        Ok(Traced::new(
+            trace_id,
+            models::DownloadOutput {
+                content_type,
+                content_length,
+                content,
+            },
+        ))
     }
 
-    /// Check if output is available for a request without downloading the content.
-    ///
-    /// This performs a HEAD request to check for the presence of output data.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The check function output request
-    ///
-    /// # Returns
-    ///
-    /// Returns `Some` with output metadata if available, or `None` if no output exists.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::CheckFunctionOutputRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let request = CheckFunctionOutputRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .request_id("request-123")
-    ///         .build()?;
-    ///     if let Some(metadata) = apps_client.check_function_output(&request).await? {
-    ///         println!("Output available, size: {:?}", metadata.content_length);
-    ///     }
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn check_function_output(
         &self,
         request: &models::CheckFunctionOutputRequest,
-    ) -> Result<Option<models::DownloadOutput>, SdkError> {
+    ) -> Result<Traced<Option<models::DownloadOutput>>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}/requests/{}/output",
             request.namespace, request.application, request.request_id
         );
-        let req_builder = self.client.request(Method::HEAD, &uri_str);
-
-        let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
+        let req = self.client.request(Method::HEAD, &uri_str).build()?;
+        let resp = self.client.execute_traced(req).await?;
+        let trace_id = resp.trace_id.clone();
         if resp.status() == StatusCode::NO_CONTENT {
-            return Ok(None);
+            return Ok(Traced::new(trace_id, None));
         }
-
-        Ok(Some(models::DownloadOutput {
-            content_type: resp.headers().get(CONTENT_TYPE).cloned(),
-            content_length: resp.headers().get(CONTENT_LENGTH).cloned(),
-            content: Bytes::new(),
-        }))
+        Ok(Traced::new(
+            trace_id,
+            Some(models::DownloadOutput {
+                content_type: resp.headers().get(CONTENT_TYPE).cloned(),
+                content_length: resp.headers().get(CONTENT_LENGTH).cloned(),
+                content: Bytes::new(),
+            }),
+        ))
     }
 
-    /// Download the complete output of a request.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The download request output request
-    ///
-    /// # Returns
-    ///
-    /// Returns the complete request output data.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::applications::{ApplicationsClient, models::DownloadRequestOutputRequest};
-    ///
-    /// async fn example(apps_client: &ApplicationsClient) -> Result<(), Box<dyn std::error::Error>> {
-    ///     let request = DownloadRequestOutputRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .request_id("request-123")
-    ///         .build()?;
-    ///     let output = apps_client.download_request_output(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn download_request_output(
         &self,
         request: &models::DownloadRequestOutputRequest,
-    ) -> Result<models::DownloadOutput, SdkError> {
+    ) -> Result<Traced<models::DownloadOutput>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}/requests/{}/output",
             request.namespace, request.application, request.request_id
         );
-        let req_builder = self.client.request(Method::GET, &uri_str);
-
-        let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
-        let mut output = models::DownloadOutput {
-            content_type: resp.headers().get(CONTENT_TYPE).cloned(),
-            content_length: resp.headers().get(CONTENT_LENGTH).cloned(),
-            content: Bytes::new(),
+        let req = self.client.request(Method::GET, &uri_str).build()?;
+        let resp = self.client.execute_traced(req).await?;
+        let trace_id = resp.trace_id.clone();
+        let content_type = resp.headers().get(CONTENT_TYPE).cloned();
+        let content_length = resp.headers().get(CONTENT_LENGTH).cloned();
+        let is_success = resp.status().is_success();
+        let content = if is_success {
+            resp.into_inner().bytes().await?
+        } else {
+            Bytes::new()
         };
-
-        if resp.status().is_success() {
-            output.content = resp.bytes().await?;
-        }
-
-        Ok(output)
+        Ok(Traced::new(
+            trace_id,
+            models::DownloadOutput {
+                content_type,
+                content_length,
+                content,
+            },
+        ))
     }
 
-    /// Get logs for an application.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The get logs request
-    ///
-    /// # Returns
-    ///
-    /// Returns the logs for the application matching the request filters.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::GetLogsRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let apps_client = ApplicationsClient::new(client);
-    ///     let request = GetLogsRequest::builder()
-    ///         .namespace("default")
-    ///         .application("my-app")
-    ///         .tail(100)
-    ///         .build()?;
-    ///     apps_client.get_logs(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn get_logs(
         &self,
         request: &models::GetLogsRequest,
-    ) -> Result<models::EventsResponse, SdkError> {
+    ) -> Result<Traced<models::EventsResponse>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}/logs",
             request.namespace, request.application
@@ -710,19 +322,13 @@ impl ApplicationsClient {
         }
 
         let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_reader(bytes.as_ref());
-        let events_resp = serde_path_to_error::deserialize(jd)?;
-
-        Ok(events_resp)
+        self.client.execute_json(req).await
     }
 
     pub async fn get_progress_updates(
         &self,
         request: &models::ProgressUpdatesRequest,
-    ) -> Result<models::ProgressUpdatesResponse, SdkError> {
+    ) -> Result<Traced<models::ProgressUpdatesResponse>, SdkError> {
         let uri_str = format!(
             "/v1/namespaces/{}/applications/{}/requests/{}/updates",
             request.namespace, request.application, request.request_id
@@ -734,8 +340,11 @@ impl ApplicationsClient {
                     .client
                     .build_event_source_request::<RequestStateChangeEvent>(&uri_str)
                     .await?;
-
-                Ok(models::ProgressUpdatesResponse::Stream(stream))
+                let trace_id = stream.trace_id.clone();
+                Ok(Traced::new(
+                    trace_id,
+                    models::ProgressUpdatesResponse::Stream(stream.into_inner()),
+                ))
             }
             models::ProgressUpdatesRequestMode::Paginated(ref token) => {
                 let query = token
@@ -744,12 +353,15 @@ impl ApplicationsClient {
                 let req = self
                     .client
                     .build_get_json_request(&uri_str, query.as_deref())?;
-                let resp = self.client.execute(req).await?;
-
-                let bytes = resp.bytes().await?;
-                let jd = &mut serde_json::Deserializer::from_slice(&bytes);
-                let response: models::ProgressUpdatesJson = serde_path_to_error::deserialize(jd)?;
-                Ok(models::ProgressUpdatesResponse::Json(response))
+                let response = self
+                    .client
+                    .execute_json::<models::ProgressUpdatesJson>(req)
+                    .await?;
+                let trace_id = response.trace_id.clone();
+                Ok(Traced::new(
+                    trace_id,
+                    models::ProgressUpdatesResponse::Json(response.into_inner()),
+                ))
             }
         }
     }

--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -90,6 +90,7 @@ pub struct ClientBuilder {
     middlewares: Vec<Arc<dyn Middleware + 'static>>,
     organization_id: Option<String>,
     project_id: Option<String>,
+    user_agent: Option<String>,
 }
 
 impl ClientBuilder {
@@ -105,7 +106,19 @@ impl ClientBuilder {
             middlewares: Vec::new(),
             organization_id: None,
             project_id: None,
+            user_agent: None,
         }
+    }
+
+    /// Override the User-Agent header sent with every request.
+    ///
+    /// Defaults to `tensorlake-rust-sdk/{CARGO_PKG_VERSION}`. Callers that
+    /// wrap this client (e.g. the Python SDK via PyO3) should set a value like
+    /// `tensorlake-python-sdk/{version}` so server logs can distinguish traffic
+    /// by SDK language.
+    pub fn user_agent(mut self, ua: &str) -> Self {
+        self.user_agent = Some(ua.to_string());
+        self
     }
 
     /// Set the bearer token for authentication.
@@ -157,7 +170,11 @@ impl ClientBuilder {
             default_headers.insert("X-Forwarded-Project-Id", str_to_header_value(project_id)?);
         }
 
-        let base_client = new_base_client(&default_headers)?;
+        let ua = self.user_agent.as_deref().unwrap_or(concat!(
+            "tensorlake-rust-sdk/",
+            env!("CARGO_PKG_VERSION")
+        ));
+        let base_client = new_base_client(&default_headers, ua)?;
         let mut builder = ReqwestClientBuilder::new(base_client.clone());
 
         for middleware in &self.middlewares {
@@ -397,14 +414,11 @@ fn ensure_rustls_provider() {
     });
 }
 
-fn new_base_client(headers: &HeaderMap) -> Result<reqwest::Client, SdkError> {
+fn new_base_client(headers: &HeaderMap, user_agent: &str) -> Result<reqwest::Client, SdkError> {
     ensure_rustls_provider();
 
     let client = reqwest::Client::builder()
-        .user_agent(format!(
-            "Tensorlake Cloud SDK/{}",
-            env!("CARGO_PKG_VERSION")
-        ))
+        .user_agent(user_agent)
         .default_headers(headers.clone())
         .build()?;
     Ok(client)

--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -8,12 +8,65 @@ use reqwest::{
 use reqwest_middleware::{ClientBuilder as ReqwestClientBuilder, ClientWithMiddleware, Middleware};
 use serde::de::DeserializeOwned;
 use std::{
+    ops::{Deref, DerefMut},
     pin::Pin,
     result::Result,
     sync::{Arc, Once},
 };
 
 use crate::error::SdkError;
+
+/// Wraps any SDK operation result with the W3C `trace_id` so callers can
+/// correlate the request with its server-side spans in Datadog APM or any
+/// other OTEL-compatible backend.
+///
+/// All fields and methods of `T` are accessible via `Deref`/`DerefMut`, so
+/// most existing code compiles unchanged. Use `into_inner()` when you need an
+/// owned `T`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let result = sdk.sandboxes("ns", false).create(&request).await?;
+/// println!("{}", result.sandbox_id); // existing field — accessible via Deref
+/// println!("{}", result.trace_id);   // new: look this up in Datadog APM
+/// ```
+#[derive(Debug, Clone)]
+pub struct Traced<T> {
+    /// W3C trace ID for this request (32 lowercase hex chars).
+    pub trace_id: String,
+    value: T,
+}
+
+impl<T> Traced<T> {
+    pub fn new(trace_id: String, value: T) -> Self {
+        Self { trace_id, value }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Traced<U> {
+        Traced {
+            trace_id: self.trace_id,
+            value: f(self.value),
+        }
+    }
+}
+
+impl<T> Deref for Traced<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for Traced<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}
 
 /// HTTP client that interacts with the Tensorlake Cloud API.
 #[derive(Clone)]
@@ -147,16 +200,58 @@ impl Client {
         }
     }
 
-    /// Execute an HTTP request.
-    pub async fn execute(&self, request: Request) -> Result<Response, SdkError> {
+    /// Execute an HTTP request. Injects a W3C `traceparent` header for server-side
+    /// correlation. Use [`execute_traced`] or [`execute_json`] when you need the
+    /// `trace_id` returned to the caller.
+    pub async fn execute(&self, mut request: Request) -> Result<Response, SdkError> {
+        let (traceparent, _) = generate_traceparent();
+        if let Ok(value) = traceparent.parse::<HeaderValue>() {
+            request.headers_mut().insert("traceparent", value);
+        }
         let response = self.client.execute(request).await?;
         self.handle_response(response).await
     }
 
     /// Execute an HTTP request without mapping non-success statuses to [`SdkError`].
-    pub async fn execute_raw(&self, request: Request) -> Result<Response, SdkError> {
+    /// Injects a W3C `traceparent` header for server-side correlation.
+    pub async fn execute_raw(&self, mut request: Request) -> Result<Response, SdkError> {
+        let (traceparent, _) = generate_traceparent();
+        if let Ok(value) = traceparent.parse::<HeaderValue>() {
+            request.headers_mut().insert("traceparent", value);
+        }
         let response = self.client.execute(request).await?;
         Ok(response)
+    }
+
+    /// Execute an HTTP request, inject a W3C `traceparent` header, and return
+    /// the raw response alongside the `trace_id`. Use this when you need the
+    /// `trace_id` but want to handle the response body yourself.
+    pub async fn execute_traced(&self, mut request: Request) -> Result<Traced<Response>, SdkError> {
+        let (traceparent, trace_id) = generate_traceparent();
+        if let Ok(value) = traceparent.parse::<HeaderValue>() {
+            request.headers_mut().insert("traceparent", value);
+        }
+        let response = self.client.execute(request).await?;
+        let response = self.handle_response(response).await?;
+        Ok(Traced::new(trace_id, response))
+    }
+
+    /// Execute an HTTP request, inject a W3C `traceparent` header, deserialize
+    /// the JSON response body, and return both alongside the `trace_id`.
+    ///
+    /// This is the primary building block for service-level methods that return
+    /// structured responses. The `trace_id` lets callers look up the full
+    /// server-side cascade in Datadog APM.
+    pub async fn execute_json<T: DeserializeOwned>(
+        &self,
+        request: Request,
+    ) -> Result<Traced<T>, SdkError> {
+        let traced = self.execute_traced(request).await?;
+        let trace_id = traced.trace_id.clone();
+        let bytes = traced.into_inner().bytes().await?;
+        let jd = &mut serde_json::Deserializer::from_slice(bytes.as_ref());
+        let value: T = serde_path_to_error::deserialize(jd)?;
+        Ok(Traced::new(trace_id, value))
     }
 
     pub fn request(
@@ -170,14 +265,16 @@ impl Client {
     pub async fn build_event_source_request<T>(
         &self,
         path: &str,
-    ) -> Result<EventSourceStream<T>, SdkError>
+    ) -> Result<Traced<EventSourceStream<T>>, SdkError>
     where
         T: DeserializeOwned,
     {
+        let (traceparent, trace_id) = generate_traceparent();
         let response = self
             .base_client
             .get(self.base_url.clone() + path)
             .header(ACCEPT, "text/event-stream")
+            .header("traceparent", traceparent)
             .send()
             .await?;
 
@@ -193,7 +290,7 @@ impl Client {
                     Err(error) => Some(Err(SdkError::EventSourceError(error.to_string()))),
                 }
             });
-        Ok(Box::pin(stream))
+        Ok(Traced::new(trace_id, Box::pin(stream)))
     }
 
     pub fn build_multipart_request(
@@ -258,6 +355,12 @@ impl Client {
             _ => Ok(response),
         }
     }
+}
+
+fn generate_traceparent() -> (String, String) {
+    let trace_id = hex::encode(rand::random::<[u8; 16]>());
+    let span_id = hex::encode(rand::random::<[u8; 8]>());
+    (format!("00-{trace_id}-{span_id}-01"), trace_id)
 }
 
 async fn body_message_or_default(response: Response, default: &str) -> String {

--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -170,10 +170,10 @@ impl ClientBuilder {
             default_headers.insert("X-Forwarded-Project-Id", str_to_header_value(project_id)?);
         }
 
-        let ua = self.user_agent.as_deref().unwrap_or(concat!(
-            "tensorlake-rust-sdk/",
-            env!("CARGO_PKG_VERSION")
-        ));
+        let ua = self
+            .user_agent
+            .as_deref()
+            .unwrap_or(concat!("tensorlake-rust-sdk/", env!("CARGO_PKG_VERSION")));
         let base_client = new_base_client(&default_headers, ua)?;
         let mut builder = ReqwestClientBuilder::new(base_client.clone());
 

--- a/crates/cloud-sdk/src/cron/mod.rs
+++ b/crates/cloud-sdk/src/cron/mod.rs
@@ -1,6 +1,9 @@
 pub mod models;
 
-use crate::{client::Client, error::SdkError};
+use crate::{
+    client::{Client, Traced},
+    error::SdkError,
+};
 use models::*;
 use reqwest::Method;
 
@@ -22,7 +25,7 @@ impl CronClient {
         application: &str,
         cron_expression: &str,
         input_base64: Option<String>,
-    ) -> Result<CreateCronScheduleResponse, SdkError> {
+    ) -> Result<Traced<CreateCronScheduleResponse>, SdkError> {
         let path = format!(
             "/v1/namespaces/{}/applications/{}/cron-schedules",
             namespace, application
@@ -34,10 +37,7 @@ impl CronClient {
         let req = self
             .client
             .build_post_json_request(Method::POST, &path, &body)?;
-        let resp = self.client.execute(req).await?;
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_reader(bytes.as_ref());
-        Ok(serde_path_to_error::deserialize(jd)?)
+        self.client.execute_json(req).await
     }
 
     /// List all cron schedules for an application.
@@ -45,16 +45,13 @@ impl CronClient {
         &self,
         namespace: &str,
         application: &str,
-    ) -> Result<ListCronSchedulesResponse, SdkError> {
+    ) -> Result<Traced<ListCronSchedulesResponse>, SdkError> {
         let path = format!(
             "/v1/namespaces/{}/applications/{}/cron-schedules",
             namespace, application
         );
         let req = self.client.build_get_json_request(&path, None)?;
-        let resp = self.client.execute(req).await?;
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_reader(bytes.as_ref());
-        Ok(serde_path_to_error::deserialize(jd)?)
+        self.client.execute_json(req).await
     }
 
     /// Delete a cron schedule by ID.
@@ -63,7 +60,7 @@ impl CronClient {
         namespace: &str,
         application: &str,
         schedule_id: &str,
-    ) -> Result<(), SdkError> {
+    ) -> Result<Traced<()>, SdkError> {
         let path = format!(
             "/v1/namespaces/{}/applications/{}/cron-schedules/{}",
             namespace, application, schedule_id
@@ -73,7 +70,6 @@ impl CronClient {
             .request(Method::DELETE, &path)
             .build()
             .map_err(SdkError::from)?;
-        self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 }

--- a/crates/cloud-sdk/src/images/mod.rs
+++ b/crates/cloud-sdk/src/images/mod.rs
@@ -32,7 +32,11 @@
 
 use std::{collections::HashMap, pin::Pin, time::Duration};
 
-use crate::{client::Client, error::SdkError, images::error::ImagesError};
+use crate::{
+    client::{Client, Traced},
+    error::SdkError,
+    images::error::ImagesError,
+};
 use futures::stream::Stream;
 use reqwest::{
     Method,
@@ -50,76 +54,11 @@ pub struct ImagesClient {
 }
 
 impl ImagesClient {
-    /// Create a new images client.
-    ///
-    /// # Arguments
-    ///
-    /// * `client` - The base HTTP client configured with authentication
-    /// * `build_service_url` - The URL of the image build service
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tensorlake_cloud_sdk::{ClientBuilder, images::ImagesClient};
-    ///
-    /// fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let images_client = ImagesClient::new(client);
-    ///     Ok(())
-    /// }
-    /// ```
     pub fn new(client: Client) -> Self {
         Self { client }
     }
 
-    /// Build a container image.
-    ///
-    /// This method submits an image build request to the Tensorlake Cloud build service
-    /// and polls for completion.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The image build request containing all necessary parameters
-    ///
-    /// # Returns
-    ///
-    /// Returns the build result containing the build ID and final status.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the build request fails or the build process encounters an error.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tensorlake_cloud_sdk::{ClientBuilder, images::{ImagesClient, models::{ImageBuildRequest, Image}}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let images_client = ImagesClient::new(client);
-    ///
-    ///     // Define an image
-    ///     let image = Image::builder()
-    ///         .name("my-app")
-    ///         .base_image("python:3.9")
-    ///         .build()?;
-    ///     let request = ImageBuildRequest::builder()
-    ///         .image(image)
-    ///         .image_tag("v1.0")
-    ///         .application_name("my-app")
-    ///         .application_version("1.0.0")
-    ///         .function_name("main")
-    ///         .sdk_version("0.2")
-    ///         .build()?;
-    ///
-    ///     images_client.build_image(request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
+    /// Build a container image, poll for completion, and return the result.
     pub async fn build_image(
         &self,
         request: ImageBuildRequest,
@@ -133,46 +72,42 @@ impl ImagesClient {
         build_service_path: &str,
         request: &CreateApplicationBuildRequest,
         image_contexts: &[ApplicationBuildContext],
-    ) -> Result<ApplicationBuildResponse, SdkError> {
+    ) -> Result<Traced<ApplicationBuildResponse>, SdkError> {
         let form = create_application_build_form(request, image_contexts)?;
-        let request =
-            self.client
-                .build_multipart_request(Method::POST, build_service_path, form)?;
-        let response = self.client.execute(request).await?;
-        Ok(response.json::<ApplicationBuildResponse>().await?)
+        let req = self
+            .client
+            .build_multipart_request(Method::POST, build_service_path, form)?;
+        self.client.execute_json(req).await
     }
 
     pub async fn application_build_info(
         &self,
         build_service_path: &str,
         application_build_id: &str,
-    ) -> Result<ApplicationBuildResponse, SdkError> {
+    ) -> Result<Traced<ApplicationBuildResponse>, SdkError> {
         let path = format!(
             "{}/{}",
             build_service_path.trim_end_matches('/'),
             application_build_id
         );
-        let request = self.client.request(Method::GET, &path).build()?;
-        let response = self.client.execute(request).await?;
-        Ok(response.json::<ApplicationBuildResponse>().await?)
+        let req = self.client.request(Method::GET, &path).build()?;
+        self.client.execute_json(req).await
     }
 
     pub async fn cancel_application_build(
         &self,
         build_service_path: &str,
         application_build_id: &str,
-    ) -> Result<ApplicationBuildResponse, SdkError> {
+    ) -> Result<Traced<ApplicationBuildResponse>, SdkError> {
         let path = format!(
             "{}/{}/cancel",
             build_service_path.trim_end_matches('/'),
             application_build_id
         );
-        let request = self.client.request(Method::POST, &path).build()?;
-        let response = self.client.execute(request).await?;
-        Ok(response.json::<ApplicationBuildResponse>().await?)
+        let req = self.client.request(Method::POST, &path).build()?;
+        self.client.execute_json(req).await
     }
 
-    /// Submit a build request to the build service.
     async fn submit_build_request(
         &self,
         request: &ImageBuildRequest,
@@ -193,27 +128,27 @@ impl ImagesClient {
                 Part::bytes(context_data).file_name("context.tar.gz"),
             );
 
-        let request =
-            self.client
-                .build_multipart_request(Method::PUT, "/images/v2/builds", form)?;
-
-        let response = self.client.execute(request).await?;
-        let json = response.json::<BuildInfo>().await?;
-
-        Ok(json)
+        let req = self
+            .client
+            .build_multipart_request(Method::PUT, "/images/v2/builds", form)?;
+        Ok(self
+            .client
+            .execute_json::<BuildInfo>(req)
+            .await?
+            .into_inner())
     }
 
-    /// Poll the build status until completion.
     async fn poll_build_status(&self, build_id: &str) -> Result<ImageBuildResult, SdkError> {
         loop {
             tokio::time::sleep(Duration::from_millis(100)).await;
 
             let uri_str = format!("/images/v2/builds/{build_id}");
-            let request = self.client.request(Method::GET, &uri_str).build()?;
-
-            let response = self.client.execute(request).await?;
-
-            let build_info: BuildInfo = response.json().await?;
+            let req = self.client.request(Method::GET, &uri_str).build()?;
+            let build_info = self
+                .client
+                .execute_json::<BuildInfo>(req)
+                .await?
+                .into_inner();
 
             match build_info.status.as_str() {
                 "completed" | "succeeded" => {
@@ -234,50 +169,15 @@ impl ImagesClient {
                         error_message: build_info.error_message,
                     });
                 }
-                _ => {
-                    // Continue polling for other statuses (pending, in_progress, building, etc.)
-                    continue;
-                }
+                _ => continue,
             }
         }
     }
 
-    /// List builds for the current project.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The list builds request
-    ///
-    /// # Returns
-    ///
-    /// Returns a paginated list of builds.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the request fails or the response cannot be parsed.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, images::{ImagesClient, models::ListBuildsRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let images_client = ImagesClient::new(client);
-    ///     let request = ListBuildsRequest::builder()
-    ///         .page(1)
-    ///         .page_size(25)
-    ///         .build()?;
-    ///     images_client.list_builds(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn list_builds(
         &self,
         request: &models::ListBuildsRequest,
-    ) -> Result<Page<BuildListResponse>, SdkError> {
+    ) -> Result<Traced<Page<BuildListResponse>>, SdkError> {
         let mut query_params = Vec::new();
         if let Some(p) = request.page {
             query_params.push(("page", p.to_string()));
@@ -286,7 +186,6 @@ impl ImagesClient {
             query_params.push(("page_size", ps.to_string()));
         }
         if let Some(s) = &request.status {
-            // Assuming BuildStatus can be converted to string
             let status_str = match s {
                 BuildStatus::Pending => "pending",
                 BuildStatus::Enqueued => "enqueued",
@@ -313,140 +212,32 @@ impl ImagesClient {
             .request(Method::GET, "/images/v2/builds")
             .query(&query_params)
             .build()?;
-
-        let response = self.client.execute(req).await?;
-
-        Ok(response.json::<Page<BuildListResponse>>().await?)
+        self.client.execute_json(req).await
     }
 
-    /// Cancel a build.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The cancel build request
-    ///
-    /// # Returns
-    ///
-    /// Returns a success message if the cancel request was accepted.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the request fails.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, images::{ImagesClient, models::CancelBuildRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let images_client = ImagesClient::new(client);
-    ///     let request = CancelBuildRequest::builder()
-    ///         .build_id("build-123".to_string())
-    ///         .build()?;
-    ///     images_client.cancel_build(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn cancel_build(&self, request: &models::CancelBuildRequest) -> Result<(), SdkError> {
+    pub async fn cancel_build(
+        &self,
+        request: &models::CancelBuildRequest,
+    ) -> Result<Traced<()>, SdkError> {
         let uri_str = format!("/images/v2/builds/{}/cancel", request.build_id);
         let req = self.client.request(Method::POST, &uri_str).build()?;
-
-        let _response = self.client.execute(req).await?;
-
-        // 202 Accepted, no body
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    /// Get build info.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The get build info request
-    ///
-    /// # Returns
-    ///
-    /// Returns the build info response containing details about the build.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the request fails or the response cannot be parsed.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, images::{ImagesClient, models::GetBuildInfoRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let images_client = ImagesClient::new(client);
-    ///     let request = GetBuildInfoRequest::builder()
-    ///         .build_id("build-123".to_string())
-    ///         .build()?;
-    ///     images_client.get_build_info(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn get_build_info(
         &self,
         request: &models::GetBuildInfoRequest,
-    ) -> Result<BuildInfoResponse, SdkError> {
+    ) -> Result<Traced<BuildInfoResponse>, SdkError> {
         let uri_str = format!("/images/v2/builds/{}", request.build_id);
         let req = self.client.request(Method::GET, &uri_str).build()?;
-
-        let response = self.client.execute(req).await?;
-
-        Ok(response.json::<BuildInfoResponse>().await?)
+        self.client.execute_json(req).await
     }
 
-    /// Stream build logs.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The stream logs request
-    ///
-    /// # Returns
-    ///
-    /// Returns a stream that yields log entries as they are received from the server.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the request fails.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, images::{ImagesClient, models::StreamLogsRequest}};
-    /// use futures::StreamExt;
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let images_client = ImagesClient::new(client);
-    ///     let request = StreamLogsRequest::builder()
-    ///         .build_id("build-123".to_string())
-    ///         .build()?;
-    ///     let mut stream = images_client.stream_logs(&request).await?;
-    ///     while let Some(log_entry) = stream.next().await {
-    ///         match log_entry {
-    ///             Ok(entry) => println!("Log: {:?}", entry),
-    ///             Err(e) => eprintln!("Error: {:?}", e),
-    ///         }
-    ///     }
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn stream_logs(
         &self,
         request: &models::StreamLogsRequest,
-    ) -> Result<ImageBuildLogStream, SdkError> {
+    ) -> Result<Traced<ImageBuildLogStream>, SdkError> {
         let uri_str = format!("/images/v2/builds/{}/logs", request.build_id);
-
         let stream = self
             .client
             .build_event_source_request::<LogEntry>(&uri_str)

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -81,7 +81,7 @@ use sandboxes::*;
 use secrets::*;
 
 mod client;
-pub use client::{Client, ClientBuilder};
+pub use client::{Client, ClientBuilder, Traced};
 
 /// The main entry point for the Tensorlake Cloud SDK.
 ///

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -5,10 +5,12 @@ use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::Method;
 use reqwest::header::ACCEPT;
-use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-use crate::{client::Client, error::SdkError};
+use crate::{
+    client::{Client, Traced},
+    error::SdkError,
+};
 pub use desktop::SandboxDesktopClient;
 
 use models::{
@@ -57,86 +59,74 @@ impl SandboxesClient {
         }
     }
 
-    async fn parse_json<T: DeserializeOwned>(response: reqwest::Response) -> Result<T, SdkError> {
-        let bytes = response.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_slice(bytes.as_ref());
-        let parsed = serde_path_to_error::deserialize(jd)?;
-        Ok(parsed)
-    }
-
     pub async fn create(
         &self,
         request: &CreateSandboxRequest,
-    ) -> Result<CreateSandboxResponse, SdkError> {
+    ) -> Result<Traced<CreateSandboxResponse>, SdkError> {
         let uri = self.endpoint("sandboxes");
         let req = self
             .client
             .build_post_json_request(Method::POST, &uri, request)?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn claim(&self, pool_id: &str) -> Result<CreateSandboxResponse, SdkError> {
+    pub async fn claim(&self, pool_id: &str) -> Result<Traced<CreateSandboxResponse>, SdkError> {
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}/sandboxes"));
         let req = self.client.request(Method::POST, &uri).build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn get(&self, sandbox_id: &str) -> Result<SandboxInfo, SdkError> {
+    pub async fn get(&self, sandbox_id: &str) -> Result<Traced<SandboxInfo>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}"));
         let req = self.client.request(Method::GET, &uri).build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn list(&self) -> Result<Vec<SandboxInfo>, SdkError> {
+    pub async fn list(&self) -> Result<Traced<Vec<SandboxInfo>>, SdkError> {
         let uri = self.endpoint("sandboxes");
         let req = self.client.request(Method::GET, &uri).build()?;
-        let resp = self.client.execute(req).await?;
-        let list: ListSandboxesResponse = Self::parse_json(resp).await?;
-        Ok(list.sandboxes)
+        Ok(self
+            .client
+            .execute_json::<ListSandboxesResponse>(req)
+            .await?
+            .map(|r| r.sandboxes))
     }
 
     pub async fn update(
         &self,
         sandbox_id: &str,
         request: &UpdateSandboxRequest,
-    ) -> Result<SandboxInfo, SdkError> {
+    ) -> Result<Traced<SandboxInfo>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}"));
         let req = self
             .client
             .build_post_json_request(Method::PATCH, &uri, request)?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn delete(&self, sandbox_id: &str) -> Result<(), SdkError> {
+    pub async fn delete(&self, sandbox_id: &str) -> Result<Traced<()>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}"));
         let req = self.client.request(Method::DELETE, &uri).build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn suspend(&self, sandbox_id: &str) -> Result<(), SdkError> {
+    pub async fn suspend(&self, sandbox_id: &str) -> Result<Traced<()>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/suspend"));
         let req = self.client.request(Method::POST, &uri).build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn resume(&self, sandbox_id: &str) -> Result<(), SdkError> {
+    pub async fn resume(&self, sandbox_id: &str) -> Result<Traced<()>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/resume"));
         let req = self.client.request(Method::POST, &uri).build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
     pub async fn snapshot(
         &self,
         sandbox_id: &str,
         content_mode: Option<SnapshotContentMode>,
-    ) -> Result<CreateSnapshotResponse, SdkError> {
+    ) -> Result<Traced<CreateSnapshotResponse>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/snapshot"));
         let req = if content_mode.is_some() {
             let body = CreateSnapshotRequest {
@@ -148,77 +138,74 @@ impl SandboxesClient {
             // Preserve today's wire shape (no body) for callers that don't set a content mode.
             self.client.request(Method::POST, &uri).build()?
         };
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn get_snapshot(&self, snapshot_id: &str) -> Result<SnapshotInfo, SdkError> {
+    pub async fn get_snapshot(&self, snapshot_id: &str) -> Result<Traced<SnapshotInfo>, SdkError> {
         let uri = self.endpoint(&format!("snapshots/{snapshot_id}"));
         let req = self.client.request(Method::GET, &uri).build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn list_snapshots(&self) -> Result<Vec<SnapshotInfo>, SdkError> {
+    pub async fn list_snapshots(&self) -> Result<Traced<Vec<SnapshotInfo>>, SdkError> {
         let uri = self.endpoint("snapshots");
         let req = self.client.request(Method::GET, &uri).build()?;
-        let resp = self.client.execute(req).await?;
-        let list: ListSnapshotsResponse = Self::parse_json(resp).await?;
-        Ok(list.snapshots)
+        Ok(self
+            .client
+            .execute_json::<ListSnapshotsResponse>(req)
+            .await?
+            .map(|r| r.snapshots))
     }
 
-    pub async fn delete_snapshot(&self, snapshot_id: &str) -> Result<(), SdkError> {
+    pub async fn delete_snapshot(&self, snapshot_id: &str) -> Result<Traced<()>, SdkError> {
         let uri = self.endpoint(&format!("snapshots/{snapshot_id}"));
         let req = self.client.request(Method::DELETE, &uri).build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
     pub async fn create_pool(
         &self,
         request: &SandboxPoolRequest,
-    ) -> Result<CreateSandboxPoolResponse, SdkError> {
+    ) -> Result<Traced<CreateSandboxPoolResponse>, SdkError> {
         let uri = self.endpoint("sandbox-pools");
         let req = self
             .client
             .build_post_json_request(Method::POST, &uri, request)?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn get_pool(&self, pool_id: &str) -> Result<SandboxPoolInfo, SdkError> {
+    pub async fn get_pool(&self, pool_id: &str) -> Result<Traced<SandboxPoolInfo>, SdkError> {
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}"));
         let req = self.client.request(Method::GET, &uri).build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn list_pools(&self) -> Result<Vec<SandboxPoolInfo>, SdkError> {
+    pub async fn list_pools(&self) -> Result<Traced<Vec<SandboxPoolInfo>>, SdkError> {
         let uri = self.endpoint("sandbox-pools");
         let req = self.client.request(Method::GET, &uri).build()?;
-        let resp = self.client.execute(req).await?;
-        let list: ListSandboxPoolsResponse = Self::parse_json(resp).await?;
-        Ok(list.pools)
+        Ok(self
+            .client
+            .execute_json::<ListSandboxPoolsResponse>(req)
+            .await?
+            .map(|r| r.pools))
     }
 
     pub async fn update_pool(
         &self,
         pool_id: &str,
         request: &SandboxPoolRequest,
-    ) -> Result<SandboxPoolInfo, SdkError> {
+    ) -> Result<Traced<SandboxPoolInfo>, SdkError> {
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}"));
         let req = self
             .client
             .build_post_json_request(Method::PUT, &uri, request)?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn delete_pool(&self, pool_id: &str) -> Result<(), SdkError> {
+    pub async fn delete_pool(&self, pool_id: &str) -> Result<Traced<()>, SdkError> {
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}"));
         let req = self.client.request(Method::DELETE, &uri).build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 }
 
@@ -255,265 +242,249 @@ impl SandboxProxyClient {
         request_builder
     }
 
-    async fn parse_json<T: DeserializeOwned>(response: reqwest::Response) -> Result<T, SdkError> {
-        let bytes = response.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_slice(bytes.as_ref());
-        let parsed = serde_path_to_error::deserialize(jd)?;
-        Ok(parsed)
-    }
-
-    pub async fn start_process(&self, payload: &Value) -> Result<ProcessInfo, SdkError> {
+    pub async fn start_process(&self, payload: &Value) -> Result<Traced<ProcessInfo>, SdkError> {
         let req = self
             .request(Method::POST, "/api/v1/processes")
             .json(payload)
             .build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn list_processes(&self) -> Result<Vec<ProcessInfo>, SdkError> {
+    pub async fn list_processes(&self) -> Result<Traced<Vec<ProcessInfo>>, SdkError> {
         let req = self.request(Method::GET, "/api/v1/processes").build()?;
-        let resp = self.client.execute(req).await?;
-        let list: ListProcessesResponse = Self::parse_json(resp).await?;
-        Ok(list.processes)
+        Ok(self
+            .client
+            .execute_json::<ListProcessesResponse>(req)
+            .await?
+            .map(|r| r.processes))
     }
 
-    pub async fn get_process(&self, pid: i64) -> Result<ProcessInfo, SdkError> {
+    pub async fn get_process(&self, pid: i64) -> Result<Traced<ProcessInfo>, SdkError> {
         let req = self
             .request(Method::GET, &format!("/api/v1/processes/{pid}"))
             .build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn kill_process(&self, pid: i64) -> Result<(), SdkError> {
+    pub async fn kill_process(&self, pid: i64) -> Result<Traced<()>, SdkError> {
         let req = self
             .request(Method::DELETE, &format!("/api/v1/processes/{pid}"))
             .build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn send_signal(&self, pid: i64, signal: i64) -> Result<SendSignalResponse, SdkError> {
+    pub async fn send_signal(
+        &self,
+        pid: i64,
+        signal: i64,
+    ) -> Result<Traced<SendSignalResponse>, SdkError> {
         let req = self
             .request(Method::POST, &format!("/api/v1/processes/{pid}/signal"))
             .json(&serde_json::json!({ "signal": signal }))
             .build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn write_stdin(&self, pid: i64, data: Vec<u8>) -> Result<(), SdkError> {
+    pub async fn write_stdin(&self, pid: i64, data: Vec<u8>) -> Result<Traced<()>, SdkError> {
         let req = self
             .request(Method::POST, &format!("/api/v1/processes/{pid}/stdin"))
             .body(data)
             .build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn close_stdin(&self, pid: i64) -> Result<(), SdkError> {
+    pub async fn close_stdin(&self, pid: i64) -> Result<Traced<()>, SdkError> {
         let req = self
             .request(
                 Method::POST,
                 &format!("/api/v1/processes/{pid}/stdin/close"),
             )
             .build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn get_stdout(&self, pid: i64) -> Result<OutputResponse, SdkError> {
+    pub async fn get_stdout(&self, pid: i64) -> Result<Traced<OutputResponse>, SdkError> {
         let req = self
             .request(Method::GET, &format!("/api/v1/processes/{pid}/stdout"))
             .build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn get_stderr(&self, pid: i64) -> Result<OutputResponse, SdkError> {
+    pub async fn get_stderr(&self, pid: i64) -> Result<Traced<OutputResponse>, SdkError> {
         let req = self
             .request(Method::GET, &format!("/api/v1/processes/{pid}/stderr"))
             .build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn get_output(&self, pid: i64) -> Result<OutputResponse, SdkError> {
+    pub async fn get_output(&self, pid: i64) -> Result<Traced<OutputResponse>, SdkError> {
         let req = self
             .request(Method::GET, &format!("/api/v1/processes/{pid}/output"))
             .build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn follow_stdout(&self, pid: i64) -> Result<Vec<OutputEvent>, SdkError> {
-        self.follow_stream(
-            Method::GET,
-            &format!("/api/v1/processes/{pid}/stdout/follow"),
-            None,
-            |data| -> Option<Result<OutputEvent, SdkError>> {
-                serde_json::from_str(data).ok().map(Ok)
-            },
-        )
-        .await
+    pub async fn follow_stdout(&self, pid: i64) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
+        self.follow_stream(&format!("/api/v1/processes/{pid}/stdout/follow"))
+            .await
     }
 
-    pub async fn follow_stderr(&self, pid: i64) -> Result<Vec<OutputEvent>, SdkError> {
-        self.follow_stream(
-            Method::GET,
-            &format!("/api/v1/processes/{pid}/stderr/follow"),
-            None,
-            |data| -> Option<Result<OutputEvent, SdkError>> {
-                serde_json::from_str(data).ok().map(Ok)
-            },
-        )
-        .await
+    pub async fn follow_stderr(&self, pid: i64) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
+        self.follow_stream(&format!("/api/v1/processes/{pid}/stderr/follow"))
+            .await
     }
 
-    pub async fn follow_output(&self, pid: i64) -> Result<Vec<OutputEvent>, SdkError> {
-        self.follow_stream(
-            Method::GET,
-            &format!("/api/v1/processes/{pid}/output/follow"),
-            None,
-            |data| -> Option<Result<OutputEvent, SdkError>> {
-                serde_json::from_str(data).ok().map(Ok)
-            },
-        )
-        .await
+    pub async fn follow_output(&self, pid: i64) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
+        self.follow_stream(&format!("/api/v1/processes/{pid}/output/follow"))
+            .await
     }
 
-    pub async fn run_process(&self, payload: &Value) -> Result<Vec<RunProcessEvent>, SdkError> {
-        self.follow_stream(
-            Method::POST,
-            "/api/v1/processes/run",
-            Some(payload),
-            |data| -> Option<Result<RunProcessEvent, SdkError>> {
-                match serde_json::from_str(data) {
-                    Ok(RunProcessEvent::Exited {
-                        exit_code: None,
-                        signal: None,
-                    }) => None,
-                    Ok(evt) => Some(Ok(evt)),
-                    Err(_) => None,
-                }
-            },
-        )
-        .await
-    }
-
-    async fn follow_stream<T, E, F>(
+    pub async fn run_process(
         &self,
-        method: Method,
-        path: &str,
-        payload: Option<&Value>,
-        filter_map: F,
-    ) -> Result<Vec<T>, SdkError>
-    where
-        E: Into<SdkError>,
-        F: Fn(&str) -> Option<Result<T, E>>,
-    {
-        let mut req = self
-            .request(method, path)
-            .header(ACCEPT, "text/event-stream");
-        if let Some(payload) = payload {
-            req = req.json(payload);
-        }
-
-        let response = self.client.execute(req.build()?).await?;
-
-        if !response.status().is_success() {
-            return Err(SdkError::ClientError(format!(
-                "expected success response from {path}, got status: {}",
-                response.status()
-            )));
-        }
-
+        payload: &Value,
+    ) -> Result<Traced<Vec<RunProcessEvent>>, SdkError> {
+        let path = "/api/v1/processes/run";
+        let req = self
+            .request(Method::POST, path)
+            .header(ACCEPT, "text/event-stream")
+            .json(payload)
+            .build()?;
+        let response = self.client.execute_traced(req).await?;
+        let trace_id = response.trace_id.clone();
         let content_type = response
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
-            .and_then(|value| value.to_str().ok())
-            .unwrap_or("");
-
-        if !content_type
-            .to_ascii_lowercase()
-            .contains("text/event-stream")
-        {
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        if !content_type.contains("text/event-stream") {
             return Err(SdkError::ClientError(format!(
                 "expected text/event-stream response from {path}, got content-type: {content_type}"
             )));
         }
-        let stream = response.bytes_stream().eventsource().filter_map(|event| {
-            let result = match event {
-                Ok(msg) => filter_map(&msg.data).map(|r| r.map_err(Into::into)),
-                Err(error) => Some(Err(SdkError::EventSourceError(error.to_string()))),
-            };
-            async move { result }
-        });
+        let stream = response
+            .into_inner()
+            .bytes_stream()
+            .eventsource()
+            .filter_map(move |event| async move {
+                match event {
+                    Ok(msg) => {
+                        // The Exited variant has all-optional fields so it acts as a
+                        // catch-all for unrecognised JSON. Discard Exited{None, None}
+                        // — a real exit always has at least one of exit_code or signal.
+                        match serde_json::from_str::<RunProcessEvent>(&msg.data) {
+                            Ok(RunProcessEvent::Exited {
+                                exit_code: None,
+                                signal: None,
+                            }) => None,
+                            Ok(evt) => Some(Ok(evt)),
+                            Err(_) => None,
+                        }
+                    }
+                    Err(error) => Some(Err(SdkError::EventSourceError(error.to_string()))),
+                }
+            });
         futures::pin_mut!(stream);
         let mut events = Vec::new();
         while let Some(event) = stream.next().await {
             events.push(event?);
         }
-        Ok(events)
+        Ok(Traced::new(trace_id, events))
     }
 
-    pub async fn read_file(&self, path: &str) -> Result<Vec<u8>, SdkError> {
+    async fn follow_stream(&self, path: &str) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
+        let req = self
+            .request(Method::GET, path)
+            .header(ACCEPT, "text/event-stream")
+            .build()?;
+        let response = self.client.execute_traced(req).await?;
+        let trace_id = response.trace_id.clone();
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        if !content_type.contains("text/event-stream") {
+            return Err(SdkError::ClientError(format!(
+                "expected text/event-stream response from {path}, got content-type: {content_type}"
+            )));
+        }
+        let stream = response
+            .into_inner()
+            .bytes_stream()
+            .eventsource()
+            .filter_map(move |event| async move {
+                match event {
+                    Ok(msg) => match serde_json::from_str::<OutputEvent>(&msg.data) {
+                        Ok(evt) => Some(Ok(evt)),
+                        Err(_) => None, // skip heartbeats / non-output events
+                    },
+                    Err(error) => Some(Err(SdkError::EventSourceError(error.to_string()))),
+                }
+            });
+        futures::pin_mut!(stream);
+        let mut events = Vec::new();
+        while let Some(event) = stream.next().await {
+            events.push(event?);
+        }
+        Ok(Traced::new(trace_id, events))
+    }
+
+    pub async fn read_file(&self, path: &str) -> Result<Traced<Vec<u8>>, SdkError> {
         let req = self
             .request(Method::GET, "/api/v1/files")
             .query(&[("path", path)])
             .build()?;
-        let resp = self.client.execute(req).await?;
-        let bytes = resp.bytes().await?;
-        Ok(bytes.to_vec())
+        let resp = self.client.execute_traced(req).await?;
+        let trace_id = resp.trace_id.clone();
+        let bytes = resp.into_inner().bytes().await?;
+        Ok(Traced::new(trace_id, bytes.to_vec()))
     }
 
-    pub async fn write_file(&self, path: &str, content: Vec<u8>) -> Result<(), SdkError> {
+    pub async fn write_file(&self, path: &str, content: Vec<u8>) -> Result<Traced<()>, SdkError> {
         let req = self
             .request(Method::PUT, "/api/v1/files")
             .query(&[("path", path)])
             .body(content)
             .build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn delete_file(&self, path: &str) -> Result<(), SdkError> {
+    pub async fn delete_file(&self, path: &str) -> Result<Traced<()>, SdkError> {
         let req = self
             .request(Method::DELETE, "/api/v1/files")
             .query(&[("path", path)])
             .build()?;
-        let _resp = self.client.execute(req).await?;
-        Ok(())
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn list_directory(&self, path: &str) -> Result<ListDirectoryResponse, SdkError> {
+    pub async fn list_directory(
+        &self,
+        path: &str,
+    ) -> Result<Traced<ListDirectoryResponse>, SdkError> {
         let req = self
             .request(Method::GET, "/api/v1/files/list")
             .query(&[("path", path)])
             .build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn create_pty_session(&self, payload: &Value) -> Result<Value, SdkError> {
+    pub async fn create_pty_session(&self, payload: &Value) -> Result<Traced<Value>, SdkError> {
         let req = self
             .request(Method::POST, "/api/v1/pty")
             .json(payload)
             .build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn health(&self) -> Result<HealthResponse, SdkError> {
+    pub async fn health(&self) -> Result<Traced<HealthResponse>, SdkError> {
         let req = self.request(Method::GET, "/api/v1/health").build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 
-    pub async fn info(&self) -> Result<DaemonInfo, SdkError> {
+    pub async fn info(&self) -> Result<Traced<DaemonInfo>, SdkError> {
         let req = self.request(Method::GET, "/api/v1/info").build()?;
-        let resp = self.client.execute(req).await?;
-        Self::parse_json(resp).await
+        self.client.execute_json(req).await
     }
 }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct ContainerResourcesInfo {
     pub cpus: f64,
     pub memory_mb: i64,
+    #[serde(default)]
     pub ephemeral_disk_mb: i64,
 }
 

--- a/crates/cloud-sdk/src/secrets/mod.rs
+++ b/crates/cloud-sdk/src/secrets/mod.rs
@@ -32,7 +32,10 @@
 pub mod error;
 pub mod models;
 
-use crate::{client::Client, error::SdkError};
+use crate::{
+    client::{Client, Traced},
+    error::SdkError,
+};
 
 use models::*;
 use reqwest::Method;
@@ -68,90 +71,25 @@ impl SecretsClient {
     }
 
     /// Upsert secrets (create or update).
-    ///
-    /// # Arguments
-    ///
-    /// * `organization_id` - The ID of the organization
-    /// * `project_id` - The ID of the project
-    /// * `upsert_secret` - The secret upsert request (single or multiple)
-    ///
-    /// # Returns
-    ///
-    /// Returns the upserted secret(s).
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tensorlake_cloud_sdk::{ClientBuilder, secrets::{SecretsClient, models::UpsertSecretRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let secrets_client = SecretsClient::new(client);
-    ///     let req = UpsertSecretRequest::builder()
-    ///         .organization_id("org-123")
-    ///         .project_id("proj-456")
-    ///         .secrets(("api-key", "secret123"))
-    ///         .build()?;
-    ///     secrets_client.upsert(req).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn upsert(
         &self,
         request: UpsertSecretRequest,
-    ) -> Result<UpsertSecretResponse, SdkError> {
+    ) -> Result<Traced<UpsertSecretResponse>, SdkError> {
         let uri_str = format!(
             "/platform/v1/organizations/{}/projects/{}/secrets",
             request.organization_id, request.project_id
         );
-
         let req = self
             .client
             .build_post_json_request(Method::PUT, &uri_str, &request.secrets)?;
-        let resp = self.client.execute(req).await?;
-
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_reader(bytes.as_ref());
-        let response = serde_path_to_error::deserialize(jd)?;
-
-        Ok(response)
+        self.client.execute_json(req).await
     }
 
     /// List secrets in a project.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The list secrets request
-    ///
-    /// # Returns
-    ///
-    /// Returns a list of secrets with pagination information.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use tensorlake_cloud_sdk::{ClientBuilder, secrets::{SecretsClient, models::ListSecretsRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let secrets_client = SecretsClient::new(client);
-    ///     let request = ListSecretsRequest::builder()
-    ///         .organization_id("org-123")
-    ///         .project_id("proj-456")
-    ///         .page_size(20)
-    ///         .build()?;
-    ///     secrets_client.list(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn list(
         &self,
         request: &models::ListSecretsRequest,
-    ) -> Result<SecretsList, SdkError> {
+    ) -> Result<Traced<SecretsList>, SdkError> {
         let uri_str = format!(
             "/platform/v1/organizations/{}/projects/{}/secrets",
             request.organization_id, request.project_id
@@ -170,98 +108,35 @@ impl SecretsClient {
         }
 
         let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_reader(bytes.as_ref());
-        let list = serde_path_to_error::deserialize(jd)?;
-
-        Ok(list)
+        self.client.execute_json(req).await
     }
 
     /// Get a specific secret by ID.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The get secret request
-    ///
-    /// # Returns
-    ///
-    /// Returns the secret details.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, secrets::{SecretsClient, models::GetSecretRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let secrets_client = SecretsClient::new(client);
-    ///     let request = GetSecretRequest::builder()
-    ///         .organization_id("org-123")
-    ///         .project_id("proj-456")
-    ///         .secret_id("secret-789")
-    ///         .build()?;
-    ///     secrets_client.get(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn get(&self, request: &models::GetSecretRequest) -> Result<Secret, SdkError> {
+    pub async fn get(
+        &self,
+        request: &models::GetSecretRequest,
+    ) -> Result<Traced<Secret>, SdkError> {
         let uri_str = format!(
             "/platform/v1/organizations/{}/projects/{}/secrets/{}",
             request.organization_id, request.project_id, request.secret_id
         );
-
-        let req_builder = self.client.request(Method::GET, &uri_str);
-
-        let req = req_builder.build()?;
-        let resp = self.client.execute(req).await?;
-
-        let bytes = resp.bytes().await?;
-        let jd = &mut serde_json::Deserializer::from_reader(bytes.as_ref());
-        let secret = serde_path_to_error::deserialize(jd)?;
-
-        Ok(secret)
+        let req = self.client.request(Method::GET, &uri_str).build()?;
+        self.client.execute_json(req).await
     }
 
     /// Delete a secret.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The delete secret request
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, secrets::{SecretsClient, models::DeleteSecretRequest}};
-    ///
-    /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let client = ClientBuilder::new("https://api.tensorlake.ai")
-    ///         .bearer_token("your-api-key")
-    ///         .build()?;
-    ///     let secrets_client = SecretsClient::new(client);
-    ///     let request = DeleteSecretRequest::builder()
-    ///         .organization_id("org-123")
-    ///         .project_id("proj-456")
-    ///         .secret_id("secret-789")
-    ///         .build()?;
-    ///     secrets_client.delete(&request).await?;
-    ///     Ok(())
-    /// }
-    /// ```
-    pub async fn delete(&self, request: &models::DeleteSecretRequest) -> Result<(), SdkError> {
+    pub async fn delete(
+        &self,
+        request: &models::DeleteSecretRequest,
+    ) -> Result<Traced<()>, SdkError> {
         let uri_str = format!(
             "/platform/v1/organizations/{}/projects/{}/secrets/{}",
             request.organization_id, request.project_id, request.secret_id
         );
-
-        let req_builder = self.client.request(reqwest::Method::DELETE, &uri_str);
-
-        let req = req_builder.build()?;
-        let _resp = self.client.execute(req).await?;
-
-        Ok(())
+        let req = self
+            .client
+            .request(reqwest::Method::DELETE, &uri_str)
+            .build()?;
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 }

--- a/crates/cloud-sdk/tests/applications.rs
+++ b/crates/cloud-sdk/tests/applications.rs
@@ -307,7 +307,7 @@ async fn test_applications_operations() {
             .await
             .map_err(|e| format!("invoke failed: {e}"))?;
 
-        let request_id = match invoke_response {
+        let request_id = match invoke_response.into_inner() {
             InvokeResponse::RequestId(id) if !id.is_empty() => id,
             _ => return Err("invoke response did not contain a non-empty request id".to_string()),
         };
@@ -353,7 +353,7 @@ async fn test_applications_operations() {
                 ));
             }
 
-            match request.outcome {
+            match &request.outcome {
                 Some(RequestOutcome::Success) => {
                     request_succeeded = true;
                     break;

--- a/crates/cloud-sdk/tests/secrets.rs
+++ b/crates/cloud-sdk/tests/secrets.rs
@@ -46,7 +46,7 @@ async fn test_secrets_operations() {
             .await
             .map_err(|e| format!("upsert failed: {e}"))?;
 
-        match upsert_response {
+        match upsert_response.into_inner() {
             UpsertSecretResponse::Single(secret) => cleanup_secret_ids.push(secret.id),
             UpsertSecretResponse::Multiple(secrets) => {
                 cleanup_secret_ids.extend(secrets.into_iter().map(|s| s.id))

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -633,7 +633,11 @@ impl CloudSandboxClient {
         })
     }
 
-    fn update_sandbox(&self, sandbox_id: String, request_json: String) -> PyResult<(String, String)> {
+    fn update_sandbox(
+        &self,
+        sandbox_id: String,
+        request_json: String,
+    ) -> PyResult<(String, String)> {
         let request: UpdateSandboxRequest = parse_json_payload(&request_json)?;
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
@@ -720,7 +724,12 @@ impl CloudSandboxClient {
     fn delete_snapshot(&self, snapshot_id: String) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let snapshot_id = snapshot_id.clone();
-            async move { client.delete_snapshot(&snapshot_id).await.map(|t| t.trace_id) }
+            async move {
+                client
+                    .delete_snapshot(&snapshot_id)
+                    .await
+                    .map(|t| t.trace_id)
+            }
         })
     }
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -381,7 +381,7 @@ impl CloudApiClient {
                 let response = images_client
                     .create_application_build(&build_service_path, &request, &image_contexts)
                     .await?;
-                Ok(serde_json::to_string(&response)?)
+                Ok(serde_json::to_string(&*response).map_err(SdkError::from)?)
             }
         })
     }
@@ -399,7 +399,7 @@ impl CloudApiClient {
                 let response = images_client
                     .application_build_info(&build_service_path, &application_build_id)
                     .await?;
-                Ok(serde_json::to_string(&response)?)
+                Ok(serde_json::to_string(&*response).map_err(SdkError::from)?)
             }
         })
     }
@@ -417,7 +417,7 @@ impl CloudApiClient {
                 let response = images_client
                     .cancel_application_build(&build_service_path, &application_build_id)
                     .await?;
-                Ok(serde_json::to_string(&response)?)
+                Ok(serde_json::to_string(&*response).map_err(SdkError::from)?)
             }
         })
     }
@@ -462,7 +462,7 @@ impl CloudApiClient {
                 async move {
                     let mut events: Vec<String> = Vec::new();
                     stream_build_log_events(client, &path, |event| {
-                        events.push(serde_json::to_string(&event)?);
+                        events.push(serde_json::to_string(&event).map_err(SdkError::from)?);
                         Ok(())
                     })
                     .await?;
@@ -581,8 +581,8 @@ impl CloudSandboxClient {
         self.run_with_retry(5, move |client| {
             let request = request.clone();
             async move {
-                let response = client.create(&request).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.create(&request).await?;
+                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
             }
         })
     }
@@ -591,8 +591,8 @@ impl CloudSandboxClient {
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
             async move {
-                let response = client.claim(&pool_id).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.claim(&pool_id).await?;
+                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
             }
         })
     }
@@ -601,17 +601,17 @@ impl CloudSandboxClient {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
             async move {
-                let response = client.get(&sandbox_id).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.get(&sandbox_id).await?;
+                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
             }
         })
     }
 
     fn list_sandboxes_json(&self) -> PyResult<String> {
         self.run_with_retry(5, move |client| async move {
-            let sandboxes = client.list().await?;
+            let sandboxes = client.list().await?.into_inner();
             let response = serde_json::json!({ "sandboxes": sandboxes });
-            Ok(serde_json::to_string(&response)?)
+            Ok(serde_json::to_string(&response).map_err(SdkError::from)?)
         })
     }
 
@@ -621,8 +621,8 @@ impl CloudSandboxClient {
             let sandbox_id = sandbox_id.clone();
             let request = request.clone();
             async move {
-                let response = client.update(&sandbox_id, &request).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.update(&sandbox_id, &request).await?;
+                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
             }
         })
     }
@@ -630,21 +630,21 @@ impl CloudSandboxClient {
     fn delete_sandbox(&self, sandbox_id: String) -> PyResult<()> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
-            async move { client.delete(&sandbox_id).await }
+            async move { client.delete(&sandbox_id).await.map(|_| ()) }
         })
     }
 
     fn suspend_sandbox(&self, sandbox_id: String) -> PyResult<()> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
-            async move { client.suspend(&sandbox_id).await }
+            async move { client.suspend(&sandbox_id).await.map(|_| ()) }
         })
     }
 
     fn resume_sandbox(&self, sandbox_id: String) -> PyResult<()> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
-            async move { client.resume(&sandbox_id).await }
+            async move { client.resume(&sandbox_id).await.map(|_| ()) }
         })
     }
 
@@ -667,8 +667,8 @@ impl CloudSandboxClient {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
             async move {
-                let response = client.snapshot(&sandbox_id, parsed_mode).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.snapshot(&sandbox_id, parsed_mode).await?;
+                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
             }
         })
     }
@@ -677,24 +677,24 @@ impl CloudSandboxClient {
         self.run_with_retry(5, move |client| {
             let snapshot_id = snapshot_id.clone();
             async move {
-                let response = client.get_snapshot(&snapshot_id).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.get_snapshot(&snapshot_id).await?;
+                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
             }
         })
     }
 
     fn list_snapshots_json(&self) -> PyResult<String> {
         self.run_with_retry(5, move |client| async move {
-            let snapshots = client.list_snapshots().await?;
+            let snapshots = client.list_snapshots().await?.into_inner();
             let response = serde_json::json!({ "snapshots": snapshots });
-            Ok(serde_json::to_string(&response)?)
+            Ok(serde_json::to_string(&response).map_err(SdkError::from)?)
         })
     }
 
     fn delete_snapshot(&self, snapshot_id: String) -> PyResult<()> {
         self.run_with_retry(5, move |client| {
             let snapshot_id = snapshot_id.clone();
-            async move { client.delete_snapshot(&snapshot_id).await }
+            async move { client.delete_snapshot(&snapshot_id).await.map(|_| ()) }
         })
     }
 
@@ -703,8 +703,8 @@ impl CloudSandboxClient {
         self.run_with_retry(5, move |client| {
             let request = request.clone();
             async move {
-                let response = client.create_pool(&request).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.create_pool(&request).await?;
+                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
             }
         })
     }
@@ -713,17 +713,17 @@ impl CloudSandboxClient {
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
             async move {
-                let response = client.get_pool(&pool_id).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.get_pool(&pool_id).await?;
+                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
             }
         })
     }
 
     fn list_pools_json(&self) -> PyResult<String> {
         self.run_with_retry(5, move |client| async move {
-            let pools = client.list_pools().await?;
+            let pools = client.list_pools().await?.into_inner();
             let response = serde_json::json!({ "pools": pools });
-            Ok(serde_json::to_string(&response)?)
+            Ok(serde_json::to_string(&response).map_err(SdkError::from)?)
         })
     }
 
@@ -733,8 +733,8 @@ impl CloudSandboxClient {
             let pool_id = pool_id.clone();
             let request = request.clone();
             async move {
-                let response = client.update_pool(&pool_id, &request).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.update_pool(&pool_id, &request).await?;
+                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
             }
         })
     }
@@ -742,7 +742,7 @@ impl CloudSandboxClient {
     fn delete_pool(&self, pool_id: String) -> PyResult<()> {
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
-            async move { client.delete_pool(&pool_id).await }
+            async move { client.delete_pool(&pool_id).await.map(|_| ()) }
         })
     }
 
@@ -858,180 +858,233 @@ impl CloudSandboxProxyClient {
         self.base_url.clone()
     }
 
-    fn start_process_json(&self, payload_json: String) -> PyResult<String> {
+    fn start_process_json(&self, payload_json: String) -> PyResult<(String, String)> {
         let payload: Value = parse_json_payload(&payload_json)?;
         self.run_with_retry(5, move |client| {
             let payload = payload.clone();
             async move {
-                let response = client.start_process(&payload).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.start_process(&payload).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn list_processes_json(&self) -> PyResult<String> {
+    fn list_processes_json(&self) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| async move {
-            let processes = client.list_processes().await?;
+            let traced = client.list_processes().await?;
+            let trace_id = traced.trace_id.clone();
+            let processes = traced.into_inner();
             let response = serde_json::json!({ "processes": processes });
-            Ok(serde_json::to_string(&response)?)
+            Ok((
+                trace_id,
+                serde_json::to_string(&response).map_err(SdkError::from)?,
+            ))
         })
     }
 
-    fn get_process_json(&self, pid: i64) -> PyResult<String> {
+    fn get_process_json(&self, pid: i64) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| async move {
-            let response = client.get_process(pid).await?;
-            Ok(serde_json::to_string(&response)?)
+            let traced = client.get_process(pid).await?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+            Ok((trace_id, json))
         })
     }
 
-    fn kill_process(&self, pid: i64) -> PyResult<()> {
-        self.run_with_retry(
-            5,
-            move |client| async move { client.kill_process(pid).await },
-        )
-    }
-
-    fn send_signal_json(&self, pid: i64, signal: i64) -> PyResult<String> {
+    fn kill_process(&self, pid: i64) -> PyResult<String> {
         self.run_with_retry(5, move |client| async move {
-            let response = client.send_signal(pid, signal).await?;
-            Ok(serde_json::to_string(&response)?)
+            let traced = client.kill_process(pid).await?;
+            Ok(traced.trace_id)
         })
     }
 
-    fn write_stdin(&self, pid: i64, data: Vec<u8>) -> PyResult<()> {
+    fn send_signal_json(&self, pid: i64, signal: i64) -> PyResult<(String, String)> {
+        self.run_with_retry(5, move |client| async move {
+            let traced = client.send_signal(pid, signal).await?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn write_stdin(&self, pid: i64, data: Vec<u8>) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let data = data.clone();
-            async move { client.write_stdin(pid, data).await }
+            async move {
+                let traced = client.write_stdin(pid, data).await?;
+                Ok(traced.trace_id)
+            }
         })
     }
 
-    fn close_stdin(&self, pid: i64) -> PyResult<()> {
-        self.run_with_retry(
-            5,
-            move |client| async move { client.close_stdin(pid).await },
-        )
-    }
-
-    fn get_stdout_json(&self, pid: i64) -> PyResult<String> {
+    fn close_stdin(&self, pid: i64) -> PyResult<String> {
         self.run_with_retry(5, move |client| async move {
-            let response = client.get_stdout(pid).await?;
-            Ok(serde_json::to_string(&response)?)
+            let traced = client.close_stdin(pid).await?;
+            Ok(traced.trace_id)
         })
     }
 
-    fn get_stderr_json(&self, pid: i64) -> PyResult<String> {
+    fn get_stdout_json(&self, pid: i64) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| async move {
-            let response = client.get_stderr(pid).await?;
-            Ok(serde_json::to_string(&response)?)
+            let traced = client.get_stdout(pid).await?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+            Ok((trace_id, json))
         })
     }
 
-    fn get_output_json(&self, pid: i64) -> PyResult<String> {
+    fn get_stderr_json(&self, pid: i64) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| async move {
-            let response = client.get_output(pid).await?;
-            Ok(serde_json::to_string(&response)?)
+            let traced = client.get_stderr(pid).await?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+            Ok((trace_id, json))
         })
     }
 
-    fn follow_stdout_json(&self, pid: i64) -> PyResult<Vec<String>> {
+    fn get_output_json(&self, pid: i64) -> PyResult<(String, String)> {
+        self.run_with_retry(5, move |client| async move {
+            let traced = client.get_output(pid).await?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn follow_stdout_json(&self, pid: i64) -> PyResult<(String, Vec<String>)> {
         self.run_with_retry(10, move |client| async move {
-            let events = client.follow_stdout(pid).await?;
-            events
+            let traced = client.follow_stdout(pid).await?;
+            let trace_id = traced.trace_id.clone();
+            let events = traced
+                .into_inner()
                 .into_iter()
                 .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
-                .collect()
+                .collect::<Result<Vec<String>, SdkError>>()?;
+            Ok((trace_id, events))
         })
     }
 
-    fn follow_stderr_json(&self, pid: i64) -> PyResult<Vec<String>> {
+    fn follow_stderr_json(&self, pid: i64) -> PyResult<(String, Vec<String>)> {
         self.run_with_retry(10, move |client| async move {
-            let events = client.follow_stderr(pid).await?;
-            events
+            let traced = client.follow_stderr(pid).await?;
+            let trace_id = traced.trace_id.clone();
+            let events = traced
+                .into_inner()
                 .into_iter()
                 .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
-                .collect()
+                .collect::<Result<Vec<String>, SdkError>>()?;
+            Ok((trace_id, events))
         })
     }
 
-    fn follow_output_json(&self, pid: i64) -> PyResult<Vec<String>> {
+    fn follow_output_json(&self, pid: i64) -> PyResult<(String, Vec<String>)> {
         self.run_with_retry(10, move |client| async move {
-            let events = client.follow_output(pid).await?;
-            events
+            let traced = client.follow_output(pid).await?;
+            let trace_id = traced.trace_id.clone();
+            let events = traced
+                .into_inner()
                 .into_iter()
                 .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
-                .collect()
+                .collect::<Result<Vec<String>, SdkError>>()?;
+            Ok((trace_id, events))
         })
     }
 
-    fn read_file_bytes(&self, py: Python<'_>, path: String) -> PyResult<Py<pyo3::types::PyBytes>> {
-        let data: Vec<u8> = self.run_with_retry(5, move |client| {
+    fn read_file_bytes(
+        &self,
+        py: Python<'_>,
+        path: String,
+    ) -> PyResult<(String, Py<pyo3::types::PyBytes>)> {
+        let (trace_id, data): (String, Vec<u8>) = self.run_with_retry(5, move |client| {
             let path = path.clone();
-            async move { client.read_file(&path).await }
+            async move {
+                let traced = client.read_file(&path).await?;
+                Ok((traced.trace_id.clone(), traced.into_inner()))
+            }
         })?;
-        Ok(pyo3::types::PyBytes::new(py, &data).into())
+        Ok((trace_id, pyo3::types::PyBytes::new(py, &data).into()))
     }
 
-    fn write_file(&self, path: String, content: Vec<u8>) -> PyResult<()> {
+    fn write_file(&self, path: String, content: Vec<u8>) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let path = path.clone();
             let content = content.clone();
-            async move { client.write_file(&path, content).await }
-        })
-    }
-
-    fn delete_file(&self, path: String) -> PyResult<()> {
-        self.run_with_retry(5, move |client| {
-            let path = path.clone();
-            async move { client.delete_file(&path).await }
-        })
-    }
-
-    fn list_directory_json(&self, path: String) -> PyResult<String> {
-        self.run_with_retry(5, move |client| {
-            let path = path.clone();
             async move {
-                let response = client.list_directory(&path).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.write_file(&path, content).await?;
+                Ok(traced.trace_id)
             }
         })
     }
 
-    fn create_pty_session_json(&self, payload_json: String) -> PyResult<String> {
-        let payload: Value = parse_json_payload(&payload_json)?;
+    fn delete_file(&self, path: String) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
-            let payload = payload.clone();
+            let path = path.clone();
             async move {
-                let response = client.create_pty_session(&payload).await?;
-                Ok(serde_json::to_string(&response)?)
+                let traced = client.delete_file(&path).await?;
+                Ok(traced.trace_id)
             }
         })
     }
 
-    fn run_process_json(&self, payload_json: String) -> PyResult<Vec<String>> {
+    fn list_directory_json(&self, path: String) -> PyResult<(String, String)> {
+        self.run_with_retry(5, move |client| {
+            let path = path.clone();
+            async move {
+                let traced = client.list_directory(&path).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
+            }
+        })
+    }
+
+    fn create_pty_session_json(&self, payload_json: String) -> PyResult<(String, String)> {
         let payload: Value = parse_json_payload(&payload_json)?;
         self.run_with_retry(5, move |client| {
             let payload = payload.clone();
             async move {
-                let events = client.run_process(&payload).await?;
-                events
+                let traced = client.create_pty_session(&payload).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
+            }
+        })
+    }
+
+    fn run_process_json(&self, payload_json: String) -> PyResult<(String, Vec<String>)> {
+        let payload: Value = parse_json_payload(&payload_json)?;
+        self.run_with_retry(5, move |client| {
+            let payload = payload.clone();
+            async move {
+                let traced = client.run_process(&payload).await?;
+                let trace_id = traced.trace_id.clone();
+                let events = traced
+                    .into_inner()
                     .into_iter()
                     .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
-                    .collect::<Result<Vec<_>, _>>()
+                    .collect::<Result<Vec<String>, SdkError>>()?;
+                Ok((trace_id, events))
             }
         })
     }
 
-    fn health_json(&self) -> PyResult<String> {
+    fn health_json(&self) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| async move {
-            let response = client.health().await?;
-            Ok(serde_json::to_string(&response)?)
+            let traced = client.health().await?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+            Ok((trace_id, json))
         })
     }
 
-    fn info_json(&self) -> PyResult<String> {
+    fn info_json(&self) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| async move {
-            let response = client.info().await?;
-            Ok(serde_json::to_string(&response)?)
+            let traced = client.info().await?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+            Ok((trace_id, json))
         })
     }
 }
@@ -1267,7 +1320,7 @@ impl CloudDocumentAIClient {
             let body_json = body_json.clone();
             async move {
                 let response = client.request(method, &path, body_json.as_ref()).await?;
-                Ok(serde_json::to_string(&response)?)
+                Ok(serde_json::to_string(&response).map_err(SdkError::from)?)
             }
         })
     }
@@ -1278,7 +1331,7 @@ impl CloudDocumentAIClient {
             let content = content.clone();
             async move {
                 let response = client.upload_file(&file_name, content).await?;
-                Ok(serde_json::to_string(&response)?)
+                Ok(serde_json::to_string(&response).map_err(SdkError::from)?)
             }
         })
     }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -48,13 +48,14 @@ pub struct CloudApiClient {
 #[pymethods]
 impl CloudApiClient {
     #[new]
-    #[pyo3(signature = (api_url, api_key=None, organization_id=None, project_id=None, namespace=None))]
+    #[pyo3(signature = (api_url, api_key=None, organization_id=None, project_id=None, namespace=None, user_agent=None))]
     fn new(
         api_url: String,
         api_key: Option<String>,
         organization_id: Option<String>,
         project_id: Option<String>,
         namespace: Option<String>,
+        user_agent: Option<String>,
     ) -> PyResult<Self> {
         let mut builder = ClientBuilder::new(&api_url);
         if let Some(token) = api_key.as_deref() {
@@ -65,6 +66,10 @@ impl CloudApiClient {
             (organization_id.as_deref(), project_id.as_deref())
         {
             builder = builder.scope(org_id, project_id);
+        }
+
+        if let Some(ua) = user_agent.as_deref() {
+            builder = builder.user_agent(ua);
         }
 
         let client = builder.build().map_err(into_py_error)?;
@@ -532,13 +537,14 @@ pub struct CloudSandboxClient {
 #[pymethods]
 impl CloudSandboxClient {
     #[new]
-    #[pyo3(signature = (api_url, api_key=None, organization_id=None, project_id=None, namespace=None))]
+    #[pyo3(signature = (api_url, api_key=None, organization_id=None, project_id=None, namespace=None, user_agent=None))]
     fn new(
         api_url: String,
         api_key: Option<String>,
         organization_id: Option<String>,
         project_id: Option<String>,
         namespace: Option<String>,
+        user_agent: Option<String>,
     ) -> PyResult<Self> {
         let mut builder = ClientBuilder::new(&api_url);
         if let Some(token) = api_key.as_deref() {
@@ -549,6 +555,10 @@ impl CloudSandboxClient {
             (organization_id.as_deref(), project_id.as_deref())
         {
             builder = builder.scope(org_id, project_id);
+        }
+
+        if let Some(ua) = user_agent.as_deref() {
+            builder = builder.user_agent(ua);
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;
@@ -810,7 +820,7 @@ pub struct CloudSandboxProxyClient {
 #[pymethods]
 impl CloudSandboxProxyClient {
     #[new]
-    #[pyo3(signature = (proxy_url, sandbox_id, api_key=None, organization_id=None, project_id=None, routing_hint=None))]
+    #[pyo3(signature = (proxy_url, sandbox_id, api_key=None, organization_id=None, project_id=None, routing_hint=None, user_agent=None))]
     fn new(
         proxy_url: String,
         sandbox_id: String,
@@ -818,6 +828,7 @@ impl CloudSandboxProxyClient {
         organization_id: Option<String>,
         project_id: Option<String>,
         routing_hint: Option<String>,
+        user_agent: Option<String>,
     ) -> PyResult<Self> {
         let (base_url, host_override) = resolve_proxy_target(&proxy_url, &sandbox_id)?;
 
@@ -830,6 +841,10 @@ impl CloudSandboxProxyClient {
             (organization_id.as_deref(), project_id.as_deref())
         {
             builder = builder.scope(org_id, project_id);
+        }
+
+        if let Some(ua) = user_agent.as_deref() {
+            builder = builder.user_agent(ua);
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;
@@ -1098,7 +1113,7 @@ pub struct CloudSandboxDesktopClient {
 #[pymethods]
 impl CloudSandboxDesktopClient {
     #[new]
-    #[pyo3(signature = (proxy_url, sandbox_id, port=5901, password=None, shared=true, connect_timeout_sec=10.0, api_key=None, organization_id=None, project_id=None))]
+    #[pyo3(signature = (proxy_url, sandbox_id, port=5901, password=None, shared=true, connect_timeout_sec=10.0, api_key=None, organization_id=None, project_id=None, user_agent=None))]
     fn new(
         proxy_url: String,
         sandbox_id: String,
@@ -1109,6 +1124,7 @@ impl CloudSandboxDesktopClient {
         api_key: Option<String>,
         organization_id: Option<String>,
         project_id: Option<String>,
+        user_agent: Option<String>,
     ) -> PyResult<Self> {
         let (base_url, host_override) = resolve_proxy_target(&proxy_url, &sandbox_id)?;
 
@@ -1121,6 +1137,10 @@ impl CloudSandboxDesktopClient {
             (organization_id.as_deref(), project_id.as_deref())
         {
             builder = builder.scope(org_id, project_id);
+        }
+
+        if let Some(ua) = user_agent.as_deref() {
+            builder = builder.user_agent(ua);
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -586,75 +586,85 @@ impl CloudSandboxClient {
         // reqwest clients are closed when dropped; this is a no-op for API parity.
     }
 
-    fn create_sandbox(&self, request_json: String) -> PyResult<String> {
+    fn create_sandbox(&self, request_json: String) -> PyResult<(String, String)> {
         let request: CreateSandboxRequest = parse_json_payload(&request_json)?;
         self.run_with_retry(5, move |client| {
             let request = request.clone();
             async move {
                 let traced = client.create(&request).await?;
-                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn claim_sandbox(&self, pool_id: String) -> PyResult<String> {
+    fn claim_sandbox(&self, pool_id: String) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
             async move {
                 let traced = client.claim(&pool_id).await?;
-                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn get_sandbox_json(&self, sandbox_id: String) -> PyResult<String> {
+    fn get_sandbox_json(&self, sandbox_id: String) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
             async move {
                 let traced = client.get(&sandbox_id).await?;
-                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn list_sandboxes_json(&self) -> PyResult<String> {
+    fn list_sandboxes_json(&self) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| async move {
-            let sandboxes = client.list().await?.into_inner();
-            let response = serde_json::json!({ "sandboxes": sandboxes });
-            Ok(serde_json::to_string(&response).map_err(SdkError::from)?)
+            let traced = client.list().await?;
+            let trace_id = traced.trace_id.clone();
+            let response = serde_json::json!({ "sandboxes": *traced });
+            let json = serde_json::to_string(&response).map_err(SdkError::from)?;
+            Ok((trace_id, json))
         })
     }
 
-    fn update_sandbox(&self, sandbox_id: String, request_json: String) -> PyResult<String> {
+    fn update_sandbox(&self, sandbox_id: String, request_json: String) -> PyResult<(String, String)> {
         let request: UpdateSandboxRequest = parse_json_payload(&request_json)?;
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
             let request = request.clone();
             async move {
                 let traced = client.update(&sandbox_id, &request).await?;
-                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn delete_sandbox(&self, sandbox_id: String) -> PyResult<()> {
+    fn delete_sandbox(&self, sandbox_id: String) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
-            async move { client.delete(&sandbox_id).await.map(|_| ()) }
+            async move { client.delete(&sandbox_id).await.map(|t| t.trace_id) }
         })
     }
 
-    fn suspend_sandbox(&self, sandbox_id: String) -> PyResult<()> {
+    fn suspend_sandbox(&self, sandbox_id: String) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
-            async move { client.suspend(&sandbox_id).await.map(|_| ()) }
+            async move { client.suspend(&sandbox_id).await.map(|t| t.trace_id) }
         })
     }
 
-    fn resume_sandbox(&self, sandbox_id: String) -> PyResult<()> {
+    fn resume_sandbox(&self, sandbox_id: String) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
-            async move { client.resume(&sandbox_id).await.map(|_| ()) }
+            async move { client.resume(&sandbox_id).await.map(|t| t.trace_id) }
         })
     }
 
@@ -663,7 +673,7 @@ impl CloudSandboxClient {
         &self,
         sandbox_id: String,
         content_mode: Option<String>,
-    ) -> PyResult<String> {
+    ) -> PyResult<(String, String)> {
         let parsed_mode = match content_mode.as_deref() {
             None => None,
             Some("full") => Some(SnapshotContentMode::Full),
@@ -678,81 +688,95 @@ impl CloudSandboxClient {
             let sandbox_id = sandbox_id.clone();
             async move {
                 let traced = client.snapshot(&sandbox_id, parsed_mode).await?;
-                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn get_snapshot_json(&self, snapshot_id: String) -> PyResult<String> {
+    fn get_snapshot_json(&self, snapshot_id: String) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| {
             let snapshot_id = snapshot_id.clone();
             async move {
                 let traced = client.get_snapshot(&snapshot_id).await?;
-                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn list_snapshots_json(&self) -> PyResult<String> {
+    fn list_snapshots_json(&self) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| async move {
-            let snapshots = client.list_snapshots().await?.into_inner();
-            let response = serde_json::json!({ "snapshots": snapshots });
-            Ok(serde_json::to_string(&response).map_err(SdkError::from)?)
+            let traced = client.list_snapshots().await?;
+            let trace_id = traced.trace_id.clone();
+            let response = serde_json::json!({ "snapshots": *traced });
+            let json = serde_json::to_string(&response).map_err(SdkError::from)?;
+            Ok((trace_id, json))
         })
     }
 
-    fn delete_snapshot(&self, snapshot_id: String) -> PyResult<()> {
+    fn delete_snapshot(&self, snapshot_id: String) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let snapshot_id = snapshot_id.clone();
-            async move { client.delete_snapshot(&snapshot_id).await.map(|_| ()) }
+            async move { client.delete_snapshot(&snapshot_id).await.map(|t| t.trace_id) }
         })
     }
 
-    fn create_pool(&self, request_json: String) -> PyResult<String> {
+    fn create_pool(&self, request_json: String) -> PyResult<(String, String)> {
         let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
         self.run_with_retry(5, move |client| {
             let request = request.clone();
             async move {
                 let traced = client.create_pool(&request).await?;
-                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn get_pool_json(&self, pool_id: String) -> PyResult<String> {
+    fn get_pool_json(&self, pool_id: String) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
             async move {
                 let traced = client.get_pool(&pool_id).await?;
-                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn list_pools_json(&self) -> PyResult<String> {
+    fn list_pools_json(&self) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| async move {
-            let pools = client.list_pools().await?.into_inner();
-            let response = serde_json::json!({ "pools": pools });
-            Ok(serde_json::to_string(&response).map_err(SdkError::from)?)
+            let traced = client.list_pools().await?;
+            let trace_id = traced.trace_id.clone();
+            let response = serde_json::json!({ "pools": *traced });
+            let json = serde_json::to_string(&response).map_err(SdkError::from)?;
+            Ok((trace_id, json))
         })
     }
 
-    fn update_pool(&self, pool_id: String, request_json: String) -> PyResult<String> {
+    fn update_pool(&self, pool_id: String, request_json: String) -> PyResult<(String, String)> {
         let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
             let request = request.clone();
             async move {
                 let traced = client.update_pool(&pool_id, &request).await?;
-                Ok(serde_json::to_string(&*traced).map_err(SdkError::from)?)
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
             }
         })
     }
 
-    fn delete_pool(&self, pool_id: String) -> PyResult<()> {
+    fn delete_pool(&self, pool_id: String) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
-            async move { client.delete_pool(&pool_id).await.map(|_| ()) }
+            async move { client.delete_pool(&pool_id).await.map(|t| t.trace_id) }
         })
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.4.50"
+version = "0.5.0"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/_tracing.py
+++ b/src/tensorlake/_tracing.py
@@ -1,0 +1,83 @@
+"""W3C traceparent header generation and traced result wrappers.
+
+Injects a fresh trace context into every request so server-side spans
+can be correlated with the initiating SDK call in distributed traces.
+No OTLP export is performed — the header is the only telemetry artifact.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Generic, Iterator, TypeVar
+
+T = TypeVar("T")
+
+
+def generate_traceparent() -> str:
+    """Return a W3C traceparent header value with a fresh trace ID and span ID.
+
+    Format: ``00-<32 hex>-<16 hex>-01`` (sampled).
+    """
+    trace_id = secrets.token_hex(16)
+    span_id = secrets.token_hex(8)
+    return f"00-{trace_id}-{span_id}-01"
+
+
+def inject_traceparent(headers: dict) -> dict:
+    """Return *headers* with a ``traceparent`` key added (or replaced).
+
+    Creates a shallow copy so the caller's dict is not mutated.
+    """
+    return {**headers, "traceparent": generate_traceparent()}
+
+
+class Traced(Generic[T]):
+    """An operation result paired with its W3C trace ID.
+
+    Attribute access is delegated to the wrapped result so existing code that
+    accesses fields directly (e.g. ``process.pid``) continues to work.  The
+    raw result is always available as ``.value`` and the trace ID as
+    ``.trace_id``.
+    """
+
+    def __init__(self, trace_id: str, result: T) -> None:
+        self.trace_id = trace_id
+        self._result = result
+
+    @property
+    def value(self) -> T:
+        """The unwrapped operation result."""
+        return self._result
+
+    def __getattr__(self, name: str):
+        try:
+            inner = object.__getattribute__(self, "_result")
+        except AttributeError:
+            raise AttributeError(name) from None
+        return getattr(inner, name)
+
+    def __repr__(self) -> str:
+        return f"Traced(trace_id={self.trace_id!r}, result={self._result!r})"
+
+
+class TracedIterator(Generic[T]):
+    """An eagerly-collected sequence of results paired with a W3C trace ID.
+
+    The underlying transport collects all items before returning (the Rust/SSE
+    boundary buffers the full response), so iteration is over a pre-fetched
+    list.  Iterating yields the individual items directly, so existing
+    ``for item in sandbox.follow_stdout(pid):`` loops continue to work.
+    """
+
+    def __init__(self, trace_id: str, items: list[T]) -> None:
+        self.trace_id = trace_id
+        self._items = items
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __repr__(self) -> str:
+        return f"TracedIterator(trace_id={self.trace_id!r}, items={self._items!r})"

--- a/src/tensorlake/_tracing.py
+++ b/src/tensorlake/_tracing.py
@@ -7,7 +7,7 @@ No OTLP export is performed — the header is the only telemetry artifact.
 
 from __future__ import annotations
 
-import secrets
+import os
 from typing import Generic, Iterator, TypeVar
 
 T = TypeVar("T")
@@ -18,8 +18,8 @@ def generate_traceparent() -> str:
 
     Format: ``00-<32 hex>-<16 hex>-01`` (sampled).
     """
-    trace_id = secrets.token_hex(16)
-    span_id = secrets.token_hex(8)
+    trace_id = os.urandom(16).hex()
+    span_id = os.urandom(8).hex()
     return f"00-{trace_id}-{span_id}-01"
 
 

--- a/src/tensorlake/_tracing.py
+++ b/src/tensorlake/_tracing.py
@@ -7,8 +7,16 @@ No OTLP export is performed — the header is the only telemetry artifact.
 
 from __future__ import annotations
 
+import importlib.metadata
 import os
 from typing import Generic, Iterator, TypeVar
+
+try:
+    _SDK_VERSION = importlib.metadata.version("tensorlake")
+except importlib.metadata.PackageNotFoundError:
+    _SDK_VERSION = "unknown"
+
+USER_AGENT = f"tensorlake-python-sdk/{_SDK_VERSION}"
 
 T = TypeVar("T")
 

--- a/src/tensorlake/applications/request_context/http_client/context.py
+++ b/src/tensorlake/applications/request_context/http_client/context.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import httpx
 
-from tensorlake._tracing import generate_traceparent
+from tensorlake._tracing import USER_AGENT, generate_traceparent
 from tensorlake.applications.blob_store import BLOBStore
 from tensorlake.applications.internal_logger import InternalLogger
 
@@ -71,14 +71,15 @@ class RequestContextHTTPClient(RequestContext):
     def create_http_client(cls, server_base_url: str) -> RequestContextHTTPTransport:
         """Creates an HTTP client for use in RequestContextHTTPClient."""
 
-        def _inject_traceparent(request: httpx.Request) -> None:
+        def _inject_headers(request: httpx.Request) -> None:
             request.headers["traceparent"] = generate_traceparent()
+            request.headers["User-Agent"] = USER_AGENT
 
         # httpx.Client is thread-safe.
         return httpx.Client(
             timeout=_DEFAULT_HTTP_REQUEST_TIMEOUT_SEC,
             base_url=server_base_url,
-            event_hooks={"request": [_inject_traceparent]},
+            event_hooks={"request": [_inject_headers]},
         )
 
     def __getstate__(self):

--- a/src/tensorlake/applications/request_context/http_client/context.py
+++ b/src/tensorlake/applications/request_context/http_client/context.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import httpx
 
+from tensorlake._tracing import generate_traceparent
 from tensorlake.applications.blob_store import BLOBStore
 from tensorlake.applications.internal_logger import InternalLogger
 
@@ -69,10 +70,15 @@ class RequestContextHTTPClient(RequestContext):
     @classmethod
     def create_http_client(cls, server_base_url: str) -> RequestContextHTTPTransport:
         """Creates an HTTP client for use in RequestContextHTTPClient."""
+
+        def _inject_traceparent(request: httpx.Request) -> None:
+            request.headers["traceparent"] = generate_traceparent()
+
         # httpx.Client is thread-safe.
         return httpx.Client(
             timeout=_DEFAULT_HTTP_REQUEST_TIMEOUT_SEC,
             base_url=server_base_url,
+            event_hooks={"request": [_inject_traceparent]},
         )
 
     def __getstate__(self):

--- a/src/tensorlake/cloud_client.py
+++ b/src/tensorlake/cloud_client.py
@@ -6,6 +6,8 @@ should use CloudClient. The Rust SDK handles HTTP, auth, and serialization.
 
 import importlib
 
+from tensorlake._tracing import USER_AGENT
+
 _IMPORT_ERROR: Exception | None = None
 _RustClient = None
 _RustClientError = None
@@ -109,6 +111,7 @@ class CloudClient:
                 organization_id=organization_id,
                 project_id=project_id,
                 namespace=namespace,
+                user_agent=USER_AGENT,
             )
         except Exception as e:
             _raise_as_tensorlake_error(e)

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from tensorlake._tracing import inject_traceparent
 from tensorlake.cli._common import Context
 from tensorlake.sandbox import Sandbox, SandboxClient
 from tensorlake.sandbox.models import ProcessStatus, SnapshotContentMode
@@ -714,7 +715,7 @@ def _register_image(
         "snapshotUri": snapshot_uri,
         "isPublic": is_public,
     }
-    resp = httpx.post(url, json=body, headers=headers, timeout=30.0)
+    resp = httpx.post(url, json=body, headers=inject_traceparent(headers), timeout=30.0)
     resp.raise_for_status()
     return resp.json()
 

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -22,7 +22,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from tensorlake._tracing import inject_traceparent
+from tensorlake._tracing import USER_AGENT, inject_traceparent
 from tensorlake.cli._common import Context
 from tensorlake.sandbox import Sandbox, SandboxClient
 from tensorlake.sandbox.models import ProcessStatus, SnapshotContentMode
@@ -703,6 +703,7 @@ def _register_image(
     headers = {
         "Authorization": f"Bearer {bearer_token}",
         "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
     }
     if ctx.personal_access_token and not ctx.api_key:
         headers["X-Forwarded-Organization-Id"] = org_id

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+import warnings
 from urllib.parse import urlparse
 
 from tensorlake._tracing import USER_AGENT, Traced, TracedIterator
@@ -153,7 +154,14 @@ class SandboxClient:
         namespace: str | None = _defaults.NAMESPACE,
         max_retries: int = _defaults.MAX_RETRIES,
         retry_backoff_sec: float = _defaults.RETRY_BACKOFF_SEC,
+        _internal: bool = False,
     ):
+        if not _internal:
+            warnings.warn(
+                "SandboxClient is deprecated; use Sandbox.create() / Sandbox.connect() instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._api_url: str = api_url
         self._api_key: str | None = api_key
         self._organization_id: str | None = organization_id
@@ -539,53 +547,96 @@ class SandboxClient:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
 
-    def suspend(self, sandbox_id: str) -> Traced[None]:
+    def suspend(
+        self,
+        sandbox_id: str,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+    ) -> Traced[None]:
         """Suspend a named sandbox.
 
         Only sandboxes created with a ``name`` can be suspended; ephemeral
-        sandboxes cannot. The call returns as soon as the server accepts
-        the request; poll :meth:`get` until
-        :attr:`SandboxStatus.SUSPENDED` if you need to wait for the
-        transition to complete.
+        sandboxes cannot. By default blocks until the sandbox is fully
+        ``Suspended``; pass ``wait=False`` for fire-and-return.
 
         Args:
             sandbox_id: ID or name of the sandbox to suspend
+            wait: If True (default), poll until Suspended; False returns immediately.
+            timeout: Max seconds to wait when wait=True (default 300)
+            poll_interval: Seconds between polls when wait=True (default 1.0)
 
         Raises:
             SandboxNotFoundError: If sandbox doesn't exist
+            SandboxError: If wait=True and sandbox doesn't suspend within timeout
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
         try:
             trace_id = self._rust_client.suspend_sandbox(sandbox_id=sandbox_id)
-            return Traced(trace_id, None)
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
+            raise  # unreachable — satisfies type checker
+        if not wait:
+            return Traced(trace_id, None)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            info = self.get(sandbox_id).value
+            if info.status == SandboxStatus.SUSPENDED:
+                return Traced(trace_id, None)
+            if info.status == SandboxStatus.TERMINATED:
+                raise SandboxError(
+                    f"Sandbox {sandbox_id!r} terminated while waiting for suspend"
+                )
+            time.sleep(poll_interval)
+        raise SandboxError(f"Sandbox {sandbox_id!r} did not suspend within {timeout}s")
 
-    def resume(self, sandbox_id: str) -> Traced[None]:
+    def resume(
+        self,
+        sandbox_id: str,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+    ) -> Traced[None]:
         """Resume a suspended sandbox.
 
-        The call returns as soon as the server accepts the request; poll
-        :meth:`get` until :attr:`SandboxStatus.RUNNING` if you need to
-        wait for the transition to complete.
+        By default blocks until the sandbox is ``Running``; pass
+        ``wait=False`` for fire-and-return.
 
         Args:
             sandbox_id: ID or name of the sandbox to resume
+            wait: If True (default), poll until Running; False returns immediately.
+            timeout: Max seconds to wait when wait=True (default 300)
+            poll_interval: Seconds between polls when wait=True (default 1.0)
 
         Raises:
             SandboxNotFoundError: If sandbox doesn't exist
+            SandboxError: If wait=True and sandbox doesn't resume within timeout
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
         try:
             trace_id = self._rust_client.resume_sandbox(sandbox_id=sandbox_id)
-            return Traced(trace_id, None)
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
+            raise  # unreachable — satisfies type checker
+        if not wait:
+            return Traced(trace_id, None)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            info = self.get(sandbox_id).value
+            if info.status == SandboxStatus.RUNNING:
+                return Traced(trace_id, None)
+            if info.status == SandboxStatus.TERMINATED:
+                raise SandboxError(
+                    f"Sandbox {sandbox_id!r} terminated while waiting for resume"
+                )
+            time.sleep(poll_interval)
+        raise SandboxError(f"Sandbox {sandbox_id!r} did not resume within {timeout}s")
 
     # --- Snapshot operations ---
 

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -6,7 +6,7 @@ import json
 import time
 from urllib.parse import urlparse
 
-from tensorlake._tracing import USER_AGENT, Traced
+from tensorlake._tracing import USER_AGENT, Traced, TracedIterator
 
 from . import _defaults
 from .exceptions import (
@@ -342,7 +342,9 @@ class SandboxClient:
             trace_id, response_json = self._rust_client.create_sandbox(
                 request_json=request_model.model_dump_json(exclude_none=True)
             )
-            return Traced(trace_id, CreateSandboxResponse.model_validate_json(response_json))
+            return Traced(
+                trace_id, CreateSandboxResponse.model_validate_json(response_json)
+            )
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -364,7 +366,9 @@ class SandboxClient:
         """
         try:
             trace_id, response_json = self._rust_client.claim_sandbox(pool_id=pool_id)
-            return Traced(trace_id, CreateSandboxResponse.model_validate_json(response_json))
+            return Traced(
+                trace_id, CreateSandboxResponse.model_validate_json(response_json)
+            )
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -383,18 +387,20 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            trace_id, response_json = self._rust_client.get_sandbox_json(sandbox_id=sandbox_id)
+            trace_id, response_json = self._rust_client.get_sandbox_json(
+                sandbox_id=sandbox_id
+            )
             return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
 
-    def list(self) -> Traced[list[SandboxInfo]]:
+    def list(self) -> TracedIterator[SandboxInfo]:
         """List all sandboxes in the namespace.
 
         Returns:
-            Traced[list[SandboxInfo]] with sandbox list and trace_id
+            TracedIterator[SandboxInfo] — iterable over sandboxes, with .trace_id
 
         Raises:
             RemoteAPIError: If the API request fails
@@ -403,7 +409,7 @@ class SandboxClient:
         try:
             trace_id, response_json = self._rust_client.list_sandboxes_json()
             data = ListSandboxesResponse.model_validate(json.loads(response_json))
-            return Traced(trace_id, data.sandboxes)
+            return TracedIterator(trace_id, data.sandboxes)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -614,7 +620,9 @@ class SandboxClient:
                 sandbox_id=sandbox_id,
                 content_mode=content_mode.value if content_mode is not None else None,
             )
-            return Traced(trace_id, CreateSnapshotResponse.model_validate_json(response_json))
+            return Traced(
+                trace_id, CreateSnapshotResponse.model_validate_json(response_json)
+            )
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
@@ -634,16 +642,18 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            trace_id, response_json = self._rust_client.get_snapshot_json(snapshot_id=snapshot_id)
+            trace_id, response_json = self._rust_client.get_snapshot_json(
+                snapshot_id=snapshot_id
+            )
             return Traced(trace_id, SnapshotInfo.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def list_snapshots(self) -> Traced[list[SnapshotInfo]]:
+    def list_snapshots(self) -> TracedIterator[SnapshotInfo]:
         """List all snapshots in the namespace.
 
         Returns:
-            Traced[list[SnapshotInfo]] with snapshot list and trace_id
+            TracedIterator[SnapshotInfo] — iterable over snapshots, with .trace_id
 
         Raises:
             RemoteAPIError: If the API request fails
@@ -652,7 +662,7 @@ class SandboxClient:
         try:
             trace_id, response_json = self._rust_client.list_snapshots_json()
             data = ListSnapshotsResponse.model_validate(json.loads(response_json))
-            return Traced(trace_id, data.snapshots)
+            return TracedIterator(trace_id, data.snapshots)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -760,7 +770,9 @@ class SandboxClient:
             trace_id, response_json = self._rust_client.create_pool(
                 request_json=request_model.model_dump_json(exclude_none=True)
             )
-            return Traced(trace_id, CreateSandboxPoolResponse.model_validate_json(response_json))
+            return Traced(
+                trace_id, CreateSandboxPoolResponse.model_validate_json(response_json)
+            )
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -786,11 +798,11 @@ class SandboxClient:
                 raise PoolNotFoundError(pool_id) from None
             _raise_as_sandbox_error(e)
 
-    def list_pools(self) -> Traced[list[SandboxPoolInfo]]:
+    def list_pools(self) -> TracedIterator[SandboxPoolInfo]:
         """List all sandbox pools in the namespace.
 
         Returns:
-            Traced[list[SandboxPoolInfo]] with pool list and trace_id
+            TracedIterator[SandboxPoolInfo] — iterable over pools, with .trace_id
 
         Raises:
             RemoteAPIError: If the API request fails
@@ -799,7 +811,7 @@ class SandboxClient:
         try:
             trace_id, response_json = self._rust_client.list_pools_json()
             data = ListSandboxPoolsResponse.model_validate(json.loads(response_json))
-            return Traced(trace_id, data.pools)
+            return TracedIterator(trace_id, data.pools)
         except Exception as e:
             _raise_as_sandbox_error(e)
 

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -6,7 +6,7 @@ import json
 import time
 from urllib.parse import urlparse
 
-from tensorlake._tracing import USER_AGENT
+from tensorlake._tracing import USER_AGENT, Traced
 
 from . import _defaults
 from .exceptions import (
@@ -280,7 +280,7 @@ class SandboxClient:
         deny_out: list[str] | None = None,
         snapshot_id: str | None = None,
         name: str | None = None,
-    ) -> CreateSandboxResponse:
+    ) -> Traced[CreateSandboxResponse]:
         """Create a new standalone sandbox.
 
         Args:
@@ -309,7 +309,7 @@ class SandboxClient:
                 suspend/resume. When absent the sandbox is ephemeral.
 
         Returns:
-            CreateSandboxResponse with sandbox_id and status
+            Traced[CreateSandboxResponse] with sandbox_id, status, and trace_id
 
         Raises:
             RemoteAPIError: If the API request fails
@@ -339,14 +339,14 @@ class SandboxClient:
         )
 
         try:
-            response_json = self._rust_client.create_sandbox(
+            trace_id, response_json = self._rust_client.create_sandbox(
                 request_json=request_model.model_dump_json(exclude_none=True)
             )
-            return CreateSandboxResponse.model_validate_json(response_json)
+            return Traced(trace_id, CreateSandboxResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def claim(self, pool_id: str) -> CreateSandboxResponse:
+    def claim(self, pool_id: str) -> Traced[CreateSandboxResponse]:
         """Claim a sandbox from a pool.
 
         Claims a warm container from the pool, or creates a new one
@@ -356,26 +356,26 @@ class SandboxClient:
             pool_id: ID of the pool to claim from
 
         Returns:
-            CreateSandboxResponse with sandbox_id and status
+            Traced[CreateSandboxResponse] with sandbox_id, status, and trace_id
 
         Raises:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            response_json = self._rust_client.claim_sandbox(pool_id=pool_id)
-            return CreateSandboxResponse.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.claim_sandbox(pool_id=pool_id)
+            return Traced(trace_id, CreateSandboxResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get(self, sandbox_id: str) -> SandboxInfo:
+    def get(self, sandbox_id: str) -> Traced[SandboxInfo]:
         """Get information about a sandbox.
 
         Args:
             sandbox_id: ID of the sandbox
 
         Returns:
-            SandboxInfo with full sandbox details
+            Traced[SandboxInfo] with full sandbox details and trace_id
 
         Raises:
             SandboxNotFoundError: If sandbox doesn't exist
@@ -383,27 +383,27 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            response_json = self._rust_client.get_sandbox_json(sandbox_id=sandbox_id)
-            return SandboxInfo.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.get_sandbox_json(sandbox_id=sandbox_id)
+            return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
 
-    def list(self) -> list[SandboxInfo]:
+    def list(self) -> Traced[list[SandboxInfo]]:
         """List all sandboxes in the namespace.
 
         Returns:
-            List of SandboxInfo objects
+            Traced[list[SandboxInfo]] with sandbox list and trace_id
 
         Raises:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            response_json = self._rust_client.list_sandboxes_json()
+            trace_id, response_json = self._rust_client.list_sandboxes_json()
             data = ListSandboxesResponse.model_validate(json.loads(response_json))
-            return data.sandboxes
+            return Traced(trace_id, data.sandboxes)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -414,7 +414,7 @@ class SandboxClient:
         *,
         allow_unauthenticated_access: bool | None = None,
         exposed_ports: list[int] | None = None,
-    ) -> SandboxInfo:
+    ) -> Traced[SandboxInfo]:
         """Update a sandbox's properties.
 
         Supports updating the sandbox name and sandbox proxy access settings.
@@ -453,24 +453,25 @@ class SandboxClient:
             exposed_ports=normalized_ports,
         )
         try:
-            response_json = self._rust_client.update_sandbox(
+            trace_id, response_json = self._rust_client.update_sandbox(
                 sandbox_id=sandbox_id,
                 request_json=request.model_dump_json(exclude_none=True),
             )
-            return SandboxInfo.model_validate_json(response_json)
+            return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
 
-    def get_port_access(self, sandbox_id: str) -> SandboxPortAccess:
+    def get_port_access(self, sandbox_id: str) -> Traced[SandboxPortAccess]:
         """Return the current sandbox proxy settings for user ports."""
-        info = self.get(sandbox_id)
-        return SandboxPortAccess(
-            allow_unauthenticated_access=info.allow_unauthenticated_access,
-            exposed_ports=sorted(set(info.exposed_ports or [])),
-            sandbox_url=info.sandbox_url,
+        traced = self.get(sandbox_id)
+        port_access = SandboxPortAccess(
+            allow_unauthenticated_access=traced.allow_unauthenticated_access,
+            exposed_ports=sorted(set(traced.exposed_ports or [])),
+            sandbox_url=traced.sandbox_url,
         )
+        return Traced(traced.trace_id, port_access)
 
     def expose_ports(
         self,
@@ -478,7 +479,7 @@ class SandboxClient:
         ports: list[int],
         *,
         allow_unauthenticated_access: bool | None = None,
-    ) -> SandboxInfo:
+    ) -> Traced[SandboxInfo]:
         """Expose additional user ports through the sandbox proxy.
 
         By default this preserves the sandbox's current auth mode for user ports.
@@ -498,7 +499,7 @@ class SandboxClient:
             exposed_ports=desired_ports,
         )
 
-    def unexpose_ports(self, sandbox_id: str, ports: list[int]) -> SandboxInfo:
+    def unexpose_ports(self, sandbox_id: str, ports: list[int]) -> Traced[SandboxInfo]:
         """Remove one or more user ports from the sandbox proxy allowlist."""
         current = self.get_port_access(sandbox_id)
         ports_to_remove = set(_normalize_user_ports(ports))
@@ -513,7 +514,7 @@ class SandboxClient:
             exposed_ports=desired_ports,
         )
 
-    def delete(self, sandbox_id: str) -> None:
+    def delete(self, sandbox_id: str) -> Traced[None]:
         """Terminate a sandbox.
 
         Args:
@@ -525,13 +526,14 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            self._rust_client.delete_sandbox(sandbox_id=sandbox_id)
+            trace_id = self._rust_client.delete_sandbox(sandbox_id=sandbox_id)
+            return Traced(trace_id, None)
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
 
-    def suspend(self, sandbox_id: str) -> None:
+    def suspend(self, sandbox_id: str) -> Traced[None]:
         """Suspend a named sandbox.
 
         Only sandboxes created with a ``name`` can be suspended; ephemeral
@@ -549,13 +551,14 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            self._rust_client.suspend_sandbox(sandbox_id=sandbox_id)
+            trace_id = self._rust_client.suspend_sandbox(sandbox_id=sandbox_id)
+            return Traced(trace_id, None)
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
 
-    def resume(self, sandbox_id: str) -> None:
+    def resume(self, sandbox_id: str) -> Traced[None]:
         """Resume a suspended sandbox.
 
         The call returns as soon as the server accepts the request; poll
@@ -571,7 +574,8 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            self._rust_client.resume_sandbox(sandbox_id=sandbox_id)
+            trace_id = self._rust_client.resume_sandbox(sandbox_id=sandbox_id)
+            return Traced(trace_id, None)
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
@@ -583,7 +587,7 @@ class SandboxClient:
         self,
         sandbox_id: str,
         content_mode: SnapshotContentMode | None = None,
-    ) -> CreateSnapshotResponse:
+    ) -> Traced[CreateSnapshotResponse]:
         """Create a snapshot of a running sandbox's filesystem.
 
         This is an asynchronous operation. Poll with :meth:`get_snapshot`
@@ -598,7 +602,7 @@ class SandboxClient:
                 them (e.g. sandbox image builds).
 
         Returns:
-            CreateSnapshotResponse with snapshot_id and status
+            Traced[CreateSnapshotResponse] with snapshot_id, status, and trace_id
 
         Raises:
             SandboxNotFoundError: If sandbox doesn't exist
@@ -606,53 +610,53 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            response_json = self._rust_client.create_snapshot(
+            trace_id, response_json = self._rust_client.create_snapshot(
                 sandbox_id=sandbox_id,
                 content_mode=content_mode.value if content_mode is not None else None,
             )
-            return CreateSnapshotResponse.model_validate_json(response_json)
+            return Traced(trace_id, CreateSnapshotResponse.model_validate_json(response_json))
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
 
-    def get_snapshot(self, snapshot_id: str) -> SnapshotInfo:
+    def get_snapshot(self, snapshot_id: str) -> Traced[SnapshotInfo]:
         """Get information about a snapshot.
 
         Args:
             snapshot_id: ID of the snapshot
 
         Returns:
-            SnapshotInfo with full snapshot details
+            Traced[SnapshotInfo] with full snapshot details and trace_id
 
         Raises:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            response_json = self._rust_client.get_snapshot_json(snapshot_id=snapshot_id)
-            return SnapshotInfo.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.get_snapshot_json(snapshot_id=snapshot_id)
+            return Traced(trace_id, SnapshotInfo.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def list_snapshots(self) -> list[SnapshotInfo]:
+    def list_snapshots(self) -> Traced[list[SnapshotInfo]]:
         """List all snapshots in the namespace.
 
         Returns:
-            List of SnapshotInfo objects
+            Traced[list[SnapshotInfo]] with snapshot list and trace_id
 
         Raises:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            response_json = self._rust_client.list_snapshots_json()
+            trace_id, response_json = self._rust_client.list_snapshots_json()
             data = ListSnapshotsResponse.model_validate(json.loads(response_json))
-            return data.snapshots
+            return Traced(trace_id, data.snapshots)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def delete_snapshot(self, snapshot_id: str) -> None:
+    def delete_snapshot(self, snapshot_id: str) -> Traced[None]:
         """Delete a snapshot.
 
         Args:
@@ -663,7 +667,8 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            self._rust_client.delete_snapshot(snapshot_id=snapshot_id)
+            trace_id = self._rust_client.delete_snapshot(snapshot_id=snapshot_id)
+            return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -673,7 +678,7 @@ class SandboxClient:
         timeout: float = 300,
         poll_interval: float = 1.0,
         content_mode: SnapshotContentMode | None = None,
-    ) -> SnapshotInfo:
+    ) -> Traced[SnapshotInfo]:
         """Create a snapshot and wait for it to complete.
 
         Args:
@@ -684,24 +689,24 @@ class SandboxClient:
                 :meth:`snapshot` for details.
 
         Returns:
-            SnapshotInfo with completed snapshot details
+            Traced[SnapshotInfo] with completed snapshot details and trace_id
 
         Raises:
             SandboxError: If snapshot fails or times out
         """
-        result = self.snapshot(sandbox_id, content_mode=content_mode)
+        traced_create = self.snapshot(sandbox_id, content_mode=content_mode)
         deadline = time.time() + timeout
         while time.time() < deadline:
-            info = self.get_snapshot(result.snapshot_id)
-            if info.status == SnapshotStatus.COMPLETED:
-                return info
-            if info.status == SnapshotStatus.FAILED:
+            traced_info = self.get_snapshot(traced_create.snapshot_id)
+            if traced_info.status == SnapshotStatus.COMPLETED:
+                return traced_info
+            if traced_info.status == SnapshotStatus.FAILED:
                 raise SandboxError(
-                    f"Snapshot {result.snapshot_id} failed: {info.error}"
+                    f"Snapshot {traced_create.snapshot_id} failed: {traced_info.error}"
                 )
             time.sleep(poll_interval)
         raise SandboxError(
-            f"Snapshot {result.snapshot_id} did not complete within {timeout}s"
+            f"Snapshot {traced_create.snapshot_id} did not complete within {timeout}s"
         )
 
     # --- Pool operations ---
@@ -717,7 +722,7 @@ class SandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
-    ) -> CreateSandboxPoolResponse:
+    ) -> Traced[CreateSandboxPoolResponse]:
         """Create a new sandbox pool.
 
         Args:
@@ -752,21 +757,21 @@ class SandboxClient:
         )
 
         try:
-            response_json = self._rust_client.create_pool(
+            trace_id, response_json = self._rust_client.create_pool(
                 request_json=request_model.model_dump_json(exclude_none=True)
             )
-            return CreateSandboxPoolResponse.model_validate_json(response_json)
+            return Traced(trace_id, CreateSandboxPoolResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get_pool(self, pool_id: str) -> SandboxPoolInfo:
+    def get_pool(self, pool_id: str) -> Traced[SandboxPoolInfo]:
         """Get information about a sandbox pool.
 
         Args:
             pool_id: ID of the pool
 
         Returns:
-            SandboxPoolInfo with full pool details
+            Traced[SandboxPoolInfo] with full pool details and trace_id
 
         Raises:
             PoolNotFoundError: If pool doesn't exist
@@ -774,27 +779,27 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            response_json = self._rust_client.get_pool_json(pool_id=pool_id)
-            return SandboxPoolInfo.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.get_pool_json(pool_id=pool_id)
+            return Traced(trace_id, SandboxPoolInfo.model_validate_json(response_json))
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise PoolNotFoundError(pool_id) from None
             _raise_as_sandbox_error(e)
 
-    def list_pools(self) -> list[SandboxPoolInfo]:
+    def list_pools(self) -> Traced[list[SandboxPoolInfo]]:
         """List all sandbox pools in the namespace.
 
         Returns:
-            List of SandboxPoolInfo objects
+            Traced[list[SandboxPoolInfo]] with pool list and trace_id
 
         Raises:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            response_json = self._rust_client.list_pools_json()
+            trace_id, response_json = self._rust_client.list_pools_json()
             data = ListSandboxPoolsResponse.model_validate(json.loads(response_json))
-            return data.pools
+            return Traced(trace_id, data.pools)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -810,7 +815,7 @@ class SandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
-    ) -> SandboxPoolInfo:
+    ) -> Traced[SandboxPoolInfo]:
         """Update a sandbox pool configuration.
 
         Args:
@@ -847,17 +852,17 @@ class SandboxClient:
         )
 
         try:
-            response_json = self._rust_client.update_pool(
+            trace_id, response_json = self._rust_client.update_pool(
                 pool_id=pool_id,
                 request_json=request_model.model_dump_json(exclude_none=True),
             )
-            return SandboxPoolInfo.model_validate_json(response_json)
+            return Traced(trace_id, SandboxPoolInfo.model_validate_json(response_json))
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise PoolNotFoundError(pool_id) from None
             _raise_as_sandbox_error(e)
 
-    def delete_pool(self, pool_id: str) -> None:
+    def delete_pool(self, pool_id: str) -> Traced[None]:
         """Delete a sandbox pool.
 
         Args:
@@ -870,7 +875,8 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            self._rust_client.delete_pool(pool_id=pool_id)
+            trace_id = self._rust_client.delete_pool(pool_id=pool_id)
+            return Traced(trace_id, None)
         except Exception as e:
             kind, status_code, message = _parse_rust_client_error_fields(e)
             if status_code == 404:

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -6,6 +6,8 @@ import json
 import time
 from urllib.parse import urlparse
 
+from tensorlake._tracing import USER_AGENT
+
 from . import _defaults
 from .exceptions import (
     PoolInUseError,
@@ -172,6 +174,7 @@ class SandboxClient:
                 organization_id=self._organization_id,
                 project_id=self._project_id,
                 namespace=self._namespace,
+                user_agent=USER_AGENT,
             )
         except Exception as e:
             _raise_as_sandbox_error(e)

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1087,6 +1087,7 @@ class SandboxClient:
             sandbox._name_loaded = True
             sandbox._owns_sandbox = True
             sandbox._lifecycle_client = self
+            sandbox._trace_id = result.trace_id
             return sandbox
 
         deadline = time.time() + startup_timeout
@@ -1104,6 +1105,7 @@ class SandboxClient:
                 sandbox._cached_info = info
                 sandbox._owns_sandbox = True
                 sandbox._lifecycle_client = self
+                sandbox._trace_id = result.trace_id
                 return sandbox
             if info.status in (SandboxStatus.SUSPENDED, SandboxStatus.TERMINATED):
                 raise SandboxError(

--- a/src/tensorlake/sandbox/pty.py
+++ b/src/tensorlake/sandbox/pty.py
@@ -9,6 +9,8 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import httpx
 
+from tensorlake._tracing import inject_traceparent
+
 from .exceptions import RemoteAPIError, SandboxConnectionError, SandboxError
 
 try:
@@ -161,7 +163,7 @@ class Pty:
         try:
             response = httpx.delete(
                 self._http_url,
-                headers=self._http_headers,
+                headers=inject_traceparent(self._http_headers),
                 timeout=self._connect_timeout,
             )
         except httpx.HTTPError as e:

--- a/src/tensorlake/sandbox/pty.py
+++ b/src/tensorlake/sandbox/pty.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import httpx
 
-from tensorlake._tracing import inject_traceparent
+from tensorlake._tracing import USER_AGENT, inject_traceparent
 
 from .exceptions import RemoteAPIError, SandboxConnectionError, SandboxError
 
@@ -163,7 +163,9 @@ class Pty:
         try:
             response = httpx.delete(
                 self._http_url,
-                headers=inject_traceparent(self._http_headers),
+                headers=inject_traceparent(
+                    {**self._http_headers, "User-Agent": USER_AGENT}
+                ),
                 timeout=self._connect_timeout,
             )
         except httpx.HTTPError as e:

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -140,6 +140,7 @@ class Sandbox:
         self._sandbox_id: str | None = None
         self._name: str | None = None
         self._name_loaded: bool = False
+        self._trace_id: str | None = None
         self._cached_info: SandboxInfo | None = None
         self._owns_sandbox: bool = False
         self._lifecycle_client: SandboxClient | None = None
@@ -523,6 +524,11 @@ class Sandbox:
             return self._sandbox_id
         self._sandbox_id = self._fetch_info().sandbox_id
         return self._sandbox_id
+
+    @property
+    def trace_id(self) -> str | None:
+        """W3C traceparent trace ID from the create/claim request, or None if not available."""
+        return self._trace_id
 
     @property
     def name(self) -> str | None:

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -341,6 +341,11 @@ class Sandbox:
 
         Args:
             snapshot_id: ID of the snapshot.
+            api_key: Tensorlake API key (defaults to TENSORLAKE_API_KEY env var).
+            api_url: API server URL (defaults to TENSORLAKE_API_URL env var).
+            organization_id: Organization ID for multi-tenant access.
+            project_id: Project ID for scoping resources.
+            namespace: Namespace for local-server deployments.
 
         Returns:
             SnapshotInfo with full snapshot details.
@@ -373,6 +378,11 @@ class Sandbox:
 
         Args:
             snapshot_id: ID of the snapshot to delete.
+            api_key: Tensorlake API key (defaults to TENSORLAKE_API_KEY env var).
+            api_url: API server URL (defaults to TENSORLAKE_API_URL env var).
+            organization_id: Organization ID for multi-tenant access.
+            project_id: Project ID for scoping resources.
+            namespace: Namespace for local-server deployments.
         """
         from .client import SandboxClient
 

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from tensorlake._tracing import Traced, TracedIterator, inject_traceparent
+from tensorlake._tracing import USER_AGENT, Traced, TracedIterator, inject_traceparent
 
 from . import _defaults
 from .exceptions import (
@@ -176,6 +176,7 @@ class Sandbox:
                     organization_id=organization_id,
                     project_id=project_id,
                     routing_hint=routing_hint,
+                    user_agent=USER_AGENT,
                 )
                 self._base_url = self._rust_client.base_url()
             except Exception as e:
@@ -711,6 +712,7 @@ class Sandbox:
                 api_key=self._api_key,
                 organization_id=self._organization_id,
                 project_id=self._project_id,
+                user_agent=USER_AGENT,
             )
             return Desktop(rust_client)
         except Exception as e:

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import httpx
+
+from tensorlake._tracing import Traced, TracedIterator, inject_traceparent
 
 from . import _defaults
 from .exceptions import (
@@ -265,7 +267,7 @@ class Sandbox:
         env: dict[str, str] | None = None,
         working_dir: str | None = None,
         timeout: float | None = None,
-    ) -> CommandResult:
+    ) -> Traced[CommandResult]:
         """Run a command to completion and return its output.
 
         Uses a single streaming ``POST /api/v1/processes/run`` request that
@@ -280,7 +282,9 @@ class Sandbox:
             timeout: Maximum seconds to wait (enforced server-side; None = no limit)
 
         Returns:
-            CommandResult with exit_code, stdout, and stderr
+            Traced[CommandResult] — access ``.trace_id`` for the W3C trace ID
+            and ``.exit_code`` / ``.stdout`` / ``.stderr`` directly (or via
+            ``.value``).
         """
         payload = self._build_command_payload(
             command,
@@ -291,7 +295,9 @@ class Sandbox:
         )
 
         try:
-            events_json = self._rust_client.run_process_json(json.dumps(payload))
+            trace_id, events_json = self._rust_client.run_process_json(
+                json.dumps(payload)
+            )
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -317,10 +323,13 @@ class Sandbox:
                 "sandbox process stream ended without an exit event"
             )
 
-        return CommandResult(
-            exit_code=exit_code,
-            stdout="\n".join(stdout_lines),
-            stderr="\n".join(stderr_lines),
+        return Traced(
+            trace_id,
+            CommandResult(
+                exit_code=exit_code,
+                stdout="\n".join(stdout_lines),
+                stderr="\n".join(stderr_lines),
+            ),
         )
 
     # --- Process management ---
@@ -334,7 +343,7 @@ class Sandbox:
         stdin_mode: StdinMode = StdinMode.CLOSED,
         stdout_mode: OutputMode = OutputMode.CAPTURE,
         stderr_mode: OutputMode = OutputMode.CAPTURE,
-    ) -> ProcessInfo:
+    ) -> Traced[ProcessInfo]:
         """Start a new process in the sandbox.
 
         Args:
@@ -347,7 +356,8 @@ class Sandbox:
             stderr_mode: OutputMode.CAPTURE or OutputMode.DISCARD
 
         Returns:
-            ProcessInfo with pid and status
+            Traced[ProcessInfo] — access ``.trace_id`` for the W3C trace ID
+            and ``.pid`` / ``.status`` directly (or via ``.value``).
         """
         payload = self._build_command_payload(
             command,
@@ -360,36 +370,39 @@ class Sandbox:
         )
 
         try:
-            response_json = self._rust_client.start_process_json(json.dumps(payload))
-            return ProcessInfo.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.start_process_json(
+                json.dumps(payload)
+            )
+            return Traced(trace_id, ProcessInfo.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def list_processes(self) -> list[ProcessInfo]:
+    def list_processes(self) -> Traced[list[ProcessInfo]]:
         """List all processes in the sandbox."""
         try:
-            response_json = self._rust_client.list_processes_json()
+            trace_id, response_json = self._rust_client.list_processes_json()
             data = ListProcessesResponse.model_validate_json(response_json)
-            return data.processes
+            return Traced(trace_id, data.processes)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get_process(self, pid: int) -> ProcessInfo:
+    def get_process(self, pid: int) -> Traced[ProcessInfo]:
         """Get information about a specific process."""
         try:
-            response_json = self._rust_client.get_process_json(pid=pid)
-            return ProcessInfo.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.get_process_json(pid=pid)
+            return Traced(trace_id, ProcessInfo.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def kill_process(self, pid: int) -> None:
+    def kill_process(self, pid: int) -> Traced[None]:
         """Kill a process."""
         try:
-            self._rust_client.kill_process(pid=pid)
+            trace_id = self._rust_client.kill_process(pid=pid)
+            return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def send_signal(self, pid: int, signal: int) -> SendSignalResponse:
+    def send_signal(self, pid: int, signal: int) -> Traced[SendSignalResponse]:
         """Send a signal to a process.
 
         Args:
@@ -397,95 +410,115 @@ class Sandbox:
             signal: Signal number (e.g. 15 for SIGTERM, 9 for SIGKILL)
         """
         try:
-            response_json = self._rust_client.send_signal_json(pid=pid, signal=signal)
-            return SendSignalResponse.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.send_signal_json(
+                pid=pid, signal=signal
+            )
+            return Traced(
+                trace_id, SendSignalResponse.model_validate_json(response_json)
+            )
         except Exception as e:
             _raise_as_sandbox_error(e)
 
     # --- Process I/O ---
 
-    def write_stdin(self, pid: int, data: bytes) -> None:
+    def write_stdin(self, pid: int, data: bytes) -> Traced[None]:
         """Write data to a process's stdin."""
         try:
-            self._rust_client.write_stdin(pid=pid, data=data)
+            trace_id = self._rust_client.write_stdin(pid=pid, data=data)
+            return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def close_stdin(self, pid: int) -> None:
+    def close_stdin(self, pid: int) -> Traced[None]:
         """Close a process's stdin."""
         try:
-            self._rust_client.close_stdin(pid=pid)
+            trace_id = self._rust_client.close_stdin(pid=pid)
+            return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get_stdout(self, pid: int) -> OutputResponse:
+    def get_stdout(self, pid: int) -> Traced[OutputResponse]:
         """Get all stdout output from a process."""
         try:
-            response_json = self._rust_client.get_stdout_json(pid=pid)
-            return OutputResponse.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.get_stdout_json(pid=pid)
+            return Traced(trace_id, OutputResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get_stderr(self, pid: int) -> OutputResponse:
+    def get_stderr(self, pid: int) -> Traced[OutputResponse]:
         """Get all stderr output from a process."""
         try:
-            response_json = self._rust_client.get_stderr_json(pid=pid)
-            return OutputResponse.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.get_stderr_json(pid=pid)
+            return Traced(trace_id, OutputResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get_output(self, pid: int) -> OutputResponse:
+    def get_output(self, pid: int) -> Traced[OutputResponse]:
         """Get all combined output from a process."""
         try:
-            response_json = self._rust_client.get_output_json(pid=pid)
-            return OutputResponse.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.get_output_json(pid=pid)
+            return Traced(trace_id, OutputResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def follow_stdout(self, pid: int) -> Iterator[OutputEvent]:
-        """Stream stdout from a process via SSE. Replays existing output then streams live."""
+    def follow_stdout(self, pid: int) -> TracedIterator[OutputEvent]:
+        """Collect all stdout output events from a process and return them as an iterable.
+
+        Blocks until the process exits and all output has been received."""
         try:
-            events_json = self._rust_client.follow_stdout_json(pid=pid)
-            for event_json in events_json:
-                yield OutputEvent.model_validate_json(event_json)
+            trace_id, events_json = self._rust_client.follow_stdout_json(pid=pid)
+            return TracedIterator(
+                trace_id,
+                [OutputEvent.model_validate_json(ej) for ej in events_json],
+            )
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def follow_stderr(self, pid: int) -> Iterator[OutputEvent]:
-        """Stream stderr from a process via SSE. Replays existing output then streams live."""
+    def follow_stderr(self, pid: int) -> TracedIterator[OutputEvent]:
+        """Collect all stderr output events from a process and return them as an iterable.
+
+        Blocks until the process exits and all output has been received."""
         try:
-            events_json = self._rust_client.follow_stderr_json(pid=pid)
-            for event_json in events_json:
-                yield OutputEvent.model_validate_json(event_json)
+            trace_id, events_json = self._rust_client.follow_stderr_json(pid=pid)
+            return TracedIterator(
+                trace_id,
+                [OutputEvent.model_validate_json(ej) for ej in events_json],
+            )
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def follow_output(self, pid: int) -> Iterator[OutputEvent]:
-        """Stream combined output from a process via SSE. Replays existing output then streams live."""
+    def follow_output(self, pid: int) -> TracedIterator[OutputEvent]:
+        """Collect all combined output events from a process and return them as an iterable.
+
+        Blocks until the process exits and all output has been received."""
         try:
-            events_json = self._rust_client.follow_output_json(pid=pid)
-            for event_json in events_json:
-                yield OutputEvent.model_validate_json(event_json)
+            trace_id, events_json = self._rust_client.follow_output_json(pid=pid)
+            return TracedIterator(
+                trace_id,
+                [OutputEvent.model_validate_json(ej) for ej in events_json],
+            )
         except Exception as e:
             _raise_as_sandbox_error(e)
 
     # --- File operations ---
 
-    def read_file(self, path: str) -> bytes:
+    def read_file(self, path: str) -> Traced[bytes]:
         """Read a file from the sandbox.
 
         Args:
             path: Absolute path inside the sandbox
 
         Returns:
-            File contents as bytes
+            Traced[bytes] — access ``.trace_id`` for the W3C trace ID and
+            ``.value`` for the raw file bytes.
         """
         try:
-            return self._rust_client.read_file_bytes(path=path)
+            trace_id, data = self._rust_client.read_file_bytes(path=path)
+            return Traced(trace_id, data)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def write_file(self, path: str, content: bytes) -> None:
+    def write_file(self, path: str, content: bytes) -> Traced[None]:
         """Write a file to the sandbox.
 
         Args:
@@ -493,33 +526,38 @@ class Sandbox:
             content: File contents as bytes
         """
         try:
-            self._rust_client.write_file(path=path, content=content)
+            trace_id = self._rust_client.write_file(path=path, content=content)
+            return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def delete_file(self, path: str) -> None:
+    def delete_file(self, path: str) -> Traced[None]:
         """Delete a file from the sandbox.
 
         Args:
             path: Absolute path inside the sandbox
         """
         try:
-            self._rust_client.delete_file(path=path)
+            trace_id = self._rust_client.delete_file(path=path)
+            return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def list_directory(self, path: str) -> ListDirectoryResponse:
+    def list_directory(self, path: str) -> Traced[ListDirectoryResponse]:
         """List contents of a directory in the sandbox.
 
         Args:
             path: Absolute path inside the sandbox
 
         Returns:
-            ListDirectoryResponse with path and entries
+            Traced[ListDirectoryResponse] — access ``.trace_id`` for the W3C
+            trace ID and ``.path`` / ``.entries`` directly (or via ``.value``).
         """
         try:
-            response_json = self._rust_client.list_directory_json(path=path)
-            return ListDirectoryResponse.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.list_directory_json(path=path)
+            return Traced(
+                trace_id, ListDirectoryResponse.model_validate_json(response_json)
+            )
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -533,10 +571,10 @@ class Sandbox:
         working_dir: str | None = None,
         rows: int = 24,
         cols: int = 80,
-    ) -> dict:
+    ) -> Traced[dict]:
         """Create an interactive PTY session.
 
-        Returns a dict with ``session_id`` and ``token`` for WebSocket
+        Returns a Traced dict with ``session_id`` and ``token`` for WebSocket
         connection via :meth:`pty_ws_url`.
         """
         payload: dict = {"command": command, "rows": rows, "cols": cols}
@@ -548,10 +586,10 @@ class Sandbox:
             payload["working_dir"] = working_dir
 
         try:
-            response_json = self._rust_client.create_pty_session_json(
+            trace_id, response_json = self._rust_client.create_pty_session_json(
                 json.dumps(payload)
             )
-            return json.loads(response_json)
+            return Traced(trace_id, json.loads(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -601,7 +639,7 @@ class Sandbox:
     def _delete_pty_session(self, session_id: str, *, timeout: float = 10.0) -> None:
         response = httpx.delete(
             f"{self._base_url.rstrip('/')}/api/v1/pty/{session_id}",
-            headers=self._proxy_headers,
+            headers=inject_traceparent(self._proxy_headers),
             timeout=timeout,
         )
         if response.is_success or response.status_code == 404:
@@ -622,7 +660,7 @@ class Sandbox:
         connect_timeout: float = 10.0,
     ):
         """Create a PTY session, connect immediately, and return its handle."""
-        session = self.create_pty_session(
+        traced_session = self.create_pty_session(
             command=command,
             args=args,
             env=env,
@@ -630,6 +668,7 @@ class Sandbox:
             rows=rows,
             cols=cols,
         )
+        session = traced_session.value
         try:
             return self.connect_pty(
                 session["session_id"],
@@ -679,18 +718,18 @@ class Sandbox:
 
     # --- Health and info ---
 
-    def health(self) -> HealthResponse:
+    def health(self) -> Traced[HealthResponse]:
         """Check the container daemon health."""
         try:
-            response_json = self._rust_client.health_json()
-            return HealthResponse.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.health_json()
+            return Traced(trace_id, HealthResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def info(self) -> DaemonInfo:
+    def info(self) -> Traced[DaemonInfo]:
         """Get container daemon info (version, uptime, process counts)."""
         try:
-            response_json = self._rust_client.info_json()
-            return DaemonInfo.model_validate_json(response_json)
+            trace_id, response_json = self._rust_client.info_json()
+            return Traced(trace_id, DaemonInfo.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -190,7 +190,7 @@ class Sandbox:
                     "Cannot resolve sandbox info: no lifecycle client available. "
                     "Connect via SandboxClient.connect() to enable sandbox_id and name lookup."
                 )
-            self._cached_info = self._lifecycle_client.get(self._identifier)
+            self._cached_info = self._lifecycle_client.get(self._identifier).value
         return self._cached_info
 
     @property

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -28,6 +29,8 @@ from .models import (
     ProcessInfo,
     SandboxInfo,
     SendSignalResponse,
+    SnapshotContentMode,
+    SnapshotInfo,
     StdinMode,
 )
 
@@ -181,6 +184,316 @@ class Sandbox:
                 self._base_url = self._rust_client.base_url()
             except Exception as e:
                 _raise_as_sandbox_error(e)
+
+    # --- Class-level factory methods ---
+
+    @classmethod
+    def create(
+        cls,
+        image: str | None = None,
+        cpus: float = 1.0,
+        memory_mb: int = 1024,
+        ephemeral_disk_mb: int = 1024,
+        secret_names: list[str] | None = None,
+        timeout_secs: int | None = None,
+        entrypoint: list[str] | None = None,
+        allow_internet_access: bool = True,
+        allow_out: list[str] | None = None,
+        deny_out: list[str] | None = None,
+        pool_id: str | None = None,
+        snapshot_id: str | None = None,
+        proxy_url: str | None = None,
+        startup_timeout: float = 60,
+        name: str | None = None,
+        api_key: str | None = _defaults.API_KEY,
+        api_url: str = _defaults.API_URL,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        namespace: str | None = _defaults.NAMESPACE,
+    ) -> "Sandbox":
+        """Create a new sandbox and return a connected, running handle.
+
+        Covers both fresh sandbox creation and restore-from-snapshot (set
+        ``snapshot_id``). Blocks until the sandbox is ``Running``.
+
+        Args:
+            image: Sandbox image name. When omitted, Tensorlake uses the
+                default managed environment.
+            cpus: Number of CPUs to allocate.
+            memory_mb: Memory in megabytes.
+            ephemeral_disk_mb: Ephemeral disk space in megabytes.
+            secret_names: List of secret names to inject.
+            timeout_secs: Sandbox timeout in seconds.
+            entrypoint: Custom entrypoint command.
+            allow_internet_access: If True (default), outbound traffic is allowed.
+            allow_out: Destination IPs/CIDRs to allow.
+            deny_out: Destination IPs/CIDRs to deny.
+            pool_id: Pool ID to claim a warm container from.
+            snapshot_id: Restore from this snapshot ID.
+            proxy_url: Override the sandbox proxy URL.
+            startup_timeout: Max seconds to wait for Running status (default 60).
+            name: Optional name; named sandboxes support suspend/resume.
+            api_key: Tensorlake API key (defaults to TENSORLAKE_API_KEY env var).
+            api_url: API server URL (defaults to TENSORLAKE_API_URL env var).
+            organization_id: Organization ID for multi-tenant access.
+            project_id: Project ID for scoping resources.
+            namespace: Namespace for local-server deployments.
+
+        Returns:
+            Connected Sandbox handle (auto-terminates in context manager).
+
+        Raises:
+            SandboxError: If sandbox fails to start or times out.
+        """
+        from .client import SandboxClient
+
+        client = SandboxClient(
+            api_url=api_url,
+            api_key=api_key,
+            organization_id=organization_id,
+            project_id=project_id,
+            namespace=namespace,
+            _internal=True,
+        )
+        return client.create_and_connect(
+            image=image,
+            cpus=cpus,
+            memory_mb=memory_mb,
+            ephemeral_disk_mb=ephemeral_disk_mb,
+            secret_names=secret_names,
+            timeout_secs=timeout_secs,
+            entrypoint=entrypoint,
+            allow_internet_access=allow_internet_access,
+            allow_out=allow_out,
+            deny_out=deny_out,
+            pool_id=pool_id,
+            snapshot_id=snapshot_id,
+            proxy_url=proxy_url,
+            startup_timeout=startup_timeout,
+            name=name,
+        )
+
+    @classmethod
+    def connect(
+        cls,
+        sandbox_id: str,
+        *,
+        proxy_url: str | None = None,
+        routing_hint: str | None = None,
+        api_key: str | None = _defaults.API_KEY,
+        api_url: str = _defaults.API_URL,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        namespace: str | None = _defaults.NAMESPACE,
+    ) -> "Sandbox":
+        """Attach to an existing sandbox and return a connected handle.
+
+        Verifies the sandbox exists via a server GET call, then returns a
+        handle in whatever state the sandbox is in. Does **not** auto-resume
+        a suspended sandbox — call ``sandbox.resume()`` explicitly.
+
+        Args:
+            sandbox_id: ID or name of the sandbox to attach to.
+            proxy_url: Override the sandbox proxy URL.
+            routing_hint: Optional routing hint for the proxy.
+            api_key: Tensorlake API key (defaults to TENSORLAKE_API_KEY env var).
+            api_url: API server URL (defaults to TENSORLAKE_API_URL env var).
+            organization_id: Organization ID for multi-tenant access.
+            project_id: Project ID for scoping resources.
+            namespace: Namespace for local-server deployments.
+
+        Returns:
+            Connected Sandbox handle (does not auto-terminate on context exit).
+
+        Raises:
+            SandboxNotFoundError: If the sandbox does not exist.
+        """
+        from .client import SandboxClient
+
+        client = SandboxClient(
+            api_url=api_url,
+            api_key=api_key,
+            organization_id=organization_id,
+            project_id=project_id,
+            namespace=namespace,
+            _internal=True,
+        )
+        client.get(sandbox_id)  # raises SandboxNotFoundError if not found
+        return client.connect(
+            sandbox_id, proxy_url=proxy_url, routing_hint=routing_hint
+        )
+
+    # --- Class-level snapshot management ---
+
+    @classmethod
+    def get_snapshot(
+        cls,
+        snapshot_id: str,
+        api_key: str | None = _defaults.API_KEY,
+        api_url: str = _defaults.API_URL,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        namespace: str | None = _defaults.NAMESPACE,
+    ) -> SnapshotInfo:
+        """Get information about a snapshot by ID.
+
+        No sandbox handle is needed — snapshots are looked up directly.
+
+        Args:
+            snapshot_id: ID of the snapshot.
+
+        Returns:
+            SnapshotInfo with full snapshot details.
+        """
+        from .client import SandboxClient
+
+        client = SandboxClient(
+            api_url=api_url,
+            api_key=api_key,
+            organization_id=organization_id,
+            project_id=project_id,
+            namespace=namespace,
+            _internal=True,
+        )
+        return client.get_snapshot(snapshot_id).value
+
+    @classmethod
+    def delete_snapshot(
+        cls,
+        snapshot_id: str,
+        api_key: str | None = _defaults.API_KEY,
+        api_url: str = _defaults.API_URL,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        namespace: str | None = _defaults.NAMESPACE,
+    ) -> None:
+        """Delete a snapshot by ID.
+
+        No sandbox handle is needed — snapshots are deleted directly.
+
+        Args:
+            snapshot_id: ID of the snapshot to delete.
+        """
+        from .client import SandboxClient
+
+        client = SandboxClient(
+            api_url=api_url,
+            api_key=api_key,
+            organization_id=organization_id,
+            project_id=project_id,
+            namespace=namespace,
+            _internal=True,
+        )
+        client.delete_snapshot(snapshot_id)
+
+    # --- Instance lifecycle methods ---
+
+    def _require_lifecycle_client(self, operation: str) -> None:
+        if self._lifecycle_client is None:
+            raise SandboxError(
+                f"Cannot {operation}: no lifecycle client available. "
+                "Use Sandbox.create() or Sandbox.connect() to get a lifecycle-aware handle."
+            )
+
+    def suspend(
+        self,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+    ) -> None:
+        """Suspend this sandbox.
+
+        By default blocks until the sandbox is fully ``Suspended``.
+        Pass ``wait=False`` for fire-and-return (the server queues the
+        suspend but this method returns immediately).
+
+        Args:
+            wait: If True (default), poll until Suspended.
+            timeout: Max seconds to wait when wait=True (default 300).
+            poll_interval: Seconds between polls when wait=True (default 1.0).
+
+        Raises:
+            SandboxError: If the sandbox does not suspend within timeout,
+                or terminates unexpectedly.
+        """
+        self._require_lifecycle_client("suspend")
+        self._lifecycle_client.suspend(
+            self.sandbox_id, wait=wait, timeout=timeout, poll_interval=poll_interval
+        )
+
+    def resume(
+        self,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+    ) -> None:
+        """Resume this sandbox.
+
+        By default blocks until the sandbox is ``Running`` and routable.
+        Pass ``wait=False`` for fire-and-return. No-op (no error) if the
+        sandbox is already Running.
+
+        Args:
+            wait: If True (default), poll until Running.
+            timeout: Max seconds to wait when wait=True (default 300).
+            poll_interval: Seconds between polls when wait=True (default 1.0).
+
+        Raises:
+            SandboxError: If the sandbox does not resume within timeout,
+                or terminates unexpectedly.
+        """
+        self._require_lifecycle_client("resume")
+        self._lifecycle_client.resume(
+            self.sandbox_id, wait=wait, timeout=timeout, poll_interval=poll_interval
+        )
+
+    def checkpoint(
+        self,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+        content_mode: SnapshotContentMode | None = None,
+    ) -> SnapshotInfo | None:
+        """Create a snapshot of this sandbox's filesystem.
+
+        By default blocks until the snapshot artifact is committed and
+        returns the completed ``SnapshotInfo``. Pass ``wait=False`` to
+        fire-and-return (returns ``None``).
+
+        Args:
+            wait: If True (default), poll until the snapshot is committed.
+            timeout: Max seconds to wait when wait=True (default 300).
+            poll_interval: Seconds between polls when wait=True (default 1.0).
+            content_mode: Optional content mode for the snapshot.
+
+        Returns:
+            Completed SnapshotInfo when wait=True; None when wait=False.
+
+        Raises:
+            SandboxError: If the snapshot fails or times out.
+        """
+        self._require_lifecycle_client("checkpoint")
+        if not wait:
+            self._lifecycle_client.snapshot(self.sandbox_id, content_mode=content_mode)
+            return None
+        return self._lifecycle_client.snapshot_and_wait(
+            self.sandbox_id,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            content_mode=content_mode,
+        ).value
+
+    def list_snapshots(self) -> TracedIterator[SnapshotInfo]:
+        """List snapshots taken from this sandbox.
+
+        Returns:
+            TracedIterator[SnapshotInfo] — iterable over this sandbox's snapshots.
+        """
+        self._require_lifecycle_client("list_snapshots")
+        all_snaps = self._lifecycle_client.list_snapshots()
+        my_id = self.sandbox_id
+        filtered = [s for s in all_snaps if s.sandbox_id == my_id]
+        return TracedIterator(all_snaps.trace_id, filtered)
 
     def _fetch_info(self) -> SandboxInfo:
         """Fetch and cache sandbox info from the server (lazy, once per instance)."""

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1225,6 +1225,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1531,6 +1532,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1585,6 +1587,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2305,6 +2308,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2354,6 +2358,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2791,6 +2796,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2838,6 +2844,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.4.50",
+  "version": "0.5.0",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -2,6 +2,8 @@ import * as defaults from "./defaults.js";
 import { SandboxError } from "./errors.js";
 import { HttpClient } from "./http.js";
 import {
+  type CheckpointOptions,
+  type ConnectOptions,
   type CreateAndConnectOptions,
   type CreatePoolOptions,
   type CreateSandboxOptions,
@@ -17,6 +19,7 @@ import {
   type SnapshotInfo,
   type SnapshotOptions,
   SnapshotStatus,
+  type SuspendResumeOptions,
   type UpdatePoolOptions,
   type UpdateSandboxOptions,
   fromSnakeKeys,
@@ -40,7 +43,13 @@ export class SandboxClient {
   private readonly namespace: string;
   private readonly local: boolean;
 
-  constructor(options?: SandboxClientOptions) {
+  /** @internal Pass `true` to suppress the deprecation warning when used by `Sandbox.create()` / `Sandbox.connect()`. */
+  constructor(options?: SandboxClientOptions, _internal = false) {
+    if (!_internal) {
+      console.warn(
+        "[tensorlake] SandboxClient is deprecated; use Sandbox.create() / Sandbox.connect() instead.",
+      );
+    }
     this.apiUrl = options?.apiUrl ?? defaults.API_URL;
     this.apiKey = options?.apiKey ?? defaults.API_KEY;
     this.organizationId = options?.organizationId;
@@ -221,18 +230,44 @@ export class SandboxClient {
     );
   }
 
-  async suspend(sandboxId: string): Promise<void> {
+  async suspend(sandboxId: string, options?: SuspendResumeOptions): Promise<void> {
     await this.http.requestResponse(
       "POST",
       this.path(`sandboxes/${sandboxId}/suspend`),
     );
+    if (options?.wait === false) return;
+    const timeout = options?.timeout ?? 300;
+    const pollInterval = options?.pollInterval ?? 1;
+    const deadline = Date.now() + timeout * 1000;
+    while (Date.now() < deadline) {
+      const info = await this.get(sandboxId);
+      if (info.status === SandboxStatus.SUSPENDED) return;
+      if (info.status === SandboxStatus.TERMINATED) {
+        throw new SandboxError(`Sandbox ${sandboxId} terminated while waiting for suspend`);
+      }
+      await sleep(pollInterval * 1000);
+    }
+    throw new SandboxError(`Sandbox ${sandboxId} did not suspend within ${timeout}s`);
   }
 
-  async resume(sandboxId: string): Promise<void> {
+  async resume(sandboxId: string, options?: SuspendResumeOptions): Promise<void> {
     await this.http.requestResponse(
       "POST",
       this.path(`sandboxes/${sandboxId}/resume`),
     );
+    if (options?.wait === false) return;
+    const timeout = options?.timeout ?? 300;
+    const pollInterval = options?.pollInterval ?? 1;
+    const deadline = Date.now() + timeout * 1000;
+    while (Date.now() < deadline) {
+      const info = await this.get(sandboxId);
+      if (info.status === SandboxStatus.RUNNING) return;
+      if (info.status === SandboxStatus.TERMINATED) {
+        throw new SandboxError(`Sandbox ${sandboxId} terminated while waiting for resume`);
+      }
+      await sleep(pollInterval * 1000);
+    }
+    throw new SandboxError(`Sandbox ${sandboxId} did not resume within ${timeout}s`);
   }
 
   async claim(poolId: string): Promise<CreateSandboxResponse> {

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1,6 +1,6 @@
 import * as defaults from "./defaults.js";
 import { SandboxError } from "./errors.js";
-import { HttpClient } from "./http.js";
+import { type Traced, HttpClient } from "./http.js";
 import {
   type CheckpointOptions,
   type ConnectOptions,
@@ -106,7 +106,7 @@ export class SandboxClient {
   // --- Sandbox CRUD ---
 
   /** Create a new sandbox. Returns immediately; the sandbox may still be starting. Use `createAndConnect()` for a blocking, ready-to-use handle. */
-  async create(options?: CreateSandboxOptions): Promise<CreateSandboxResponse> {
+  async create(options?: CreateSandboxOptions): Promise<Traced<CreateSandboxResponse>> {
     const body: Record<string, unknown> = {
       resources: {
         cpus: options?.cpus ?? 1.0,
@@ -139,7 +139,8 @@ export class SandboxClient {
       this.path("sandboxes"),
       { body },
     );
-    return fromSnakeKeys(raw, "sandboxId") as CreateSandboxResponse;
+    const result = fromSnakeKeys(raw, "sandboxId") as CreateSandboxResponse;
+    return Object.assign(result, { traceId: raw.traceId }) as Traced<CreateSandboxResponse>;
   }
 
   /** Get current state and metadata for a sandbox by ID. */
@@ -306,12 +307,13 @@ export class SandboxClient {
   }
 
   /** Claim a warm sandbox from a pool, creating one if no warm containers are available. */
-  async claim(poolId: string): Promise<CreateSandboxResponse> {
+  async claim(poolId: string): Promise<Traced<CreateSandboxResponse>> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "POST",
       this.path(`sandbox-pools/${poolId}/sandboxes`),
     );
-    return fromSnakeKeys(raw, "sandboxId") as CreateSandboxResponse;
+    const result = fromSnakeKeys(raw, "sandboxId") as CreateSandboxResponse;
+    return Object.assign(result, { traceId: raw.traceId }) as Traced<CreateSandboxResponse>;
   }
 
   // --- Snapshots ---
@@ -524,7 +526,7 @@ export class SandboxClient {
   ): Promise<Sandbox> {
     const startupTimeout = options?.startupTimeout ?? 60;
 
-    let result: CreateSandboxResponse;
+    let result: Traced<CreateSandboxResponse>;
     if (options?.poolId != null) {
       result = await this.claim(options.poolId);
     } else {
@@ -537,6 +539,7 @@ export class SandboxClient {
     if (result.status === SandboxStatus.RUNNING) {
       const sandbox = this.connect(result.sandboxId, options?.proxyUrl, result.routingHint);
       sandbox._setOwner(this);
+      sandbox.traceId = result.traceId;
       return sandbox;
     }
 
@@ -547,6 +550,7 @@ export class SandboxClient {
       if (info.status === SandboxStatus.RUNNING) {
         const sandbox = this.connect(result.sandboxId, options?.proxyUrl, info.routingHint);
         sandbox._setOwner(this);
+        sandbox.traceId = result.traceId;
         return sandbox;
       }
       if (info.status === SandboxStatus.TERMINATED) {

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -105,6 +105,7 @@ export class SandboxClient {
 
   // --- Sandbox CRUD ---
 
+  /** Create a new sandbox. Returns immediately; the sandbox may still be starting. Use `createAndConnect()` for a blocking, ready-to-use handle. */
   async create(options?: CreateSandboxOptions): Promise<CreateSandboxResponse> {
     const body: Record<string, unknown> = {
       resources: {
@@ -141,6 +142,7 @@ export class SandboxClient {
     return fromSnakeKeys(raw, "sandboxId") as CreateSandboxResponse;
   }
 
+  /** Get current state and metadata for a sandbox by ID. */
   async get(sandboxId: string): Promise<SandboxInfo> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
@@ -149,6 +151,7 @@ export class SandboxClient {
     return fromSnakeKeys(raw, "sandboxId") as SandboxInfo;
   }
 
+  /** List all sandboxes in the namespace. */
   async list(): Promise<SandboxInfo[]> {
     const raw = await this.http.requestJson<{ sandboxes: Record<string, unknown>[] }>(
       "GET",
@@ -159,6 +162,7 @@ export class SandboxClient {
     );
   }
 
+  /** Update sandbox properties such as name, exposed ports, and proxy auth settings. */
   async update(sandboxId: string, options: UpdateSandboxOptions): Promise<SandboxInfo> {
     const body: Record<string, unknown> = {};
     if (options.name != null) body.name = options.name;
@@ -179,6 +183,7 @@ export class SandboxClient {
     return fromSnakeKeys(raw, "sandboxId") as SandboxInfo;
   }
 
+  /** Get the current proxy port settings for a sandbox. */
   async getPortAccess(sandboxId: string): Promise<SandboxPortAccess> {
     const info = await this.get(sandboxId);
     return {
@@ -188,6 +193,7 @@ export class SandboxClient {
     };
   }
 
+  /** Add one or more user ports to the sandbox proxy allowlist. */
   async exposePorts(
     sandboxId: string,
     ports: number[],
@@ -207,6 +213,7 @@ export class SandboxClient {
     });
   }
 
+  /** Remove one or more user ports from the sandbox proxy allowlist. */
   async unexposePorts(
     sandboxId: string,
     ports: number[],
@@ -223,6 +230,7 @@ export class SandboxClient {
     });
   }
 
+  /** Terminate and delete a sandbox. */
   async delete(sandboxId: string): Promise<void> {
     await this.http.requestJson(
       "DELETE",
@@ -230,6 +238,20 @@ export class SandboxClient {
     );
   }
 
+  /**
+   * Suspend a named sandbox, preserving its state for later resume.
+   *
+   * Only sandboxes created with a `name` can be suspended; ephemeral sandboxes
+   * cannot. By default blocks until the sandbox is fully `Suspended`. Pass
+   * `{ wait: false }` to return immediately after the request is sent
+   * (fire-and-return); the server processes the suspend asynchronously.
+   *
+   * @param sandboxId - ID or name of the sandbox.
+   * @param options.wait - If `true` (default), poll until `Suspended`. Pass `false` to fire-and-return.
+   * @param options.timeout - Max seconds to wait when `wait=true` (default 300).
+   * @param options.pollInterval - Seconds between status polls when `wait=true` (default 1).
+   * @throws {SandboxError} If `wait=true` and the sandbox does not reach `Suspended` within `timeout`.
+   */
   async suspend(sandboxId: string, options?: SuspendResumeOptions): Promise<void> {
     await this.http.requestResponse(
       "POST",
@@ -250,6 +272,19 @@ export class SandboxClient {
     throw new SandboxError(`Sandbox ${sandboxId} did not suspend within ${timeout}s`);
   }
 
+  /**
+   * Resume a suspended sandbox and bring it back to `Running`.
+   *
+   * By default blocks until the sandbox is `Running` and routable. Pass
+   * `{ wait: false }` to return immediately after the request is sent
+   * (fire-and-return); the server processes the resume asynchronously.
+   *
+   * @param sandboxId - ID or name of the sandbox.
+   * @param options.wait - If `true` (default), poll until `Running`. Pass `false` to fire-and-return.
+   * @param options.timeout - Max seconds to wait when `wait=true` (default 300).
+   * @param options.pollInterval - Seconds between status polls when `wait=true` (default 1).
+   * @throws {SandboxError} If `wait=true` and the sandbox does not reach `Running` within `timeout`.
+   */
   async resume(sandboxId: string, options?: SuspendResumeOptions): Promise<void> {
     await this.http.requestResponse(
       "POST",
@@ -270,6 +305,7 @@ export class SandboxClient {
     throw new SandboxError(`Sandbox ${sandboxId} did not resume within ${timeout}s`);
   }
 
+  /** Claim a warm sandbox from a pool, creating one if no warm containers are available. */
   async claim(poolId: string): Promise<CreateSandboxResponse> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "POST",
@@ -280,6 +316,16 @@ export class SandboxClient {
 
   // --- Snapshots ---
 
+  /**
+   * Request a snapshot of a running sandbox's filesystem.
+   *
+   * This call **returns immediately** with a `snapshotId` and `in_progress`
+   * status — the snapshot is created asynchronously. Poll `getSnapshot()` until
+   * `completed` or `failed`, or use `snapshotAndWait()` to block automatically.
+   *
+   * @param options.contentMode - `"filesystem_only"` for cold-boot snapshots (e.g. image builds).
+   *   Omit to use the server default (full VM snapshot).
+   */
   async snapshot(
     sandboxId: string,
     options?: SnapshotOptions,
@@ -297,6 +343,7 @@ export class SandboxClient {
     return fromSnakeKeys(raw, "snapshotId") as CreateSnapshotResponse;
   }
 
+  /** Get current status and metadata for a snapshot by ID. */
   async getSnapshot(snapshotId: string): Promise<SnapshotInfo> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
@@ -305,6 +352,7 @@ export class SandboxClient {
     return fromSnakeKeys(raw, "snapshotId") as SnapshotInfo;
   }
 
+  /** List all snapshots in the namespace. */
   async listSnapshots(): Promise<SnapshotInfo[]> {
     const raw = await this.http.requestJson<{ snapshots: Record<string, unknown>[] }>(
       "GET",
@@ -315,6 +363,7 @@ export class SandboxClient {
     );
   }
 
+  /** Delete a snapshot by ID. */
   async deleteSnapshot(snapshotId: string): Promise<void> {
     await this.http.requestJson(
       "DELETE",
@@ -322,6 +371,19 @@ export class SandboxClient {
     );
   }
 
+  /**
+   * Create a snapshot and block until it is committed.
+   *
+   * Combines `snapshot()` with polling `getSnapshot()` until `completed`.
+   * Prefer `sandbox.checkpoint()` on a `Sandbox` handle for the same behavior
+   * without managing the client separately.
+   *
+   * @param sandboxId - ID of the running sandbox to snapshot.
+   * @param options.timeout - Max seconds to wait (default 300).
+   * @param options.pollInterval - Seconds between status polls (default 1).
+   * @param options.contentMode - Content mode passed through to `snapshot()`.
+   * @throws {SandboxError} If the snapshot fails or `timeout` elapses.
+   */
   async snapshotAndWait(
     sandboxId: string,
     options?: SnapshotAndWaitOptions,
@@ -352,6 +414,7 @@ export class SandboxClient {
 
   // --- Pools ---
 
+  /** Create a new sandbox pool with warm pre-booted containers. */
   async createPool(options: CreatePoolOptions): Promise<CreateSandboxPoolResponse> {
     const body: Record<string, unknown> = {
       image: options.image,
@@ -376,6 +439,7 @@ export class SandboxClient {
     return fromSnakeKeys(raw, "poolId") as CreateSandboxPoolResponse;
   }
 
+  /** Get current state and metadata for a sandbox pool by ID. */
   async getPool(poolId: string): Promise<SandboxPoolInfo> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
@@ -384,6 +448,7 @@ export class SandboxClient {
     return fromSnakeKeys(raw, "poolId") as SandboxPoolInfo;
   }
 
+  /** List all sandbox pools in the namespace. */
   async listPools(): Promise<SandboxPoolInfo[]> {
     const raw = await this.http.requestJson<{ pools: Record<string, unknown>[] }>(
       "GET",
@@ -394,6 +459,7 @@ export class SandboxClient {
     );
   }
 
+  /** Replace the configuration of an existing sandbox pool. */
   async updatePool(
     poolId: string,
     options: UpdatePoolOptions,
@@ -421,6 +487,7 @@ export class SandboxClient {
     return fromSnakeKeys(raw, "poolId") as SandboxPoolInfo;
   }
 
+  /** Delete a sandbox pool. Fails if the pool has active containers. */
   async deletePool(poolId: string): Promise<void> {
     await this.http.requestJson(
       "DELETE",
@@ -430,6 +497,7 @@ export class SandboxClient {
 
   // --- Connect ---
 
+  /** Return a `Sandbox` handle for an existing running sandbox without verifying it exists. */
   connect(identifier: string, proxyUrl?: string, routingHint?: string): Sandbox {
     const resolvedProxy = proxyUrl ?? resolveProxyUrl(this.apiUrl);
     return new Sandbox({
@@ -442,6 +510,15 @@ export class SandboxClient {
     });
   }
 
+  /**
+   * Create a sandbox, wait for it to reach `Running`, and return a connected handle.
+   *
+   * Blocks until the sandbox is ready or `startupTimeout` elapses. The returned
+   * `Sandbox` auto-terminates when `terminate()` is called.
+   *
+   * @param options.startupTimeout - Max seconds to wait for `Running` status (default 60).
+   * @throws {SandboxError} If the sandbox terminates during startup or the timeout elapses.
+   */
   async createAndConnect(
     options?: CreateAndConnectOptions,
   ): Promise<Sandbox> {

--- a/typescript/src/defaults.ts
+++ b/typescript/src/defaults.ts
@@ -1,3 +1,5 @@
+export const SDK_VERSION = "0.4.49";
+
 export const API_URL =
   process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai";
 export const API_KEY = process.env.TENSORLAKE_API_KEY ?? undefined;

--- a/typescript/src/http.ts
+++ b/typescript/src/http.ts
@@ -87,7 +87,9 @@ export class HttpClient {
     this.retryBackoffMs = options.retryBackoffMs ?? defaults.RETRY_BACKOFF_MS;
     this.timeoutMs = options.timeoutMs ?? defaults.DEFAULT_HTTP_TIMEOUT_MS;
 
-    this.headers = {};
+    this.headers = {
+      "User-Agent": `tensorlake-typescript-sdk/${defaults.SDK_VERSION}`,
+    };
     if (options.apiKey) {
       this.headers["Authorization"] = `Bearer ${options.apiKey}`;
     }

--- a/typescript/src/http.ts
+++ b/typescript/src/http.ts
@@ -60,6 +60,9 @@ export type Traced<T> = T & { readonly traceId: string };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function withTraceId<T>(value: T, traceId: string): Traced<T> {
+  if (value == null) {
+    return { traceId } as unknown as Traced<T>;
+  }
   return Object.assign(value as any, { traceId }) as Traced<T>;
 }
 

--- a/typescript/src/http.ts
+++ b/typescript/src/http.ts
@@ -43,6 +43,27 @@ export interface HttpRequestOptions {
 }
 
 /**
+ * The return value of every SDK operation. Carries the W3C `trace_id` so callers
+ * can correlate a specific request with its server-side spans in Datadog APM or
+ * any other OTEL-compatible backend.
+ *
+ * Because this is an intersection type, all properties of `T` are accessible
+ * directly — existing code that ignores `traceId` continues to compile and run
+ * unchanged.
+ *
+ * @example
+ * const sandbox = await client.createSandbox(req);
+ * console.log(sandbox.id);      // existing field — unchanged
+ * console.log(sandbox.traceId); // new: look this up in Datadog APM
+ */
+export type Traced<T> = T & { readonly traceId: string };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function withTraceId<T>(value: T, traceId: string): Traced<T> {
+  return Object.assign(value as any, { traceId }) as Traced<T>;
+}
+
+/**
  * Internal HTTP client with retry logic, auth headers, and error mapping.
  *
  * Uses native `fetch`. Retries on transient status codes (429, 502, 503, 504)
@@ -95,15 +116,15 @@ export class HttpClient {
       headers?: Record<string, string>;
       signal?: AbortSignal;
     },
-  ): Promise<T> {
+  ): Promise<Traced<T>> {
     const response = await this.requestResponse(method, path, {
       json: options?.body,
       headers: options?.headers,
       signal: options?.signal,
     });
     const text = await response.text();
-    if (!text) return undefined as T;
-    return JSON.parse(text) as T;
+    const data = (text ? JSON.parse(text) : undefined) as T;
+    return withTraceId(data, response.traceId);
   }
 
   /** Make a request returning raw bytes. */
@@ -116,7 +137,7 @@ export class HttpClient {
       headers?: Record<string, string>;
       signal?: AbortSignal;
     },
-  ): Promise<Uint8Array> {
+  ): Promise<Traced<Uint8Array>> {
     const headers = { ...(options?.headers ?? {}) };
     if (options?.contentType) {
       headers["Content-Type"] = options.contentType;
@@ -128,7 +149,7 @@ export class HttpClient {
       signal: options?.signal,
     });
     const buffer = await response.arrayBuffer();
-    return new Uint8Array(buffer);
+    return withTraceId(new Uint8Array(buffer), response.traceId);
   }
 
   /** Make a request and return the response body as an SSE stream. */
@@ -136,7 +157,7 @@ export class HttpClient {
     method: string,
     path: string,
     options?: { signal?: AbortSignal; json?: unknown },
-  ): Promise<ReadableStream<Uint8Array>> {
+  ): Promise<Traced<ReadableStream<Uint8Array>>> {
     const response = await this.requestResponse(method, path, {
       json: options?.json,
       headers: { Accept: "text/event-stream" },
@@ -148,7 +169,7 @@ export class HttpClient {
         "No response body for SSE stream",
       );
     }
-    return response.body;
+    return withTraceId(response.body, response.traceId);
   }
 
   /** Make a request and return the raw Response. */
@@ -156,7 +177,7 @@ export class HttpClient {
     method: string,
     path: string,
     options?: HttpRequestOptions,
-  ): Promise<Response> {
+  ): Promise<Traced<Response>> {
     const headers = {
       ...this.headers,
       ...(options?.headers ?? {}),
@@ -170,7 +191,7 @@ export class HttpClient {
       ? JSON.stringify(options?.json)
       : normalizeRequestBody(options?.body);
 
-    return this.doFetch(
+    const { response, traceId } = await this.doFetch(
       method,
       path,
       body,
@@ -178,6 +199,17 @@ export class HttpClient {
       options?.signal,
       options?.allowHttpErrors ?? false,
     );
+    return withTraceId(response, traceId);
+  }
+
+  private static makeTraceparent(): { traceparent: string; traceId: string } {
+    const randomHex = (bytes: number) =>
+      Array.from(crypto.getRandomValues(new Uint8Array(bytes)))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+    const traceId = randomHex(16);
+    const spanId = randomHex(8);
+    return { traceparent: `00-${traceId}-${spanId}-01`, traceId };
   }
 
   private async doFetch(
@@ -187,8 +219,10 @@ export class HttpClient {
     headers: Record<string, string>,
     signal?: AbortSignal,
     allowHttpErrors = false,
-  ): Promise<Response> {
+  ): Promise<{ response: Response; traceId: string }> {
     const url = `${this.baseUrl}${path}`;
+    const { traceparent, traceId } = HttpClient.makeTraceparent();
+    headers["traceparent"] = traceparent;
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
@@ -218,7 +252,7 @@ export class HttpClient {
 
         clearTimeout(timeoutId);
 
-        if (response.ok) return response;
+        if (response.ok) return { response, traceId };
 
         // Check if retryable
         if (
@@ -233,7 +267,7 @@ export class HttpClient {
         }
 
         if (allowHttpErrors) {
-          return response;
+          return { response, traceId };
         }
 
         // Non-retryable error — throw mapped error

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -108,6 +108,9 @@ export type {
   SandboxClientOptions,
   SandboxOptions,
   CreateAndConnectOptions,
+  SuspendResumeOptions,
+  CheckpointOptions,
+  ConnectOptions,
 } from "./models.js";
 
 export type {

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -337,6 +337,25 @@ export interface CreateAndConnectOptions extends CreateSandboxOptions {
   startupTimeout?: number;
 }
 
+export interface SuspendResumeOptions {
+  /** If false, fire-and-return without waiting for completion. Default: true. */
+  wait?: boolean;
+  /** Max seconds to wait when wait=true. Default: 300. */
+  timeout?: number;
+  /** Seconds between status polls when wait=true. Default: 1. */
+  pollInterval?: number;
+}
+
+export interface CheckpointOptions extends SuspendResumeOptions {
+  contentMode?: SnapshotContentMode;
+}
+
+export interface ConnectOptions {
+  sandboxId: string;
+  proxyUrl?: string;
+  routingHint?: string;
+}
+
 // --- JSON key conversion helpers ---
 
 const CAMEL_TO_SNAKE_RE = /[A-Z]/g;

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -290,6 +290,7 @@ function sendPtyFrame(socket: WebSocket, frame: Buffer): Promise<void> {
  */
 export class Sandbox {
   readonly sandboxId: string;
+  traceId: string | null = null;
   private readonly http: HttpClient;
   private readonly baseUrl: string;
   private readonly wsHeaders: Record<string, string>;

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -7,22 +7,30 @@ import * as defaults from "./defaults.js";
 import { SandboxError } from "./errors.js";
 import { HttpClient } from "./http.js";
 import {
+  type CheckpointOptions,
   type CommandResult,
+  type ConnectOptions,
+  type CreateAndConnectOptions,
   type CreatePtySessionOptions,
   type DaemonInfo,
   type DirectoryEntry,
   type HealthResponse,
   type ListDirectoryResponse,
-  OutputMode,
   type OutputEvent,
   type OutputResponse,
+  OutputMode,
   type ProcessInfo,
   type PtySessionInfo,
   type RunOptions,
+  type SandboxClientOptions,
   type SandboxOptions,
   type SendSignalResponse,
+  type SnapshotInfo,
   type StartProcessOptions,
+  SandboxStatus,
+  SnapshotStatus,
   StdinMode,
+  type SuspendResumeOptions,
   fromSnakeKeys,
 } from "./models.js";
 import {
@@ -322,6 +330,129 @@ export class Sandbox {
   _setOwner(client: SandboxClient): void {
     this.ownsSandbox = true;
     this.lifecycleClient = client;
+  }
+
+  // --- Static factory methods ---
+
+  /**
+   * Create a new sandbox and return a connected, running handle.
+   *
+   * Covers both fresh sandbox creation and restore-from-snapshot (set
+   * `snapshotId`). Blocks until the sandbox is `Running`.
+   */
+  static async create(
+    options?: CreateAndConnectOptions & Partial<SandboxClientOptions>,
+  ): Promise<Sandbox> {
+    // Dynamic import to break the circular dependency (client.ts imports Sandbox).
+    const { SandboxClient } = await import("./client.js");
+    const client = new SandboxClient(options, /* _internal */ true);
+    const sandbox = await client.createAndConnect(options);
+    sandbox.lifecycleClient = client;
+    return sandbox;
+  }
+
+  /**
+   * Attach to an existing sandbox and return a connected handle.
+   *
+   * Verifies the sandbox exists via a server GET call, then returns a handle
+   * in whatever state the sandbox is in. Does **not** auto-resume a suspended
+   * sandbox — call `sandbox.resume()` explicitly.
+   */
+  static async connect(
+    options: ConnectOptions & Partial<SandboxClientOptions>,
+  ): Promise<Sandbox> {
+    const { SandboxClient } = await import("./client.js");
+    const client = new SandboxClient(options, /* _internal */ true);
+    await client.get(options.sandboxId); // throws SandboxNotFoundError if not found
+    const sandbox = client.connect(options.sandboxId, options.proxyUrl, options.routingHint);
+    sandbox.lifecycleClient = client;
+    return sandbox;
+  }
+
+  // --- Static snapshot management ---
+
+  /** Get information about a snapshot by ID. No sandbox handle needed. */
+  static async getSnapshot(
+    snapshotId: string,
+    options?: Partial<SandboxClientOptions>,
+  ): Promise<SnapshotInfo> {
+    const { SandboxClient } = await import("./client.js");
+    const client = new SandboxClient(options, /* _internal */ true);
+    return client.getSnapshot(snapshotId);
+  }
+
+  /** Delete a snapshot by ID. No sandbox handle needed. */
+  static async deleteSnapshot(
+    snapshotId: string,
+    options?: Partial<SandboxClientOptions>,
+  ): Promise<void> {
+    const { SandboxClient } = await import("./client.js");
+    const client = new SandboxClient(options, /* _internal */ true);
+    await client.deleteSnapshot(snapshotId);
+  }
+
+  // --- Instance lifecycle methods ---
+
+  private requireLifecycleClient(operation: string): SandboxClient {
+    if (!this.lifecycleClient) {
+      throw new SandboxError(
+        `Cannot ${operation}: no lifecycle client available. ` +
+          "Use Sandbox.create() or Sandbox.connect() to get a lifecycle-aware handle.",
+      );
+    }
+    return this.lifecycleClient;
+  }
+
+  /**
+   * Suspend this sandbox.
+   *
+   * By default blocks until the sandbox is fully `Suspended`. Pass
+   * `{ wait: false }` for fire-and-return.
+   */
+  async suspend(options?: SuspendResumeOptions): Promise<void> {
+    const client = this.requireLifecycleClient("suspend");
+    await client.suspend(this.sandboxId, options);
+  }
+
+  /**
+   * Resume this sandbox.
+   *
+   * By default blocks until the sandbox is `Running` and routable. Pass
+   * `{ wait: false }` for fire-and-return.
+   */
+  async resume(options?: SuspendResumeOptions): Promise<void> {
+    const client = this.requireLifecycleClient("resume");
+    await client.resume(this.sandboxId, options);
+  }
+
+  /**
+   * Create a snapshot of this sandbox's filesystem and wait for it to
+   * be committed.
+   *
+   * By default blocks until the snapshot artifact is ready and returns
+   * the completed `SnapshotInfo`. Pass `{ wait: false }` to fire-and-return
+   * (returns `undefined`).
+   */
+  async checkpoint(options?: CheckpointOptions): Promise<SnapshotInfo | undefined> {
+    const client = this.requireLifecycleClient("checkpoint");
+    if (options?.wait === false) {
+      await client.snapshot(this.sandboxId, { contentMode: options.contentMode });
+      return undefined;
+    }
+    return client.snapshotAndWait(this.sandboxId, {
+      timeout: options?.timeout,
+      pollInterval: options?.pollInterval,
+      contentMode: options?.contentMode,
+    });
+  }
+
+  /**
+   * List snapshots taken from this sandbox.
+   */
+  async listSnapshots(): Promise<SnapshotInfo[]> {
+    const client = this.requireLifecycleClient("listSnapshots");
+    const all = await client.listSnapshots();
+    return all.filter((s) => s.sandboxId === this.sandboxId);
   }
 
   close(): void {

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -455,10 +455,12 @@ export class Sandbox {
     return all.filter((s) => s.sandboxId === this.sandboxId);
   }
 
+  /** Close the HTTP client. The sandbox keeps running. */
   close(): void {
     this.http.close();
   }
 
+  /** Terminate the sandbox and release all resources. */
   async terminate(): Promise<void> {
     const client = this.lifecycleClient;
     this.ownsSandbox = false;
@@ -519,6 +521,14 @@ export class Sandbox {
 
   // --- Process management ---
 
+  /**
+   * Start a process in the sandbox without waiting for it to exit.
+   *
+   * Returns a `ProcessInfo` with the assigned `pid`. Use `getProcess()` to
+   * poll status, or `followStdout()` / `followOutput()` to stream output
+   * until the process exits. Use `run()` instead to block until completion
+   * and get combined output in one call.
+   */
   async startProcess(
     command: string,
     options?: StartProcessOptions,
@@ -545,6 +555,7 @@ export class Sandbox {
     return fromSnakeKeys(raw) as ProcessInfo;
   }
 
+  /** List all processes (running and exited) tracked by the sandbox daemon. */
   async listProcesses(): Promise<ProcessInfo[]> {
     const raw = await this.http.requestJson<{ processes: Record<string, unknown>[] }>(
       "GET",
@@ -553,6 +564,7 @@ export class Sandbox {
     return (raw.processes ?? []).map((p) => fromSnakeKeys(p) as ProcessInfo);
   }
 
+  /** Get current status and metadata for a process by PID. */
   async getProcess(pid: number): Promise<ProcessInfo> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
@@ -561,10 +573,12 @@ export class Sandbox {
     return fromSnakeKeys(raw) as ProcessInfo;
   }
 
+  /** Send SIGKILL to a process. */
   async killProcess(pid: number): Promise<void> {
     await this.http.requestJson("DELETE", `/api/v1/processes/${pid}`);
   }
 
+  /** Send an arbitrary signal to a process (e.g. `15` for SIGTERM, `9` for SIGKILL). */
   async sendSignal(pid: number, signal: number): Promise<SendSignalResponse> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "POST",
@@ -576,6 +590,7 @@ export class Sandbox {
 
   // --- Process I/O ---
 
+  /** Write bytes to a process's stdin. The process must have been started with `stdinMode: StdinMode.PIPE`. */
   async writeStdin(pid: number, data: Uint8Array): Promise<void> {
     await this.http.requestBytes("POST", `/api/v1/processes/${pid}/stdin`, {
       body: data,
@@ -583,10 +598,12 @@ export class Sandbox {
     });
   }
 
+  /** Close a process's stdin pipe, signalling EOF to the process. */
   async closeStdin(pid: number): Promise<void> {
     await this.http.requestJson("POST", `/api/v1/processes/${pid}/stdin/close`);
   }
 
+  /** Return all captured stdout lines produced so far by a process. */
   async getStdout(pid: number): Promise<OutputResponse> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
@@ -595,6 +612,7 @@ export class Sandbox {
     return fromSnakeKeys(raw) as OutputResponse;
   }
 
+  /** Return all captured stderr lines produced so far by a process. */
   async getStderr(pid: number): Promise<OutputResponse> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
@@ -603,6 +621,7 @@ export class Sandbox {
     return fromSnakeKeys(raw) as OutputResponse;
   }
 
+  /** Return all captured stdout+stderr lines produced so far by a process. */
   async getOutput(pid: number): Promise<OutputResponse> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
@@ -613,6 +632,7 @@ export class Sandbox {
 
   // --- Streaming (SSE) ---
 
+  /** Stream stdout events from a process until it exits. Yields one `OutputEvent` per line. */
   async *followStdout(
     pid: number,
     options?: { signal?: AbortSignal },
@@ -630,6 +650,7 @@ export class Sandbox {
     }
   }
 
+  /** Stream stderr events from a process until it exits. Yields one `OutputEvent` per line. */
   async *followStderr(
     pid: number,
     options?: { signal?: AbortSignal },
@@ -647,6 +668,7 @@ export class Sandbox {
     }
   }
 
+  /** Stream combined stdout+stderr events from a process until it exits. Yields one `OutputEvent` per line. */
   async *followOutput(
     pid: number,
     options?: { signal?: AbortSignal },
@@ -666,6 +688,7 @@ export class Sandbox {
 
   // --- File operations ---
 
+  /** Read a file from the sandbox and return its raw bytes. */
   async readFile(path: string): Promise<Uint8Array> {
     return this.http.requestBytes(
       "GET",
@@ -673,6 +696,7 @@ export class Sandbox {
     );
   }
 
+  /** Write raw bytes to a file in the sandbox, creating it if it does not exist. */
   async writeFile(path: string, content: Uint8Array): Promise<void> {
     await this.http.requestBytes(
       "PUT",
@@ -681,6 +705,7 @@ export class Sandbox {
     );
   }
 
+  /** Delete a file from the sandbox. */
   async deleteFile(path: string): Promise<void> {
     await this.http.requestJson(
       "DELETE",
@@ -688,6 +713,7 @@ export class Sandbox {
     );
   }
 
+  /** List the contents of a directory in the sandbox. */
   async listDirectory(path: string): Promise<ListDirectoryResponse> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
@@ -698,6 +724,7 @@ export class Sandbox {
 
   // --- PTY ---
 
+  /** Create an interactive PTY session. Returns a `sessionId` and `token` for WebSocket connection via `connectPty()`. */
   async createPtySession(
     options: CreatePtySessionOptions,
   ): Promise<PtySessionInfo> {
@@ -718,6 +745,7 @@ export class Sandbox {
     return fromSnakeKeys(raw) as PtySessionInfo;
   }
 
+  /** Create a PTY session and connect to it immediately. Cleans up the session if the WebSocket connection fails. */
   async createPty(options: CreatePtyOptions): Promise<Pty> {
     const { onData, onExit, ...createOptions } = options;
     const session = await this.createPtySession(createOptions);
@@ -731,6 +759,7 @@ export class Sandbox {
     }
   }
 
+  /** Attach to an existing PTY session by ID and token and return a connected `Pty` handle. */
   async connectPty(
     sessionId: string,
     token: string,
@@ -763,6 +792,7 @@ export class Sandbox {
     return pty;
   }
 
+  /** Open a TCP tunnel to a port inside the sandbox and return the local listener. */
   async createTunnel(
     remotePort: number,
     options?: CreateTunnelOptions,
@@ -777,6 +807,7 @@ export class Sandbox {
     });
   }
 
+  /** Connect to a sandbox VNC session for programmatic desktop control. */
   async connectDesktop(options?: ConnectDesktopOptions): Promise<Desktop> {
     return Desktop.connect({
       baseUrl: this.baseUrl,
@@ -802,6 +833,7 @@ export class Sandbox {
 
   // --- Health ---
 
+  /** Check the sandbox daemon health. */
   async health(): Promise<HealthResponse> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
@@ -810,6 +842,7 @@ export class Sandbox {
     return fromSnakeKeys(raw) as HealthResponse;
   }
 
+  /** Get sandbox daemon info (version, uptime, process counts). */
   async info(): Promise<DaemonInfo> {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -438,7 +438,7 @@ describe("SandboxClient", () => {
   });
 
   describe("suspend", () => {
-    it("suspends a sandbox", async () => {
+    it("sends POST to suspend endpoint with wait=false", async () => {
       mockFetch((url, init) => {
         expect(url).toContain("/sandboxes/sbx-1/suspend");
         expect(init?.method).toBe("POST");
@@ -446,13 +446,38 @@ describe("SandboxClient", () => {
       });
 
       const client = SandboxClient.forLocalhost();
+      await expect(client.suspend("sbx-1", { wait: false })).resolves.toBeUndefined();
+      client.close();
+    });
+
+    it("polls until Suspended when wait=true (default)", async () => {
+      let callCount = 0;
+      vi.mocked(undici.fetch).mockImplementation(((url: string, init?: RequestInit) => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: POST suspend
+          expect(url).toContain("/sandboxes/sbx-1/suspend");
+          return Promise.resolve(new Response("", { status: 202 }));
+        }
+        // Subsequent calls: GET sandbox status
+        expect(url).toContain("/sandboxes/sbx-1");
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ sandbox_id: "sbx-1", status: "suspended", namespace: "default", resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 }, secret_names: [] }),
+            { status: 200 },
+          ),
+        );
+      }) as typeof undici.fetch);
+
+      const client = SandboxClient.forLocalhost();
       await expect(client.suspend("sbx-1")).resolves.toBeUndefined();
+      expect(callCount).toBeGreaterThanOrEqual(2);
       client.close();
     });
   });
 
   describe("resume", () => {
-    it("resumes a sandbox", async () => {
+    it("sends POST to resume endpoint with wait=false", async () => {
       mockFetch((url, init) => {
         expect(url).toContain("/sandboxes/sbx-1/resume");
         expect(init?.method).toBe("POST");
@@ -460,7 +485,32 @@ describe("SandboxClient", () => {
       });
 
       const client = SandboxClient.forLocalhost();
+      await expect(client.resume("sbx-1", { wait: false })).resolves.toBeUndefined();
+      client.close();
+    });
+
+    it("polls until Running when wait=true (default)", async () => {
+      let callCount = 0;
+      vi.mocked(undici.fetch).mockImplementation(((url: string, init?: RequestInit) => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: POST resume
+          expect(url).toContain("/sandboxes/sbx-1/resume");
+          return Promise.resolve(new Response("", { status: 202 }));
+        }
+        // Subsequent calls: GET sandbox status
+        expect(url).toContain("/sandboxes/sbx-1");
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ sandbox_id: "sbx-1", status: "running", namespace: "default", resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 }, secret_names: [] }),
+            { status: 200 },
+          ),
+        );
+      }) as typeof undici.fetch);
+
+      const client = SandboxClient.forLocalhost();
       await expect(client.resume("sbx-1")).resolves.toBeUndefined();
+      expect(callCount).toBeGreaterThanOrEqual(2);
       client.close();
     });
   });

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -367,7 +367,6 @@ describe("SandboxClient", () => {
             ),
           );
         });
-      
 
       const client = SandboxClient.forLocalhost();
       const info = await client.exposePorts("sbx-1", [8081, 8080], {
@@ -412,7 +411,6 @@ describe("SandboxClient", () => {
             ),
           );
         });
-      
 
       const client = SandboxClient.forLocalhost();
       const info = await client.unexposePorts("sbx-1", [8080]);

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -432,7 +432,7 @@ describe("SandboxClient", () => {
     it("deletes a sandbox", async () => {
       mockFetch(() => new Response("", { status: 200 }));
       const client = SandboxClient.forLocalhost();
-      await expect(client.delete("sbx-1")).resolves.toBeUndefined();
+      await client.delete("sbx-1");
       client.close();
     });
   });

--- a/typescript/tests/http.test.ts
+++ b/typescript/tests/http.test.ts
@@ -32,7 +32,7 @@ describe("HttpClient", () => {
 
     const client = new HttpClient({ baseUrl: "http://localhost:8900" });
     const result = await client.requestJson<{ ok: boolean }>("GET", "/test");
-    expect(result).toEqual({ ok: true });
+    expect(result).toMatchObject({ ok: true });
     client.close();
   });
 
@@ -99,7 +99,7 @@ describe("HttpClient", () => {
       retryBackoffMs: 10,
     });
     const result = await client.requestJson<{ ok: boolean }>("GET", "/test");
-    expect(result).toEqual({ ok: true });
+    expect(result).toMatchObject({ ok: true });
     expect(attempts).toBe(3);
     client.close();
   });
@@ -187,7 +187,7 @@ describe("HttpClient", () => {
       retryBackoffMs: 10,
     });
     const result = await client.requestJson<{ ok: boolean }>("GET", "/test");
-    expect(result).toEqual({ ok: true });
+    expect(result).toMatchObject({ ok: true });
     expect(attempts).toBe(2);
     client.close();
   });


### PR DESCRIPTION
## Summary

Two major feature areas:

### 1. End-to-end observability via W3C traceparent

- Inject a `traceparent` header (W3C Trace Context) on every outbound HTTP request across the Python, TypeScript, and Rust SDKs — all calls share a single trace ID per CLI invocation
- Surface trace IDs in all `SandboxClient` response objects as `Traced<T>` / `TracedIterator<T>` wrappers (Python) and plain return values (TypeScript/Rust)
- Add `--show-trace-id` flag to CLI commands; print trace ID to stderr when enabled
- Add SDK-specific `User-Agent` headers across all three SDKs

### 2. New sandbox lifecycle API (`Sandbox.create()` / `Sandbox.connect()`)

- **`Sandbox.create()`** — single class-method entry point that creates a sandbox and returns a ready handle; no more juggling `SandboxClient` + `create_and_connect()` separately
- **`Sandbox.connect()`** — reconnects to an existing sandbox by ID (verifies it exists via a server round-trip)
- **Instance lifecycle methods** on the `Sandbox` handle: `suspend()`, `resume()`, `checkpoint()`, `list_snapshots()`
- **Blocking by default** (`wait=True` / `wait=true`): `suspend()` and `resume()` poll until the sandbox reaches the target state; `checkpoint()` polls until the snapshot is committed
- **`wait=False` escape hatch** for fire-and-return callers
- **`SandboxClient` deprecated** with a `DeprecationWarning` (Python) / `console.warn` (TypeScript); existing code keeps working unchanged
- **CLI**: `tl sbx new` renamed to `tl sbx create` (old name kept as alias); `tl sbx snapshot` renamed to `tl sbx checkpoint` (old name kept as alias)
- **Version bump**: all SDKs and CLI bumped to **0.5.0**

## Files changed (key areas)

| Area | Files |
|---|---|
| Python SDK | `src/tensorlake/sandbox/sandbox.py`, `src/tensorlake/sandbox/client.py` |
| TypeScript SDK | `typescript/src/sandbox.ts`, `typescript/src/client.ts`, `typescript/src/models.ts`, `typescript/src/index.ts` |
| Rust SDK | `crates/cloud-sdk/src/` (applications, cron, images, sandboxes, secrets, client) |
| CLI | `crates/cli/src/main.rs` |
| Tests | `typescript/tests/client.test.ts` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)