### PR TITLE
feat(rust-sdk): rename crate to tensorlake and add crates.io publish workflow

### DIFF
--- a/.github/workflows/publish_crates_io.yaml
+++ b/.github/workflows/publish_crates_io.yaml
@@ -1,0 +1,27 @@
+name: Publish tensorlake to crates.io
+
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Publish to crates.io
+        run: cargo publish -p tensorlake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,12 +246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,27 +1432,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -2152,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2298,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2669,6 +2668,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,50 +2797,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tensorlake-cli"
-version = "0.5.0"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bollard",
- "bytes",
- "chrono",
- "clap",
- "comfy-table",
- "console",
- "crossterm",
- "dialoguer",
- "dirs",
- "docker-credentials-config",
- "eventsource-stream",
- "futures",
- "gethostname",
- "hex",
- "http-body-util",
- "indicatif",
- "minijinja",
- "open",
- "rand 0.9.4",
- "reqwest",
- "rustls",
- "rustpython-parser",
- "serde",
- "serde_json",
- "sha2",
- "shlex",
- "tempfile",
- "tensorlake-cloud-sdk",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "toml",
- "url",
- "urlencoding",
-]
-
-[[package]]
-name = "tensorlake-cloud-sdk"
-version = "0.5.0"
+name = "tensorlake"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2862,15 +2835,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "tensorlake-cli"
+version = "0.5.1"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bollard",
+ "bytes",
+ "chrono",
+ "clap",
+ "comfy-table",
+ "console",
+ "crossterm",
+ "dialoguer",
+ "dirs",
+ "docker-credentials-config",
+ "eventsource-stream",
+ "futures",
+ "gethostname",
+ "hex",
+ "http-body-util",
+ "indicatif",
+ "minijinja",
+ "open",
+ "rand 0.9.4",
+ "reqwest",
+ "rustls",
+ "rustpython-parser",
+ "serde",
+ "serde_json",
+ "sha2",
+ "shlex",
+ "tempfile",
+ "tensorlake",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "toml",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "futures",
  "pyo3",
  "reqwest",
  "serde",
  "serde_json",
- "tensorlake-cloud-sdk",
+ "tensorlake",
  "tokio",
 ]
 
@@ -3641,15 +3656,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -3686,21 +3692,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
@@ -3732,12 +3723,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3750,12 +3735,6 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -3765,12 +3744,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3792,12 +3765,6 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -3807,12 +3774,6 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3828,12 +3789,6 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -3843,12 +3798,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 async-trait = "0.1"
 
 # Internal crates
-tensorlake-cloud-sdk = { path = "crates/cloud-sdk" }
+tensorlake = { path = "crates/cloud-sdk" }
 
 # Async runtime
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "time", "process", "io-std", "io-util", "signal"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ name = "tensorlake"
 path = "src/tensorlake.rs"
 
 [dependencies]
-tensorlake-cloud-sdk = { workspace = true }
+tensorlake = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/cli/src/commands/build_images.rs
+++ b/crates/cli/src/commands/build_images.rs
@@ -5,7 +5,7 @@ use docker_credentials_config::{DockerConfig, image_registry};
 use futures::StreamExt;
 use http_body_util::{Either, Full};
 use minijinja::Environment;
-use tensorlake_cloud_sdk::images::models::{Image, ImageBuildOperation, ImageBuildOperationType};
+use tensorlake::images::models::{Image, ImageBuildOperation, ImageBuildOperationType};
 
 use crate::error::{CliError, Result};
 

--- a/crates/cli/src/commands/cron.rs
+++ b/crates/cli/src/commands/cron.rs
@@ -1,9 +1,9 @@
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use chrono::{DateTime, Utc};
 use comfy_table::Cell;
-use tensorlake_cloud_sdk::ClientBuilder;
-use tensorlake_cloud_sdk::cron::CronClient;
-use tensorlake_cloud_sdk::error::SdkError;
+use tensorlake::ClientBuilder;
+use tensorlake::cron::CronClient;
+use tensorlake::error::SdkError;
 
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -6,7 +6,7 @@ use std::{
 
 use serde_json::{Map, Value};
 use shlex::split as shlex_split;
-use tensorlake_cloud_sdk::{
+use tensorlake::{
     Client,
     sandbox_templates::models::CreateSandboxTemplateRequest,
     sandboxes::{
@@ -1080,7 +1080,7 @@ mod tests {
         resolve_context_source_path, wait_for_snapshot,
     };
     use std::{cell::Cell, io::Write, time::Duration};
-    use tensorlake_cloud_sdk::sandboxes::models::SnapshotInfo;
+    use tensorlake::sandboxes::models::SnapshotInfo;
 
     #[test]
     fn default_registered_name_uses_parent_for_dockerfile() {

--- a/crates/cli/src/commands/sbx/image/mod.rs
+++ b/crates/cli/src/commands/sbx/image/mod.rs
@@ -5,7 +5,7 @@ pub mod register;
 
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
-use tensorlake_cloud_sdk::{Client, ClientBuilder, sandbox_templates::SandboxTemplatesClient};
+use tensorlake::{Client, ClientBuilder, sandbox_templates::SandboxTemplatesClient};
 
 /// Build the sandbox-templates API base URL for the current org/project.
 pub fn templates_base_url(ctx: &CliContext) -> Result<(String, String, String)> {

--- a/crates/cli/src/commands/sbx/image/register.rs
+++ b/crates/cli/src/commands/sbx/image/register.rs
@@ -1,7 +1,7 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::snapshot::fetch_snapshot_info;
 use crate::error::{CliError, Result};
-use tensorlake_cloud_sdk::sandbox_templates::models::CreateSandboxTemplateRequest;
+use tensorlake::sandbox_templates::models::CreateSandboxTemplateRequest;
 
 #[derive(Debug)]
 struct SnapshotRegistrationMetadata {

--- a/crates/cli/src/commands/secrets.rs
+++ b/crates/cli/src/commands/secrets.rs
@@ -1,10 +1,10 @@
 use comfy_table::Cell;
-use tensorlake_cloud_sdk::error::SdkError;
-use tensorlake_cloud_sdk::secrets::SecretsClient;
-use tensorlake_cloud_sdk::secrets::models::{
+use tensorlake::error::SdkError;
+use tensorlake::secrets::SecretsClient;
+use tensorlake::secrets::models::{
     DeleteSecretRequest, ListSecretsRequest, NewSecret, UpsertSecret, UpsertSecretRequest,
 };
-use tensorlake_cloud_sdk::{Client, ClientBuilder};
+use tensorlake::{Client, ClientBuilder};
 
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -27,7 +27,7 @@ pub enum CliError {
     TomlSer(#[from] toml::ser::Error),
 
     #[error("{0}")]
-    Sdk(#[from] tensorlake_cloud_sdk::error::SdkError),
+    Sdk(#[from] tensorlake::error::SdkError),
 
     #[error("{0}")]
     Other(#[from] anyhow::Error),

--- a/crates/cloud-sdk/Cargo.toml
+++ b/crates/cloud-sdk/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
-name = "tensorlake-cloud-sdk"
+name = "tensorlake"
 version.workspace = true
 authors = ["support@tensorlake.ai"]
 description = "A Rust SDK for interacting with Tensorlake Cloud APIs."
 license = "Apache-2.0"
 edition = "2024"
+repository = "https://github.com/tensorlakeai/tensorlake"
+homepage = "https://tensorlake.ai"
+documentation = "https://docs.rs/tensorlake"
 
 [dependencies]
 bytes = { workspace = true }

--- a/crates/cloud-sdk/src/applications/mod.rs
+++ b/crates/cloud-sdk/src/applications/mod.rs
@@ -5,7 +5,7 @@
 //! ## Usage
 //!
 //! ```rust,no_run
-//! use tensorlake_cloud_sdk::{ClientBuilder, applications::{ApplicationsClient, models::{ListApplicationsRequest, GetApplicationRequest}}};
+//! use tensorlake::{ClientBuilder, applications::{ApplicationsClient, models::{ListApplicationsRequest, GetApplicationRequest}}};
 //!
 //! async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //!     let client = ClientBuilder::new("https://api.tensorlake.ai")

--- a/crates/cloud-sdk/src/images/mod.rs
+++ b/crates/cloud-sdk/src/images/mod.rs
@@ -6,7 +6,7 @@
 //! ## Usage
 //!
 //! ```rust
-//! use tensorlake_cloud_sdk::{Sdk, images::models::{ImageBuildRequest, Image}};
+//! use tensorlake::{Sdk, images::models::{ImageBuildRequest, Image}};
 //!
 //! let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key").unwrap();
 //! let images_client = sdk.images();

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -7,7 +7,7 @@
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use tensorlake_cloud_sdk::{Sdk, applications::models::ListApplicationsRequest};
+//! use tensorlake::{Sdk, applications::models::ListApplicationsRequest};
 //!
 //! async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create the SDK client
@@ -31,7 +31,7 @@
 //! Provide your token when creating the SDK:
 //!
 //! ```rust,no_run
-//! use tensorlake_cloud_sdk::Sdk;
+//! use tensorlake::Sdk;
 //!
 //! let sdk = Sdk::new("https://api.tensorlake.ai", "your-token").unwrap();
 //! ```
@@ -49,7 +49,7 @@
 //! The SDK provides detailed error types for different scenarios:
 //!
 //! ```rust,no_run
-//! use tensorlake_cloud_sdk::{Sdk, applications::models::ListApplicationsRequest};
+//! use tensorlake::{Sdk, applications::models::ListApplicationsRequest};
 //!
 //! async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //!     let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key")?;
@@ -93,7 +93,7 @@ pub use client::{Client, ClientBuilder, Traced};
 /// ## Example
 ///
 /// ```rust
-/// use tensorlake_cloud_sdk::Sdk;
+/// use tensorlake::Sdk;
 ///
 /// let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key").unwrap();
 ///
@@ -125,7 +125,7 @@ impl Sdk {
     /// # Example
     ///
     /// ```rust
-    /// use tensorlake_cloud_sdk::Sdk;
+    /// use tensorlake::Sdk;
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key").unwrap();
@@ -159,7 +159,7 @@ impl Sdk {
     /// # Example
     ///
     /// ```rust
-    /// use tensorlake_cloud_sdk::{Sdk, ClientBuilder};
+    /// use tensorlake::{Sdk, ClientBuilder};
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let builder = ClientBuilder::new("https://api.tensorlake.ai")
@@ -188,7 +188,7 @@ impl Sdk {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{Sdk, applications::models::ListApplicationsRequest};
+    /// use tensorlake::{Sdk, applications::models::ListApplicationsRequest};
     ///
     /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
     ///     let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key")?;
@@ -219,7 +219,7 @@ impl Sdk {
     /// # Example
     ///
     /// ```rust
-    /// use tensorlake_cloud_sdk::Sdk;
+    /// use tensorlake::Sdk;
     ///
     /// let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key").unwrap();
     /// let images_client = sdk.images();
@@ -278,7 +278,7 @@ impl Sdk {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{Sdk, secrets::models::ListSecretsRequest};
+    /// use tensorlake::{Sdk, secrets::models::ListSecretsRequest};
     ///
     /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
     ///     let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key")?;

--- a/crates/cloud-sdk/src/secrets/mod.rs
+++ b/crates/cloud-sdk/src/secrets/mod.rs
@@ -5,7 +5,7 @@
 //! ## Usage
 //!
 //! ```rust
-//! use tensorlake_cloud_sdk::{Sdk, secrets::models::{UpsertSecretRequest, ListSecretsRequest}};
+//! use tensorlake::{Sdk, secrets::models::{UpsertSecretRequest, ListSecretsRequest}};
 //!
 //! async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //!     let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key")?;
@@ -56,7 +56,7 @@ impl SecretsClient {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use tensorlake_cloud_sdk::{ClientBuilder, secrets::SecretsClient};
+    /// use tensorlake::{ClientBuilder, secrets::SecretsClient};
     ///
     /// fn example() -> Result<(), Box<dyn std::error::Error>> {
     ///     let client = ClientBuilder::new("https://api.tensorlake.ai")

--- a/crates/cloud-sdk/tests/applications.rs
+++ b/crates/cloud-sdk/tests/applications.rs
@@ -1,6 +1,6 @@
 use data_encoding::BASE64;
 use std::{collections::HashMap, io::Write, time::Duration};
-use tensorlake_cloud_sdk::{applications::models::*, images::models::BuildStatus};
+use tensorlake::{applications::models::*, images::models::BuildStatus};
 use tokio::time::sleep;
 
 use crate::common::random_string;

--- a/crates/cloud-sdk/tests/common.rs
+++ b/crates/cloud-sdk/tests/common.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 use std::env;
-use tensorlake_cloud_sdk::{Sdk, images::models::*};
+use tensorlake::{Sdk, images::models::*};
 
 fn env_var(name: &str) -> Result<String, String> {
     env::var(name).map_err(|_| format!("{name} must be set"))

--- a/crates/cloud-sdk/tests/images.rs
+++ b/crates/cloud-sdk/tests/images.rs
@@ -1,5 +1,5 @@
-use tensorlake_cloud_sdk::images::models::*;
-use tensorlake_cloud_sdk::{ClientBuilder, images::ImagesClient};
+use tensorlake::images::models::*;
+use tensorlake::{ClientBuilder, images::ImagesClient};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 

--- a/crates/cloud-sdk/tests/secrets.rs
+++ b/crates/cloud-sdk/tests/secrets.rs
@@ -1,4 +1,4 @@
-use tensorlake_cloud_sdk::secrets::models::*;
+use tensorlake::secrets::models::*;
 
 use crate::common::random_string;
 

--- a/crates/rust-cloud-sdk-py/Cargo.toml
+++ b/crates/rust-cloud-sdk-py/Cargo.toml
@@ -10,7 +10,7 @@ name = "_cloud_sdk"
 crate-type = ["cdylib"]
 
 [dependencies]
-tensorlake-cloud-sdk = { workspace = true }
+tensorlake = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -17,18 +17,18 @@ use reqwest::Method;
 use reqwest::multipart::{Form, Part};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use tensorlake_cloud_sdk::document_ai::DocumentAiClient;
-use tensorlake_cloud_sdk::images::ImagesClient;
-use tensorlake_cloud_sdk::images::models::{
+use tensorlake::document_ai::DocumentAiClient;
+use tensorlake::images::ImagesClient;
+use tensorlake::images::models::{
     ApplicationBuildContext, CreateApplicationBuildRequest,
 };
-use tensorlake_cloud_sdk::sandboxes::models::{
+use tensorlake::sandboxes::models::{
     CreateSandboxRequest, SandboxPoolRequest, SnapshotContentMode, UpdateSandboxRequest,
 };
-use tensorlake_cloud_sdk::sandboxes::{
+use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
 };
-use tensorlake_cloud_sdk::{Client, ClientBuilder, error::SdkError};
+use tensorlake::{Client, ClientBuilder, error::SdkError};
 use tokio::runtime::Runtime;
 
 create_exception!(_cloud_sdk, CloudApiClientError, PyException);
@@ -1858,7 +1858,7 @@ fn create_image_context_file(
     operations_json: String,
     file_path: String,
 ) -> PyResult<()> {
-    use tensorlake_cloud_sdk::images::models::{Image, ImageBuildOperation};
+    use tensorlake::images::models::{Image, ImageBuildOperation};
 
     let operations: Vec<ImageBuildOperation> =
         serde_json::from_str(&operations_json).map_err(|e| {


### PR DESCRIPTION
## Summary

- Renames the `tensorlake-cloud-sdk` crate to `tensorlake` for a clean public name on crates.io
- Updates all internal references (`tensorlake_cloud_sdk` → `tensorlake`) across Cargo.toml files and Rust source/test files
- Adds `repository`, `homepage`, and `documentation` fields to the crate manifest (required by crates.io)
- Adds `.github/workflows/publish_crates_io.yaml` — a manually triggered workflow that publishes to crates.io using OIDC trusted publishing (no `CARGO_REGISTRY_TOKEN` secret needed)

## Before publishing

Configure a trusted publisher on crates.io for the `tensorlake` crate:
- Org: `tensorlakeai`, Repo: `tensorlake`, Workflow: `publish_crates_io.yaml`

Then trigger the first publish via "Run workflow" in GitHub Actions.

## Test plan

- [x] `cargo check -p tensorlake` passes
- [x] `cargo check -p tensorlake-cli -p tensorlake-rust-cloud-sdk-py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)