### PR TITLE
feat(cli): tl ssh-keys (ls/add/rm) for sandbox SSH access

### DIFF
--- a/crates/cli/src/auth/guard.rs
+++ b/crates/cli/src/auth/guard.rs
@@ -5,6 +5,43 @@ use crate::config::resolver;
 use crate::error::{CliError, Result};
 use crate::project::detection::find_project_root;
 
+/// Ensure the caller is authenticated, but do not require an
+/// organization/project context. Used by user-scoped commands like
+/// `ssh-keys` that act on the user's profile rather than a project.
+pub async fn ensure_auth(ctx: &mut CliContext) -> Result<()> {
+    if ctx.has_authentication() {
+        return Ok(());
+    }
+    eprintln!("It seems like you're not logged in. Let's log you in...\n");
+    let login_result = match run_login_flow(ctx, true).await {
+        Ok(result) => result,
+        Err(CliError::Cancelled) => {
+            return Err(CliError::auth(
+                "Login cancelled. Set TENSORLAKE_API_KEY or run 'tl login' to authenticate.",
+            ));
+        }
+        Err(e) => return Err(e),
+    };
+    let resolved = resolver::resolve(
+        Some(&ctx.api_url),
+        Some(&ctx.cloud_url),
+        None,
+        Some(&login_result.token),
+        Some(&ctx.namespace),
+        login_result.organization_id.as_deref(),
+        login_result.project_id.as_deref(),
+        ctx.debug,
+        ctx.show_trace_id,
+    );
+    *ctx = CliContext::from_resolved(resolved);
+    if !ctx.has_authentication() {
+        return Err(CliError::auth(
+            "Authentication failed. Please try running 'tl login' manually.",
+        ));
+    }
+    Ok(())
+}
+
 /// Ensure authentication and org/project are available.
 /// Triggers login and/or init flows as needed.
 pub async fn ensure_auth_and_project(ctx: &mut CliContext) -> Result<()> {

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -8,4 +8,5 @@ pub mod new;
 pub mod parse;
 pub mod sbx;
 pub mod secrets;
+pub mod ssh_keys;
 pub mod whoami;

--- a/crates/cli/src/commands/ssh_keys.rs
+++ b/crates/cli/src/commands/ssh_keys.rs
@@ -1,0 +1,287 @@
+use comfy_table::Cell;
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use tensorlake::error::SdkError;
+use tensorlake::{Client, ClientBuilder};
+
+use crate::auth::context::CliContext;
+use crate::error::{CliError, Result};
+use crate::output::table::new_table;
+
+const BASE_PATH: &str = "/platform/v1/users/me/ssh-keys";
+
+#[derive(Debug, Clone, Deserialize)]
+struct ApiSshKey {
+    id: String,
+    name: String,
+    #[serde(rename = "keyType")]
+    key_type: String,
+    fingerprint: String,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "lastUsedAt")]
+    last_used_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ListResponse {
+    items: Vec<ApiSshKey>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CreateRequest<'a> {
+    name: &'a str,
+    #[serde(rename = "publicKey")]
+    public_key: &'a str,
+}
+
+pub async fn list(ctx: &CliContext) -> Result<()> {
+    let client = http_client(ctx)?;
+    let request = client
+        .build_get_json_request(BASE_PATH, None)
+        .map_err(map_sdk_error)?;
+    let traced = client
+        .execute_json::<ListResponse>(request)
+        .await
+        .map_err(map_sdk_error)?;
+    let keys = traced.into_inner().items;
+
+    if keys.is_empty() {
+        println!("no ssh keys registered");
+        return Ok(());
+    }
+
+    let mut table = new_table(&["ID", "Name", "Type", "Fingerprint", "Created", "Last Used"]);
+    for key in &keys {
+        table.add_row(vec![
+            Cell::new(&key.id),
+            Cell::new(&key.name),
+            Cell::new(&key.key_type),
+            Cell::new(&key.fingerprint),
+            Cell::new(&key.created_at),
+            Cell::new(key.last_used_at.as_deref().unwrap_or("-")),
+        ]);
+    }
+    println!("{table}");
+
+    let count = keys.len();
+    if count == 1 {
+        println!("1 ssh key");
+    } else {
+        println!("{count} ssh keys");
+    }
+    Ok(())
+}
+
+/// Add a key. `public_key_arg` is interpreted as a file path first; if the
+/// path doesn't exist, the argument is treated as the literal key body. This
+/// lets `tl ssh-keys add ~/.ssh/id_ed25519.pub` and
+/// `tl ssh-keys add "ssh-ed25519 AAAA..."` both work.
+pub async fn add(ctx: &CliContext, name: &str, public_key_arg: &str) -> Result<()> {
+    let public_key = read_public_key(public_key_arg)?;
+    let trimmed_name = name.trim();
+    if trimmed_name.is_empty() {
+        return Err(CliError::usage("name must not be empty"));
+    }
+
+    let client = http_client(ctx)?;
+    let body = CreateRequest {
+        name: trimmed_name,
+        public_key: public_key.trim(),
+    };
+    let request = client
+        .build_post_json_request(Method::POST, BASE_PATH, &body)
+        .map_err(map_sdk_error)?;
+    let traced = client
+        .execute_json::<ApiSshKey>(request)
+        .await
+        .map_err(map_create_sdk_error)?;
+    let created = traced.into_inner();
+    println!("registered {}", created.id);
+    println!("  name        {}", created.name);
+    println!("  type        {}", created.key_type);
+    println!("  fingerprint {}", created.fingerprint);
+    Ok(())
+}
+
+pub async fn remove(ctx: &CliContext, key_ids: &[String]) -> Result<()> {
+    if key_ids.is_empty() {
+        return Err(CliError::usage("at least one key id is required"));
+    }
+    let client = http_client(ctx)?;
+
+    // Resolve "name or id" inputs to ids. We list once then look each up.
+    let request = client
+        .build_get_json_request(BASE_PATH, None)
+        .map_err(map_sdk_error)?;
+    let listing = client
+        .execute_json::<ListResponse>(request)
+        .await
+        .map_err(map_sdk_error)?
+        .into_inner()
+        .items;
+
+    let mut removed = 0_usize;
+    for raw in key_ids {
+        let resolved = resolve_key_id(raw, &listing).ok_or_else(|| {
+            CliError::usage(format!("no ssh key matches \"{raw}\""))
+        })?;
+        let path = format!("{BASE_PATH}/{resolved}");
+        let request = client
+            .request(Method::DELETE, &path)
+            .build()
+            .map_err(SdkError::from)
+            .map_err(map_sdk_error)?;
+        client.execute(request).await.map_err(map_sdk_error)?;
+        removed += 1;
+    }
+    if removed == 1 {
+        println!("removed 1 ssh key");
+    } else {
+        println!("removed {removed} ssh keys");
+    }
+    Ok(())
+}
+
+fn resolve_key_id(input: &str, listing: &[ApiSshKey]) -> Option<String> {
+    // 1) Exact id match (the `ssh_key_<nanoid>` form returned by the API).
+    if listing.iter().any(|k| k.id == input) {
+        return Some(input.to_string());
+    }
+    // 2) Exact name match. Fingerprint match is intentionally not supported
+    //    here — it would conflate "is this fingerprint registered?" with
+    //    "delete the key with this fingerprint" and risks accidental deletes
+    //    if the same key has been re-registered after a rotation.
+    let matches: Vec<&ApiSshKey> = listing.iter().filter(|k| k.name == input).collect();
+    match matches.as_slice() {
+        [single] => Some(single.id.clone()),
+        _ => None, // 0 or >1 — ambiguous
+    }
+}
+
+fn read_public_key(arg: &str) -> Result<String> {
+    let path = std::path::Path::new(arg);
+    if path.is_file() {
+        std::fs::read_to_string(path).map_err(|e| {
+            CliError::usage(format!("failed to read {}: {e}", path.display()))
+        })
+    } else {
+        Ok(arg.to_string())
+    }
+}
+
+fn http_client(ctx: &CliContext) -> Result<Client> {
+    let token = ctx.bearer_token()?;
+    let mut builder = ClientBuilder::new(&ctx.api_url).bearer_token(&token);
+    let use_scope_headers = ctx.personal_access_token.is_some() && ctx.api_key.is_none();
+    if use_scope_headers
+        && let (Some(org), Some(proj)) =
+            (ctx.effective_organization_id(), ctx.effective_project_id())
+    {
+        builder = builder.scope(&org, &proj);
+    }
+    builder.build().map_err(Into::into)
+}
+
+fn map_sdk_error(error: SdkError) -> CliError {
+    match error {
+        SdkError::Authentication(_) => {
+            CliError::auth("authentication failed; run 'tl login'")
+        }
+        SdkError::Authorization(_) => CliError::auth(
+            "permission denied; run 'tl login' or check your account permissions",
+        ),
+        SdkError::ServerError { status, message } => {
+            let code = status.as_u16();
+            if (400..500).contains(&code) {
+                CliError::usage(format!(
+                    "ssh-keys request rejected ({code}): {}",
+                    parse_remote_message(&message)
+                ))
+            } else {
+                CliError::Other(anyhow::anyhow!(
+                    "platform server error ({code}) on ssh-keys request"
+                ))
+            }
+        }
+        other => CliError::from(other),
+    }
+}
+
+fn map_create_sdk_error(error: SdkError) -> CliError {
+    if let SdkError::ServerError { status, message } = &error
+        && status.as_u16() == 409
+    {
+        return CliError::usage(format!(
+            "this ssh key is already registered: {}",
+            parse_remote_message(message)
+        ));
+    }
+    map_sdk_error(error)
+}
+
+fn parse_remote_message(raw: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|body| {
+            body.get("message")
+                .and_then(|v| v.as_str())
+                .map(String::from)
+        })
+        .unwrap_or_else(|| raw.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(id: &str, name: &str) -> ApiSshKey {
+        ApiSshKey {
+            id: id.into(),
+            name: name.into(),
+            key_type: "ssh-ed25519".into(),
+            fingerprint: "SHA256:fake".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            last_used_at: None,
+        }
+    }
+
+    #[test]
+    fn resolve_id_matches_exact_id_first() {
+        let listing = vec![mk("ssh_key_aaa", "laptop"), mk("ssh_key_bbb", "ssh_key_aaa")];
+        assert_eq!(resolve_key_id("ssh_key_aaa", &listing).as_deref(), Some("ssh_key_aaa"));
+    }
+
+    #[test]
+    fn resolve_id_matches_unique_name() {
+        let listing = vec![mk("ssh_key_aaa", "laptop"), mk("ssh_key_bbb", "desktop")];
+        assert_eq!(resolve_key_id("desktop", &listing).as_deref(), Some("ssh_key_bbb"));
+    }
+
+    #[test]
+    fn resolve_id_rejects_ambiguous_name() {
+        let listing = vec![mk("ssh_key_aaa", "laptop"), mk("ssh_key_bbb", "laptop")];
+        assert_eq!(resolve_key_id("laptop", &listing), None);
+    }
+
+    #[test]
+    fn resolve_id_rejects_unknown() {
+        let listing = vec![mk("ssh_key_aaa", "laptop")];
+        assert_eq!(resolve_key_id("nope", &listing), None);
+    }
+
+    #[test]
+    fn read_public_key_returns_literal_when_not_a_path() {
+        let literal = "ssh-ed25519 AAAA test@host";
+        assert_eq!(read_public_key(literal).unwrap(), literal);
+    }
+
+    #[test]
+    fn read_public_key_reads_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("id_ed25519.pub");
+        std::fs::write(&path, "ssh-ed25519 AAAA file@host\n").unwrap();
+        let body = read_public_key(path.to_str().unwrap()).unwrap();
+        assert!(body.starts_with("ssh-ed25519 AAAA"));
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,7 +12,7 @@ use clap::{Parser, Subcommand};
 use std::num::NonZeroUsize;
 
 use auth::context::CliContext;
-use auth::guard::ensure_auth_and_project;
+use auth::guard::{ensure_auth, ensure_auth_and_project};
 use config::resolver;
 use error::CliError;
 
@@ -173,6 +173,10 @@ enum Commands {
     #[command(subcommand)]
     Secrets(SecretsCommands),
 
+    /// Manage SSH public keys for sandbox SSH access
+    #[command(subcommand, name = "ssh-keys", alias = "ssh-key")]
+    SshKeys(SshKeysCommands),
+
     /// List applications
     #[command(name = "ls")]
     Applications(ApplicationsArgs),
@@ -197,6 +201,27 @@ enum SecretsCommands {
         /// Secret names to unset
         #[arg(required = true)]
         secret_names: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum SshKeysCommands {
+    /// List the SSH public keys registered to your account
+    Ls,
+    /// Register an SSH public key (path to a `.pub` file or the key body
+    /// itself). The fingerprint is computed server-side.
+    Add {
+        /// Friendly label, e.g. `laptop` or `ci-runner`
+        #[arg(short, long)]
+        name: String,
+        /// Path to an OpenSSH public key file or the literal key body
+        public_key: String,
+    },
+    /// Remove one or more SSH keys (by id or by unique name)
+    Rm {
+        /// Key ids (`ssh_key_…`) or unique names to remove
+        #[arg(required = true)]
+        keys: Vec<String>,
     },
 }
 
@@ -789,6 +814,18 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                 SecretsCommands::Rm { secret_names } => {
                     commands::secrets::unset(ctx, &secret_names).await
                 }
+            }
+        }
+        Commands::SshKeys(subcmd) => {
+            // SSH keys live on the user, not on a project — only auth (PAT or
+            // logged-in session) is required, no org/project context.
+            ensure_auth(ctx).await?;
+            match subcmd {
+                SshKeysCommands::Ls => commands::ssh_keys::list(ctx).await,
+                SshKeysCommands::Add { name, public_key } => {
+                    commands::ssh_keys::add(ctx, &name, &public_key).await
+                }
+                SshKeysCommands::Rm { keys } => commands::ssh_keys::remove(ctx, &keys).await,
             }
         }
         Commands::Applications(app_args) => {


### PR DESCRIPTION
## Summary

Adds `tl ssh-keys {ls,add,rm}` to manage the OpenSSH public keys that the sandbox SSH gateway will accept on behalf of the logged-in user. Backed by the new platform-api endpoints landed in [tensorlakeai/platform-api#477](https://github.com/tensorlakeai/platform-api/pull/477).

```
tl ssh-keys ls
tl ssh-keys add --name laptop ~/.ssh/id_ed25519.pub
tl ssh-keys add --name ci-runner "ssh-ed25519 AAAA..."
tl ssh-keys rm laptop                 # by unique name
tl ssh-keys rm ssh_key_abc123         # by id
tl ssh-keys rm laptop ci-runner       # bulk
```

The `add` arg is path-or-literal — a readable file path is loaded, otherwise the argument is treated as the OpenSSH key body. Server-side parsing/fingerprinting is authoritative.

## What changed

- New `commands/ssh_keys.rs` — list/add/rm against `/platform/v1/users/me/ssh-keys` via `tensorlake_cloud_sdk::Client::{build_get_json_request, build_post_json_request, request, execute_json}`. Reuses the same scope-headers logic as `tl secrets` (PAT → `X-Forwarded-Organization-Id` / `X-Forwarded-Project-Id`; API key → none).
- New `ensure_auth` helper in `auth/guard.rs` that skips the org/project enforcement of `ensure_auth_and_project`. SSH keys are user-scoped.
- Wired `SshKeysCommands` enum + dispatch in `main.rs`. Aliased as `ssh-key` for the singular form.
- Special-cases the platform's 409 on duplicate fingerprint into `\"this ssh key is already registered\"` instead of a generic HTTP error.

## Test plan

- [x] `cargo test -p tensorlake-cli ssh_keys` — 6 unit tests passing (resolve_key_id: exact-id / unique-name / ambiguous-name / unknown; read_public_key: path vs. literal)
- [x] `RUSTFLAGS=\"-D warnings\" cargo build -p tensorlake-cli --bins --tests` clean
- [x] `tl ssh-keys --help` renders correctly
- [ ] End-to-end against staging: `tl ssh-keys add --name e2e ~/.ssh/id_ed25519.pub` then `tl ssh-keys ls` then `tl ssh-keys rm e2e`
- [ ] 409 path: register a key, register the same key again, see the friendly error

## Notes

- Cargo.lock has tensorlake workspace version bumps (0.5.0 → 0.5.1) that came in via local `cargo check`; these are unrelated to the SSH-keys work but are part of the same commit since the lockfile must stay in sync.
- The user-facing endpoints are gated on session/PAT, not API keys. If the caller has only an API key set, `tl ssh-keys add` will surface the 4xx as a usage error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)