### PR TITLE
feat: add disk_mb support for sandbox create + image build

### DIFF
--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -63,6 +63,7 @@ pub struct CreateArgs<'a> {
     pub name: Option<&'a str>,
     pub cpus: Option<f64>,
     pub memory: Option<i64>,
+    pub disk_mb: Option<u64>,
     pub timeout: Option<i64>,
     pub entrypoint: &'a [String],
     pub snapshot_id: Option<&'a str>,
@@ -80,6 +81,7 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         name,
         cpus,
         memory,
+        disk_mb,
         timeout,
         entrypoint,
         snapshot_id,
@@ -92,8 +94,15 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         network_deny,
     } = args;
 
-    let mut body =
-        build_create_request_body(cpus, memory, timeout, entrypoint, snapshot_id, image_name);
+    let mut body = build_create_request_body(
+        cpus,
+        memory,
+        disk_mb,
+        timeout,
+        entrypoint,
+        snapshot_id,
+        image_name,
+    );
     if let Some(n) = name {
         body["name"] = serde_json::Value::String(n.to_string());
     }
@@ -200,6 +209,7 @@ fn print_post_create_tip(ctx: &CliContext, sandbox_id: &str, display_id: &str, i
 fn build_create_request_body(
     cpus: Option<f64>,
     memory: Option<i64>,
+    disk_mb: Option<u64>,
     timeout: Option<i64>,
     entrypoint: &[String],
     snapshot_id: Option<&str>,
@@ -215,6 +225,9 @@ fn build_create_request_body(
         if let Some(memory) = memory {
             resources.insert("memory_mb".to_string(), serde_json::json!(memory));
         }
+        if let Some(disk_mb) = disk_mb {
+            resources.insert("disk_mb".to_string(), serde_json::json!(disk_mb));
+        }
         if !resources.is_empty() {
             body["resources"] = serde_json::Value::Object(resources);
         }
@@ -224,6 +237,9 @@ fn build_create_request_body(
             "cpus": cpus.unwrap_or(DEFAULT_SANDBOX_CPUS),
             "memory_mb": memory.unwrap_or(DEFAULT_SANDBOX_MEMORY_MB),
         });
+        if let Some(disk_mb) = disk_mb {
+            body["resources"]["disk_mb"] = serde_json::json!(disk_mb);
+        }
     }
 
     if let Some(t) = timeout {
@@ -245,16 +261,17 @@ mod tests {
 
     #[test]
     fn create_body_uses_defaults_without_snapshot() {
-        let body = build_create_request_body(None, None, None, &[], None, None);
+        let body = build_create_request_body(None, None, None, None, &[], None, None);
 
         assert_eq!(body["resources"]["cpus"], 1.0);
         assert_eq!(body["resources"]["memory_mb"], 1024);
+        assert!(body["resources"].get("disk_mb").is_none());
         assert!(body.get("snapshot_id").is_none());
     }
 
     #[test]
     fn create_body_omits_resources_for_snapshot_without_overrides() {
-        let body = build_create_request_body(None, None, None, &[], Some("snap-1"), None);
+        let body = build_create_request_body(None, None, None, None, &[], Some("snap-1"), None);
 
         assert_eq!(body["snapshot_id"], "snap-1");
         assert!(body.get("resources").is_none());
@@ -262,10 +279,31 @@ mod tests {
 
     #[test]
     fn create_body_includes_only_explicit_snapshot_overrides() {
-        let body = build_create_request_body(Some(2.5), None, None, &[], Some("snap-1"), None);
+        let body =
+            build_create_request_body(Some(2.5), None, None, None, &[], Some("snap-1"), None);
 
         assert_eq!(body["snapshot_id"], "snap-1");
         assert_eq!(body["resources"]["cpus"], 2.5);
+        assert!(body["resources"].get("memory_mb").is_none());
+    }
+
+    #[test]
+    fn create_body_includes_disk_override_without_snapshot() {
+        let body = build_create_request_body(None, None, Some(25 * 1024), None, &[], None, None);
+
+        assert_eq!(body["resources"]["cpus"], 1.0);
+        assert_eq!(body["resources"]["memory_mb"], 1024);
+        assert_eq!(body["resources"]["disk_mb"], 25 * 1024);
+    }
+
+    #[test]
+    fn create_body_includes_disk_override_for_snapshot_restore() {
+        let body =
+            build_create_request_body(None, None, Some(25 * 1024), None, &[], Some("snap-1"), None);
+
+        assert_eq!(body["snapshot_id"], "snap-1");
+        assert_eq!(body["resources"]["disk_mb"], 25 * 1024);
+        assert!(body["resources"].get("cpus").is_none());
         assert!(body["resources"].get("memory_mb").is_none());
     }
 
@@ -274,6 +312,7 @@ mod tests {
         let body = build_create_request_body(
             None,
             None,
+            Some(25 * 1024),
             None,
             &[],
             None,
@@ -281,6 +320,7 @@ mod tests {
         );
 
         assert_eq!(body["image"], "tensorlake/ubuntu-minimal");
+        assert_eq!(body["resources"]["disk_mb"], 25 * 1024);
         assert!(body.get("snapshot_id").is_none());
     }
 }

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -10,6 +10,8 @@ pub async fn run(
     dockerfile_path: &str,
     registered_name: Option<&str>,
     disk_gb: Option<u64>,
+    cpus: Option<f64>,
+    memory_mb: Option<i64>,
     is_public: bool,
 ) -> Result<()> {
     let mut cmd = tokio::process::Command::new("tensorlake-create-sandbox-image");
@@ -20,6 +22,12 @@ pub async fn run(
     }
     if let Some(disk_gb) = disk_gb {
         cmd.arg("--disk").arg(disk_gb.to_string());
+    }
+    if let Some(cpus) = cpus {
+        cmd.arg("--cpus").arg(cpus.to_string());
+    }
+    if let Some(memory_mb) = memory_mb {
+        cmd.arg("--memory").arg(memory_mb.to_string());
     }
     if is_public {
         cmd.arg("--public");

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -9,6 +9,7 @@ pub async fn run(
     ctx: &CliContext,
     dockerfile_path: &str,
     registered_name: Option<&str>,
+    disk_gb: Option<u64>,
     is_public: bool,
 ) -> Result<()> {
     let mut cmd = tokio::process::Command::new("tensorlake-create-sandbox-image");
@@ -16,6 +17,9 @@ pub async fn run(
 
     if let Some(name) = registered_name {
         cmd.arg("--name").arg(name);
+    }
+    if let Some(disk_gb) = disk_gb {
+        cmd.arg("--disk").arg(disk_gb.to_string());
     }
     if is_public {
         cmd.arg("--public");

--- a/crates/cli/src/commands/sbx/ls.rs
+++ b/crates/cli/src/commands/sbx/ls.rs
@@ -107,7 +107,7 @@ pub async fn run(
             .map(|v| format!("{} MB", v))
             .unwrap_or_else(|| "-".to_string());
         let disk = resources
-            .and_then(|r| r.get("ephemeral_disk_mb"))
+            .and_then(|r| r.get("disk_mb").or_else(|| r.get("ephemeral_disk_mb")))
             .and_then(|v| v.as_i64())
             .map(|v| format!("{} MB", v))
             .unwrap_or_else(|| "-".to_string());

--- a/crates/cli/src/commands/sbx/ls.rs
+++ b/crates/cli/src/commands/sbx/ls.rs
@@ -107,7 +107,7 @@ pub async fn run(
             .map(|v| format!("{} MB", v))
             .unwrap_or_else(|| "-".to_string());
         let disk = resources
-            .and_then(|r| r.get("disk_mb").or_else(|| r.get("ephemeral_disk_mb")))
+            .and_then(|r| r.get("disk_mb"))
             .and_then(|v| v.as_i64())
             .map(|v| format!("{} MB", v))
             .unwrap_or_else(|| "-".to_string());

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -533,6 +533,14 @@ enum ImageCommands {
         #[arg(long)]
         disk: Option<u64>,
 
+        /// CPUs for the temporary build sandbox
+        #[arg(long)]
+        cpus: Option<f64>,
+
+        /// Memory in MB for the temporary build sandbox
+        #[arg(long)]
+        memory: Option<i64>,
+
         /// Make this sandbox image publicly accessible
         #[arg(short, long)]
         public: bool,
@@ -923,6 +931,8 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         dockerfile_path,
                         registered_name,
                         disk,
+                        cpus,
+                        memory,
                         public,
                     } => {
                         commands::sbx::image::create::run(
@@ -930,6 +940,8 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             &dockerfile_path,
                             registered_name.as_deref(),
                             disk,
+                            cpus,
+                            memory,
                             public,
                         )
                         .await
@@ -978,6 +990,38 @@ mod tests {
         let result = Cli::try_parse_from(["tl", "sbx", "clone", "sbx-123", "--times", "0"]);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn image_create_parses_cpu_memory_and_disk_overrides() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "image",
+            "create",
+            "./Dockerfile",
+            "--cpus",
+            "3.5",
+            "--memory",
+            "8192",
+            "--disk",
+            "30",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Image(ImageCommands::Create {
+                cpus,
+                memory,
+                disk,
+                ..
+            })) => {
+                assert_eq!(cpus, Some(3.5));
+                assert_eq!(memory, Some(8192));
+                assert_eq!(disk, Some(30));
+            }
+            _ => panic!("expected sbx image create command"),
+        }
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -286,6 +286,10 @@ enum SbxCommands {
         #[arg(short, long)]
         memory: Option<i64>,
 
+        /// Root disk size in GB
+        #[arg(long)]
+        disk: Option<u64>,
+
         /// Timeout in seconds
         #[arg(short, long)]
         timeout: Option<i64>,
@@ -525,6 +529,10 @@ enum ImageCommands {
         #[arg(short = 'n', long)]
         registered_name: Option<String>,
 
+        /// Root disk size in GB for the temporary build sandbox
+        #[arg(long)]
+        disk: Option<u64>,
+
         /// Make this sandbox image publicly accessible
         #[arg(short, long)]
         public: bool,
@@ -758,6 +766,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     name,
                     cpus,
                     memory,
+                    disk,
                     timeout,
                     entrypoint,
                     snapshot,
@@ -769,12 +778,20 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     network_allow,
                     network_deny,
                 } => {
+                    let disk_mb = disk
+                        .map(|value| {
+                            value.checked_mul(1024).ok_or_else(|| {
+                                CliError::usage("--disk is too large to convert to MiB")
+                            })
+                        })
+                        .transpose()?;
                     commands::sbx::create::run(
                         ctx,
                         commands::sbx::create::CreateArgs {
                             name: name.as_deref(),
                             cpus,
                             memory,
+                            disk_mb,
                             timeout,
                             entrypoint: &entrypoint,
                             snapshot_id: snapshot.as_deref(),
@@ -905,12 +922,14 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     ImageCommands::Create {
                         dockerfile_path,
                         registered_name,
+                        disk,
                         public,
                     } => {
                         commands::sbx::image::create::run(
                             ctx,
                             &dockerfile_path,
                             registered_name.as_deref(),
+                            disk,
                             public,
                         )
                         .await

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -9,6 +9,14 @@ pub struct ContainerResourcesInfo {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CreateSandboxResources {
+    pub cpus: f64,
+    pub memory_mb: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_mb: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct NetworkConfig {
     #[serde(default = "default_allow_internet_access")]
     pub allow_internet_access: bool,
@@ -26,7 +34,7 @@ fn default_allow_internet_access() -> bool {
 pub struct CreateSandboxRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
-    pub resources: ContainerResourcesInfo,
+    pub resources: CreateSandboxResources,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_names: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -103,6 +103,7 @@ class Image:
         registered_name: str | None = None,
         cpus: float = 2.0,
         memory_mb: int = 4096,
+        disk_mb: int | None = None,
         is_public: bool = False,
         context_dir: str | None = None,
         verbose: bool = False,
@@ -116,6 +117,7 @@ class Image:
             registered_name: Name to register the image under. Defaults to ``self.name``.
             cpus: CPUs for the build sandbox (default 2.0).
             memory_mb: Memory for the build sandbox in MB (default 4096).
+            disk_mb: Root disk size for the build sandbox in MB.
             is_public: Make the registered image publicly accessible.
             context_dir: Directory used to resolve relative COPY/ADD paths.
                 Defaults to the current working directory.
@@ -131,6 +133,7 @@ class Image:
             registered_name=registered_name,
             cpus=cpus,
             memory_mb=memory_mb,
+            disk_mb=disk_mb,
             is_public=is_public,
             context_dir=context_dir,
             verbose=verbose,

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -728,6 +728,7 @@ def _run_plan(
     memory_mb: int,
     is_public: bool,
     emit: EmitFn,
+    disk_mb: int | None = None,
 ) -> dict:
     """Materialize a plan in a sandbox, snapshot, and register it."""
     emit(
@@ -746,11 +747,15 @@ def _run_plan(
 
     sandbox = None
     try:
-        sandbox = sandbox_client.create_and_connect(
-            image=plan.base_image,
-            cpus=cpus,
-            memory_mb=memory_mb,
-        )
+        create_kwargs: dict[str, float | int | str] = {
+            "image": plan.base_image,
+            "cpus": cpus,
+            "memory_mb": memory_mb,
+        }
+        if disk_mb is not None:
+            create_kwargs["disk_mb"] = disk_mb
+
+        sandbox = sandbox_client.create_and_connect(**create_kwargs)
         emit(
             {
                 "type": "status",
@@ -812,6 +817,7 @@ def build_sandbox_image(
     registered_name: str | None = None,
     cpus: float = 2.0,
     memory_mb: int = 4096,
+    disk_mb: int | None = None,
     is_public: bool = False,
     context_dir: str | None = None,
     verbose: bool = False,
@@ -828,6 +834,7 @@ def build_sandbox_image(
             image's ``name`` or the Dockerfile stem.
         cpus: CPUs for the build sandbox.
         memory_mb: Memory for the build sandbox in MB.
+        disk_mb: Root disk size for the build sandbox in MB.
         is_public: Make the registered image publicly accessible.
         context_dir: Directory used to resolve relative COPY/ADD sources.
             Ignored when ``source`` is a Dockerfile path (the Dockerfile's
@@ -875,7 +882,7 @@ def build_sandbox_image(
 
     ctx = _build_context_from_env()
     try:
-        return _run_plan(plan, ctx, cpus, memory_mb, is_public, emit=emit)
+        return _run_plan(plan, ctx, cpus, memory_mb, is_public, emit=emit, disk_mb=disk_mb)
     except SandboxImageError:
         raise
     except Exception as e:

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -882,7 +882,9 @@ def build_sandbox_image(
 
     ctx = _build_context_from_env()
     try:
-        return _run_plan(plan, ctx, cpus, memory_mb, is_public, emit=emit, disk_mb=disk_mb)
+        return _run_plan(
+            plan, ctx, cpus, memory_mb, is_public, emit=emit, disk_mb=disk_mb
+        )
     except SandboxImageError:
         raise
     except Exception as e:

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -796,7 +796,6 @@ def _run_plan(
                 "image_id": result.get("id", ""),
                 "name": plan.registered_name,
                 "snapshot_id": snapshot.snapshot_id,
-                "snapshot_uri": snapshot.snapshot_uri,
             }
         )
         return result

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -22,6 +22,7 @@ from .models import (
     ContainerResourcesInfo,
     CreateSandboxPoolResponse,
     CreateSandboxRequest,
+    CreateSandboxResources,
     CreateSandboxResponse,
     CreateSnapshotResponse,
     ListSandboxesResponse,
@@ -279,7 +280,8 @@ class SandboxClient:
         image: str | None = None,
         cpus: float = 1.0,
         memory_mb: int = 1024,
-        ephemeral_disk_mb: int = 1024,
+        ephemeral_disk_mb: int | None = None,
+        disk_mb: int | None = None,
         secret_names: list[str] | None = None,
         timeout_secs: int | None = None,
         entrypoint: list[str] | None = None,
@@ -297,7 +299,10 @@ class SandboxClient:
                 When omitted, Tensorlake uses the default managed environment.
             cpus: Number of CPUs to allocate
             memory_mb: Memory in megabytes
-            ephemeral_disk_mb: Ephemeral disk space in megabytes
+            ephemeral_disk_mb: Deprecated for sandbox creation and ignored.
+                Use ``disk_mb`` instead.
+            disk_mb: Root disk size in megabytes. When omitted, the server
+                uses its default disk size.
             secret_names: List of secret names to inject
             timeout_secs: Timeout in seconds (optional)
             entrypoint: Custom entrypoint command (optional)
@@ -333,10 +338,10 @@ class SandboxClient:
 
         request_model = CreateSandboxRequest(
             image=image,
-            resources=ContainerResourcesInfo(
+            resources=CreateSandboxResources(
                 cpus=cpus,
                 memory_mb=memory_mb,
-                ephemeral_disk_mb=ephemeral_disk_mb,
+                disk_mb=disk_mb,
             ),
             secret_names=secret_names,
             timeout_secs=timeout_secs,
@@ -1004,7 +1009,8 @@ class SandboxClient:
         image: str | None = None,
         cpus: float = 1.0,
         memory_mb: int = 1024,
-        ephemeral_disk_mb: int = 1024,
+        ephemeral_disk_mb: int | None = None,
+        disk_mb: int | None = None,
         secret_names: list[str] | None = None,
         timeout_secs: int | None = None,
         entrypoint: list[str] | None = None,
@@ -1029,7 +1035,10 @@ class SandboxClient:
                 (optional if using pool).
             cpus: Number of CPUs to allocate
             memory_mb: Memory in megabytes
-            ephemeral_disk_mb: Ephemeral disk space in megabytes
+            ephemeral_disk_mb: Deprecated for sandbox creation and ignored.
+                Use ``disk_mb`` instead.
+            disk_mb: Root disk size in megabytes. When omitted, the server
+                uses its default disk size.
             secret_names: List of secret names to inject
             timeout_secs: Timeout in seconds (optional)
             entrypoint: Custom entrypoint command (optional)
@@ -1062,7 +1071,7 @@ class SandboxClient:
                 image=image,
                 cpus=cpus,
                 memory_mb=memory_mb,
-                ephemeral_disk_mb=ephemeral_disk_mb,
+                disk_mb=disk_mb,
                 secret_names=secret_names,
                 timeout_secs=timeout_secs,
                 entrypoint=entrypoint,

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -280,7 +280,6 @@ class SandboxClient:
         image: str | None = None,
         cpus: float = 1.0,
         memory_mb: int = 1024,
-        ephemeral_disk_mb: int | None = None,
         disk_mb: int | None = None,
         secret_names: list[str] | None = None,
         timeout_secs: int | None = None,
@@ -299,8 +298,6 @@ class SandboxClient:
                 When omitted, Tensorlake uses the default managed environment.
             cpus: Number of CPUs to allocate
             memory_mb: Memory in megabytes
-            ephemeral_disk_mb: Deprecated for sandbox creation and ignored.
-                Use ``disk_mb`` instead.
             disk_mb: Root disk size in megabytes. When omitted, the server
                 uses its default disk size.
             secret_names: List of secret names to inject
@@ -1009,7 +1006,6 @@ class SandboxClient:
         image: str | None = None,
         cpus: float = 1.0,
         memory_mb: int = 1024,
-        ephemeral_disk_mb: int | None = None,
         disk_mb: int | None = None,
         secret_names: list[str] | None = None,
         timeout_secs: int | None = None,
@@ -1035,8 +1031,6 @@ class SandboxClient:
                 (optional if using pool).
             cpus: Number of CPUs to allocate
             memory_mb: Memory in megabytes
-            ephemeral_disk_mb: Deprecated for sandbox creation and ignored.
-                Use ``disk_mb`` instead.
             disk_mb: Root disk size in megabytes. When omitted, the server
                 uses its default disk size.
             secret_names: List of secret names to inject

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -71,6 +71,14 @@ class ContainerResourcesInfo(BaseModel):
     ephemeral_disk_mb: int
 
 
+class CreateSandboxResources(BaseModel):
+    """Resource overrides accepted when creating a sandbox."""
+
+    cpus: float
+    memory_mb: int
+    disk_mb: int | None = None
+
+
 class NetworkConfig(BaseModel):
     """Network access control policy for sandbox containers.
 
@@ -114,7 +122,7 @@ class CreateSandboxRequest(BaseModel):
     """Request payload for creating a sandbox."""
 
     image: str | None = None
-    resources: ContainerResourcesInfo
+    resources: CreateSandboxResources
     secret_names: list[str] | None = None
     timeout_secs: int | None = None
     entrypoint: list[str] | None = None

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -194,7 +194,7 @@ class Sandbox:
         image: str | None = None,
         cpus: float = 1.0,
         memory_mb: int = 1024,
-        ephemeral_disk_mb: int = 1024,
+        disk_mb: int | None = None,
         secret_names: list[str] | None = None,
         timeout_secs: int | None = None,
         entrypoint: list[str] | None = None,
@@ -222,7 +222,8 @@ class Sandbox:
                 default managed environment.
             cpus: Number of CPUs to allocate.
             memory_mb: Memory in megabytes.
-            ephemeral_disk_mb: Ephemeral disk space in megabytes.
+            disk_mb: Root disk size in megabytes. When omitted, the server
+                uses its default disk size.
             secret_names: List of secret names to inject.
             timeout_secs: Sandbox timeout in seconds.
             entrypoint: Custom entrypoint command.
@@ -260,7 +261,7 @@ class Sandbox:
             image=image,
             cpus=cpus,
             memory_mb=memory_mb,
-            ephemeral_disk_mb=ephemeral_disk_mb,
+            disk_mb=disk_mb,
             secret_names=secret_names,
             timeout_secs=timeout_secs,
             entrypoint=entrypoint,

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -138,6 +138,28 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(request_json["resources"]["cpus"], 2.0)
         self.assertEqual(request_json["resources"]["memory_mb"], 1024)
 
+    def test_create_sends_disk_override_when_provided(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        client.create(disk_mb=25 * 1024)
+
+        request_json = json.loads(fake.create_request_json)
+        self.assertEqual(request_json["resources"]["disk_mb"], 25 * 1024)
+        self.assertNotIn("ephemeral_disk_mb", request_json["resources"])
+
+    def test_create_ignores_deprecated_ephemeral_disk_mb(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        client.create(ephemeral_disk_mb=2048)
+
+        request_json = json.loads(fake.create_request_json)
+        self.assertNotIn("ephemeral_disk_mb", request_json["resources"])
+        self.assertNotIn("disk_mb", request_json["resources"])
+
     def test_list_uses_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         client._rust_client = _FakeRustClient()

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -149,17 +149,6 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(request_json["resources"]["disk_mb"], 25 * 1024)
         self.assertNotIn("ephemeral_disk_mb", request_json["resources"])
 
-    def test_create_ignores_deprecated_ephemeral_disk_mb(self):
-        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
-        fake = _FakeRustClient()
-        client._rust_client = fake
-
-        client.create(ephemeral_disk_mb=2048)
-
-        request_json = json.loads(fake.create_request_json)
-        self.assertNotIn("ephemeral_disk_mb", request_json["resources"])
-        self.assertNotIn("disk_mb", request_json["resources"])
-
     def test_list_uses_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         client._rust_client = _FakeRustClient()

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -140,7 +140,7 @@ class TestSandboxLifecycle(BaseSandboxTest):
             image=_SANDBOX_IMAGE,
             cpus=_SANDBOX_CPUS,
             memory_mb=_SANDBOX_MEMORY_MB,
-            ephemeral_disk_mb=_SANDBOX_DISK_MB,
+            disk_mb=_SANDBOX_DISK_MB,
             entrypoint=["sleep", "300"],
         )
         self.assertIsNotNone(resp.sandbox_id)
@@ -770,7 +770,7 @@ class TestNamedSandboxIdentifier(BaseSandboxTest):
             image=_SANDBOX_IMAGE,
             cpus=_SANDBOX_CPUS,
             memory_mb=_SANDBOX_MEMORY_MB,
-            ephemeral_disk_mb=_SANDBOX_DISK_MB,
+            disk_mb=_SANDBOX_DISK_MB,
             entrypoint=["sleep", "300"],
             name=self.__class__.sandbox_name,
         )
@@ -869,7 +869,7 @@ class TestSandboxRun(BaseSandboxTest):
             image=_SANDBOX_IMAGE,
             cpus=_SANDBOX_CPUS,
             memory_mb=_SANDBOX_MEMORY_MB,
-            ephemeral_disk_mb=_SANDBOX_DISK_MB,
+            disk_mb=_SANDBOX_DISK_MB,
             entrypoint=["sleep", "300"],
         )
         cls.sandbox_id = resp.sandbox_id

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -107,12 +107,11 @@ export class SandboxClient {
 
   /** Create a new sandbox. Returns immediately; the sandbox may still be starting. Use `createAndConnect()` for a blocking, ready-to-use handle. */
   async create(options?: CreateSandboxOptions): Promise<Traced<CreateSandboxResponse>> {
-    const diskMb = options?.diskMb ?? options?.disk_mb;
     const body: Record<string, unknown> = {
       resources: {
         cpus: options?.cpus ?? 1.0,
         memory_mb: options?.memoryMb ?? 1024,
-        ...(diskMb != null ? { disk_mb: diskMb } : {}),
+        ...(options?.diskMb != null ? { disk_mb: options.diskMb } : {}),
       },
     };
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -107,11 +107,12 @@ export class SandboxClient {
 
   /** Create a new sandbox. Returns immediately; the sandbox may still be starting. Use `createAndConnect()` for a blocking, ready-to-use handle. */
   async create(options?: CreateSandboxOptions): Promise<Traced<CreateSandboxResponse>> {
+    const diskMb = options?.diskMb ?? options?.disk_mb;
     const body: Record<string, unknown> = {
       resources: {
         cpus: options?.cpus ?? 1.0,
         memory_mb: options?.memoryMb ?? 1024,
-        ephemeral_disk_mb: options?.ephemeralDiskMb ?? 1024,
+        ...(diskMb != null ? { disk_mb: diskMb } : {}),
       },
     };
 

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -69,7 +69,12 @@ export interface CreateSandboxOptions {
   image?: string;
   cpus?: number;
   memoryMb?: number;
+  /** @deprecated Ignored for sandbox creation. Use `diskMb` instead. */
   ephemeralDiskMb?: number;
+  /** Root disk size in megabytes. When omitted, the server uses its default disk size. */
+  diskMb?: number;
+  /** @deprecated Use `diskMb` instead. */
+  disk_mb?: number;
   secretNames?: string[];
   timeoutSecs?: number;
   entrypoint?: string[];

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -69,8 +69,6 @@ export interface CreateSandboxOptions {
   image?: string;
   cpus?: number;
   memoryMb?: number;
-  /** @deprecated Ignored for sandbox creation. Use `diskMb` instead. */
-  ephemeralDiskMb?: number;
   /** Root disk size in megabytes. When omitted, the server uses its default disk size. */
   diskMb?: number;
   /** @deprecated Use `diskMb` instead. */

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -71,8 +71,6 @@ export interface CreateSandboxOptions {
   memoryMb?: number;
   /** Root disk size in megabytes. When omitted, the server uses its default disk size. */
   diskMb?: number;
-  /** @deprecated Use `diskMb` instead. */
-  disk_mb?: number;
   secretNames?: string[];
   timeoutSecs?: number;
   entrypoint?: string[];

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -1022,7 +1022,6 @@ export async function createSandboxImage(
     emit({
       type: "snapshot_created",
       snapshot_id: snapshot.snapshotId,
-      snapshot_uri: snapshot.snapshotUri ?? null,
     });
 
     if (!snapshot.snapshotUri) {

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -47,6 +47,7 @@ export interface CreateSandboxImageOptions {
   registeredName?: string;
   cpus?: number;
   memoryMb?: number;
+  diskMb?: number;
   isPublic?: boolean;
   contextDir?: string;
   /**
@@ -100,6 +101,7 @@ interface BuildClient {
     image?: string;
     cpus?: number;
     memoryMb?: number;
+    diskMb?: number;
   }): Promise<BuildSandbox>;
   snapshotAndWait(
     sandboxId: string,
@@ -1004,6 +1006,7 @@ export async function createSandboxImage(
       ...(plan.baseImage == null ? {} : { image: plan.baseImage }),
       cpus: options.cpus ?? 2.0,
       memoryMb: options.memoryMb ?? 4096,
+      ...(options.diskMb != null ? { diskMb: options.diskMb } : {}),
     });
 
     emit({
@@ -1069,24 +1072,30 @@ export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {
       name: { type: "string", short: "n" },
       cpus: { type: "string" },
       memory: { type: "string" },
+      disk: { type: "string" },
       public: { type: "boolean", default: false },
     },
   });
 
   const dockerfilePath = parsed.positionals[0];
   if (!dockerfilePath) {
-    throw new Error("Usage: tensorlake-create-sandbox-image <dockerfile_path> [--name NAME] [--cpus N] [--memory MB] [--public]");
+    throw new Error("Usage: tensorlake-create-sandbox-image <dockerfile_path> [--name NAME] [--cpus N] [--memory MB] [--disk GB] [--public]");
   }
 
   const cpus =
     parsed.values.cpus != null ? Number(parsed.values.cpus) : undefined;
   const memoryMb =
     parsed.values.memory != null ? Number(parsed.values.memory) : undefined;
+  const diskGb =
+    parsed.values.disk != null ? Number(parsed.values.disk) : undefined;
   if (cpus != null && !Number.isFinite(cpus)) {
     throw new Error(`Invalid --cpus value: ${parsed.values.cpus}`);
   }
   if (memoryMb != null && !Number.isInteger(memoryMb)) {
     throw new Error(`Invalid --memory value: ${parsed.values.memory}`);
+  }
+  if (diskGb != null && !Number.isInteger(diskGb)) {
+    throw new Error(`Invalid --disk value: ${parsed.values.disk}`);
   }
 
   await createSandboxImage(
@@ -1095,6 +1104,7 @@ export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {
       registeredName: parsed.values.name,
       cpus,
       memoryMb,
+      diskMb: diskGb != null ? diskGb * 1024 : undefined,
       isPublic: parsed.values.public,
     },
     { emit: ndjsonStdoutEmit },

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -106,22 +106,6 @@ describe("SandboxClient", () => {
       client.close();
     });
 
-    it("ignores deprecated ephemeralDiskMb on sandbox create", async () => {
-      mockFetch((_url, init) => {
-        const body = JSON.parse(init?.body as string);
-        expect(body.resources.ephemeral_disk_mb).toBeUndefined();
-        expect(body.resources.disk_mb).toBeUndefined();
-        return new Response(
-          JSON.stringify({ sandbox_id: "sbx-2", status: "pending" }),
-          { status: 200 },
-        );
-      });
-
-      const client = SandboxClient.forLocalhost();
-      await client.create({ ephemeralDiskMb: 25 * 1024 });
-      client.close();
-    });
-
     it("sends name in request body when provided", async () => {
       mockFetch((_url, init) => {
         const body = JSON.parse(init?.body as string);

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -91,21 +91,6 @@ describe("SandboxClient", () => {
       client.close();
     });
 
-    it("supports disk_mb as a backwards-compatible alias", async () => {
-      mockFetch((_url, init) => {
-        const body = JSON.parse(init?.body as string);
-        expect(body.resources.disk_mb).toBe(25 * 1024);
-        return new Response(
-          JSON.stringify({ sandbox_id: "sbx-2", status: "pending" }),
-          { status: 200 },
-        );
-      });
-
-      const client = SandboxClient.forLocalhost();
-      await client.create({ disk_mb: 25 * 1024 });
-      client.close();
-    });
-
     it("sends name in request body when provided", async () => {
       mockFetch((_url, init) => {
         const body = JSON.parse(init?.body as string);

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -43,7 +43,6 @@ describe("SandboxClient", () => {
         expect(body.resources).toEqual({
           cpus: 1.0,
           memory_mb: 1024,
-          ephemeral_disk_mb: 1024,
         });
         return new Response(
           JSON.stringify({ sandbox_id: "sbx-1", status: "pending" }),
@@ -64,6 +63,8 @@ describe("SandboxClient", () => {
         expect(body.image).toBe("python:3.12");
         expect(body.resources.cpus).toBe(2);
         expect(body.resources.memory_mb).toBe(1024);
+        expect(body.resources.ephemeral_disk_mb).toBeUndefined();
+        expect(body.resources.disk_mb).toBe(25 * 1024);
         expect(body.secret_names).toEqual(["my-secret"]);
         expect(body.network).toEqual({
           allow_internet_access: false,
@@ -81,11 +82,43 @@ describe("SandboxClient", () => {
         image: "python:3.12",
         cpus: 2,
         memoryMb: 1024,
+        diskMb: 25 * 1024,
         secretNames: ["my-secret"],
         allowInternetAccess: false,
         allowOut: ["8.8.8.8"],
       });
       expect(result.sandboxId).toBe("sbx-2");
+      client.close();
+    });
+
+    it("supports disk_mb as a backwards-compatible alias", async () => {
+      mockFetch((_url, init) => {
+        const body = JSON.parse(init?.body as string);
+        expect(body.resources.disk_mb).toBe(25 * 1024);
+        return new Response(
+          JSON.stringify({ sandbox_id: "sbx-2", status: "pending" }),
+          { status: 200 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost();
+      await client.create({ disk_mb: 25 * 1024 });
+      client.close();
+    });
+
+    it("ignores deprecated ephemeralDiskMb on sandbox create", async () => {
+      mockFetch((_url, init) => {
+        const body = JSON.parse(init?.body as string);
+        expect(body.resources.ephemeral_disk_mb).toBeUndefined();
+        expect(body.resources.disk_mb).toBeUndefined();
+        return new Response(
+          JSON.stringify({ sandbox_id: "sbx-2", status: "pending" }),
+          { status: 200 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost();
+      await client.create({ ephemeralDiskMb: 25 * 1024 });
       client.close();
     });
 

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -141,7 +141,7 @@ describe(
         image: SANDBOX_IMAGE,
         cpus: SANDBOX_CPUS,
         memoryMb: SANDBOX_MEMORY_MB,
-        ephemeralDiskMb: SANDBOX_DISK_MB,
+        diskMb: SANDBOX_DISK_MB,
         entrypoint: ["sleep", "300"],
       });
       expect(resp.sandboxId).toBeTruthy();

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -321,6 +321,66 @@ describe("sandbox image helpers", () => {
     expect(sandbox.terminate).toHaveBeenCalled();
   });
 
+  it("createSandboxImage forwards custom disk size to the build sandbox", async () => {
+    vi.stubEnv("TENSORLAKE_API_URL", "https://api.tensorlake.ai");
+    vi.stubEnv("TENSORLAKE_API_KEY", "tl_key_test");
+    vi.stubEnv("INDEXIFY_NAMESPACE", "default");
+    vi.stubEnv("TENSORLAKE_ORGANIZATION_ID", "org_123");
+    vi.stubEnv("TENSORLAKE_PROJECT_ID", "proj_123");
+
+    const tempDir = await mkdir(path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-disk`), {
+      recursive: true,
+    });
+    const dockerfilePath = path.join(tempDir, "Dockerfile");
+    await writeFile(dockerfilePath, "FROM python:3.12-slim\nRUN echo hi\n", "utf8");
+
+    const sandbox = {
+      sandboxId: "sbx-1",
+      run: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
+      startProcess: vi.fn(async () => ({ pid: 1 })),
+      getStdout: vi.fn(async () => ({ pid: 1, lines: [], lineCount: 0 })),
+      getStderr: vi.fn(async () => ({ pid: 1, lines: [], lineCount: 0 })),
+      getProcess: vi.fn(async () => ({
+        pid: 1,
+        status: "exited",
+        stdinWritable: false,
+        command: "sh",
+        args: [],
+        startedAt: new Date(),
+        exitCode: 0,
+      })),
+      writeFile: vi.fn(async () => {}),
+      terminate: vi.fn(async () => {}),
+    };
+
+    const client = {
+      createAndConnect: vi.fn(async () => sandbox),
+      snapshotAndWait: vi.fn(async () => ({
+        snapshotId: "snap-1",
+        snapshotUri: "s3://snapshots/snap-1.tar.zst",
+      })),
+      close: vi.fn(() => {}),
+    };
+
+    await createSandboxImage(
+      dockerfilePath,
+      { diskMb: 25 * 1024 },
+      {
+        emit: () => {},
+        createClient: () => client as never,
+        registerImage: async () => ({ id: "tpl-1" }),
+        sleep: async () => {},
+      },
+    );
+
+    expect(client.createAndConnect).toHaveBeenCalledWith({
+      image: "python:3.12-slim",
+      cpus: 2.0,
+      memoryMb: 4096,
+      diskMb: 25 * 1024,
+    });
+  });
+
   it("createSandboxImage lets the server choose the base image when the Image DSL omits one", async () => {
     vi.stubEnv("TENSORLAKE_API_URL", "https://api.tensorlake.ai");
     vi.stubEnv("TENSORLAKE_API_KEY", "tl_key_test");


### PR DESCRIPTION
## Summary
- add `disk_mb` support to sandbox create across Rust cloud SDK, Python SDK, and TypeScript SDK
- add CLI `tl sbx new --disk <GB>` and plumb to `resources.disk_mb` (GB -> MiB)
- stop sending deprecated `ephemeral_disk_mb` on sandbox create; send `disk_mb` only when explicitly provided
- add image build support for custom disk size in Python/TypeScript image build flows and CLI image builder path
- update tests for create payload serialization and image builder disk forwarding

## Verification
- `npm --prefix typescript test -- --run tests/client.test.ts tests/sandbox-image.test.ts` (pass)
- `PYTHONPATH=src python3 -m pytest tests/image/test_sandbox_builder.py -q` (pass)
- `PYTHONPATH=src python3 -m pytest tests/sandbox/test_client_rust_backend.py -q` requires local rust client build in this environment (`make build_rust_py_client`)
