### PR TITLE
feat: add sandbox .name / .status / .update 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -76,6 +76,8 @@ pub struct CreateSandboxResponse {
     pub status: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing_hint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.0"
+version = "0.5.1"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1083,8 +1083,6 @@ class SandboxClient:
                 routing_hint=result.routing_hint,
             )
             sandbox._sandbox_id = result.sandbox_id
-            sandbox._name = result.name
-            sandbox._name_loaded = True
             sandbox._owns_sandbox = True
             sandbox._lifecycle_client = self
             sandbox._trace_id = result.trace_id
@@ -1100,8 +1098,6 @@ class SandboxClient:
                     routing_hint=info.routing_hint,
                 )
                 sandbox._sandbox_id = info.sandbox_id
-                sandbox._name = info.name
-                sandbox._name_loaded = True
                 sandbox._cached_info = info
                 sandbox._owns_sandbox = True
                 sandbox._lifecycle_client = self

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1055,6 +1055,9 @@ class SandboxClient:
             SandboxError: If sandbox fails to start or times out
             SandboxConnectionError: If the server is unreachable
         """
+        # claim() never sends `name` to the server, so only the create() path
+        # may fall back to the requested name when caching info locally.
+        requested_name = None if pool_id is not None else name
         if pool_id is not None:
             result = self.claim(pool_id)
         else:
@@ -1086,6 +1089,11 @@ class SandboxClient:
             sandbox._owns_sandbox = True
             sandbox._lifecycle_client = self
             sandbox._trace_id = result.trace_id
+            sandbox._cached_info = SandboxInfo.model_construct(
+                sandbox_id=result.sandbox_id,
+                status=result.status,
+                name=result.name or requested_name,
+            )
             return sandbox
 
         deadline = time.time() + startup_timeout

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -36,6 +36,7 @@ class SandboxStatus(str, Enum):
     PENDING = "pending"
     RUNNING = "running"
     SNAPSHOTTING = "snapshotting"
+    SUSPENDING = "suspending"
     SUSPENDED = "suspended"
     TERMINATED = "terminated"
 

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -535,6 +535,13 @@ class Sandbox:
         """The human-readable name for this sandbox, or None if unnamed."""
         return self._fetch_info().name
 
+    @name.setter
+    def name(self, value: str) -> None:
+        """Assign or change this sandbox's name. Equivalent to ``self.update(name=value)``."""
+        if not value:
+            raise SandboxError("sandbox name must be a non-empty string")
+        self.update(name=value)
+
     @property
     def status(self) -> SandboxStatus:
         """Current sandbox status fetched fresh from the server."""

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -317,10 +317,12 @@ class Sandbox:
             namespace=namespace,
             _internal=True,
         )
-        client.get(sandbox_id)  # raises SandboxNotFoundError if not found
-        return client.connect(
+        info = client.get(sandbox_id).value  # raises SandboxNotFoundError if not found
+        sandbox = client.connect(
             sandbox_id, proxy_url=proxy_url, routing_hint=routing_hint
         )
+        sandbox._cached_info = info
+        return sandbox
 
     # --- Class-level snapshot management ---
 
@@ -570,6 +572,7 @@ class Sandbox:
             exposed_ports=exposed_ports,
         )
         self._cached_info = traced.value
+        self._identifier = traced.value.sandbox_id
         return traced
 
     def __enter__(self) -> Sandbox:

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -317,14 +317,11 @@ class Sandbox:
             namespace=namespace,
             _internal=True,
         )
-        info = client.get(sandbox_id).value  # raises SandboxNotFoundError if not found
-        # Bind the proxy client to the stable sandbox UUID, not the user-supplied
-        # name, so a subsequent `update(name=...)` rename doesn't leave proxy
-        # traffic targeting a stale routing identity.
+        info = client.get(sandbox_id)  # raises SandboxNotFoundError if not found
         sandbox = client.connect(
-            info.sandbox_id, proxy_url=proxy_url, routing_hint=routing_hint
+            sandbox_id, proxy_url=proxy_url, routing_hint=routing_hint
         )
-        sandbox._cached_info = info
+        sandbox._cached_info = info.value
         return sandbox
 
     # --- Class-level snapshot management ---
@@ -575,7 +572,6 @@ class Sandbox:
             exposed_ports=exposed_ports,
         )
         self._cached_info = traced.value
-        self._identifier = traced.value.sandbox_id
         return traced
 
     def __enter__(self) -> Sandbox:

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -28,6 +28,7 @@ from .models import (
     OutputResponse,
     ProcessInfo,
     SandboxInfo,
+    SandboxStatus,
     SendSignalResponse,
     SnapshotContentMode,
     SnapshotInfo,
@@ -138,8 +139,6 @@ class Sandbox:
 
         self._identifier = sandbox_identifier
         self._sandbox_id: str | None = None
-        self._name: str | None = None
-        self._name_loaded: bool = False
         self._trace_id: str | None = None
         self._cached_info: SandboxInfo | None = None
         self._owns_sandbox: bool = False
@@ -532,11 +531,46 @@ class Sandbox:
     @property
     def name(self) -> str | None:
         """The human-readable name for this sandbox, or None if unnamed."""
-        if self._name_loaded:
-            return self._name
-        self._name = self._fetch_info().name
-        self._name_loaded = True
-        return self._name
+        return self._fetch_info().name
+
+    @property
+    def status(self) -> SandboxStatus:
+        """Current sandbox status fetched fresh from the server."""
+        self._require_lifecycle_client("read_status")
+        return self._lifecycle_client.get(self._identifier).value.status
+
+    def update(
+        self,
+        name: str | None = None,
+        *,
+        allow_unauthenticated_access: bool | None = None,
+        exposed_ports: list[int] | None = None,
+    ) -> Traced[SandboxInfo]:
+        """Update this sandbox's properties.
+
+        Supports updating the sandbox name and sandbox proxy access settings.
+        Naming an ephemeral sandbox makes it non-ephemeral and enables
+        suspend/resume.
+
+        Args:
+            name: New name for the sandbox.
+            allow_unauthenticated_access: Whether exposed user ports should be
+                reachable without TensorLake auth.
+            exposed_ports: User ports that should be routable through the
+                sandbox proxy. Port ``9501`` is reserved.
+
+        Returns:
+            Traced[SandboxInfo] with the updated sandbox details.
+        """
+        self._require_lifecycle_client("update")
+        traced = self._lifecycle_client.update_sandbox(
+            self._identifier,
+            name=name,
+            allow_unauthenticated_access=allow_unauthenticated_access,
+            exposed_ports=exposed_ports,
+        )
+        self._cached_info = traced.value
+        return traced
 
     def __enter__(self) -> Sandbox:
         return self

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -319,8 +319,11 @@ class Sandbox:
         )
         info = client.get(sandbox_id)  # raises SandboxNotFoundError if not found
         sandbox = client.connect(
-            sandbox_id, proxy_url=proxy_url, routing_hint=routing_hint
+            info.sandbox_id,
+            proxy_url=proxy_url,
+            routing_hint=routing_hint or info.routing_hint,
         )
+        sandbox._sandbox_id = info.sandbox_id
         sandbox._cached_info = info.value
         return sandbox
 
@@ -514,8 +517,22 @@ class Sandbox:
                     "Cannot resolve sandbox info: no lifecycle client available. "
                     "Connect via SandboxClient.connect() to enable sandbox_id and name lookup."
                 )
-            self._cached_info = self._lifecycle_client.get(self._identifier).value
+            lookup_id = self._sandbox_id or self._identifier
+            self._cached_info = self._lifecycle_client.get(lookup_id).value
         return self._cached_info
+
+    def _lifecycle_identifier(self) -> str:
+        """Best-effort stable identifier for lifecycle API calls.
+
+        Prefer a known server-assigned sandbox ID, but avoid forcing an extra
+        GET solely to resolve it.
+        """
+        if self._sandbox_id is not None:
+            return self._sandbox_id
+        if self._cached_info is not None:
+            self._sandbox_id = self._cached_info.sandbox_id
+            return self._sandbox_id
+        return self._identifier
 
     @property
     def sandbox_id(self) -> str:
@@ -546,7 +563,10 @@ class Sandbox:
     def status(self) -> SandboxStatus:
         """Current sandbox status fetched fresh from the server."""
         self._require_lifecycle_client("read_status")
-        return self._lifecycle_client.get(self._identifier).value.status
+        info = self._lifecycle_client.get(self._lifecycle_identifier()).value
+        self._sandbox_id = info.sandbox_id
+        self._cached_info = info
+        return info.status
 
     def update(
         self,
@@ -573,11 +593,12 @@ class Sandbox:
         """
         self._require_lifecycle_client("update")
         traced = self._lifecycle_client.update_sandbox(
-            self._identifier,
+            self._lifecycle_identifier(),
             name=name,
             allow_unauthenticated_access=allow_unauthenticated_access,
             exposed_ports=exposed_ports,
         )
+        self._sandbox_id = traced.sandbox_id
         self._cached_info = traced.value
         return traced
 
@@ -603,11 +624,12 @@ class Sandbox:
     def terminate(self):
         """Terminate the sandbox and close the connection."""
         lifecycle_client = self._lifecycle_client
+        delete_identifier = self._sandbox_id or self._identifier
         self._owns_sandbox = False
         self._lifecycle_client = None
         self.close()
         if lifecycle_client is not None:
-            lifecycle_client.delete(self._identifier)
+            lifecycle_client.delete(delete_identifier)
 
     @staticmethod
     def _build_command_payload(

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -318,8 +318,11 @@ class Sandbox:
             _internal=True,
         )
         info = client.get(sandbox_id).value  # raises SandboxNotFoundError if not found
+        # Bind the proxy client to the stable sandbox UUID, not the user-supplied
+        # name, so a subsequent `update(name=...)` rename doesn't leave proxy
+        # traffic targeting a stale routing identity.
         sandbox = client.connect(
-            sandbox_id, proxy_url=proxy_url, routing_hint=routing_hint
+            info.sandbox_id, proxy_url=proxy_url, routing_hint=routing_hint
         )
         sandbox._cached_info = info
         return sandbox

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -1,9 +1,16 @@
 import json
 import unittest
+from unittest.mock import MagicMock
 
-from tensorlake._tracing import TracedIterator
+from tensorlake._tracing import Traced, TracedIterator
 from tensorlake.sandbox import Sandbox, SandboxConnectionError
-from tensorlake.sandbox.models import StdinMode
+from tensorlake.sandbox.exceptions import SandboxError
+from tensorlake.sandbox.models import (
+    ContainerResourcesInfo,
+    SandboxInfo,
+    SandboxStatus,
+    StdinMode,
+)
 
 _TRACE_ID = "00-deadbeefdeadbeefdeadbeefdeadbeef-cafebabecafebabe-01"
 
@@ -91,6 +98,19 @@ def _make_sandbox(fake=None):
         ),
         client,
     )
+
+
+def _sandbox_info(status=SandboxStatus.RUNNING, **overrides) -> SandboxInfo:
+    fields = {
+        "id": "sbx-1",
+        "namespace": "default",
+        "status": status,
+        "resources": ContainerResourcesInfo(
+            cpus=1.0, memory_mb=512, ephemeral_disk_mb=1024
+        ),
+    }
+    fields.update(overrides)
+    return SandboxInfo(**fields)
 
 
 class TestSandboxRustBackend(unittest.TestCase):
@@ -198,6 +218,72 @@ class TestSandboxRustBackend(unittest.TestCase):
             SandboxConnectionError, "stream ended without an exit event"
         ):
             sandbox.run("echo", args=["hello"])
+
+    def test_name_property_fetches_via_lifecycle_client(self):
+        sandbox, _ = _make_sandbox()
+        sandbox._lifecycle_client = MagicMock()
+        sandbox._lifecycle_client.get.return_value = Traced(
+            _TRACE_ID, _sandbox_info(name="my-sandbox")
+        )
+
+        self.assertEqual(sandbox.name, "my-sandbox")
+        self.assertEqual(sandbox.name, "my-sandbox")
+        sandbox._lifecycle_client.get.assert_called_once_with("sbx-1")
+
+    def test_name_raises_without_lifecycle_client(self):
+        sandbox, _ = _make_sandbox()
+        with self.assertRaises(SandboxError):
+            _ = sandbox.name
+
+    def test_status_property_fetches_live(self):
+        sandbox, _ = _make_sandbox()
+        sandbox._lifecycle_client = MagicMock()
+        sandbox._lifecycle_client.get.side_effect = [
+            Traced(_TRACE_ID, _sandbox_info(status=SandboxStatus.RUNNING)),
+            Traced(_TRACE_ID, _sandbox_info(status=SandboxStatus.SUSPENDED)),
+        ]
+
+        self.assertEqual(sandbox.status, SandboxStatus.RUNNING)
+        self.assertEqual(sandbox.status, SandboxStatus.SUSPENDED)
+        self.assertEqual(sandbox._lifecycle_client.get.call_count, 2)
+
+    def test_status_raises_without_lifecycle_client(self):
+        sandbox, _ = _make_sandbox()
+        with self.assertRaises(SandboxError):
+            _ = sandbox.status
+
+    def test_update_calls_lifecycle_client_and_refreshes_name(self):
+        sandbox, _ = _make_sandbox()
+        sandbox._cached_info = _sandbox_info(name="old-name")
+        sandbox._lifecycle_client = MagicMock()
+        sandbox._lifecycle_client.update_sandbox.return_value = Traced(
+            _TRACE_ID,
+            _sandbox_info(
+                name="renamed",
+                exposed_ports=[8080],
+                allow_unauthenticated_access=True,
+            ),
+        )
+
+        traced = sandbox.update(
+            name="renamed",
+            allow_unauthenticated_access=True,
+            exposed_ports=[8080],
+        )
+
+        sandbox._lifecycle_client.update_sandbox.assert_called_once_with(
+            "sbx-1",
+            name="renamed",
+            allow_unauthenticated_access=True,
+            exposed_ports=[8080],
+        )
+        self.assertEqual(traced.name, "renamed")
+        self.assertEqual(sandbox.name, "renamed")
+
+    def test_update_raises_without_lifecycle_client(self):
+        sandbox, _ = _make_sandbox()
+        with self.assertRaises(SandboxError):
+            sandbox.update(name="anything")
 
     def test_health_maps_connection_error(self):
         class FakeRustError(Exception):

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -252,6 +252,18 @@ class TestSandboxRustBackend(unittest.TestCase):
         with self.assertRaises(SandboxError):
             _ = sandbox.status
 
+    def test_status_prefers_canonical_sandbox_id_over_original_identifier(self):
+        sandbox, _ = _make_sandbox()
+        sandbox._identifier = "old-name"
+        sandbox._sandbox_id = "sbx-1"
+        sandbox._lifecycle_client = MagicMock()
+        sandbox._lifecycle_client.get.return_value = Traced(
+            _TRACE_ID, _sandbox_info(status=SandboxStatus.RUNNING)
+        )
+
+        self.assertEqual(sandbox.status, SandboxStatus.RUNNING)
+        sandbox._lifecycle_client.get.assert_called_once_with("sbx-1")
+
     def test_update_calls_lifecycle_client_and_refreshes_name(self):
         sandbox, _ = _make_sandbox()
         sandbox._cached_info = _sandbox_info(name="old-name")
@@ -279,6 +291,25 @@ class TestSandboxRustBackend(unittest.TestCase):
         )
         self.assertEqual(traced.name, "renamed")
         self.assertEqual(sandbox.name, "renamed")
+
+    def test_update_prefers_canonical_sandbox_id_over_original_identifier(self):
+        sandbox, _ = _make_sandbox()
+        sandbox._identifier = "old-name"
+        sandbox._sandbox_id = "sbx-1"
+        sandbox._cached_info = _sandbox_info(name="old-name")
+        sandbox._lifecycle_client = MagicMock()
+        sandbox._lifecycle_client.update_sandbox.return_value = Traced(
+            _TRACE_ID, _sandbox_info(name="new-name")
+        )
+
+        sandbox.update(name="new-name")
+
+        sandbox._lifecycle_client.update_sandbox.assert_called_once_with(
+            "sbx-1",
+            name="new-name",
+            allow_unauthenticated_access=None,
+            exposed_ports=None,
+        )
 
     def test_update_raises_without_lifecycle_client(self):
         sandbox, _ = _make_sandbox()
@@ -309,6 +340,10 @@ class TestSandboxRustBackend(unittest.TestCase):
         with self.assertRaises(SandboxError):
             sandbox.name = ""
         sandbox._lifecycle_client.update_sandbox.assert_not_called()
+
+    def test_sandbox_info_accepts_suspending_status(self):
+        info = _sandbox_info(status=SandboxStatus.SUSPENDING)
+        self.assertEqual(info.status, SandboxStatus.SUSPENDING)
 
     def test_health_maps_connection_error(self):
         class FakeRustError(Exception):

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -285,6 +285,31 @@ class TestSandboxRustBackend(unittest.TestCase):
         with self.assertRaises(SandboxError):
             sandbox.update(name="anything")
 
+    def test_name_setter_delegates_to_update(self):
+        sandbox, _ = _make_sandbox()
+        sandbox._cached_info = _sandbox_info(name="old-env")
+        sandbox._lifecycle_client = MagicMock()
+        sandbox._lifecycle_client.update_sandbox.return_value = Traced(
+            _TRACE_ID, _sandbox_info(name="new-env")
+        )
+
+        sandbox.name = "new-env"
+
+        sandbox._lifecycle_client.update_sandbox.assert_called_once_with(
+            "sbx-1",
+            name="new-env",
+            allow_unauthenticated_access=None,
+            exposed_ports=None,
+        )
+        self.assertEqual(sandbox.name, "new-env")
+
+    def test_name_setter_rejects_empty_string(self):
+        sandbox, _ = _make_sandbox()
+        sandbox._lifecycle_client = MagicMock()
+        with self.assertRaises(SandboxError):
+            sandbox.name = ""
+        sandbox._lifecycle_client.update_sandbox.assert_not_called()
+
     def test_health_maps_connection_error(self):
         class FakeRustError(Exception):
             pass

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -280,28 +280,6 @@ class TestSandboxRustBackend(unittest.TestCase):
         self.assertEqual(traced.name, "renamed")
         self.assertEqual(sandbox.name, "renamed")
 
-    def test_update_switches_identifier_to_stable_sandbox_id(self):
-        # Connect by name, then rename: subsequent lookups must use the
-        # stable id, not the now-stale old name.
-        sandbox = Sandbox(
-            identifier="old-name",
-            proxy_url="http://localhost:9443",
-            api_key="k",
-            _proxy_rust_client=_FakeRustProxyClient(),
-        )
-        sandbox._lifecycle_client = MagicMock()
-        sandbox._lifecycle_client.update_sandbox.return_value = Traced(
-            _TRACE_ID, _sandbox_info(name="renamed")
-        )
-        sandbox._lifecycle_client.get.return_value = Traced(
-            _TRACE_ID, _sandbox_info(name="renamed", status=SandboxStatus.RUNNING)
-        )
-
-        sandbox.update(name="renamed")
-        _ = sandbox.status
-
-        sandbox._lifecycle_client.get.assert_called_once_with("sbx-1")
-
     def test_update_raises_without_lifecycle_client(self):
         sandbox, _ = _make_sandbox()
         with self.assertRaises(SandboxError):

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -280,6 +280,28 @@ class TestSandboxRustBackend(unittest.TestCase):
         self.assertEqual(traced.name, "renamed")
         self.assertEqual(sandbox.name, "renamed")
 
+    def test_update_switches_identifier_to_stable_sandbox_id(self):
+        # Connect by name, then rename: subsequent lookups must use the
+        # stable id, not the now-stale old name.
+        sandbox = Sandbox(
+            identifier="old-name",
+            proxy_url="http://localhost:9443",
+            api_key="k",
+            _proxy_rust_client=_FakeRustProxyClient(),
+        )
+        sandbox._lifecycle_client = MagicMock()
+        sandbox._lifecycle_client.update_sandbox.return_value = Traced(
+            _TRACE_ID, _sandbox_info(name="renamed")
+        )
+        sandbox._lifecycle_client.get.return_value = Traced(
+            _TRACE_ID, _sandbox_info(name="renamed", status=SandboxStatus.RUNNING)
+        )
+
+        sandbox.update(name="renamed")
+        _ = sandbox.status
+
+        sandbox._lifecycle_client.get.assert_called_once_with("sbx-1")
+
     def test_update_raises_without_lifecycle_client(self):
         sandbox, _ = _make_sandbox()
         with self.assertRaises(SandboxError):

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.4.50",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.4.50",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -536,14 +536,19 @@ export class SandboxClient {
       result = await this.create(options);
     }
 
+    const finishConnect = (routingHint: string | undefined, name: string | null | undefined) => {
+      const sandbox = this.connect(result.sandboxId, options?.proxyUrl, routingHint);
+      sandbox._setOwner(this);
+      sandbox.traceId = result.traceId;
+      sandbox.name = name ?? options?.name ?? null;
+      return sandbox;
+    };
+
     // Fast path: the blocking create/claim response already carries Running status
     // and a short-lived routing hint. Use it immediately to skip an extra poll RTT
     // and let the proxy route the first request without a placement lookup.
     if (result.status === SandboxStatus.RUNNING) {
-      const sandbox = this.connect(result.sandboxId, options?.proxyUrl, result.routingHint);
-      sandbox._setOwner(this);
-      sandbox.traceId = result.traceId;
-      return sandbox;
+      return finishConnect(result.routingHint, result.name);
     }
 
     const deadline = Date.now() + startupTimeout * 1000;
@@ -551,10 +556,7 @@ export class SandboxClient {
     while (Date.now() < deadline) {
       const info = await this.get(result.sandboxId);
       if (info.status === SandboxStatus.RUNNING) {
-        const sandbox = this.connect(result.sandboxId, options?.proxyUrl, info.routingHint);
-        sandbox._setOwner(this);
-        sandbox.traceId = result.traceId;
-        return sandbox;
+        return finishConnect(info.routingHint, info.name);
       }
       if (info.status === SandboxStatus.TERMINATED) {
         throw new SandboxError(

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -540,7 +540,8 @@ export class SandboxClient {
       const sandbox = this.connect(result.sandboxId, options?.proxyUrl, routingHint);
       sandbox._setOwner(this);
       sandbox.traceId = result.traceId;
-      sandbox.name = name ?? requestedName;
+      sandbox._setLifecycleIdentifier(result.sandboxId);
+      sandbox._setName(name ?? requestedName);
       return sandbox;
     };
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -529,18 +529,18 @@ export class SandboxClient {
   ): Promise<Sandbox> {
     const startupTimeout = options?.startupTimeout ?? 60;
 
-    let result: Traced<CreateSandboxResponse>;
-    if (options?.poolId != null) {
-      result = await this.claim(options.poolId);
-    } else {
-      result = await this.create(options);
-    }
+    // claim() never sends options.name to the server, so only create() should fall
+    // back to it locally when the server response omits a name.
+    const result = options?.poolId != null
+      ? await this.claim(options.poolId)
+      : await this.create(options);
+    const requestedName = options?.poolId != null ? null : options?.name ?? null;
 
     const finishConnect = (routingHint: string | undefined, name: string | null | undefined) => {
       const sandbox = this.connect(result.sandboxId, options?.proxyUrl, routingHint);
       sandbox._setOwner(this);
       sandbox.traceId = result.traceId;
-      sandbox.name = name ?? options?.name ?? null;
+      sandbox.name = name ?? requestedName;
       return sandbox;
     };
 

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -94,6 +94,7 @@ export interface CreateSandboxResponse {
   sandboxId: string;
   status: SandboxStatus;
   routingHint?: string;
+  name?: string | null;
 }
 
 export interface SandboxInfo {

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -291,7 +291,7 @@ function sendPtyFrame(socket: WebSocket, frame: Buffer): Promise<void> {
  * through the sandbox proxy.
  */
 export class Sandbox {
-  readonly sandboxId: string;
+  sandboxId: string;
   name: string | null = null;
   traceId: string | null = null;
   private readonly http: HttpClient;
@@ -370,6 +370,7 @@ export class Sandbox {
     const info = await client.get(options.sandboxId); // throws SandboxNotFoundError if not found
     const sandbox = client.connect(options.sandboxId, options.proxyUrl, options.routingHint);
     sandbox.lifecycleClient = client;
+    sandbox.sandboxId = info.sandboxId;
     sandbox.name = info.name ?? null;
     return sandbox;
   }
@@ -429,6 +430,7 @@ export class Sandbox {
   async update(options: UpdateSandboxOptions): Promise<SandboxInfo> {
     const client = this.requireLifecycleClient("update");
     const info = await client.update(this.sandboxId, options);
+    this.sandboxId = info.sandboxId;
     this.name = info.name ?? null;
     return info;
   }

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -292,16 +292,18 @@ function sendPtyFrame(socket: WebSocket, frame: Buffer): Promise<void> {
  */
 export class Sandbox {
   readonly sandboxId: string;
-  name: string | null = null;
   traceId: string | null = null;
   private readonly http: HttpClient;
   private readonly baseUrl: string;
   private readonly wsHeaders: Record<string, string>;
   private ownsSandbox = false;
   private lifecycleClient: SandboxClient | null = null;
+  private lifecycleIdentifier: string;
+  private sandboxName: string | null = null;
 
   constructor(options: SandboxOptions) {
     this.sandboxId = options.sandboxId;
+    this.lifecycleIdentifier = options.sandboxId;
 
     const proxyUrl = options.proxyUrl ?? defaults.SANDBOX_PROXY_URL;
     const { baseUrl, hostHeader } = resolveProxyTarget(proxyUrl, options.sandboxId);
@@ -328,6 +330,20 @@ export class Sandbox {
       hostHeader,
       routingHint: options.routingHint,
     });
+  }
+
+  get name(): string | null {
+    return this.sandboxName;
+  }
+
+  /** @internal Used by client wiring to keep locally cached name in sync. */
+  _setName(name: string | null): void {
+    this.sandboxName = name;
+  }
+
+  /** @internal Used by lifecycle operations to pin to canonical sandbox ID. */
+  _setLifecycleIdentifier(identifier: string): void {
+    this.lifecycleIdentifier = identifier;
   }
 
   /** @internal Used by SandboxClient.createAndConnect to set ownership. */
@@ -368,9 +384,14 @@ export class Sandbox {
     const { SandboxClient } = await import("./client.js");
     const client = new SandboxClient(options, /* _internal */ true);
     const info = await client.get(options.sandboxId); // throws SandboxNotFoundError if not found
-    const sandbox = client.connect(options.sandboxId, options.proxyUrl, options.routingHint);
+    const sandbox = client.connect(
+      info.sandboxId,
+      options.proxyUrl,
+      options.routingHint ?? info.routingHint,
+    );
     sandbox.lifecycleClient = client;
-    sandbox.name = info.name ?? null;
+    sandbox._setLifecycleIdentifier(info.sandboxId);
+    sandbox._setName(info.name ?? null);
     return sandbox;
   }
 
@@ -416,7 +437,9 @@ export class Sandbox {
    */
   async status(): Promise<SandboxStatus> {
     const client = this.requireLifecycleClient("read_status");
-    const info = await client.get(this.sandboxId);
+    const info = await client.get(this.lifecycleIdentifier);
+    this._setLifecycleIdentifier(info.sandboxId);
+    this._setName(info.name ?? null);
     return info.status;
   }
 
@@ -428,8 +451,9 @@ export class Sandbox {
    */
   async update(options: UpdateSandboxOptions): Promise<SandboxInfo> {
     const client = this.requireLifecycleClient("update");
-    const info = await client.update(this.sandboxId, options);
-    this.name = info.name ?? null;
+    const info = await client.update(this.lifecycleIdentifier, options);
+    this._setLifecycleIdentifier(info.sandboxId);
+    this._setName(info.name ?? null);
     return info;
   }
 
@@ -441,7 +465,7 @@ export class Sandbox {
    */
   async suspend(options?: SuspendResumeOptions): Promise<void> {
     const client = this.requireLifecycleClient("suspend");
-    await client.suspend(this.sandboxId, options);
+    await client.suspend(this.lifecycleIdentifier, options);
   }
 
   /**
@@ -452,7 +476,7 @@ export class Sandbox {
    */
   async resume(options?: SuspendResumeOptions): Promise<void> {
     const client = this.requireLifecycleClient("resume");
-    await client.resume(this.sandboxId, options);
+    await client.resume(this.lifecycleIdentifier, options);
   }
 
   /**
@@ -466,10 +490,10 @@ export class Sandbox {
   async checkpoint(options?: CheckpointOptions): Promise<SnapshotInfo | undefined> {
     const client = this.requireLifecycleClient("checkpoint");
     if (options?.wait === false) {
-      await client.snapshot(this.sandboxId, { contentMode: options.contentMode });
+      await client.snapshot(this.lifecycleIdentifier, { contentMode: options.contentMode });
       return undefined;
     }
-    return client.snapshotAndWait(this.sandboxId, {
+    return client.snapshotAndWait(this.lifecycleIdentifier, {
       timeout: options?.timeout,
       pollInterval: options?.pollInterval,
       contentMode: options?.contentMode,
@@ -482,7 +506,7 @@ export class Sandbox {
   async listSnapshots(): Promise<Traced<SnapshotInfo[]>> {
     const client = this.requireLifecycleClient("listSnapshots");
     const all = await client.listSnapshots();
-    const filtered = all.filter((s) => s.sandboxId === this.sandboxId);
+    const filtered = all.filter((s) => s.sandboxId === this.lifecycleIdentifier);
     return Object.assign(filtered, { traceId: all.traceId });
   }
 
@@ -498,7 +522,7 @@ export class Sandbox {
     this.lifecycleClient = null;
     this.close();
     if (client) {
-      await client.delete(this.sandboxId);
+      await client.delete(this.lifecycleIdentifier);
     }
   }
 

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -23,6 +23,7 @@ import {
   type PtySessionInfo,
   type RunOptions,
   type SandboxClientOptions,
+  type SandboxInfo,
   type SandboxOptions,
   type SendSignalResponse,
   type SnapshotInfo,
@@ -31,6 +32,7 @@ import {
   SnapshotStatus,
   StdinMode,
   type SuspendResumeOptions,
+  type UpdateSandboxOptions,
   fromSnakeKeys,
 } from "./models.js";
 import {
@@ -290,6 +292,7 @@ function sendPtyFrame(socket: WebSocket, frame: Buffer): Promise<void> {
  */
 export class Sandbox {
   readonly sandboxId: string;
+  name: string | null = null;
   traceId: string | null = null;
   private readonly http: HttpClient;
   private readonly baseUrl: string;
@@ -364,9 +367,10 @@ export class Sandbox {
   ): Promise<Sandbox> {
     const { SandboxClient } = await import("./client.js");
     const client = new SandboxClient(options, /* _internal */ true);
-    await client.get(options.sandboxId); // throws SandboxNotFoundError if not found
+    const info = await client.get(options.sandboxId); // throws SandboxNotFoundError if not found
     const sandbox = client.connect(options.sandboxId, options.proxyUrl, options.routingHint);
     sandbox.lifecycleClient = client;
+    sandbox.name = info.name ?? null;
     return sandbox;
   }
 
@@ -402,6 +406,31 @@ export class Sandbox {
       );
     }
     return this.lifecycleClient;
+  }
+
+  /**
+   * Fetch the current sandbox status from the server.
+   *
+   * Always hits the network — the value is not cached locally because the
+   * status changes over the sandbox's lifecycle.
+   */
+  async status(): Promise<SandboxStatus> {
+    const client = this.requireLifecycleClient("read_status");
+    const info = await client.get(this.sandboxId);
+    return info.status;
+  }
+
+  /**
+   * Update this sandbox's properties (name, exposed ports, proxy auth).
+   *
+   * Naming an ephemeral sandbox makes it non-ephemeral and enables
+   * suspend/resume.
+   */
+  async update(options: UpdateSandboxOptions): Promise<SandboxInfo> {
+    const client = this.requireLifecycleClient("update");
+    const info = await client.update(this.sandboxId, options);
+    this.name = info.name ?? null;
+    return info;
   }
 
   /**

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -291,7 +291,7 @@ function sendPtyFrame(socket: WebSocket, frame: Buffer): Promise<void> {
  * through the sandbox proxy.
  */
 export class Sandbox {
-  sandboxId: string;
+  readonly sandboxId: string;
   name: string | null = null;
   traceId: string | null = null;
   private readonly http: HttpClient;
@@ -368,10 +368,7 @@ export class Sandbox {
     const { SandboxClient } = await import("./client.js");
     const client = new SandboxClient(options, /* _internal */ true);
     const info = await client.get(options.sandboxId); // throws SandboxNotFoundError if not found
-    // Bind the proxy client to the stable sandbox UUID, not the user-supplied
-    // name, so a subsequent `update({ name })` rename doesn't leave proxy
-    // traffic targeting a stale routing identity.
-    const sandbox = client.connect(info.sandboxId, options.proxyUrl, options.routingHint);
+    const sandbox = client.connect(options.sandboxId, options.proxyUrl, options.routingHint);
     sandbox.lifecycleClient = client;
     sandbox.name = info.name ?? null;
     return sandbox;
@@ -432,7 +429,6 @@ export class Sandbox {
   async update(options: UpdateSandboxOptions): Promise<SandboxInfo> {
     const client = this.requireLifecycleClient("update");
     const info = await client.update(this.sandboxId, options);
-    this.sandboxId = info.sandboxId;
     this.name = info.name ?? null;
     return info;
   }

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -368,9 +368,11 @@ export class Sandbox {
     const { SandboxClient } = await import("./client.js");
     const client = new SandboxClient(options, /* _internal */ true);
     const info = await client.get(options.sandboxId); // throws SandboxNotFoundError if not found
-    const sandbox = client.connect(options.sandboxId, options.proxyUrl, options.routingHint);
+    // Bind the proxy client to the stable sandbox UUID, not the user-supplied
+    // name, so a subsequent `update({ name })` rename doesn't leave proxy
+    // traffic targeting a stale routing identity.
+    const sandbox = client.connect(info.sandboxId, options.proxyUrl, options.routingHint);
     sandbox.lifecycleClient = client;
-    sandbox.sandboxId = info.sandboxId;
     sandbox.name = info.name ?? null;
     return sandbox;
   }

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as undici from "undici";
 import { Sandbox } from "../src/sandbox.js";
+import { SandboxClient } from "../src/client.js";
 import { ProcessStatus, SandboxStatus } from "../src/models.js";
 import { SandboxError } from "../src/errors.js";
 
@@ -345,6 +346,130 @@ describe("Sandbox", () => {
       const sbx = makeSandbox();
       await expect(sbx.update({ name: "x" })).rejects.toThrow(SandboxError);
       sbx.close();
+    });
+
+    it("lifecycle calls stay pinned to canonical sandbox ID after renaming a name-connected handle", async () => {
+      const calls: string[] = [];
+      mockFetch((url, init) => {
+        const method = init?.method ?? "GET";
+        calls.push(`${method} ${url}`);
+
+        if (method === "PATCH") {
+          expect(url).toContain("/sandboxes/sbx-1");
+          return new Response(
+            sandboxInfoBody({ id: "sbx-1", name: "renamed-by-handle" }),
+            { status: 200 },
+          );
+        }
+
+        if (url.includes("/sandboxes/sbx-1")) {
+          return new Response(
+            sandboxInfoBody({ id: "sbx-1", name: "renamed-by-handle", status: "running" }),
+            { status: 200 },
+          );
+        }
+
+        if (url.includes("/sandboxes/my-original-name")) {
+          return new Response(
+            sandboxInfoBody({ id: "sbx-1", name: "my-original-name", status: "running" }),
+            { status: 200 },
+          );
+        }
+
+        return new Response("", { status: 404 });
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "my-original-name",
+        apiUrl: "http://localhost:8900",
+      });
+      await sbx.update({ name: "renamed-by-handle" });
+      expect(await sbx.status()).toBe(SandboxStatus.RUNNING);
+      expect(sbx.name).toBe("renamed-by-handle");
+
+      const patchCalls = calls.filter((line) => line.startsWith("PATCH "));
+      expect(patchCalls).toHaveLength(1);
+      expect(patchCalls[0]).toContain("/sandboxes/sbx-1");
+      expect(calls.some((line) => line.includes("/sandboxes/my-original-name"))).toBe(true);
+      expect(calls.some((line) => line.includes("/sandboxes/sbx-1"))).toBe(true);
+      sbx.close();
+    });
+
+    it("checkpoint() uses canonical sandbox ID after renaming a SandboxClient.connect(name) handle", async () => {
+      const calls: string[] = [];
+      mockFetch((url, init) => {
+        const method = init?.method ?? "GET";
+        calls.push(`${method} ${url}`);
+
+        if (method === "PATCH") {
+          expect(url).toContain("/sandboxes/my-original-name");
+          return new Response(
+            sandboxInfoBody({ id: "sbx-1", name: "renamed-by-handle" }),
+            { status: 200 },
+          );
+        }
+
+        if (method === "POST") {
+          expect(url).toContain("/sandboxes/sbx-1/snapshot");
+          return new Response(
+            JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
+            { status: 200 },
+          );
+        }
+
+        return new Response("", { status: 404 });
+      });
+
+      const client = new SandboxClient({ apiUrl: "http://localhost:8900" }, true);
+      const sbx = client.connect("my-original-name");
+      sbx._setOwner(client);
+
+      await sbx.update({ name: "renamed-by-handle" });
+      await sbx.checkpoint({ wait: false });
+
+      expect(calls.some((line) => line.startsWith("POST ") && line.includes("/sandboxes/sbx-1/snapshot"))).toBe(true);
+      sbx.close();
+      client.close();
+    });
+
+    it("listSnapshots() filters by canonical sandbox ID after renaming a SandboxClient.connect(name) handle", async () => {
+      mockFetch((url, init) => {
+        const method = init?.method ?? "GET";
+
+        if (method === "PATCH") {
+          expect(url).toContain("/sandboxes/my-original-name");
+          return new Response(
+            sandboxInfoBody({ id: "sbx-1", name: "renamed-by-handle" }),
+            { status: 200 },
+          );
+        }
+
+        if (method === "GET" && url.includes("/snapshots")) {
+          return new Response(
+            JSON.stringify({
+              snapshots: [
+                { snapshot_id: "snap-1", sandbox_id: "sbx-1", status: "completed" },
+                { snapshot_id: "snap-2", sandbox_id: "other-sbx", status: "completed" },
+              ],
+            }),
+            { status: 200 },
+          );
+        }
+
+        return new Response("", { status: 404 });
+      });
+
+      const client = new SandboxClient({ apiUrl: "http://localhost:8900" }, true);
+      const sbx = client.connect("my-original-name");
+      sbx._setOwner(client);
+
+      await sbx.update({ name: "renamed-by-handle" });
+      const snaps = await sbx.listSnapshots();
+
+      expect(snaps).toHaveLength(1);
+      expect(snaps[0].snapshotId).toBe("snap-1");
+      sbx.close();
+      client.close();
     });
   });
 

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as undici from "undici";
 import { Sandbox } from "../src/sandbox.js";
-import { ProcessStatus } from "../src/models.js";
+import { ProcessStatus, SandboxStatus } from "../src/models.js";
+import { SandboxError } from "../src/errors.js";
 
 vi.mock("undici", async (importOriginal) => {
   const actual = await importOriginal<typeof import("undici")>();
@@ -242,6 +243,107 @@ describe("Sandbox", () => {
       expect(info.version).toBe("1.0.0");
       expect(info.uptimeSecs).toBe(3600);
       expect(info.runningProcesses).toBe(2);
+      sbx.close();
+    });
+  });
+
+  describe("name / status / update", () => {
+    function sandboxInfoBody(overrides: Record<string, unknown> = {}) {
+      return JSON.stringify({
+        id: "sbx-1",
+        namespace: "default",
+        status: "running",
+        resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
+        secret_names: [],
+        ...overrides,
+      });
+    }
+
+    it("connect() populates name from server info", async () => {
+      mockFetch(() =>
+        new Response(sandboxInfoBody({ name: "my-sandbox" }), { status: 200 }),
+      );
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-1",
+        apiUrl: "http://localhost:8900",
+      });
+      expect(sbx.name).toBe("my-sandbox");
+      sbx.close();
+    });
+
+    it("connect() leaves name null when server omits it", async () => {
+      mockFetch(() => new Response(sandboxInfoBody(), { status: 200 }));
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-1",
+        apiUrl: "http://localhost:8900",
+      });
+      expect(sbx.name).toBeNull();
+      sbx.close();
+    });
+
+    it("status() fetches fresh status from the server every call", async () => {
+      const responses = [
+        sandboxInfoBody({ status: "running" }), // initial GET inside Sandbox.connect()
+        sandboxInfoBody({ status: "running" }),
+        sandboxInfoBody({ status: "suspended" }),
+      ];
+      mockFetch(() => new Response(responses.shift()!, { status: 200 }));
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-1",
+        apiUrl: "http://localhost:8900",
+      });
+      expect(await sbx.status()).toBe(SandboxStatus.RUNNING);
+      expect(await sbx.status()).toBe(SandboxStatus.SUSPENDED);
+      sbx.close();
+    });
+
+    it("status() throws when no lifecycle client is wired", async () => {
+      const sbx = makeSandbox();
+      await expect(sbx.status()).rejects.toThrow(SandboxError);
+      sbx.close();
+    });
+
+    it("update() PATCHes the sandbox and refreshes the local name", async () => {
+      let patchBody: Record<string, unknown> | null = null;
+      let patchUrl = "";
+      mockFetch((url, init) => {
+        if (init?.method === "PATCH") {
+          patchUrl = url;
+          patchBody = JSON.parse(init.body as string);
+          return new Response(
+            sandboxInfoBody({ name: "renamed", exposed_ports: [8080] }),
+            { status: 200 },
+          );
+        }
+        // Initial GET from Sandbox.connect()
+        return new Response(sandboxInfoBody({ name: "old-name" }), {
+          status: 200,
+        });
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-1",
+        apiUrl: "http://localhost:8900",
+      });
+      expect(sbx.name).toBe("old-name");
+
+      const info = await sbx.update({ name: "renamed", exposedPorts: [8080] });
+
+      expect(patchUrl).toContain("/sandboxes/sbx-1");
+      expect(patchBody).not.toBeNull();
+      expect(patchBody!.name).toBe("renamed");
+      expect(patchBody!.exposed_ports).toEqual([8080]);
+      expect(info.name).toBe("renamed");
+      expect(sbx.name).toBe("renamed");
+      sbx.close();
+    });
+
+    it("update() throws when no lifecycle client is wired", async () => {
+      const sbx = makeSandbox();
+      await expect(sbx.update({ name: "x" })).rejects.toThrow(SandboxError);
       sbx.close();
     });
   });

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -341,36 +341,6 @@ describe("Sandbox", () => {
       sbx.close();
     });
 
-    it("update() switches sandboxId to the stable id so post-rename lookups work", async () => {
-      // Connect by name, rename via update, then call status. The status GET
-      // must target the stable id, not the now-stale name.
-      const getUrls: string[] = [];
-      mockFetch((url, init) => {
-        if (init?.method === "PATCH") {
-          return new Response(
-            sandboxInfoBody({ id: "sbx-stable", name: "renamed" }),
-            { status: 200 },
-          );
-        }
-        getUrls.push(url);
-        return new Response(sandboxInfoBody({ id: "sbx-stable", name: "old-name" }), {
-          status: 200,
-        });
-      });
-
-      const sbx = await Sandbox.connect({
-        sandboxId: "old-name",
-        apiUrl: "http://localhost:8900",
-      });
-      await sbx.update({ name: "renamed" });
-      await sbx.status();
-
-      // Initial connect GET hits "old-name"; status GET must hit "sbx-stable".
-      expect(getUrls[0]).toContain("/sandboxes/old-name");
-      expect(getUrls[1]).toContain("/sandboxes/sbx-stable");
-      sbx.close();
-    });
-
     it("update() throws when no lifecycle client is wired", async () => {
       const sbx = makeSandbox();
       await expect(sbx.update({ name: "x" })).rejects.toThrow(SandboxError);

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -341,6 +341,36 @@ describe("Sandbox", () => {
       sbx.close();
     });
 
+    it("update() switches sandboxId to the stable id so post-rename lookups work", async () => {
+      // Connect by name, rename via update, then call status. The status GET
+      // must target the stable id, not the now-stale name.
+      const getUrls: string[] = [];
+      mockFetch((url, init) => {
+        if (init?.method === "PATCH") {
+          return new Response(
+            sandboxInfoBody({ id: "sbx-stable", name: "renamed" }),
+            { status: 200 },
+          );
+        }
+        getUrls.push(url);
+        return new Response(sandboxInfoBody({ id: "sbx-stable", name: "old-name" }), {
+          status: 200,
+        });
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "old-name",
+        apiUrl: "http://localhost:8900",
+      });
+      await sbx.update({ name: "renamed" });
+      await sbx.status();
+
+      // Initial connect GET hits "old-name"; status GET must hit "sbx-stable".
+      expect(getUrls[0]).toContain("/sandboxes/old-name");
+      expect(getUrls[1]).toContain("/sandboxes/sbx-stable");
+      sbx.close();
+    });
+
     it("update() throws when no lifecycle client is wired", async () => {
       const sbx = makeSandbox();
       await expect(sbx.update({ name: "x" })).rejects.toThrow(SandboxError);


### PR DESCRIPTION
Right now all these are not working with Sandbox


  ## Summary                                                                            
  - Adds `Sandbox.name`, `Sandbox.status`, and `Sandbox.update(...)` to both Python and 
  TypeScript SDKs, mirroring the existing `tl sbx` CLI.                                 
  - `name` is settable: `sb.name = "my-env"` (Python) / `sb.name = "my-env"` (TS)       
  renames via `update()`. Works for both naming an unnamed (ephemeral) sandbox and
  renaming a named one.                                                                 
  - `status` always fetches fresh from the server.          
  - `update()` covers `name`, `allow_unauthenticated_access`, and `exposed_ports` in one
   call; refreshes the cached `SandboxInfo`.                                            
  - Fast-path in `create_and_connect` now caches `SandboxInfo` (id + status + name) so  
  the first `name`/`status` read doesn't need an extra GET.                             
  - `CreateSandboxResponse` (Rust + TS models) now carries `name`, so the create        
  response is the source of truth when caching. 