### PR TITLE
fix(ci): fix crates.io trusted publishing and standardize release workflow names

### DIFF
--- a/.github/workflows/publish_cli.yaml
+++ b/.github/workflows/publish_cli.yaml
@@ -1,4 +1,6 @@
-name: Release Tensorlake CLI binaries
+name: Release - CLI Binaries
+
+run-name: "Release - CLI Binaries · ${{ github.ref_name }} · @${{ github.actor }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish_crates_io.yaml
+++ b/.github/workflows/publish_crates_io.yaml
@@ -1,4 +1,6 @@
-name: Publish tensorlake to crates.io
+name: Release - Rust SDK (crates.io)
+
+run-name: "Release - Rust SDK (crates.io) · ${{ github.ref_name }} · @${{ github.actor }}"
 
 on:
   workflow_dispatch:
@@ -23,5 +25,15 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
 
+      - name: Obtain OIDC token for crates.io
+        id: oidc
+        run: |
+          token=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=crates.io" | jq -r '.value')
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
       - name: Publish to crates.io
         run: cargo publish -p tensorlake
+        env:
+          CARGO_REGISTRY_TOKEN: "Bearer ${{ steps.oidc.outputs.token }}"

--- a/.github/workflows/publish_npm.yaml
+++ b/.github/workflows/publish_npm.yaml
@@ -1,4 +1,6 @@
-name: Release tensorlake npm package
+name: Release - TypeScript SDK (npm)
+
+run-name: "Release - TypeScript SDK (npm) · ${{ github.ref_name }} · @${{ github.actor }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -1,4 +1,6 @@
-name: Release Tensorlake SDK package.
+name: Release - Python SDK (PyPI)
+
+run-name: "Release - Python SDK (PyPI) · ${{ github.ref_name }} · @${{ github.actor }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish_test_pypi.yaml
+++ b/.github/workflows/publish_test_pypi.yaml
@@ -1,4 +1,6 @@
-name: Release Tensorlake SDK package to TestPyPi.
+name: Release - Python SDK (TestPyPI)
+
+run-name: "Release - Python SDK (TestPyPI) · ${{ github.ref_name }} · @${{ github.actor }}"
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

- **Fix crates.io publish**: `cargo publish` does not automatically exchange GitHub OIDC tokens. Added an explicit step that requests a JWT with `audience=crates.io` and passes it as `CARGO_REGISTRY_TOKEN: "Bearer <token>"`.
- **Consistent naming**: All release workflows now use a `Release - <target>` naming scheme (`Release - Rust SDK (crates.io)`, `Release - Python SDK (PyPI)`, `Release - Python SDK (TestPyPI)`, `Release - TypeScript SDK (npm)`, `Release - CLI Binaries`).
- **Dynamic run names**: Each workflow has a `run-name` showing the branch/tag and actor (e.g. `Release - Rust SDK (crates.io) · v0.5.1 · @david`).

## Test plan

- [ ] Trigger the `Release - Rust SDK (crates.io)` workflow manually and verify it publishes successfully to crates.io
- [ ] Confirm the run name in the Actions UI shows the branch and actor

🤖 Generated with [Claude Code](https://claude.com/claude-code)