### PR TITLE
Drop darwin-x86_64 from CLI release matrix

### DIFF
--- a/.github/workflows/publish_cli.yaml
+++ b/.github/workflows/publish_cli.yaml
@@ -29,10 +29,6 @@ jobs:
             target: aarch64-apple-darwin
             target_id: darwin-aarch64
             archive: tar.gz
-          - os: macos-13
-            target: x86_64-apple-darwin
-            target_id: darwin-x86_64
-            archive: tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             target_id: windows-x86_64


### PR DESCRIPTION
## Summary

Removes the `darwin-x86_64` (Intel Mac) entry from the matrix in `.github/workflows/publish_cli.yaml`. Intel Macs can transparently run the `darwin-aarch64` build under Rosetta 2.

## Effect

- One fewer runner per release (saves ~10 min of CI and a few bucks)
- Companion PR on the website repo (tensorlakeai/new-website#20) silently remaps Intel Macs to the aarch64 archive, so `curl | sh` still works for those users

## Test plan

- [ ] Dispatch the workflow after merge; confirm release has 4 archives instead of 5
- [ ] Confirm `SHA256SUMS` only lists 4 archives
- [ ] After both PRs land, confirm install works on an Intel Mac (runs the aarch64 binary under Rosetta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)