### PR TITLE
feat(cli/login): send device fingerprint on /cli/login/start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -944,6 +944,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1506,6 +1516,12 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.3",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2199,6 +2215,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2206,7 +2235,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2726,7 +2755,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2748,6 +2777,7 @@ dependencies = [
  "docker-credentials-config",
  "eventsource-stream",
  "futures",
+ "gethostname",
  "hex",
  "http-body-util",
  "indicatif",
@@ -3983,7 +4013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ console = "0.16.2"
 dialoguer = "0.12"
 open = "5"
 crossterm = "0.29"
+gethostname = "0.5"
 
 # Python bindings
 pyo3 = { version = "0.28.2", features = ["abi3-py310", "extension-module"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,6 +33,7 @@ open = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
 crossterm = { workspace = true }
+gethostname = { workspace = true }
 tokio-tungstenite = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }

--- a/crates/cli/src/auth/login.rs
+++ b/crates/cli/src/auth/login.rs
@@ -13,6 +13,34 @@ pub struct LoginResult {
     pub project_id: Option<String>,
 }
 
+/// Build the optional device-fingerprint body we send on /cli/login/start.
+///
+/// The server tolerates any subset of these fields (see platform-api
+/// /cli/login/start — pickString trims + truncates at 512 chars). We send
+/// what we can resolve locally so the browser approve screen can show the
+/// user what terminal is asking for access: hostname, OS + arch, and CLI
+/// version.
+fn device_fingerprint() -> serde_json::Value {
+    let hostname = gethostname::gethostname()
+        .into_string()
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let os = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+    let client_version = format!("tensorlake-cli/{}", env!("CARGO_PKG_VERSION"));
+
+    let mut body = serde_json::Map::new();
+    if let Some(h) = hostname {
+        body.insert("device_name".into(), serde_json::Value::String(h));
+    }
+    body.insert("os".into(), serde_json::Value::String(os));
+    body.insert(
+        "client_version".into(),
+        serde_json::Value::String(client_version),
+    );
+    serde_json::Value::Object(body)
+}
+
 /// Run the interactive device code login flow.
 pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginResult> {
     let login_start_url = format!("{}/platform/cli/login/start", ctx.api_url);
@@ -22,6 +50,7 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
         .map_err(|e| CliError::auth(format!("failed to initialize HTTP client: {}", e)))?;
     let resp = http
         .post(&login_start_url)
+        .json(&device_fingerprint())
         .send()
         .await
         .map_err(|e| CliError::auth(format!("cannot reach {}: {}", ctx.api_url, e)))?;


### PR DESCRIPTION
## Summary

The dashboard device-authorize page ([platform-ui /cli/login](https://github.com/tensorlakeai/platform-ui/pull/1367)) has a dedicated block showing the approver *what terminal is asking for access* — hostname, OS + arch, CLI version. The server (platform-api #475) accepts those as optional fields on \`/cli/login/start\`; the CLI just wasn't sending them.

Before: approve screen falls back to "unknown device"; user has no way to tell whether the login request is theirs.

After:
\`\`\`
Diptanu-MacBook-Pro-2.local  on  macos-aarch64
tensorlake-cli/0.4.49
\`\`\`

### Changes

- Add \`gethostname = "0.5"\` to workspace deps, inherit in \`tensorlake-cli\`.
- New \`device_fingerprint()\` helper builds an optional JSON body:
  - \`device_name\` — \`gethostname::gethostname()\` if resolvable
  - \`os\` — \`{std::env::consts::OS}-{std::env::consts::ARCH}\`
  - \`client_version\` — \`tensorlake-cli/{CARGO_PKG_VERSION}\`
- Post the body on \`/cli/login/start\`.

### Server tolerance

platform-api [#476](https://github.com/tensorlakeai/platform-api/pull/476) makes \`/cli/login/start\` accept empty / partial / over-long bodies without rejecting (trim + truncate at 512 chars). So omitting any single field is safe, and old CLI builds that post no body at all still work.

## Test plan

- [ ] \`cargo check -p tensorlake-cli\` passes (verified)
- [ ] \`tl login\` against a dev API — device_name / os / client_version render on the approve screen
- [ ] On a machine with no resolvable hostname, \`device_name\` is simply omitted and the approve screen still shows OS + version
- [ ] On macOS / Linux / Windows, the \`os\` string uses \`std::env::consts::OS\` values (\`macos\`, \`linux\`, \`windows\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)