### PR TITLE
fix(sdk): make list methods iterable with traceId in Python and TypeScript SDKs

### DIFF
--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -162,15 +162,14 @@ class Sandbox:
         if self._host_header:
             self._proxy_headers["Host"] = self._host_header
 
-        if not _RUST_SANDBOX_PROXY_CLIENT_AVAILABLE:
+        if _proxy_rust_client is not None:
+            self._rust_client = _proxy_rust_client
+            self._base_url = self._rust_client.base_url()
+        elif not _RUST_SANDBOX_PROXY_CLIENT_AVAILABLE:
             raise SandboxError(
                 "Rust Cloud SDK sandbox proxy client is required but unavailable. "
                 "Build/install it with `make build_rust_py_client`."
             )
-
-        if _proxy_rust_client is not None:
-            self._rust_client = _proxy_rust_client
-            self._base_url = self._rust_client.base_url()
         else:
             try:
                 self._rust_client = RustCloudSandboxProxyClient(
@@ -707,12 +706,12 @@ class Sandbox:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def list_processes(self) -> Traced[list[ProcessInfo]]:
+    def list_processes(self) -> TracedIterator[ProcessInfo]:
         """List all processes in the sandbox."""
         try:
             trace_id, response_json = self._rust_client.list_processes_json()
             data = ListProcessesResponse.model_validate_json(response_json)
-            return Traced(trace_id, data.processes)
+            return TracedIterator(trace_id, data.processes)
         except Exception as e:
             _raise_as_sandbox_error(e)
 

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -1,8 +1,11 @@
 import json
 import unittest
 
+from tensorlake._tracing import TracedIterator
 from tensorlake.sandbox import Sandbox, SandboxConnectionError
 from tensorlake.sandbox.models import StdinMode
+
+_TRACE_ID = "00-deadbeefdeadbeefdeadbeefdeadbeef-cafebabecafebabe-01"
 
 
 class _FakeRustProxyClient:
@@ -18,7 +21,7 @@ class _FakeRustProxyClient:
 
     def start_process_json(self, payload_json):
         self.start_payload_json = payload_json
-        return json.dumps(
+        return _TRACE_ID, json.dumps(
             {
                 "pid": 101,
                 "status": "running",
@@ -30,7 +33,7 @@ class _FakeRustProxyClient:
         )
 
     def list_processes_json(self):
-        return json.dumps(
+        return _TRACE_ID, json.dumps(
             {
                 "processes": [
                     {
@@ -47,7 +50,7 @@ class _FakeRustProxyClient:
 
     def follow_output_json(self, pid):
         assert pid == 101
-        return [
+        return _TRACE_ID, [
             json.dumps(
                 {
                     "line": "hello",
@@ -59,7 +62,7 @@ class _FakeRustProxyClient:
 
     def run_process_json(self, payload_json):
         self.run_payload_json = payload_json
-        return [
+        return _TRACE_ID, [
             json.dumps(
                 {"line": "out1", "stream": "stdout", "timestamp": 1_700_000_001}
             ),
@@ -73,26 +76,34 @@ class _FakeRustProxyClient:
         ]
 
     def health_json(self):
-        return json.dumps({"healthy": True})
+        return _TRACE_ID, json.dumps({"healthy": True})
+
+
+def _make_sandbox(fake=None):
+    """Return a Sandbox wired to *fake* (or a fresh _FakeRustProxyClient)."""
+    client = fake or _FakeRustProxyClient()
+    return Sandbox(
+        sandbox_id="sbx-1",
+        proxy_url="http://localhost:9443",
+        api_key="k",
+        _proxy_rust_client=client,
+    ), client
 
 
 class TestSandboxRustBackend(unittest.TestCase):
     def test_sandbox_accepts_sandbox_name(self):
-        sandbox = Sandbox(
+        sandbox, _ = _make_sandbox()
+        # Rename so the identifier is set from `identifier=` kwarg.
+        sandbox2 = Sandbox(
             identifier="stable-name",
             proxy_url="http://localhost:9443",
             api_key="k",
+            _proxy_rust_client=_FakeRustProxyClient(),
         )
-
-        self.assertEqual(sandbox._identifier, "stable-name")
+        self.assertEqual(sandbox2._identifier, "stable-name")
 
     def test_start_process_uses_rust_backend(self):
-        sandbox = Sandbox(
-            sandbox_id="sbx-1", proxy_url="http://localhost:9443", api_key="k"
-        )
-        fake = _FakeRustProxyClient()
-        sandbox._rust_client = fake
-        sandbox._base_url = fake.base_url()
+        sandbox, fake = _make_sandbox()
 
         process = sandbox.start_process(
             command="echo",
@@ -107,22 +118,33 @@ class TestSandboxRustBackend(unittest.TestCase):
         self.assertEqual(payload["stdin_mode"], "pipe")
 
     def test_list_processes_uses_rust_backend(self):
-        sandbox = Sandbox(
-            sandbox_id="sbx-1", proxy_url="http://localhost:9443", api_key="k"
-        )
-        sandbox._rust_client = _FakeRustProxyClient()
+        sandbox, _ = _make_sandbox()
+
+        processes = sandbox.list_processes()
+        items = list(processes)
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].pid, 101)
+        self.assertEqual(items[0].status, "running")
+
+    def test_list_processes_returns_traced_iterator(self):
+        sandbox, _ = _make_sandbox()
 
         processes = sandbox.list_processes()
 
-        self.assertEqual(len(processes), 1)
-        self.assertEqual(processes[0].pid, 101)
-        self.assertEqual(processes[0].status, "running")
+        self.assertIsInstance(processes, TracedIterator)
+        self.assertEqual(processes.trace_id, _TRACE_ID)
+
+    def test_list_processes_is_iterable(self):
+        sandbox, _ = _make_sandbox()
+
+        processes = sandbox.list_processes()
+
+        pids = [p.pid for p in processes]
+        self.assertEqual(pids, [101])
 
     def test_follow_output_uses_rust_backend(self):
-        sandbox = Sandbox(
-            sandbox_id="sbx-1", proxy_url="http://localhost:9443", api_key="k"
-        )
-        sandbox._rust_client = _FakeRustProxyClient()
+        sandbox, _ = _make_sandbox()
 
         events = list(sandbox.follow_output(101))
 
@@ -130,50 +152,44 @@ class TestSandboxRustBackend(unittest.TestCase):
         self.assertEqual(events[0].line, "hello")
         self.assertEqual(events[0].stream, "stdout")
 
+    def test_follow_output_returns_traced_iterator(self):
+        sandbox, _ = _make_sandbox()
+
+        events = sandbox.follow_output(101)
+
+        self.assertIsInstance(events, TracedIterator)
+        self.assertEqual(events.trace_id, _TRACE_ID)
+
     def test_run_uses_streaming_endpoint(self):
-        sandbox = Sandbox(
-            sandbox_id="sbx-1", proxy_url="http://localhost:9443", api_key="k"
-        )
-        fake = _FakeRustProxyClient()
-        sandbox._rust_client = fake
+        sandbox, fake = _make_sandbox()
 
         result = sandbox.run("echo", args=["hello"])
 
-        # Verify the payload sent to the Rust client.
         payload = json.loads(fake.run_payload_json)
         self.assertEqual(payload["command"], "echo")
         self.assertEqual(payload["args"], ["hello"])
 
-        # Verify stdout/stderr lines are collected from streaming events.
         self.assertEqual(result.stdout, "out1\nout2")
         self.assertEqual(result.stderr, "err1")
         self.assertEqual(result.exit_code, 0)
 
     def test_run_signal_maps_to_negative_exit_code(self):
-        sandbox = Sandbox(
-            sandbox_id="sbx-1", proxy_url="http://localhost:9443", api_key="k"
-        )
-
         class _SignaledFakeClient(_FakeRustProxyClient):
             def run_process_json(self, payload_json):
-                return [json.dumps({"signal": 9})]
+                return _TRACE_ID, [json.dumps({"signal": 9})]
 
-        sandbox._rust_client = _SignaledFakeClient()
+        sandbox, _ = _make_sandbox(_SignaledFakeClient())
 
         result = sandbox.run("sleep", args=["100"])
 
         self.assertEqual(result.exit_code, -9)
 
     def test_run_raises_when_stream_has_no_exit_event(self):
-        sandbox = Sandbox(
-            sandbox_id="sbx-1", proxy_url="http://localhost:9443", api_key="k"
-        )
-
         class _MissingExitFakeClient(_FakeRustProxyClient):
             def run_process_json(self, payload_json):
-                return []
+                return _TRACE_ID, []
 
-        sandbox._rust_client = _MissingExitFakeClient()
+        sandbox, _ = _make_sandbox(_MissingExitFakeClient())
 
         with self.assertRaisesRegex(
             SandboxConnectionError, "stream ended without an exit event"
@@ -193,12 +209,7 @@ class TestSandboxRustBackend(unittest.TestCase):
         previous = sandbox_module.RustCloudSandboxClientError
         try:
             sandbox_module.RustCloudSandboxClientError = FakeRustError
-            sandbox = Sandbox(
-                sandbox_id="sbx-1",
-                proxy_url="http://localhost:9443",
-                api_key="k",
-            )
-            sandbox._rust_client = _FailingRustProxyClient()
+            sandbox, _ = _make_sandbox(_FailingRustProxyClient())
 
             with self.assertRaises(SandboxConnectionError):
                 sandbox.health()

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -82,12 +82,15 @@ class _FakeRustProxyClient:
 def _make_sandbox(fake=None):
     """Return a Sandbox wired to *fake* (or a fresh _FakeRustProxyClient)."""
     client = fake or _FakeRustProxyClient()
-    return Sandbox(
-        sandbox_id="sbx-1",
-        proxy_url="http://localhost:9443",
-        api_key="k",
-        _proxy_rust_client=client,
-    ), client
+    return (
+        Sandbox(
+            sandbox_id="sbx-1",
+            proxy_url="http://localhost:9443",
+            api_key="k",
+            _proxy_rust_client=client,
+        ),
+        client,
+    )
 
 
 class TestSandboxRustBackend(unittest.TestCase):

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -153,14 +153,15 @@ export class SandboxClient {
   }
 
   /** List all sandboxes in the namespace. */
-  async list(): Promise<SandboxInfo[]> {
+  async list(): Promise<Traced<SandboxInfo[]>> {
     const raw = await this.http.requestJson<{ sandboxes: Record<string, unknown>[] }>(
       "GET",
       this.path("sandboxes"),
     );
-    return (raw.sandboxes ?? []).map(
+    const sandboxes = (raw.sandboxes ?? []).map(
       (s) => fromSnakeKeys(s, "sandboxId") as SandboxInfo,
     );
+    return Object.assign(sandboxes, { traceId: raw.traceId });
   }
 
   /** Update sandbox properties such as name, exposed ports, and proxy auth settings. */
@@ -355,14 +356,15 @@ export class SandboxClient {
   }
 
   /** List all snapshots in the namespace. */
-  async listSnapshots(): Promise<SnapshotInfo[]> {
+  async listSnapshots(): Promise<Traced<SnapshotInfo[]>> {
     const raw = await this.http.requestJson<{ snapshots: Record<string, unknown>[] }>(
       "GET",
       this.path("snapshots"),
     );
-    return (raw.snapshots ?? []).map(
+    const snapshots = (raw.snapshots ?? []).map(
       (s) => fromSnakeKeys(s, "snapshotId") as SnapshotInfo,
     );
+    return Object.assign(snapshots, { traceId: raw.traceId });
   }
 
   /** Delete a snapshot by ID. */
@@ -451,14 +453,15 @@ export class SandboxClient {
   }
 
   /** List all sandbox pools in the namespace. */
-  async listPools(): Promise<SandboxPoolInfo[]> {
+  async listPools(): Promise<Traced<SandboxPoolInfo[]>> {
     const raw = await this.http.requestJson<{ pools: Record<string, unknown>[] }>(
       "GET",
       this.path("sandbox-pools"),
     );
-    return (raw.pools ?? []).map(
+    const pools = (raw.pools ?? []).map(
       (p) => fromSnakeKeys(p, "poolId") as SandboxPoolInfo,
     );
+    return Object.assign(pools, { traceId: raw.traceId });
   }
 
   /** Replace the configuration of an existing sandbox pool. */

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -5,7 +5,7 @@ import {
 } from "./desktop.js";
 import * as defaults from "./defaults.js";
 import { SandboxError } from "./errors.js";
-import { HttpClient } from "./http.js";
+import { type Traced, HttpClient } from "./http.js";
 import {
   type CheckpointOptions,
   type CommandResult,
@@ -450,10 +450,11 @@ export class Sandbox {
   /**
    * List snapshots taken from this sandbox.
    */
-  async listSnapshots(): Promise<SnapshotInfo[]> {
+  async listSnapshots(): Promise<Traced<SnapshotInfo[]>> {
     const client = this.requireLifecycleClient("listSnapshots");
     const all = await client.listSnapshots();
-    return all.filter((s) => s.sandboxId === this.sandboxId);
+    const filtered = all.filter((s) => s.sandboxId === this.sandboxId);
+    return Object.assign(filtered, { traceId: all.traceId });
   }
 
   /** Close the HTTP client. The sandbox keeps running. */
@@ -557,12 +558,13 @@ export class Sandbox {
   }
 
   /** List all processes (running and exited) tracked by the sandbox daemon. */
-  async listProcesses(): Promise<ProcessInfo[]> {
+  async listProcesses(): Promise<Traced<ProcessInfo[]>> {
     const raw = await this.http.requestJson<{ processes: Record<string, unknown>[] }>(
       "GET",
       "/api/v1/processes",
     );
-    return (raw.processes ?? []).map((p) => fromSnakeKeys(p) as ProcessInfo);
+    const processes = (raw.processes ?? []).map((p) => fromSnakeKeys(p) as ProcessInfo);
+    return Object.assign(processes, { traceId: raw.traceId });
   }
 
   /** Get current status and metadata for a process by PID. */

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -237,6 +237,24 @@ describe("SandboxClient", () => {
       expect(list[0].sandboxId).toBe("sbx-1");
       client.close();
     });
+
+    it("returns traceId on the array", async () => {
+      mockFetch(() =>
+        new Response(
+          JSON.stringify({ sandboxes: [] }),
+          {
+            status: 200,
+            headers: { traceparent: "00-aabbccdd00112233aabbccdd00112233-cafebabe12345678-01" },
+          },
+        ),
+      );
+
+      const client = SandboxClient.forLocalhost();
+      const list = await client.list();
+      expect(typeof list.traceId).toBe("string");
+      expect(list.traceId.length).toBeGreaterThan(0);
+      client.close();
+    });
   });
 
   describe("update", () => {
@@ -608,6 +626,25 @@ describe("SandboxClient", () => {
       expect(info.status).toBe(SnapshotStatus.COMPLETED);
       client.close();
     });
+
+    it("listSnapshots returns traceId on the array", async () => {
+      mockFetch(() =>
+        new Response(
+          JSON.stringify({ snapshots: [] }),
+          {
+            status: 200,
+            headers: { traceparent: "00-aabbccdd00112233aabbccdd00112233-cafebabe12345678-01" },
+          },
+        ),
+      );
+
+      const client = SandboxClient.forLocalhost();
+      const snaps = await client.listSnapshots();
+      expect(Array.isArray(snaps)).toBe(true);
+      expect(typeof snaps.traceId).toBe("string");
+      expect(snaps.traceId.length).toBeGreaterThan(0);
+      client.close();
+    });
   });
 
   describe("pools", () => {
@@ -650,6 +687,25 @@ describe("SandboxClient", () => {
       const info = await client.getPool("pool-1");
       expect(info.poolId).toBe("pool-1");
       expect(info.image).toBe("node:20");
+      client.close();
+    });
+
+    it("listPools returns traceId on the array", async () => {
+      mockFetch(() =>
+        new Response(
+          JSON.stringify({ pools: [] }),
+          {
+            status: 200,
+            headers: { traceparent: "00-aabbccdd00112233aabbccdd00112233-cafebabe12345678-01" },
+          },
+        ),
+      );
+
+      const client = SandboxClient.forLocalhost();
+      const pools = await client.listPools();
+      expect(Array.isArray(pools)).toBe(true);
+      expect(typeof pools.traceId).toBe("string");
+      expect(pools.traceId.length).toBeGreaterThan(0);
       client.close();
     });
   });

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -67,6 +67,62 @@ describe("Sandbox", () => {
     });
   });
 
+  describe("listProcesses", () => {
+    it("returns an array with traceId", async () => {
+      mockFetch(() =>
+        new Response(
+          JSON.stringify({
+            processes: [
+              {
+                pid: 42,
+                status: "running",
+                command: "bash",
+                args: [],
+                stdin_writable: false,
+                started_at: 1700000000,
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { traceparent: "00-aabbccdd00112233aabbccdd00112233-cafebabe12345678-01" },
+          },
+        ),
+      );
+
+      const sbx = makeSandbox();
+      const procs = await sbx.listProcesses();
+
+      expect(Array.isArray(procs)).toBe(true);
+      expect(procs).toHaveLength(1);
+      expect(procs[0].pid).toBe(42);
+      expect(typeof procs.traceId).toBe("string");
+      expect(procs.traceId.length).toBeGreaterThan(0);
+      sbx.close();
+    });
+
+    it("list comprehension pattern works on result", async () => {
+      mockFetch(() =>
+        new Response(
+          JSON.stringify({
+            processes: [
+              { pid: 1, status: "running", command: "bash", args: [], stdin_writable: false, started_at: 1700000000 },
+              { pid: 2, status: "exited", command: "ls", args: [], stdin_writable: false, started_at: 1700000001 },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const sbx = makeSandbox();
+      const procs = await sbx.listProcesses();
+      const pids = procs.map((p) => p.pid);
+
+      expect(pids).toEqual([1, 2]);
+      sbx.close();
+    });
+  });
+
   describe("startProcess", () => {
     it("sends correct payload", async () => {
       mockFetch((_url, init) => {


### PR DESCRIPTION
## Summary

- **Python**: `Sandbox.list_processes()` was returning `Traced[list[ProcessInfo]]`, causing `TypeError: 'Traced' object is not iterable` when iterating (e.g. `[p.pid for p in procs]`). Changed to `TracedIterator[ProcessInfo]`, consistent with `list_snapshots()`, `follow_stdout()`, `follow_stderr()`, and `follow_output()`.
- **TypeScript**: `listProcesses()`, `SandboxClient.list()`, `SandboxClient.listSnapshots()`, `SandboxClient.listPools()`, and `Sandbox.listSnapshots()` were discarding `traceId` when unpacking inner arrays. Fixed by attaching `traceId` via `Object.assign` onto the result array — `Traced<T[]>` stays fully iterable while exposing `.traceId`.
- **Test infrastructure**: Fixed `Sandbox` constructor to check `_proxy_rust_client` before the Rust availability guard (making the injection parameter actually usable without the native module built); updated the Python fake client to return proper `(trace_id, data)` tuples matching the real Rust client interface.

## Test plan

- [x] 11 Python unit tests pass (`tests/sandbox/test_sandbox_rust_backend.py`), including 3 new tests: `test_list_processes_returns_traced_iterator`, `test_list_processes_is_iterable`, `test_follow_output_returns_traced_iterator`
- [x] 121 TypeScript unit tests pass, including 4 new tests covering `traceId` presence on `listProcesses`, `list`, `listSnapshots`, and `listPools`

🤖 Generated with [Claude Code](https://claude.com/claude-code)