### PR TITLE
feat(cli/login): pre-fill the code field via ?user_code query param

### DIFF
--- a/crates/cli/src/auth/login.rs
+++ b/crates/cli/src/auth/login.rs
@@ -82,7 +82,14 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
     eprintln!("we're going to open a web browser for you to enter a one-time code.");
     eprintln!("Your code is: {}", user_code);
 
-    let verification_uri = format!("{}/cli/login", ctx.cloud_url);
+    // Embed the code in the URL so the browser can pre-fill the field.
+    // The user still verifies the code matches what's in their terminal —
+    // pre-fill is a UX improvement, not a security downgrade.
+    let verification_uri = format!(
+        "{}/cli/login?user_code={}",
+        ctx.cloud_url,
+        urlencoding::encode(&user_code),
+    );
     eprintln!("URL: {}", verification_uri);
     eprintln!("opening web browser...");
 


### PR DESCRIPTION
## Summary

Embeds the user code in the verification URL the CLI opens so the browser page can seed the 8-char input field automatically. Saves the user transcribing a code between windows.

**Before:**
\`\`\`
$ tl login
Your code is: JH7K-M29Q
URL: https://cloud.tensorlake.ai/cli/login
\`\`\`
User looks at terminal → types \`JH7K-M29Q\` into browser.

**After:**
\`\`\`
$ tl login
Your code is: JH7K-M29Q
URL: https://cloud.tensorlake.ai/cli/login?user_code=JH7K-M29Q
\`\`\`
Browser opens with the code already in the field; user just clicks **Authorize** after verifying it matches.

### Security model

Unchanged. The user is *verifying* that the code shown in the browser matches the one printed in the terminal — not proving they typed it. Pre-fill is UX polish, not an auth downgrade. Same pattern GitHub (\`gh auth login\`), Docker, and gcloud use.

### Companion PR

Requires the matching UI change in platform-ui that reads \`?user_code=\` on mount and calls \`applyCode(prefill)\`. The UI change is safe to ship independently — older CLIs that don't include the query param just land on an empty field as before.

## Test plan

- [ ] \`cargo check -p tensorlake-cli\` clean (verified)
- [ ] \`tl login\` against a dev API — browser opens with the code already in the boxes
- [ ] Code is URL-encoded (no bare hyphens would break without \`urlencoding::encode\`, but hyphens are URL-safe, so this is defensive)
- [ ] Old UI (pre-prefill) ignores the unknown query param and renders the empty page — graceful

🤖 Generated with [Claude Code](https://claude.com/claude-code)