### PR TITLE
fix(ci): remove double Bearer prefix in crates.io OIDC token

### DIFF
--- a/.github/workflows/publish_crates_io.yaml
+++ b/.github/workflows/publish_crates_io.yaml
@@ -36,4 +36,4 @@ jobs:
       - name: Publish to crates.io
         run: cargo publish -p tensorlake
         env:
-          CARGO_REGISTRY_TOKEN: "Bearer ${{ steps.oidc.outputs.token }}"
+          CARGO_REGISTRY_TOKEN: ${{ steps.oidc.outputs.token }}


### PR DESCRIPTION
## Summary

- Removes the `Bearer ` prefix from `CARGO_REGISTRY_TOKEN` in the crates.io publish workflow

## Root cause

Cargo constructs the `Authorization` header as `Bearer <CARGO_REGISTRY_TOKEN>`. The previous value `"Bearer <jwt>"` caused cargo to send `Authorization: Bearer Bearer <jwt>`, so crates.io received `Bearer <jwt>` as the token — which matches neither JWT format nor API token format, producing the 401 error.

Setting `CARGO_REGISTRY_TOKEN` to the raw JWT lets cargo produce the correct `Authorization: Bearer <jwt>` header, which crates.io recognises as an OIDC token and validates against the trusted publisher configuration.

## Test plan

- [ ] Trigger the `Release - Rust SDK (crates.io)` workflow and verify it publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)