### PR TITLE
chore: bump release version to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2824,7 +2824,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cloud-sdk"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.1"
+version = "0.5.2"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bump SDK version 0.5.1 → 0.5.2 across `pyproject.toml`, `Cargo.toml` workspace, and `typescript/package.json`
- Refresh `Cargo.lock` to match the new workspace version

## Test plan
- [ ] CI builds pass for Python, Rust, and TypeScript packages
- [ ] Verify published artifacts carry version 0.5.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)