### PR TITLE
Register sandbox images with snapshot metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,6 +2812,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "shlex",
  "tempfile",
  "tensorlake-cloud-sdk",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ urlencoding = "2.1"
 sha2 = "0.10"
 hex = "0.4"
 base64 = "0.22"
+shlex = "1.3"
 
 # Docker
 bollard = "0.20"

--- a/contributing.md
+++ b/contributing.md
@@ -126,7 +126,7 @@ Wrapper scripts live in `tensorlake.data/scripts/` and are installed into the vi
 | `tl parse` | `tensorlake-parse` |
 | `tl generate-dockerfiles` | `tensorlake-generate-dockerfiles` |
 
-`tl sbx image create` is served by the TypeScript CLI (`typescript/bin/tensorlake-create-sandbox-image.cjs`) rather than a Python wrapper. Programmatic Python use is available via `tensorlake.image.Image.build()` / `tensorlake.image.sandbox_builder.build_sandbox_image()`.
+`tl sbx image create` is handled directly by the Rust CLI. Programmatic SDK image builds should go through the language-native `Image` DSL APIs rather than passing raw Dockerfile paths into the Python or TypeScript packages.
 
 ### Available Makefile Commands
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -47,6 +47,7 @@ base64 = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
+shlex = { workspace = true }
 rustpython-parser = "0.3"
 
 [dev-dependencies]

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -1,9 +1,62 @@
-use std::process::Stdio;
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
-use tokio::io::{AsyncBufReadExt, BufReader};
+use serde_json::{Map, Value};
+use shlex::split as shlex_split;
+use tensorlake_cloud_sdk::{
+    Client,
+    sandbox_templates::models::CreateSandboxTemplateRequest,
+    sandboxes::{
+        SandboxProxyClient, SandboxesClient,
+        models::{
+            CreateSandboxRequest, CreateSandboxResources, ProcessInfo, SnapshotContentMode,
+            SnapshotInfo,
+        },
+    },
+};
 
-use crate::auth::context::CliContext;
-use crate::error::{CliError, Result};
+use crate::{
+    auth::context::CliContext,
+    commands::sbx::{DEFAULT_SANDBOX_WAIT_TIMEOUT, sandbox_proxy_base, wait_for_sandbox_status},
+    error::{CliError, Result},
+};
+
+const BUILD_SANDBOX_PIP_ENV: &[(&str, &str)] = &[("PIP_BREAK_SYSTEM_PACKAGES", "1")];
+const DEFAULT_CPUS: f64 = 2.0;
+const DEFAULT_MEMORY_MB: i64 = 4096;
+const SNAPSHOT_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const SNAPSHOT_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(300);
+const PROCESS_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(200);
+const PROCESS_EXIT_POLL_ATTEMPTS: usize = 10;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DockerfileInstruction {
+    keyword: String,
+    value: String,
+    line_number: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DockerfileBuildPlan {
+    context_dir: PathBuf,
+    registered_name: String,
+    dockerfile_text: String,
+    base_image: String,
+    instructions: Vec<DockerfileInstruction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SnapshotRegistrationMetadata {
+    snapshot_id: String,
+    sandbox_id: String,
+    snapshot_uri: String,
+    snapshot_size_bytes: u64,
+    rootfs_disk_bytes: u64,
+}
 
 pub async fn run(
     ctx: &CliContext,
@@ -14,150 +67,1138 @@ pub async fn run(
     memory_mb: Option<i64>,
     is_public: bool,
 ) -> Result<()> {
-    let mut cmd = tokio::process::Command::new("tensorlake-create-sandbox-image");
-    cmd.arg(dockerfile_path);
+    eprintln!("⚙️  Loading Dockerfile...");
+    let plan = load_dockerfile_plan(dockerfile_path, registered_name)?;
+    eprintln!("⚙️  Selected image name: {}", plan.registered_name);
 
-    if let Some(name) = registered_name {
-        cmd.arg("--name").arg(name);
+    let client = super::scoped_cloud_client(ctx)?;
+    let sandboxes = SandboxesClient::new(client.clone(), ctx.namespace.clone(), is_localhost(ctx));
+    let templates = super::sandbox_templates_client(ctx)?;
+
+    let resources = CreateSandboxResources {
+        cpus: cpus.unwrap_or(DEFAULT_CPUS),
+        memory_mb: memory_mb.unwrap_or(DEFAULT_MEMORY_MB),
+        disk_mb: disk_gb
+            .map(|gib| {
+                gib.checked_mul(1024).ok_or_else(|| {
+                    CliError::usage("disk size is too large to express in MiB".to_string())
+                })
+            })
+            .transpose()?,
+    };
+
+    eprintln!("⚙️  Creating build sandbox...");
+    let created = sandboxes
+        .create(&CreateSandboxRequest {
+            image: Some(plan.base_image.clone()),
+            resources,
+            secret_names: None,
+            timeout_secs: None,
+            entrypoint: None,
+            network: None,
+            snapshot_id: None,
+            name: None,
+        })
+        .await?;
+    let sandbox_id = created.sandbox_id.clone();
+    let routing_hint = created.routing_hint.clone();
+
+    let result = async {
+        wait_for_sandbox_status(
+            ctx,
+            &sandbox_id,
+            &format!("Waiting for build sandbox {sandbox_id}"),
+            "running",
+            DEFAULT_SANDBOX_WAIT_TIMEOUT,
+        )
+        .await?;
+        eprintln!("⚙️  Build sandbox {sandbox_id} is running");
+
+        let proxy = sandbox_proxy_client(ctx, &client, &sandbox_id, routing_hint)?;
+        execute_dockerfile_plan(&proxy, &plan).await?;
+
+        eprintln!("⚙️  Creating snapshot...");
+        let snapshot = create_snapshot_and_wait(&sandboxes, &sandbox_id).await?;
+        eprintln!("📸 Snapshot created: {}", snapshot.snapshot_id);
+
+        eprintln!("⚙️  Registering image '{}'...", plan.registered_name);
+        let registered = templates
+            .create(&CreateSandboxTemplateRequest {
+                name: plan.registered_name.clone(),
+                dockerfile: plan.dockerfile_text.clone(),
+                snapshot_id: snapshot.snapshot_id.clone(),
+                snapshot_sandbox_id: snapshot.sandbox_id.clone(),
+                snapshot_uri: snapshot.snapshot_uri.clone(),
+                snapshot_size_bytes: snapshot.snapshot_size_bytes,
+                rootfs_disk_bytes: snapshot.rootfs_disk_bytes,
+                public: is_public,
+            })
+            .await?;
+
+        let template_id = registered.id.as_deref().unwrap_or("-");
+        eprintln!(
+            "✅ Image '{}' registered ({})",
+            plan.registered_name, template_id
+        );
+        Ok(())
     }
-    if let Some(disk_gb) = disk_gb {
-        cmd.arg("--disk").arg(disk_gb.to_string());
-    }
-    if let Some(cpus) = cpus {
-        cmd.arg("--cpus").arg(cpus.to_string());
-    }
-    if let Some(memory_mb) = memory_mb {
-        cmd.arg("--memory").arg(memory_mb.to_string());
-    }
-    if is_public {
-        cmd.arg("--public");
+    .await;
+
+    if let Err(error) = sandboxes.delete(&sandbox_id).await {
+        eprintln!(
+            "⚠️  Failed to terminate build sandbox {} during cleanup: {}",
+            sandbox_id, error
+        );
     }
 
-    cmd.env("TENSORLAKE_API_URL", &ctx.api_url);
-    if let Some(key) = &ctx.api_key {
-        cmd.env("TENSORLAKE_API_KEY", key);
-    }
-    if let Some(pat) = &ctx.personal_access_token {
-        cmd.env("TENSORLAKE_PAT", pat);
-    }
-    if let Some(org_id) = ctx.effective_organization_id() {
-        cmd.env("TENSORLAKE_ORGANIZATION_ID", &org_id);
-    }
-    if let Some(proj_id) = ctx.effective_project_id() {
-        cmd.env("TENSORLAKE_PROJECT_ID", &proj_id);
-    }
-    cmd.env("INDEXIFY_NAMESPACE", &ctx.namespace);
-    if ctx.debug {
-        cmd.env("TENSORLAKE_DEBUG", "1");
-    }
+    result
+}
 
-    cmd.stdin(Stdio::inherit())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit());
+fn sandbox_proxy_client(
+    ctx: &CliContext,
+    client: &Client,
+    sandbox_id: &str,
+    routing_hint: Option<String>,
+) -> Result<SandboxProxyClient> {
+    let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
+    Ok(
+        SandboxProxyClient::new(client.with_base_url(&proxy_base), host_override)
+            .with_routing_hint(routing_hint),
+    )
+}
 
-    let mut child = cmd.spawn().map_err(|e: std::io::Error| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            CliError::usage(
-                "'tensorlake-create-sandbox-image' not found on PATH. \
-                 Install the Python tensorlake package: pip install tensorlake",
-            )
-        } else {
-            CliError::Io(e)
+async fn create_snapshot_and_wait(
+    sandboxes: &SandboxesClient,
+    sandbox_id: &str,
+) -> Result<SnapshotRegistrationMetadata> {
+    let snapshot = sandboxes
+        .snapshot(sandbox_id, Some(SnapshotContentMode::FilesystemOnly))
+        .await?;
+    let snapshot_id = snapshot.snapshot_id.clone();
+
+    wait_for_snapshot(&snapshot_id, SNAPSHOT_WAIT_TIMEOUT, || {
+        let snapshot_id = snapshot_id.clone();
+        async move {
+            sandboxes
+                .get_snapshot(&snapshot_id)
+                .await
+                .map(|snapshot| snapshot.into_inner())
+                .map_err(Into::into)
         }
-    })?;
+    })
+    .await
+}
 
-    let stdout = child.stdout.take().expect("stdout was piped");
-    let reader = BufReader::new(stdout);
-    let mut lines = reader.lines();
-    let mut ctrl_c = Box::pin(tokio::signal::ctrl_c());
+async fn wait_for_snapshot<F, Fut>(
+    snapshot_id: &str,
+    timeout: Duration,
+    mut fetch_snapshot: F,
+) -> Result<SnapshotRegistrationMetadata>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<SnapshotInfo>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
 
     loop {
-        let maybe_line = tokio::select! {
-            line_result = lines.next_line() => line_result,
-            _ = &mut ctrl_c => {
-                terminate_child(&mut child).await?;
-                return Err(CliError::Cancelled);
-            }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(CliError::Other(anyhow::anyhow!(
+                "snapshot {} did not complete within {}s",
+                snapshot_id,
+                timeout.as_secs()
+            )));
         }
-        .map_err(CliError::Io)?;
 
-        let Some(line) = maybe_line else {
-            break;
-        };
-
-        let Ok(event) = serde_json::from_str::<serde_json::Value>(&line) else {
-            eprintln!("{}", line);
-            continue;
-        };
-
-        let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
-
-        match event_type {
-            "status" => {
-                let message = event.get("message").and_then(|v| v.as_str()).unwrap_or("");
-                eprintln!("⚙️  {}", message);
-            }
-            "build_log" => {
-                let message = event.get("message").and_then(|v| v.as_str()).unwrap_or("");
-                if !message.is_empty() {
-                    eprintln!("{}", message);
-                }
-            }
-            "warning" => {
-                let message = event.get("message").and_then(|v| v.as_str()).unwrap_or("");
-                eprintln!("⚠️  {}", message);
-            }
-            "snapshot_created" => {
-                let snapshot_id = event
-                    .get("snapshot_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                eprintln!("📸 Snapshot created: {}", snapshot_id);
-            }
-            "image_registered" => {
-                let name = event.get("name").and_then(|v| v.as_str()).unwrap_or("");
-                let image_id = event.get("image_id").and_then(|v| v.as_str()).unwrap_or("");
-                eprintln!("✅ Image '{}' registered ({})", name, image_id);
-            }
-            "done" => {}
-            "error" => {
-                let message = event
-                    .get("message")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown error");
-                eprintln!("Error: {}", message);
-                if let Some(details) = event.get("details").and_then(|v| v.as_str())
-                    && !details.is_empty()
-                {
-                    eprintln!("{}", details);
-                }
-                if let Some(traceback) = event.get("traceback").and_then(|v| v.as_str())
-                    && !traceback.is_empty()
-                {
-                    eprintln!("\nPython traceback:\n{}", traceback);
-                }
+        let info = fetch_snapshot().await?;
+        match info.status.as_str() {
+            "completed" => return parse_completed_snapshot(&info),
+            "failed" => {
+                let error = info.error.as_deref().unwrap_or("unknown error");
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "snapshot {} failed: {}",
+                    snapshot_id,
+                    error
+                )));
             }
             _ => {
-                eprintln!("{}", line);
+                tokio::time::sleep(SNAPSHOT_POLL_INTERVAL).await;
             }
         }
     }
+}
 
-    let status = child.wait().await.map_err(CliError::Io)?;
-    if !status.success() {
-        let code = status.code().unwrap_or(1);
-        return Err(CliError::ExitCode(code));
+fn parse_completed_snapshot(info: &SnapshotInfo) -> Result<SnapshotRegistrationMetadata> {
+    let snapshot_uri = info.snapshot_uri.clone().ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!(
+            "snapshot {} completed without snapshot_uri",
+            info.snapshot_id
+        ))
+    })?;
+    let snapshot_size_bytes = info
+        .size_bytes
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "snapshot {} completed without size_bytes",
+                info.snapshot_id
+            ))
+        })?
+        .try_into()
+        .map_err(|_| {
+            CliError::Other(anyhow::anyhow!(
+                "snapshot {} reported a negative size_bytes",
+                info.snapshot_id
+            ))
+        })?;
+    let rootfs_disk_bytes = info.rootfs_disk_bytes.ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!(
+            "snapshot {} completed without rootfs_disk_bytes",
+            info.snapshot_id
+        ))
+    })?;
+
+    Ok(SnapshotRegistrationMetadata {
+        snapshot_id: info.snapshot_id.clone(),
+        sandbox_id: info.sandbox_id.clone(),
+        snapshot_uri,
+        snapshot_size_bytes,
+        rootfs_disk_bytes,
+    })
+}
+
+async fn execute_dockerfile_plan(
+    proxy: &SandboxProxyClient,
+    plan: &DockerfileBuildPlan,
+) -> Result<()> {
+    let mut process_env = BUILD_SANDBOX_PIP_ENV
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect::<Vec<(String, String)>>();
+    let mut working_dir = "/".to_string();
+
+    for instruction in &plan.instructions {
+        match instruction.keyword.as_str() {
+            "RUN" => {
+                eprintln!("⚙️  RUN {}", instruction.value);
+                run_streaming_process(
+                    proxy,
+                    "sh",
+                    vec!["-c".to_string(), instruction.value.clone()],
+                    Some(build_env_map(&process_env)),
+                    Some(working_dir.clone()),
+                )
+                .await?;
+            }
+            "WORKDIR" => {
+                let tokens = shlex_split(&instruction.value).ok_or_else(|| {
+                    CliError::Other(anyhow::anyhow!(
+                        "line {}: invalid WORKDIR syntax",
+                        instruction.line_number
+                    ))
+                })?;
+                if tokens.len() != 1 {
+                    return Err(CliError::Other(anyhow::anyhow!(
+                        "line {}: WORKDIR must include exactly one path",
+                        instruction.line_number
+                    )));
+                }
+                working_dir = resolve_container_path(&tokens[0], &working_dir);
+                eprintln!("⚙️  WORKDIR {}", working_dir);
+                run_streaming_process(
+                    proxy,
+                    "mkdir",
+                    vec!["-p".to_string(), working_dir.clone()],
+                    Some(build_env_map(&process_env)),
+                    None,
+                )
+                .await?;
+            }
+            "ENV" => {
+                for (key, value) in parse_env_pairs(&instruction.value, instruction.line_number)? {
+                    eprintln!("⚙️  ENV {}={}", key, value);
+                    process_env.push((key.clone(), value.clone()));
+                    persist_env_var(proxy, &process_env, &key, &value).await?;
+                }
+            }
+            "COPY" => {
+                let (_, sources, destination) = parse_copy_like_values(
+                    &instruction.value,
+                    instruction.line_number,
+                    &instruction.keyword,
+                )?;
+                copy_from_context(
+                    proxy,
+                    &plan.context_dir,
+                    &sources,
+                    &destination,
+                    &working_dir,
+                    &instruction.keyword,
+                    &process_env,
+                )
+                .await?;
+            }
+            "ADD" => {
+                let (_, sources, destination) = parse_copy_like_values(
+                    &instruction.value,
+                    instruction.line_number,
+                    &instruction.keyword,
+                )?;
+                if sources.len() == 1 && is_http_source(&sources[0]) {
+                    add_url_to_sandbox(
+                        proxy,
+                        &sources[0],
+                        &destination,
+                        &working_dir,
+                        &process_env,
+                    )
+                    .await?;
+                } else {
+                    copy_from_context(
+                        proxy,
+                        &plan.context_dir,
+                        &sources,
+                        &destination,
+                        &working_dir,
+                        &instruction.keyword,
+                        &process_env,
+                    )
+                    .await?;
+                }
+            }
+            "CMD" | "ENTRYPOINT" | "EXPOSE" | "HEALTHCHECK" | "LABEL" | "STOPSIGNAL" | "VOLUME" => {
+                eprintln!(
+                    "⚠️  Skipping Dockerfile instruction '{}' during snapshot materialization. It is still preserved in the registered Dockerfile.",
+                    instruction.keyword
+                );
+            }
+            other => {
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "line {}: Dockerfile instruction '{}' is not supported for sandbox image creation",
+                    instruction.line_number,
+                    other
+                )));
+            }
+        }
     }
 
     Ok(())
 }
 
-async fn terminate_child(child: &mut tokio::process::Child) -> Result<()> {
-    match child.start_kill() {
-        Ok(()) => {}
-        Err(err) if err.kind() == std::io::ErrorKind::InvalidInput => {}
-        Err(err) => return Err(CliError::Io(err)),
+async fn run_streaming_process(
+    proxy: &SandboxProxyClient,
+    command: &str,
+    args: Vec<String>,
+    env: Option<Map<String, Value>>,
+    working_dir: Option<String>,
+) -> Result<()> {
+    let mut payload = Map::new();
+    payload.insert("command".to_string(), Value::String(command.to_string()));
+    payload.insert(
+        "args".to_string(),
+        Value::Array(args.into_iter().map(Value::String).collect()),
+    );
+    if let Some(env) = env {
+        payload.insert("env".to_string(), Value::Object(env));
     }
-    let _ = child.wait().await;
+    if let Some(working_dir) = working_dir {
+        payload.insert("working_dir".to_string(), Value::String(working_dir));
+    }
+
+    let started = proxy.start_process(&Value::Object(payload)).await?;
+    let pid = started.pid;
+    let mut stdout_seen = 0usize;
+    let mut stderr_seen = 0usize;
+    let mut info: ProcessInfo;
+
+    loop {
+        let stdout = proxy.get_stdout(pid).await?;
+        for line in stdout.lines.iter().skip(stdout_seen) {
+            eprintln!("{}", line);
+        }
+        stdout_seen = stdout.lines.len();
+
+        let stderr = proxy.get_stderr(pid).await?;
+        for line in stderr.lines.iter().skip(stderr_seen) {
+            eprintln!("{}", line);
+        }
+        stderr_seen = stderr.lines.len();
+
+        info = proxy.get_process(pid).await?.into_inner();
+        if info.status != "running" {
+            break;
+        }
+
+        tokio::time::sleep(PROCESS_POLL_INTERVAL).await;
+    }
+
+    for _ in 0..PROCESS_EXIT_POLL_ATTEMPTS {
+        if info.exit_code.is_some() || info.signal.is_some() {
+            break;
+        }
+        tokio::time::sleep(PROCESS_EXIT_POLL_INTERVAL).await;
+        info = proxy.get_process(pid).await?.into_inner();
+    }
+
+    let exit_code = if let Some(code) = info.exit_code {
+        code
+    } else if let Some(signal) = info.signal {
+        -signal
+    } else {
+        0
+    };
+
+    if exit_code != 0 {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "Command '{}' failed with exit code {}",
+            command,
+            exit_code
+        )));
+    }
+
     Ok(())
+}
+
+async fn persist_env_var(
+    proxy: &SandboxProxyClient,
+    process_env: &[(String, String)],
+    key: &str,
+    value: &str,
+) -> Result<()> {
+    let escaped_value = value.replace('\\', "\\\\").replace('"', "\\\"");
+    let export_line = format!("export {key}=\"{escaped_value}\"");
+    run_streaming_process(
+        proxy,
+        "sh",
+        vec![
+            "-c".to_string(),
+            format!(
+                "printf '%s\\n' {} >> /etc/environment",
+                shell_quote(&export_line)
+            ),
+        ],
+        Some(build_env_map(process_env)),
+        None,
+    )
+    .await
+}
+
+async fn copy_from_context(
+    proxy: &SandboxProxyClient,
+    context_dir: &Path,
+    sources: &[String],
+    destination: &str,
+    working_dir: &str,
+    keyword: &str,
+    process_env: &[(String, String)],
+) -> Result<()> {
+    let destination_path = resolve_container_path(destination, working_dir);
+    if sources.len() > 1 && !destination_path.ends_with('/') {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "{} with multiple sources requires a directory destination ending in '/'",
+            keyword
+        )));
+    }
+
+    for source in sources {
+        let local_source = resolve_context_source_path(context_dir, source)?;
+        let remote_destination = if sources.len() > 1 {
+            join_posix(
+                destination_path.trim_end_matches('/'),
+                file_name_string(Path::new(source))?.as_str(),
+            )
+        } else if local_source.is_file() && destination_path.ends_with('/') {
+            join_posix(
+                destination_path.trim_end_matches('/'),
+                file_name_string(Path::new(source))?.as_str(),
+            )
+        } else {
+            destination_path.clone()
+        };
+
+        eprintln!("⚙️  {} {} -> {}", keyword, source, remote_destination);
+        copy_local_path(proxy, &local_source, &remote_destination, process_env).await?;
+    }
+
+    Ok(())
+}
+
+async fn add_url_to_sandbox(
+    proxy: &SandboxProxyClient,
+    url: &str,
+    destination: &str,
+    working_dir: &str,
+    process_env: &[(String, String)],
+) -> Result<()> {
+    let mut destination_path = resolve_container_path(destination, working_dir);
+    let parsed = url::Url::parse(url).map_err(|error| {
+        CliError::Other(anyhow::anyhow!("invalid ADD URL '{}': {}", url, error))
+    })?;
+    let file_name = parsed
+        .path_segments()
+        .and_then(|segments| segments.filter(|segment| !segment.is_empty()).next_back())
+        .unwrap_or("downloaded");
+    if destination_path.ends_with('/') {
+        destination_path = join_posix(destination_path.trim_end_matches('/'), file_name);
+    }
+    let parent_dir = parent_posix(&destination_path);
+
+    eprintln!("⚙️  ADD {} -> {}", url, destination_path);
+    run_streaming_process(
+        proxy,
+        "mkdir",
+        vec!["-p".to_string(), parent_dir.clone()],
+        Some(build_env_map(process_env)),
+        None,
+    )
+    .await?;
+    run_streaming_process(
+        proxy,
+        "sh",
+        vec![
+            "-c".to_string(),
+            format!(
+                "curl -fsSL --location {} -o {}",
+                shell_quote(url),
+                shell_quote(&destination_path)
+            ),
+        ],
+        Some(build_env_map(process_env)),
+        Some(working_dir.to_string()),
+    )
+    .await
+}
+
+async fn copy_local_path(
+    proxy: &SandboxProxyClient,
+    local_path: &Path,
+    remote_path: &str,
+    process_env: &[(String, String)],
+) -> Result<()> {
+    if local_path.is_file() {
+        ensure_remote_parent_dir(proxy, remote_path, process_env).await?;
+        let content = tokio::fs::read(local_path).await.map_err(CliError::Io)?;
+        proxy.write_file(remote_path, content).await?;
+        return Ok(());
+    }
+
+    if local_path.is_dir() {
+        for (full_path, relative_path) in collect_dir_files(local_path, local_path)? {
+            let remote_destination = join_posix(remote_path, &relative_path);
+            ensure_remote_parent_dir(proxy, &remote_destination, process_env).await?;
+            let content = tokio::fs::read(&full_path).await.map_err(CliError::Io)?;
+            proxy.write_file(&remote_destination, content).await?;
+        }
+        return Ok(());
+    }
+
+    Err(CliError::Other(anyhow::anyhow!(
+        "Local path not found: {}",
+        local_path.display()
+    )))
+}
+
+async fn ensure_remote_parent_dir(
+    proxy: &SandboxProxyClient,
+    remote_path: &str,
+    process_env: &[(String, String)],
+) -> Result<()> {
+    let parent_dir = parent_posix(remote_path);
+    run_streaming_process(
+        proxy,
+        "mkdir",
+        vec!["-p".to_string(), parent_dir],
+        Some(build_env_map(process_env)),
+        None,
+    )
+    .await
+}
+
+fn resolve_context_source_path(context_dir: &Path, source: &str) -> Result<PathBuf> {
+    let resolved_context_dir = std::fs::canonicalize(context_dir).map_err(CliError::Io)?;
+    let candidate = if Path::new(source).is_absolute() {
+        PathBuf::from(source)
+    } else {
+        resolved_context_dir.join(source)
+    };
+    let resolved_source = std::fs::canonicalize(&candidate).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            CliError::Other(anyhow::anyhow!(
+                "Local path not found: {}",
+                candidate.display()
+            ))
+        } else {
+            CliError::Io(error)
+        }
+    })?;
+
+    if !resolved_source.starts_with(&resolved_context_dir) {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "Local path escapes the build context: {}",
+            source
+        )));
+    }
+
+    Ok(resolved_source)
+}
+
+fn build_env_map(env: &[(String, String)]) -> Map<String, Value> {
+    env.iter()
+        .map(|(key, value)| (key.clone(), Value::String(value.clone())))
+        .collect()
+}
+
+fn is_localhost(ctx: &CliContext) -> bool {
+    if let Ok(parsed) = url::Url::parse(&ctx.api_url) {
+        return matches!(parsed.host_str(), Some("localhost" | "127.0.0.1"));
+    }
+    false
+}
+
+fn load_dockerfile_plan(
+    dockerfile_path: &str,
+    registered_name: Option<&str>,
+) -> Result<DockerfileBuildPlan> {
+    let path = Path::new(dockerfile_path);
+    let absolute_path = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().map_err(CliError::Io)?.join(path)
+    };
+    if !absolute_path.is_file() {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "Dockerfile not found: {}",
+            dockerfile_path
+        )));
+    }
+
+    let dockerfile_text = std::fs::read_to_string(&absolute_path).map_err(CliError::Io)?;
+    let mut base_image: Option<String> = None;
+    let mut instructions = Vec::new();
+
+    for (line_number, line) in logical_dockerfile_lines(&dockerfile_text) {
+        let (keyword, value) = split_instruction(&line, line_number)?;
+        if keyword == "FROM" {
+            if base_image.is_some() {
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "line {}: multi-stage Dockerfiles are not supported for sandbox image creation",
+                    line_number
+                )));
+            }
+            base_image = Some(parse_from_value(&value, line_number)?);
+            continue;
+        }
+
+        if matches!(keyword.as_str(), "ARG" | "ONBUILD" | "SHELL" | "USER") {
+            return Err(CliError::Other(anyhow::anyhow!(
+                "line {}: Dockerfile instruction '{}' is not supported for sandbox image creation",
+                line_number,
+                keyword
+            )));
+        }
+
+        instructions.push(DockerfileInstruction {
+            keyword,
+            value,
+            line_number,
+        });
+    }
+
+    let base_image = base_image.ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!(
+            "Dockerfile must contain a FROM instruction"
+        ))
+    })?;
+
+    Ok(DockerfileBuildPlan {
+        context_dir: absolute_path
+            .parent()
+            .unwrap_or(Path::new("."))
+            .to_path_buf(),
+        registered_name: registered_name
+            .map(str::to_string)
+            .unwrap_or_else(|| default_registered_name(&absolute_path)),
+        dockerfile_text,
+        base_image,
+        instructions,
+    })
+}
+
+fn default_registered_name(dockerfile_path: &Path) -> String {
+    let stem = dockerfile_path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    if stem.eq_ignore_ascii_case("dockerfile") {
+        return dockerfile_path
+            .parent()
+            .and_then(|value| value.file_name())
+            .and_then(|value| value.to_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("sandbox-image")
+            .to_string();
+    }
+    if stem.is_empty() {
+        "sandbox-image".to_string()
+    } else {
+        stem.to_string()
+    }
+}
+
+fn logical_dockerfile_lines(dockerfile_text: &str) -> Vec<(usize, String)> {
+    let mut logical_lines = Vec::new();
+    let mut parts = Vec::new();
+    let mut start_line = None;
+
+    for (index, raw_line) in dockerfile_text.lines().enumerate() {
+        let line_number = index + 1;
+        let stripped = raw_line.trim();
+        if parts.is_empty() && (stripped.is_empty() || stripped.starts_with('#')) {
+            continue;
+        }
+
+        if start_line.is_none() {
+            start_line = Some(line_number);
+        }
+
+        let mut line = raw_line.trim_end().to_string();
+        let continued = line.ends_with('\\');
+        if continued {
+            line.pop();
+        }
+
+        let normalized = line.trim();
+        if !normalized.is_empty() && !normalized.starts_with('#') {
+            parts.push(normalized.to_string());
+        }
+
+        if continued {
+            continue;
+        }
+
+        if !parts.is_empty() {
+            logical_lines.push((start_line.unwrap_or(1), parts.join(" ")));
+        }
+        parts.clear();
+        start_line = None;
+    }
+
+    if !parts.is_empty() {
+        logical_lines.push((start_line.unwrap_or(1), parts.join(" ")));
+    }
+
+    logical_lines
+}
+
+fn split_instruction(line: &str, line_number: usize) -> Result<(String, String)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "line {}: empty Dockerfile instruction",
+            line_number
+        )));
+    }
+    if let Some(index) = trimmed.find(char::is_whitespace) {
+        let keyword = trimmed[..index].to_ascii_uppercase();
+        let value = trimmed[index..].trim().to_string();
+        Ok((keyword, value))
+    } else {
+        Ok((trimmed.to_ascii_uppercase(), String::new()))
+    }
+}
+
+fn parse_from_value(value: &str, line_number: usize) -> Result<String> {
+    let (_, remainder) = strip_leading_flags(value)?;
+    let tokens = shlex_split(&remainder).ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!(
+            "line {}: invalid FROM syntax '{}'",
+            line_number,
+            value
+        ))
+    })?;
+    if tokens.is_empty() {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "line {}: FROM must include a base image",
+            line_number
+        )));
+    }
+    if tokens.len() > 1 && !tokens[1].eq_ignore_ascii_case("as") {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "line {}: unsupported FROM syntax '{}'",
+            line_number,
+            value
+        )));
+    }
+    Ok(tokens[0].clone())
+}
+
+fn strip_leading_flags(value: &str) -> Result<(Vec<(String, String)>, String)> {
+    let mut flags = Vec::new();
+    let mut remaining = value.trim_start().to_string();
+
+    while remaining.starts_with("--") {
+        let (token, rest) = match remaining.split_once(' ') {
+            Some((token, rest)) => (token.to_string(), rest.trim_start().to_string()),
+            None => {
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "invalid Dockerfile flag syntax: {}",
+                    value
+                )));
+            }
+        };
+
+        let flag_body = &token[2..];
+        if let Some((key, flag_value)) = flag_body.split_once('=') {
+            flags.push((key.to_string(), flag_value.to_string()));
+            remaining = rest;
+        } else if let Some((flag_value, tail)) = rest.split_once(' ') {
+            flags.push((flag_body.to_string(), flag_value.to_string()));
+            remaining = tail.trim_start().to_string();
+        } else {
+            return Err(CliError::Other(anyhow::anyhow!(
+                "missing value for Dockerfile flag '{}'",
+                token
+            )));
+        }
+    }
+
+    Ok((flags, remaining))
+}
+
+fn parse_copy_like_values(
+    value: &str,
+    line_number: usize,
+    keyword: &str,
+) -> Result<(Vec<(String, String)>, Vec<String>, String)> {
+    let (flags, payload) = strip_leading_flags(value)?;
+    if flags.iter().any(|(key, _)| key == "from") {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "line {}: {} --from is not supported for sandbox image creation",
+            line_number,
+            keyword
+        )));
+    }
+    let payload = payload.trim();
+    if payload.is_empty() {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "line {}: {} must include source and destination",
+            line_number,
+            keyword
+        )));
+    }
+
+    let parts = if payload.starts_with('[') {
+        let items: Vec<String> = serde_json::from_str(payload).map_err(|error| {
+            CliError::Other(anyhow::anyhow!(
+                "line {}: invalid JSON array syntax for {}: {}",
+                line_number,
+                keyword,
+                error
+            ))
+        })?;
+        if items.len() < 2 {
+            return Err(CliError::Other(anyhow::anyhow!(
+                "line {}: {} JSON array form requires at least two string values",
+                line_number,
+                keyword
+            )));
+        }
+        items
+    } else {
+        let parts = shlex_split(payload).ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "line {}: invalid {} syntax",
+                line_number,
+                keyword
+            ))
+        })?;
+        if parts.len() < 2 {
+            return Err(CliError::Other(anyhow::anyhow!(
+                "line {}: {} must include at least one source and one destination",
+                line_number,
+                keyword
+            )));
+        }
+        parts
+    };
+
+    let (destination, sources) = parts.split_last().unwrap();
+    Ok((flags, sources.to_vec(), destination.clone()))
+}
+
+fn parse_env_pairs(value: &str, line_number: usize) -> Result<Vec<(String, String)>> {
+    let tokens = shlex_split(value).ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!(
+            "line {}: invalid ENV syntax '{}'",
+            line_number,
+            value
+        ))
+    })?;
+    if tokens.is_empty() {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "line {}: ENV must include a key and value",
+            line_number
+        )));
+    }
+
+    if tokens.iter().all(|token| token.contains('=')) {
+        return tokens
+            .into_iter()
+            .map(|token| {
+                let (key, env_value) = token.split_once('=').ok_or_else(|| {
+                    CliError::Other(anyhow::anyhow!(
+                        "line {}: invalid ENV token '{}'",
+                        line_number,
+                        token
+                    ))
+                })?;
+                if key.is_empty() {
+                    return Err(CliError::Other(anyhow::anyhow!(
+                        "line {}: invalid ENV token '{}'",
+                        line_number,
+                        token
+                    )));
+                }
+                Ok((key.to_string(), env_value.to_string()))
+            })
+            .collect();
+    }
+
+    if tokens.len() < 2 {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "line {}: ENV must include a key and value",
+            line_number
+        )));
+    }
+
+    Ok(vec![(tokens[0].clone(), tokens[1..].join(" "))])
+}
+
+fn resolve_container_path(path: &str, working_dir: &str) -> String {
+    if path.is_empty() {
+        return working_dir.to_string();
+    }
+    let preserve_trailing_slash = path.ends_with('/');
+    let raw = if path.starts_with('/') {
+        path.to_string()
+    } else if working_dir == "/" {
+        format!("/{}", path)
+    } else {
+        format!("{}/{}", working_dir.trim_end_matches('/'), path)
+    };
+
+    let normalized = normalize_posix(&raw);
+    if preserve_trailing_slash && normalized != "/" {
+        format!("{}/", normalized.trim_end_matches('/'))
+    } else {
+        normalized
+    }
+}
+
+fn normalize_posix(path: &str) -> String {
+    let mut parts = Vec::new();
+    for segment in path.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                parts.pop();
+            }
+            other => parts.push(other),
+        }
+    }
+
+    if parts.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", parts.join("/"))
+    }
+}
+
+fn parent_posix(path: &str) -> String {
+    let normalized = normalize_posix(path);
+    if normalized == "/" {
+        return "/".to_string();
+    }
+    match normalized.rsplit_once('/') {
+        Some(("", _)) | None => "/".to_string(),
+        Some((parent, _)) => parent.to_string(),
+    }
+}
+
+fn join_posix(base: &str, child: &str) -> String {
+    normalize_posix(&format!("{}/{}", base.trim_end_matches('/'), child))
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn is_http_source(source: &str) -> bool {
+    url::Url::parse(source)
+        .map(|url| matches!(url.scheme(), "http" | "https"))
+        .unwrap_or(false)
+}
+
+fn collect_dir_files(root: &Path, current: &Path) -> Result<Vec<(PathBuf, String)>> {
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(current).map_err(CliError::Io)? {
+        let entry = entry.map_err(CliError::Io)?;
+        let path = entry.path();
+        if path.is_dir() {
+            files.extend(collect_dir_files(root, &path)?);
+        } else if path.is_file() {
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|error| CliError::Other(anyhow::anyhow!("{}", error)))?;
+            let relative = relative
+                .components()
+                .map(|component| component.as_os_str().to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("/");
+            files.push((path, relative));
+        }
+    }
+    Ok(files)
+}
+
+fn file_name_string(path: &Path) -> Result<String> {
+    path.file_name()
+        .map(OsString::from)
+        .and_then(|value| value.into_string().ok())
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "path '{}' has no file name",
+                path.display()
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        default_registered_name, load_dockerfile_plan, logical_dockerfile_lines, normalize_posix,
+        parse_copy_like_values, parse_env_pairs, resolve_container_path,
+        resolve_context_source_path, wait_for_snapshot,
+    };
+    use std::{cell::Cell, io::Write, time::Duration};
+    use tensorlake_cloud_sdk::sandboxes::models::SnapshotInfo;
+
+    #[test]
+    fn default_registered_name_uses_parent_for_dockerfile() {
+        let path = std::path::Path::new("/tmp/example/Dockerfile");
+        assert_eq!(default_registered_name(path), "example");
+    }
+
+    #[test]
+    fn logical_dockerfile_lines_collapses_continuations() {
+        let lines = logical_dockerfile_lines("FROM ubuntu\nRUN echo one \\\n  && echo two\n");
+        assert_eq!(
+            lines,
+            vec![
+                (1, "FROM ubuntu".to_string()),
+                (2, "RUN echo one && echo two".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_copy_like_values_supports_json_array_form() {
+        let (_, sources, destination) =
+            parse_copy_like_values(r#"["a.txt", "b.txt", "/dst/"]"#, 1, "COPY").unwrap();
+        assert_eq!(sources, vec!["a.txt".to_string(), "b.txt".to_string()]);
+        assert_eq!(destination, "/dst/");
+    }
+
+    #[test]
+    fn parse_env_pairs_supports_equals_form() {
+        let pairs = parse_env_pairs("A=1 B=two", 1).unwrap();
+        assert_eq!(
+            pairs,
+            vec![
+                ("A".to_string(), "1".to_string()),
+                ("B".to_string(), "two".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_container_path_normalizes_relative_paths() {
+        assert_eq!(
+            resolve_container_path("app", "/workspace"),
+            "/workspace/app"
+        );
+        assert_eq!(
+            resolve_container_path("../bin", "/workspace/app"),
+            "/workspace/bin"
+        );
+        assert_eq!(normalize_posix("/a//b/../c"), "/a/c");
+    }
+
+    #[test]
+    fn resolve_container_path_preserves_trailing_slash_for_directories() {
+        assert_eq!(resolve_container_path("/dst/", "/"), "/dst/");
+        assert_eq!(
+            resolve_container_path("dst/", "/workspace"),
+            "/workspace/dst/"
+        );
+    }
+
+    #[test]
+    fn load_dockerfile_plan_reads_base_image_and_name() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dockerfile_path = temp_dir.path().join("Dockerfile");
+        let mut file = std::fs::File::create(&dockerfile_path).unwrap();
+        writeln!(file, "FROM python:3.12-slim\nRUN echo hi").unwrap();
+
+        let plan = load_dockerfile_plan(dockerfile_path.to_str().unwrap(), None).unwrap();
+        assert_eq!(plan.base_image, "python:3.12-slim");
+        assert_eq!(
+            plan.registered_name,
+            temp_dir.path().file_name().unwrap().to_string_lossy()
+        );
+        assert_eq!(plan.instructions.len(), 1);
+    }
+
+    #[test]
+    fn resolve_context_source_path_rejects_escaping_the_build_context() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let context_dir = temp_dir.path().join("context");
+        std::fs::create_dir_all(&context_dir).unwrap();
+        let outside_file = temp_dir.path().join("secret.txt");
+        std::fs::write(&outside_file, b"secret").unwrap();
+
+        let error = resolve_context_source_path(&context_dir, "../secret.txt").unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Local path escapes the build context"),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wait_for_snapshot_times_out() {
+        let polls = Cell::new(0usize);
+        let error = wait_for_snapshot("snap-1", Duration::from_secs(0), || {
+            polls.set(polls.get() + 1);
+            async {
+                Ok(SnapshotInfo {
+                    snapshot_id: "snap-1".to_string(),
+                    namespace: "ns".to_string(),
+                    sandbox_id: "sbx-1".to_string(),
+                    base_image: None,
+                    status: "pending".to_string(),
+                    error: None,
+                    snapshot_uri: None,
+                    size_bytes: None,
+                    rootfs_disk_bytes: None,
+                    created_at: None,
+                })
+            }
+        })
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("did not complete within 0s"));
+        assert_eq!(polls.get(), 0);
+    }
 }

--- a/crates/cli/src/commands/sbx/image/mod.rs
+++ b/crates/cli/src/commands/sbx/image/mod.rs
@@ -5,6 +5,7 @@ pub mod register;
 
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
+use tensorlake_cloud_sdk::{Client, ClientBuilder, sandbox_templates::SandboxTemplatesClient};
 
 /// Build the sandbox-templates API base URL for the current org/project.
 pub fn templates_base_url(ctx: &CliContext) -> Result<(String, String, String)> {
@@ -21,6 +22,37 @@ pub fn templates_base_url(ctx: &CliContext) -> Result<(String, String, String)> 
         proj_id
     );
     Ok((base, org_id, proj_id))
+}
+
+pub fn org_and_project(ctx: &CliContext) -> Result<(String, String)> {
+    let org_id = ctx
+        .effective_organization_id()
+        .ok_or_else(|| CliError::auth("Organization ID is required for --image"))?;
+    let proj_id = ctx
+        .effective_project_id()
+        .ok_or_else(|| CliError::auth("Project ID is required for --image"))?;
+    Ok((org_id, proj_id))
+}
+
+pub fn scoped_cloud_client(ctx: &CliContext) -> Result<Client> {
+    let token = ctx.bearer_token()?;
+    let mut builder = ClientBuilder::new(&ctx.api_url).bearer_token(&token);
+    let use_scope_headers = ctx.personal_access_token.is_some() && ctx.api_key.is_none();
+
+    if use_scope_headers
+        && let (Some(organization_id), Some(project_id)) =
+            (ctx.effective_organization_id(), ctx.effective_project_id())
+    {
+        builder = builder.scope(&organization_id, &project_id);
+    }
+
+    builder.build().map_err(Into::into)
+}
+
+pub fn sandbox_templates_client(ctx: &CliContext) -> Result<SandboxTemplatesClient> {
+    let client = scoped_cloud_client(ctx)?;
+    let (org_id, proj_id) = org_and_project(ctx)?;
+    Ok(SandboxTemplatesClient::new(client, org_id, proj_id))
 }
 
 /// Page through the list, returning the full JSON item if found.

--- a/crates/cli/src/commands/sbx/image/mod.rs
+++ b/crates/cli/src/commands/sbx/image/mod.rs
@@ -1,6 +1,7 @@
 pub mod create;
 pub mod describe;
 pub mod ls;
+pub mod register;
 
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};

--- a/crates/cli/src/commands/sbx/image/register.rs
+++ b/crates/cli/src/commands/sbx/image/register.rs
@@ -1,6 +1,7 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::snapshot::fetch_snapshot_info;
 use crate::error::{CliError, Result};
+use tensorlake_cloud_sdk::sandbox_templates::models::CreateSandboxTemplateRequest;
 
 #[derive(Debug)]
 struct SnapshotRegistrationMetadata {
@@ -14,12 +15,15 @@ fn parse_snapshot_registration_metadata(
     snapshot_id: &str,
     info: &serde_json::Value,
 ) -> Result<SnapshotRegistrationMetadata> {
-    let status = info.get("status").and_then(|value| value.as_str()).ok_or_else(|| {
-        CliError::Other(anyhow::anyhow!(
-            "snapshot {} is missing status",
-            snapshot_id
-        ))
-    })?;
+    let status = info
+        .get("status")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "snapshot {} is missing status",
+                snapshot_id
+            ))
+        })?;
     if status != "completed" {
         return Err(CliError::Other(anyhow::anyhow!(
             "snapshot {} is not completed (status: {})",
@@ -92,58 +96,35 @@ pub async fn run(
     is_public: bool,
 ) -> Result<()> {
     let client = ctx.client()?;
-    let (url, _, _) = super::templates_base_url(ctx)?;
+    let templates_client = super::sandbox_templates_client(ctx)?;
     let dockerfile = tokio::fs::read_to_string(dockerfile_path)
         .await
         .map_err(CliError::Io)?;
     let snapshot_info = fetch_snapshot_info(ctx, &client, snapshot_id).await?;
     let snapshot = parse_snapshot_registration_metadata(snapshot_id, &snapshot_info)?;
 
-    let body = serde_json::json!({
-        "name": image_name,
-        "dockerfile": dockerfile,
-        "snapshotId": snapshot_id,
-        "snapshotSandboxId": snapshot.sandbox_id,
-        "snapshotUri": snapshot.snapshot_uri,
-        "snapshotSizeBytes": snapshot.snapshot_size_bytes,
-        "rootfsDiskBytes": snapshot.rootfs_disk_bytes,
-        "public": is_public,
-    });
+    let registered = templates_client
+        .create(&CreateSandboxTemplateRequest {
+            name: image_name.to_string(),
+            dockerfile,
+            snapshot_id: snapshot_id.to_string(),
+            snapshot_sandbox_id: snapshot.sandbox_id.clone(),
+            snapshot_uri: snapshot.snapshot_uri.clone(),
+            snapshot_size_bytes: snapshot.snapshot_size_bytes,
+            rootfs_disk_bytes: snapshot.rootfs_disk_bytes,
+            public: is_public,
+        })
+        .await?;
 
-    let resp = client
-        .post(&url)
-        .json(&body)
-        .send()
-        .await
-        .map_err(CliError::Http)?;
-
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        return Err(CliError::Other(anyhow::anyhow!(
-            "failed to register sandbox image '{}' (HTTP {}): {}",
-            image_name,
-            status,
-            body
-        )));
-    }
-
-    let registered: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
     let rootfs_disk_bytes = registered
-        .get("rootfsDiskBytes")
-        .or_else(|| registered.get("rootfs_disk_bytes"))
-        .and_then(|value| value.as_u64())
+        .rootfs_disk_bytes
         .unwrap_or(snapshot.rootfs_disk_bytes);
     let rootfs_disk_gib = rootfs_disk_bytes / (1024 * 1024 * 1024);
     let snapshot_uri = registered
-        .get("snapshotUri")
-        .or_else(|| registered.get("snapshot_uri"))
-        .and_then(|value| value.as_str())
+        .snapshot_uri
+        .as_deref()
         .unwrap_or(&snapshot.snapshot_uri);
-    let template_id = registered
-        .get("id")
-        .and_then(|value| value.as_str())
-        .unwrap_or("-");
+    let template_id = registered.id.as_deref().unwrap_or("-");
 
     println!(
         "Registered image '{}' -> snapshot {} (rootfs {} GiB)\nTemplate: {}\n{}",

--- a/crates/cli/src/commands/sbx/image/register.rs
+++ b/crates/cli/src/commands/sbx/image/register.rs
@@ -1,0 +1,199 @@
+use crate::auth::context::CliContext;
+use crate::commands::sbx::snapshot::fetch_snapshot_info;
+use crate::error::{CliError, Result};
+
+#[derive(Debug)]
+struct SnapshotRegistrationMetadata {
+    sandbox_id: String,
+    snapshot_uri: String,
+    snapshot_size_bytes: u64,
+    rootfs_disk_bytes: u64,
+}
+
+fn parse_snapshot_registration_metadata(
+    snapshot_id: &str,
+    info: &serde_json::Value,
+) -> Result<SnapshotRegistrationMetadata> {
+    let status = info.get("status").and_then(|value| value.as_str()).ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!(
+            "snapshot {} is missing status",
+            snapshot_id
+        ))
+    })?;
+    if status != "completed" {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "snapshot {} is not completed (status: {})",
+            snapshot_id,
+            status
+        )));
+    }
+
+    let sandbox_id = info
+        .get("sandbox_id")
+        .or_else(|| info.get("sandboxId"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "snapshot {} is missing sandbox_id",
+                snapshot_id
+            ))
+        })?
+        .to_string();
+
+    let snapshot_uri = info
+        .get("snapshot_uri")
+        .or_else(|| info.get("snapshotUri"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "snapshot {} is missing snapshot_uri",
+                snapshot_id
+            ))
+        })?
+        .to_string();
+
+    let snapshot_size_bytes = info
+        .get("size_bytes")
+        .or_else(|| info.get("sizeBytes"))
+        .and_then(|value| value.as_u64())
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "snapshot {} is missing size_bytes",
+                snapshot_id
+            ))
+        })?;
+
+    let rootfs_disk_bytes = info
+        .get("rootfs_disk_bytes")
+        .or_else(|| info.get("rootfsDiskBytes"))
+        .and_then(|value| value.as_u64())
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "snapshot {} is missing rootfs_disk_bytes",
+                snapshot_id
+            ))
+        })?;
+
+    Ok(SnapshotRegistrationMetadata {
+        sandbox_id,
+        snapshot_uri,
+        snapshot_size_bytes,
+        rootfs_disk_bytes,
+    })
+}
+
+pub async fn run(
+    ctx: &CliContext,
+    image_name: &str,
+    snapshot_id: &str,
+    dockerfile_path: &str,
+    is_public: bool,
+) -> Result<()> {
+    let client = ctx.client()?;
+    let (url, _, _) = super::templates_base_url(ctx)?;
+    let dockerfile = tokio::fs::read_to_string(dockerfile_path)
+        .await
+        .map_err(CliError::Io)?;
+    let snapshot_info = fetch_snapshot_info(ctx, &client, snapshot_id).await?;
+    let snapshot = parse_snapshot_registration_metadata(snapshot_id, &snapshot_info)?;
+
+    let body = serde_json::json!({
+        "name": image_name,
+        "dockerfile": dockerfile,
+        "snapshotId": snapshot_id,
+        "snapshotSandboxId": snapshot.sandbox_id,
+        "snapshotUri": snapshot.snapshot_uri,
+        "snapshotSizeBytes": snapshot.snapshot_size_bytes,
+        "rootfsDiskBytes": snapshot.rootfs_disk_bytes,
+        "public": is_public,
+    });
+
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to register sandbox image '{}' (HTTP {}): {}",
+            image_name,
+            status,
+            body
+        )));
+    }
+
+    let registered: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
+    let rootfs_disk_bytes = registered
+        .get("rootfsDiskBytes")
+        .or_else(|| registered.get("rootfs_disk_bytes"))
+        .and_then(|value| value.as_u64())
+        .unwrap_or(snapshot.rootfs_disk_bytes);
+    let rootfs_disk_gib = rootfs_disk_bytes / (1024 * 1024 * 1024);
+    let snapshot_uri = registered
+        .get("snapshotUri")
+        .or_else(|| registered.get("snapshot_uri"))
+        .and_then(|value| value.as_str())
+        .unwrap_or(&snapshot.snapshot_uri);
+    let template_id = registered
+        .get("id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("-");
+
+    println!(
+        "Registered image '{}' -> snapshot {} (rootfs {} GiB)\nTemplate: {}\n{}",
+        image_name, snapshot_id, rootfs_disk_gib, template_id, snapshot_uri
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_snapshot_registration_metadata;
+    use serde_json::json;
+
+    #[test]
+    fn parse_snapshot_registration_metadata_requires_completed_snapshot() {
+        let err = parse_snapshot_registration_metadata(
+            "snap-1",
+            &json!({
+                "status": "in_progress",
+                "sandbox_id": "sbx-1",
+                "snapshot_uri": "s3://snapshots/snap-1.tar.zst",
+                "size_bytes": 123,
+                "rootfs_disk_bytes": 10 * 1024 * 1024 * 1024_u64,
+            }),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("snapshot snap-1 is not completed (status: in_progress)")
+        );
+    }
+
+    #[test]
+    fn parse_snapshot_registration_metadata_accepts_completed_snapshot() {
+        let metadata = parse_snapshot_registration_metadata(
+            "snap-1",
+            &json!({
+                "status": "completed",
+                "sandbox_id": "sbx-1",
+                "snapshot_uri": "s3://snapshots/snap-1.tar.zst",
+                "size_bytes": 123,
+                "rootfs_disk_bytes": 10 * 1024 * 1024 * 1024_u64,
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(metadata.sandbox_id, "sbx-1");
+        assert_eq!(metadata.snapshot_uri, "s3://snapshots/snap-1.tar.zst");
+        assert_eq!(metadata.snapshot_size_bytes, 123);
+        assert_eq!(metadata.rootfs_disk_bytes, 10 * 1024 * 1024 * 1024_u64);
+    }
+}

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -197,12 +197,48 @@ fn sandbox_termination_detail(info: &serde_json::Value) -> Option<String> {
     }
 }
 
+fn error_details_message(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Null => None,
+        serde_json::Value::String(message) => {
+            let trimmed = message.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        serde_json::Value::Array(items) => {
+            let parts: Vec<String> = items.iter().filter_map(error_details_message).collect();
+            if parts.is_empty() {
+                serde_json::to_string(value).ok()
+            } else {
+                Some(parts.join("; "))
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for key in ["message", "detail", "error", "reason"] {
+                if let Some(serde_json::Value::String(message)) = map.get(key) {
+                    let trimmed = message.trim();
+                    if !trimmed.is_empty() {
+                        return Some(trimmed.to_string());
+                    }
+                }
+            }
+            serde_json::to_string(value).ok()
+        }
+        _ => Some(value.to_string()),
+    }
+}
+
+fn sandbox_failure_detail(info: &serde_json::Value) -> Option<String> {
+    info.get("error_details")
+        .and_then(error_details_message)
+        .or_else(|| sandbox_termination_detail(info))
+}
+
 fn format_sandbox_wait_termination_message(
     subject: &str,
     target_status: &str,
     info: &serde_json::Value,
 ) -> String {
-    if let Some(detail) = sandbox_termination_detail(info) {
+    if let Some(detail) = sandbox_failure_detail(info) {
         format!("{subject} failed to reach '{target_status}': {detail}")
     } else {
         format!("{subject} terminated while waiting to reach '{target_status}'")
@@ -345,7 +381,8 @@ fn parse_numeric_timestamp(timestamp: f64) -> Option<DateTime<Utc>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_created_at, format_sandbox_wait_termination_message, sandbox_termination_detail,
+        error_details_message, format_created_at, format_sandbox_wait_termination_message,
+        sandbox_termination_detail,
     };
     use chrono::{Duration, Utc};
 
@@ -419,6 +456,39 @@ mod tests {
         assert_eq!(
             message,
             "Sandbox failed to reach 'running': termination reason: StartupFailedInternalError"
+        );
+    }
+
+    #[test]
+    fn error_details_message_prefers_message_field() {
+        let details = serde_json::json!({
+            "message": "failed to pull image tensorlake/missing-image",
+            "phase": "pull",
+        });
+
+        let detail = error_details_message(&details);
+
+        assert_eq!(
+            detail.as_deref(),
+            Some("failed to pull image tensorlake/missing-image")
+        );
+    }
+
+    #[test]
+    fn sandbox_wait_termination_message_prefers_error_details() {
+        let info = serde_json::json!({
+            "status": "terminated",
+            "termination_reason": "StartupFailedInternalError",
+            "error_details": {
+                "message": "failed to pull image tensorlake/missing-image",
+            },
+        });
+
+        let message = format_sandbox_wait_termination_message("Sandbox", "running", &info);
+
+        assert_eq!(
+            message,
+            "Sandbox failed to reach 'running': failed to pull image tensorlake/missing-image"
         );
     }
 }

--- a/crates/cli/src/commands/sbx/snapshot.rs
+++ b/crates/cli/src/commands/sbx/snapshot.rs
@@ -8,7 +8,7 @@ pub struct SnapshotDetails {
     pub snapshot_uri: String,
 }
 
-async fn fetch_snapshot_info(
+pub(crate) async fn fetch_snapshot_info(
     ctx: &CliContext,
     client: &reqwest::Client,
     snapshot_id: &str,

--- a/crates/cli/src/commands/whoami.rs
+++ b/crates/cli/src/commands/whoami.rs
@@ -57,10 +57,7 @@ pub async fn run(ctx: &mut CliContext, output_json: bool) -> Result<()> {
                 obj.insert("keyId".to_string(), serde_json::Value::String(id));
             }
             if let Some(org) = ctx.introspect_org_id() {
-                obj.insert(
-                    "organizationId".to_string(),
-                    serde_json::Value::String(org),
-                );
+                obj.insert("organizationId".to_string(), serde_json::Value::String(org));
             }
             if let Some(proj) = ctx.introspect_project_id() {
                 obj.insert("projectId".to_string(), serde_json::Value::String(proj));
@@ -77,10 +74,7 @@ pub async fn run(ctx: &mut CliContext, output_json: bool) -> Result<()> {
                 );
             }
             if let Some(org) = pat_org {
-                obj.insert(
-                    "organizationId".to_string(),
-                    serde_json::Value::String(org),
-                );
+                obj.insert("organizationId".to_string(), serde_json::Value::String(org));
             }
             if let Some(proj) = pat_project {
                 obj.insert("projectId".to_string(), serde_json::Value::String(proj));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -526,6 +526,23 @@ enum SbxCommands {
 
 #[derive(Subcommand)]
 enum ImageCommands {
+    /// Register a custom snapshot-backed sandbox image name
+    Register {
+        /// Image name to register
+        image_name: String,
+
+        /// Completed snapshot ID backing this image
+        snapshot_id: String,
+
+        /// Dockerfile to store in the platform sandbox template registry
+        #[arg(long = "dockerfile", value_name = "PATH")]
+        dockerfile_path: String,
+
+        /// Whether the registered image should be public
+        #[arg(long)]
+        public: bool,
+    },
+
     /// Register a sandbox image from a Dockerfile
     Create {
         /// Path to the Dockerfile
@@ -862,7 +879,9 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     }
                     None => {
                         let sandbox_id = snapshot_args.sandbox_id.ok_or_else(|| {
-                            CliError::usage("checkpoint requires a sandbox ID or the 'ls' subcommand")
+                            CliError::usage(
+                                "checkpoint requires a sandbox ID or the 'ls' subcommand",
+                            )
                         })?;
                         commands::sbx::snapshot::run(ctx, &sandbox_id, snapshot_args.timeout).await
                     }
@@ -936,6 +955,21 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     .await
                 }
                 SbxCommands::Image(image_cmd) => match image_cmd {
+                    ImageCommands::Register {
+                        image_name,
+                        snapshot_id,
+                        dockerfile_path,
+                        public,
+                    } => {
+                        commands::sbx::image::register::run(
+                            ctx,
+                            &image_name,
+                            &snapshot_id,
+                            &dockerfile_path,
+                            public,
+                        )
+                        .await
+                    }
                     ImageCommands::Create {
                         dockerfile_path,
                         registered_name,
@@ -1020,16 +1054,44 @@ mod tests {
 
         match cli.command {
             Commands::Sbx(SbxCommands::Image(ImageCommands::Create {
-                cpus,
-                memory,
-                disk,
-                ..
+                cpus, memory, disk, ..
             })) => {
                 assert_eq!(cpus, Some(3.5));
                 assert_eq!(memory, Some(8192));
                 assert_eq!(disk, Some(30));
             }
             _ => panic!("expected sbx image create command"),
+        }
+    }
+
+    #[test]
+    fn image_register_parses_name_and_snapshot_id() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "image",
+            "register",
+            "mighty-agent-0.0.69",
+            "snap_123",
+            "--dockerfile",
+            "./Dockerfile",
+            "--public",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Image(ImageCommands::Register {
+                image_name,
+                snapshot_id,
+                dockerfile_path,
+                public,
+            })) => {
+                assert_eq!(image_name, "mighty-agent-0.0.69");
+                assert_eq!(snapshot_id, "snap_123");
+                assert_eq!(dockerfile_path, "./Dockerfile");
+                assert!(public);
+            }
+            _ => panic!("expected sbx image register command"),
         }
     }
 

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -71,12 +71,14 @@ pub mod cron;
 pub mod document_ai;
 pub mod error;
 pub mod images;
+pub mod sandbox_templates;
 pub mod sandboxes;
 pub mod secrets;
 use applications::*;
 use cron::*;
 use document_ai::*;
 use images::*;
+use sandbox_templates::*;
 use sandboxes::*;
 use secrets::*;
 
@@ -227,6 +229,19 @@ impl Sdk {
     /// ```
     pub fn images(&self) -> ImagesClient {
         ImagesClient::new(self.client.clone())
+    }
+
+    /// Get a client for managing snapshot-backed sandbox image registrations.
+    pub fn sandbox_templates(
+        &self,
+        organization_id: &str,
+        project_id: &str,
+    ) -> SandboxTemplatesClient {
+        SandboxTemplatesClient::new(
+            self.client.clone(),
+            organization_id.to_string(),
+            project_id.to_string(),
+        )
     }
 
     /// Get a client for managing sandbox lifecycle, pools, and snapshots.

--- a/crates/cloud-sdk/src/sandbox_templates/mod.rs
+++ b/crates/cloud-sdk/src/sandbox_templates/mod.rs
@@ -1,0 +1,48 @@
+use reqwest::Method;
+
+use crate::{
+    client::{Client, Traced},
+    error::SdkError,
+};
+
+pub mod models;
+
+use models::{CreateSandboxTemplateRequest, SandboxTemplate};
+
+#[derive(Clone)]
+pub struct SandboxTemplatesClient {
+    client: Client,
+    organization_id: String,
+    project_id: String,
+}
+
+impl SandboxTemplatesClient {
+    pub fn new(
+        client: Client,
+        organization_id: impl Into<String>,
+        project_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            organization_id: organization_id.into(),
+            project_id: project_id.into(),
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!(
+            "/platform/v1/organizations/{}/projects/{}/sandbox-templates",
+            self.organization_id, self.project_id
+        )
+    }
+
+    pub async fn create(
+        &self,
+        request: &CreateSandboxTemplateRequest,
+    ) -> Result<Traced<SandboxTemplate>, SdkError> {
+        let req = self
+            .client
+            .build_post_json_request(Method::POST, &self.endpoint(), request)?;
+        self.client.execute_json(req).await
+    }
+}

--- a/crates/cloud-sdk/src/sandbox_templates/models.rs
+++ b/crates/cloud-sdk/src/sandbox_templates/models.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateSandboxTemplateRequest {
+    pub name: String,
+    pub dockerfile: String,
+    pub snapshot_id: String,
+    pub snapshot_sandbox_id: String,
+    pub snapshot_uri: String,
+    pub snapshot_size_bytes: u64,
+    pub rootfs_disk_bytes: u64,
+    pub public: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxTemplate {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub snapshot_id: Option<String>,
+    #[serde(default)]
+    pub snapshot_sandbox_id: Option<String>,
+    #[serde(default)]
+    pub snapshot_uri: Option<String>,
+    #[serde(default)]
+    pub snapshot_size_bytes: Option<u64>,
+    #[serde(default)]
+    pub rootfs_disk_bytes: Option<u64>,
+    #[serde(default)]
+    pub public: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CreateSandboxTemplateRequest;
+
+    #[test]
+    fn create_sandbox_template_request_serializes_as_camel_case() {
+        let request = CreateSandboxTemplateRequest {
+            name: "image1".to_string(),
+            dockerfile: "FROM ubuntu:24.04\n".to_string(),
+            snapshot_id: "snap-1".to_string(),
+            snapshot_sandbox_id: "sbx-1".to_string(),
+            snapshot_uri: "s3://snapshots/snap-1".to_string(),
+            snapshot_size_bytes: 123,
+            rootfs_disk_bytes: 456,
+            public: true,
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert_eq!(
+            json,
+            r#"{"name":"image1","dockerfile":"FROM ubuntu:24.04\n","snapshotId":"snap-1","snapshotSandboxId":"sbx-1","snapshotUri":"s3://snapshots/snap-1","snapshotSizeBytes":123,"rootfsDiskBytes":456,"public":true}"#
+        );
+    }
+}

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -86,6 +86,10 @@ pub struct CreateSandboxResponse {
     pub routing_hint: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub termination_reason: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_details: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -111,6 +115,8 @@ pub struct SandboxInfo {
     pub outcome: Option<String>,
     #[serde(default)]
     pub termination_reason: Option<String>,
+    #[serde(default)]
+    pub error_details: Option<serde_json::Value>,
     #[serde(default)]
     pub created_at: Option<serde_json::Value>,
     #[serde(default)]

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -209,6 +209,8 @@ pub struct SnapshotInfo {
     #[serde(default)]
     pub size_bytes: Option<i64>,
     #[serde(default)]
+    pub rootfs_disk_bytes: Option<u64>,
+    #[serde(default)]
     pub created_at: Option<serde_json::Value>,
 }
 

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -687,7 +687,10 @@ def _register_image(
     name: str,
     dockerfile: str,
     snapshot_id: str,
+    snapshot_sandbox_id: str,
     snapshot_uri: str,
+    snapshot_size_bytes: int,
+    rootfs_disk_bytes: int,
     is_public: bool = False,
 ) -> dict:
     """POST to Platform API through the ingress to register the image."""
@@ -713,8 +716,11 @@ def _register_image(
         "name": name,
         "dockerfile": dockerfile,
         "snapshotId": snapshot_id,
+        "snapshotSandboxId": snapshot_sandbox_id,
         "snapshotUri": snapshot_uri,
-        "isPublic": is_public,
+        "snapshotSizeBytes": snapshot_size_bytes,
+        "rootfsDiskBytes": rootfs_disk_bytes,
+        "public": is_public,
     }
     resp = httpx.post(url, json=body, headers=inject_traceparent(headers), timeout=30.0)
     resp.raise_for_status()
@@ -782,12 +788,23 @@ def _run_plan(
             raise RuntimeError(
                 f"Snapshot {snapshot.snapshot_id} completed without a snapshot URI"
             )
+        if snapshot.size_bytes is None:
+            raise RuntimeError(
+                f"Snapshot {snapshot.snapshot_id} completed without size_bytes"
+            )
+        if snapshot.rootfs_disk_bytes is None:
+            raise RuntimeError(
+                f"Snapshot {snapshot.snapshot_id} completed without rootfs_disk_bytes"
+            )
         result = _register_image(
             ctx,
             plan.registered_name,
             plan.dockerfile_text,
             snapshot.snapshot_id,
+            snapshot.sandbox_id,
             snapshot.snapshot_uri,
+            snapshot.size_bytes,
+            snapshot.rootfs_disk_bytes,
             is_public,
         )
         emit(

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -139,6 +139,53 @@ def _normalize_user_ports(ports: list[int]) -> list[int]:
     return sorted(normalized)
 
 
+def _format_error_details(error_details: object | None) -> str | None:
+    if error_details is None:
+        return None
+    if isinstance(error_details, str):
+        detail = error_details.strip()
+        return detail or None
+    if isinstance(error_details, dict):
+        for key in ("message", "detail", "error", "reason"):
+            value = error_details.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        if error_details:
+            return json.dumps(error_details, sort_keys=True)
+        return None
+    if isinstance(error_details, list):
+        parts = [
+            formatted
+            for item in error_details
+            if (formatted := _format_error_details(item)) is not None
+        ]
+        if parts:
+            return "; ".join(parts)
+        return json.dumps(error_details)
+    return str(error_details)
+
+
+def _startup_failure_message(
+    sandbox_id: str,
+    status: SandboxStatus | str,
+    *,
+    error_details: object | None = None,
+    termination_reason: str | None = None,
+) -> str:
+    status_value = status.value if isinstance(status, SandboxStatus) else str(status)
+    prefix = (
+        f"Sandbox {sandbox_id} terminated during startup"
+        if status_value == SandboxStatus.TERMINATED.value
+        else f"Sandbox {sandbox_id} became {status_value} during startup"
+    )
+    detail = _format_error_details(error_details)
+    if detail:
+        return f"{prefix}: {detail}"
+    if termination_reason:
+        return f"{prefix}: termination reason: {termination_reason}"
+    return prefix
+
+
 class SandboxClient:
     """Client for managing Tensorlake sandboxes and sandbox pools.
 
@@ -1098,6 +1145,15 @@ class SandboxClient:
                 name=result.name or requested_name,
             )
             return sandbox
+        if result.status in (SandboxStatus.SUSPENDED, SandboxStatus.TERMINATED):
+            raise SandboxError(
+                _startup_failure_message(
+                    result.sandbox_id,
+                    result.status,
+                    error_details=result.error_details,
+                    termination_reason=result.termination_reason,
+                )
+            )
 
         deadline = time.time() + startup_timeout
         while time.time() < deadline:
@@ -1116,7 +1172,12 @@ class SandboxClient:
                 return sandbox
             if info.status in (SandboxStatus.SUSPENDED, SandboxStatus.TERMINATED):
                 raise SandboxError(
-                    f"Sandbox {result.sandbox_id} became {info.status.value} during startup"
+                    _startup_failure_message(
+                        result.sandbox_id,
+                        info.status,
+                        error_details=info.error_details,
+                        termination_reason=info.termination_reason,
+                    )
                 )
             # Poll at 0.5s — balances responsiveness against API load.
             time.sleep(0.5)

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -276,6 +276,7 @@ class SnapshotInfo(BaseModel):
     error: str | None = None
     snapshot_uri: str | None = None
     size_bytes: int | None = None
+    rootfs_disk_bytes: int | None = None
     created_at: OptionalTimestamp = None
 
     model_config = {"populate_by_name": True}

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import BaseModel, BeforeValidator, Field
 
@@ -162,6 +162,8 @@ class CreateSandboxResponse(BaseModel):
     status: SandboxStatus
     routing_hint: str | None = None
     name: str | None = None
+    termination_reason: str | None = None
+    error_details: Any | None = None
 
 
 class SandboxInfo(BaseModel):
@@ -178,6 +180,8 @@ class SandboxInfo(BaseModel):
     network: NetworkConfig | None = None
     pool_id: str | None = None
     outcome: str | None = None
+    termination_reason: str | None = None
+    error_details: Any | None = None
     created_at: OptionalTimestamp = None
     terminated_at: OptionalTimestamp = None
     name: str | None = None

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -149,6 +149,36 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(request_json["resources"]["disk_mb"], 25 * 1024)
         self.assertNotIn("ephemeral_disk_mb", request_json["resources"])
 
+    def test_create_and_connect_raises_error_details_from_startup_failure(self):
+        class _StartupFailureRustClient(_FakeRustClient):
+            def get_sandbox_json(self, sandbox_id):
+                self.last_get_sandbox_id = sandbox_id
+                return """
+{
+  "id": "sbx-1",
+  "namespace": "default",
+  "status": "terminated",
+  "resources": {
+    "cpus": 1.0,
+    "memory_mb": 512,
+    "ephemeral_disk_mb": 1024
+  },
+  "secret_names": [],
+  "error_details": {
+    "message": "failed to pull image tensorlake/missing-image"
+  }
+}
+"""
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _StartupFailureRustClient()
+
+        with self.assertRaisesRegex(
+            SandboxError,
+            "terminated during startup: failed to pull image tensorlake/missing-image",
+        ):
+            client.create_and_connect(image="tensorlake/missing-image")
+
     def test_list_uses_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         client._rust_client = _FakeRustClient()

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -551,6 +551,17 @@ export class SandboxClient {
     if (result.status === SandboxStatus.RUNNING) {
       return finishConnect(result.routingHint, result.name);
     }
+    if (
+      result.status === SandboxStatus.SUSPENDED ||
+      result.status === SandboxStatus.TERMINATED
+    ) {
+      throw new SandboxError(
+        formatStartupFailureMessage(result.sandboxId, result.status, {
+          errorDetails: result.errorDetails,
+          terminationReason: result.terminationReason,
+        }),
+      );
+    }
 
     const deadline = Date.now() + startupTimeout * 1000;
 
@@ -559,9 +570,15 @@ export class SandboxClient {
       if (info.status === SandboxStatus.RUNNING) {
         return finishConnect(info.routingHint, info.name);
       }
-      if (info.status === SandboxStatus.TERMINATED) {
+      if (
+        info.status === SandboxStatus.SUSPENDED ||
+        info.status === SandboxStatus.TERMINATED
+      ) {
         throw new SandboxError(
-          `Sandbox ${result.sandboxId} terminated during startup`,
+          formatStartupFailureMessage(result.sandboxId, info.status, {
+            errorDetails: info.errorDetails,
+            terminationReason: info.terminationReason,
+          }),
         );
       }
       await sleep(500);
@@ -581,6 +598,51 @@ export class SandboxClient {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatStartupFailureMessage(
+  sandboxId: string,
+  status: SandboxStatus | string,
+  options: {
+    errorDetails?: unknown;
+    terminationReason?: string;
+  },
+): string {
+  const prefix = status === SandboxStatus.TERMINATED
+    ? `Sandbox ${sandboxId} terminated during startup`
+    : `Sandbox ${sandboxId} became ${status} during startup`;
+  const detail = formatErrorDetails(options.errorDetails);
+  if (detail) {
+    return `${prefix}: ${detail}`;
+  }
+  if (options.terminationReason) {
+    return `${prefix}: termination reason: ${options.terminationReason}`;
+  }
+  return prefix;
+}
+
+function formatErrorDetails(errorDetails: unknown): string | undefined {
+  if (errorDetails == null) return undefined;
+  if (typeof errorDetails === "string") {
+    const detail = errorDetails.trim();
+    return detail || undefined;
+  }
+  if (Array.isArray(errorDetails)) {
+    const parts = errorDetails
+      .map((item) => formatErrorDetails(item))
+      .filter((item): item is string => Boolean(item));
+    return parts.length > 0 ? parts.join("; ") : JSON.stringify(errorDetails);
+  }
+  if (typeof errorDetails === "object") {
+    for (const key of ["message", "detail", "error", "reason"]) {
+      const value = (errorDetails as Record<string, unknown>)[key];
+      if (typeof value === "string" && value.trim()) {
+        return value.trim();
+      }
+    }
+    return JSON.stringify(errorDetails);
+  }
+  return String(errorDetails);
 }
 
 const RESERVED_SANDBOX_MANAGEMENT_PORT = 9501;

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -96,6 +96,8 @@ export interface CreateSandboxResponse {
   status: SandboxStatus;
   routingHint?: string;
   name?: string | null;
+  terminationReason?: string;
+  errorDetails?: unknown;
 }
 
 export interface SandboxInfo {
@@ -111,6 +113,8 @@ export interface SandboxInfo {
   network?: NetworkConfig;
   poolId?: string;
   outcome?: string;
+  terminationReason?: string;
+  errorDetails?: unknown;
   createdAt?: Date;
   terminatedAt?: Date;
   name?: string;

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -141,6 +141,7 @@ export interface SnapshotInfo {
   error?: string;
   snapshotUri?: string;
   sizeBytes?: number;
+  rootfsDiskBytes?: number;
   createdAt?: Date;
 }
 

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -122,7 +122,10 @@ interface CreateSandboxImageDeps {
     name: string,
     dockerfile: string,
     snapshotId: string,
+    snapshotSandboxId: string,
     snapshotUri: string,
+    snapshotSizeBytes: number,
+    rootfsDiskBytes: number,
     isPublic: boolean,
   ) => Promise<Record<string, unknown>>;
   sleep?: (ms: number) => Promise<void>;
@@ -919,7 +922,10 @@ async function registerImage(
   name: string,
   dockerfile: string,
   snapshotId: string,
+  snapshotSandboxId: string,
   snapshotUri: string,
+  snapshotSizeBytes: number,
+  rootfsDiskBytes: number,
   isPublic: boolean,
 ): Promise<Record<string, unknown>> {
   if (!context.organizationId || !context.projectId) {
@@ -955,8 +961,11 @@ async function registerImage(
       name,
       dockerfile,
       snapshotId,
+      snapshotSandboxId,
       snapshotUri,
-      isPublic,
+      snapshotSizeBytes,
+      rootfsDiskBytes,
+      public: isPublic,
     }),
   });
 
@@ -1029,6 +1038,16 @@ export async function createSandboxImage(
         `Snapshot ${snapshot.snapshotId} is missing snapshotUri and cannot be registered as a sandbox image.`,
       );
     }
+    if (snapshot.sizeBytes == null) {
+      throw new Error(
+        `Snapshot ${snapshot.snapshotId} is missing sizeBytes and cannot be registered as a sandbox image.`,
+      );
+    }
+    if (snapshot.rootfsDiskBytes == null) {
+      throw new Error(
+        `Snapshot ${snapshot.snapshotId} is missing rootfsDiskBytes and cannot be registered as a sandbox image.`,
+      );
+    }
 
     emit({
       type: "status",
@@ -1039,7 +1058,10 @@ export async function createSandboxImage(
       plan.registeredName,
       plan.dockerfileText,
       snapshot.snapshotId,
+      snapshot.sandboxId,
       snapshot.snapshotUri,
+      snapshot.sizeBytes,
+      snapshot.rootfsDiskBytes,
       options.isPublic ?? false,
     );
 

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -551,6 +551,39 @@ describe("SandboxClient", () => {
     });
   });
 
+  describe("createAndConnect", () => {
+    it("includes sandbox errorDetails in startup failures", async () => {
+      vi.mocked(undici.fetch)
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ sandbox_id: "sbx-1", status: "pending" }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              id: "sbx-1",
+              namespace: "default",
+              status: "terminated",
+              resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
+              secret_names: [],
+              error_details: { message: "failed to pull image tensorlake/missing-image" },
+            }),
+            { status: 200 },
+          ),
+        );
+
+      const client = SandboxClient.forLocalhost();
+      await expect(
+        client.createAndConnect({ image: "tensorlake/missing-image" }),
+      ).rejects.toThrow(
+        "Sandbox sbx-1 terminated during startup: failed to pull image tensorlake/missing-image",
+      );
+      client.close();
+    });
+  });
+
   describe("snapshots", () => {
     it("creates a snapshot", async () => {
       mockFetch(() =>

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -183,7 +183,10 @@ describe("sandbox image helpers", () => {
       createAndConnect: vi.fn(async () => sandbox),
       snapshotAndWait: vi.fn(async () => ({
         snapshotId: "snap-1",
+        sandboxId: "sbx-source-1",
         snapshotUri: "s3://snapshots/snap-1.tar.zst",
+        sizeBytes: 123,
+        rootfsDiskBytes: 10 * 1024 * 1024 * 1024,
       })),
       close: vi.fn(() => {}),
     };
@@ -220,7 +223,10 @@ describe("sandbox image helpers", () => {
       "sandbox-image",
       `${dockerfileText}\n`,
       "snap-1",
+      "sbx-source-1",
       "s3://snapshots/snap-1.tar.zst",
+      123,
+      10 * 1024 * 1024 * 1024,
       false,
     );
     expect(sandbox.terminate).toHaveBeenCalled();
@@ -271,7 +277,10 @@ describe("sandbox image helpers", () => {
       createAndConnect: vi.fn(async () => sandbox),
       snapshotAndWait: vi.fn(async () => ({
         snapshotId: "snap-1",
+        sandboxId: "sbx-source-1",
         snapshotUri: "s3://snapshots/snap-1.tar.zst",
+        sizeBytes: 123,
+        rootfsDiskBytes: 10 * 1024 * 1024 * 1024,
       })),
       close: vi.fn(() => {}),
     };
@@ -315,7 +324,10 @@ describe("sandbox image helpers", () => {
         "RUN cat /workspace/hello.txt",
       ].join("\n"),
       "snap-1",
+      "sbx-source-1",
       "s3://snapshots/snap-1.tar.zst",
+      123,
+      10 * 1024 * 1024 * 1024,
       false,
     );
     expect(sandbox.terminate).toHaveBeenCalled();
@@ -357,7 +369,10 @@ describe("sandbox image helpers", () => {
       createAndConnect: vi.fn(async () => sandbox),
       snapshotAndWait: vi.fn(async () => ({
         snapshotId: "snap-1",
+        sandboxId: "sbx-source-1",
         snapshotUri: "s3://snapshots/snap-1.tar.zst",
+        sizeBytes: 123,
+        rootfsDiskBytes: 10 * 1024 * 1024 * 1024,
       })),
       close: vi.fn(() => {}),
     };
@@ -419,7 +434,10 @@ describe("sandbox image helpers", () => {
       createAndConnect: vi.fn(async () => sandbox),
       snapshotAndWait: vi.fn(async () => ({
         snapshotId: "snap-1",
+        sandboxId: "sbx-source-1",
         snapshotUri: "s3://snapshots/snap-1.tar.zst",
+        sizeBytes: 123,
+        rootfsDiskBytes: 10 * 1024 * 1024 * 1024,
       })),
       close: vi.fn(() => {}),
     };
@@ -453,7 +471,10 @@ describe("sandbox image helpers", () => {
         "RUN echo ready",
       ].join("\n"),
       "snap-1",
+      "sbx-source-1",
       "s3://snapshots/snap-1.tar.zst",
+      123,
+      10 * 1024 * 1024 * 1024,
       false,
     );
   });
@@ -498,7 +519,10 @@ describe("sandbox image helpers", () => {
       createAndConnect: vi.fn(async () => sandbox),
       snapshotAndWait: vi.fn(async () => ({
         snapshotId: "snap-1",
+        sandboxId: "sbx-source-1",
         snapshotUri: "s3://snapshots/snap-1.tar.zst",
+        sizeBytes: 123,
+        rootfsDiskBytes: 10 * 1024 * 1024 * 1024,
       })),
       close: vi.fn(() => {}),
     };


### PR DESCRIPTION
## Summary
- send full snapshot metadata when registering sandbox images from the Python and TypeScript image builders
- route `tl sbx image register` through platform API instead of posting raw image+snapshot ids to Indexify
- require manual CLI registration to use a completed snapshot before sending explicit metadata

## Validation
- `python3 -m py_compile src/tensorlake/image/sandbox_builder.py src/tensorlake/sandbox/models.py`
- `cargo test -p tensorlake-cli parse_snapshot_registration_metadata -- --test-threads 1`
- `cargo test -p tensorlake-cli image_register_parses_name_and_snapshot_id -- --test-threads 1`
- `cargo build -p tensorlake-cli -p tensorlake-cloud-sdk --quiet`
- `cargo fmt --all --check`
- `npm run typecheck`

## Notes
- `npm run test -- tests/sandbox-image.test.ts` is not runnable on this host because the local Node runtime is `18.19.0` while `typescript/package.json` requires Node `>=22`, and Vitest fails inside `undici` under Node 18.