### PR TITLE
Rename CLI disk flags to disk_mb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,8 +2797,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tensorlake-cli"
-version = "0.5.2"
+name = "tensorlake"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -2835,8 +2835,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tensorlake-cloud-sdk"
-version = "0.5.2"
+name = "tensorlake-cli"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -62,7 +62,7 @@ pub async fn run(
     ctx: &CliContext,
     dockerfile_path: &str,
     registered_name: Option<&str>,
-    disk_gb: Option<u64>,
+    disk_mb: Option<u64>,
     cpus: Option<f64>,
     memory_mb: Option<i64>,
     is_public: bool,
@@ -78,13 +78,7 @@ pub async fn run(
     let resources = CreateSandboxResources {
         cpus: cpus.unwrap_or(DEFAULT_CPUS),
         memory_mb: memory_mb.unwrap_or(DEFAULT_MEMORY_MB),
-        disk_mb: disk_gb
-            .map(|gib| {
-                gib.checked_mul(1024).ok_or_else(|| {
-                    CliError::usage("disk size is too large to express in MiB".to_string())
-                })
-            })
-            .transpose()?,
+        disk_mb,
     };
 
     eprintln!("⚙️  Creating build sandbox...");

--- a/crates/cli/src/commands/sbx/run.rs
+++ b/crates/cli/src/commands/sbx/run.rs
@@ -10,6 +10,7 @@ pub async fn run(
     image: Option<&str>,
     cpus: f64,
     memory: i64,
+    disk_mb: Option<u64>,
     timeout: Option<f64>,
     workdir: Option<&str>,
     env: &[String],
@@ -34,6 +35,9 @@ pub async fn run(
             "memory_mb": memory,
         },
     });
+    if let Some(disk_mb) = disk_mb {
+        create_body["resources"]["disk_mb"] = serde_json::json!(disk_mb);
+    }
     if let Some(img) = image {
         create_body["image"] = serde_json::Value::String(img.to_string());
     }

--- a/crates/cli/src/commands/sbx/run.rs
+++ b/crates/cli/src/commands/sbx/run.rs
@@ -10,7 +10,6 @@ pub async fn run(
     image: Option<&str>,
     cpus: f64,
     memory: i64,
-    disk_mb: Option<u64>,
     timeout: Option<f64>,
     workdir: Option<&str>,
     env: &[String],
@@ -35,9 +34,6 @@ pub async fn run(
             "memory_mb": memory,
         },
     });
-    if let Some(disk_mb) = disk_mb {
-        create_body["resources"]["disk_mb"] = serde_json::json!(disk_mb);
-    }
     if let Some(img) = image {
         create_body["image"] = serde_json::Value::String(img.to_string());
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -439,6 +439,10 @@ enum SbxCommands {
         #[arg(short, long, default_value = "1024")]
         memory: i64,
 
+        /// Root disk size in MB (default: 10240 for new sandboxes)
+        #[arg(long = "disk_mb")]
+        disk_mb: Option<u64>,
+
         /// Command timeout in seconds
         #[arg(short, long)]
         timeout: Option<f64>,
@@ -921,6 +925,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     image,
                     cpus,
                     memory,
+                    disk_mb,
                     timeout,
                     workdir,
                     env,
@@ -938,6 +943,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         image.as_deref(),
                         cpus,
                         memory,
+                        disk_mb,
                         timeout,
                         workdir.as_deref(),
                         &env,
@@ -1058,6 +1064,27 @@ mod tests {
         let result = Cli::try_parse_from(["tl", "sbx", "clone", "sbx-123", "--times", "0"]);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn sbx_run_parses_disk_mb_override() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "run",
+            "--disk_mb",
+            "30720",
+            "echo",
+            "hello",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Run { disk_mb, .. }) => {
+                assert_eq!(disk_mb, Some(30720));
+            }
+            _ => panic!("expected sbx run command"),
+        }
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -439,10 +439,6 @@ enum SbxCommands {
         #[arg(short, long, default_value = "1024")]
         memory: i64,
 
-        /// Root disk size in MB (default: 10240 for new sandboxes)
-        #[arg(long = "disk_mb")]
-        disk_mb: Option<u64>,
-
         /// Command timeout in seconds
         #[arg(short, long)]
         timeout: Option<f64>,
@@ -925,7 +921,6 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     image,
                     cpus,
                     memory,
-                    disk_mb,
                     timeout,
                     workdir,
                     env,
@@ -943,7 +938,6 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         image.as_deref(),
                         cpus,
                         memory,
-                        disk_mb,
                         timeout,
                         workdir.as_deref(),
                         &env,
@@ -1064,27 +1058,6 @@ mod tests {
         let result = Cli::try_parse_from(["tl", "sbx", "clone", "sbx-123", "--times", "0"]);
 
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn sbx_run_parses_disk_mb_override() {
-        let cli = Cli::try_parse_from([
-            "tl",
-            "sbx",
-            "run",
-            "--disk_mb",
-            "30720",
-            "echo",
-            "hello",
-        ])
-        .unwrap();
-
-        match cli.command {
-            Commands::Sbx(SbxCommands::Run { disk_mb, .. }) => {
-                assert_eq!(disk_mb, Some(30720));
-            }
-            _ => panic!("expected sbx run command"),
-        }
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -297,6 +297,10 @@ enum SbxCommands {
         #[arg(long = "disk_mb")]
         disk_mb: Option<u64>,
 
+        /// Deprecated: root disk size in GB
+        #[arg(long = "disk", hide = true, conflicts_with = "disk_mb")]
+        disk_gb: Option<u64>,
+
         /// Timeout in seconds
         #[arg(short, long)]
         timeout: Option<i64>,
@@ -557,6 +561,10 @@ enum ImageCommands {
         #[arg(long = "disk_mb")]
         disk_mb: Option<u64>,
 
+        /// Deprecated: root disk size in GB for the temporary build sandbox
+        #[arg(long = "disk", hide = true, conflicts_with = "disk_mb")]
+        disk_gb: Option<u64>,
+
         /// CPUs for the temporary build sandbox
         #[arg(long)]
         cpus: Option<f64>,
@@ -801,6 +809,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     cpus,
                     memory,
                     disk_mb,
+                    disk_gb,
                     timeout,
                     entrypoint,
                     snapshot,
@@ -812,6 +821,17 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     network_allow,
                     network_deny,
                 } => {
+                    let disk_mb = if let Some(value) = disk_mb {
+                        Some(value)
+                    } else {
+                        disk_gb
+                            .map(|value| {
+                                value.checked_mul(1024).ok_or_else(|| {
+                                    CliError::usage("--disk is too large to convert to MiB")
+                                })
+                            })
+                            .transpose()?
+                    };
                     commands::sbx::create::run(
                         ctx,
                         commands::sbx::create::CreateArgs {
@@ -967,10 +987,22 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         dockerfile_path,
                         registered_name,
                         disk_mb,
+                        disk_gb,
                         cpus,
                         memory,
                         public,
                     } => {
+                        let disk_mb = if let Some(value) = disk_mb {
+                            Some(value)
+                        } else {
+                            disk_gb
+                                .map(|value| {
+                                    value.checked_mul(1024).ok_or_else(|| {
+                                        CliError::usage("--disk is too large to convert to MiB")
+                                    })
+                                })
+                                .transpose()?
+                        };
                         commands::sbx::image::create::run(
                             ctx,
                             &dockerfile_path,
@@ -1050,6 +1082,30 @@ mod tests {
     }
 
     #[test]
+    fn sbx_create_parses_hidden_disk_gb_override() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "create",
+            "--disk",
+            "25",
+            "--image",
+            "tensorlake/ubuntu-minimal",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Create {
+                disk_mb, disk_gb, ..
+            }) => {
+                assert_eq!(disk_mb, None);
+                assert_eq!(disk_gb, Some(25));
+            }
+            _ => panic!("expected sbx create command"),
+        }
+    }
+
+    #[test]
     fn image_create_parses_cpu_memory_and_disk_overrides() {
         let cli = Cli::try_parse_from([
             "tl",
@@ -1073,6 +1129,30 @@ mod tests {
                 assert_eq!(cpus, Some(3.5));
                 assert_eq!(memory, Some(8192));
                 assert_eq!(disk_mb, Some(30720));
+            }
+            _ => panic!("expected sbx image create command"),
+        }
+    }
+
+    #[test]
+    fn image_create_parses_hidden_disk_gb_override() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "image",
+            "create",
+            "./Dockerfile",
+            "--disk",
+            "25",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Image(ImageCommands::Create {
+                disk_mb, disk_gb, ..
+            })) => {
+                assert_eq!(disk_mb, None);
+                assert_eq!(disk_gb, Some(25));
             }
             _ => panic!("expected sbx image create command"),
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -293,9 +293,9 @@ enum SbxCommands {
         #[arg(short, long)]
         memory: Option<i64>,
 
-        /// Root disk size in GB
-        #[arg(long)]
-        disk: Option<u64>,
+        /// Root disk size in MB (default: 10240 for new sandboxes)
+        #[arg(long = "disk_mb")]
+        disk_mb: Option<u64>,
 
         /// Timeout in seconds
         #[arg(short, long)]
@@ -553,9 +553,9 @@ enum ImageCommands {
         #[arg(short = 'n', long)]
         registered_name: Option<String>,
 
-        /// Root disk size in GB for the temporary build sandbox
-        #[arg(long)]
-        disk: Option<u64>,
+        /// Root disk size in MB for the temporary build sandbox (default: 10240 for new sandboxes)
+        #[arg(long = "disk_mb")]
+        disk_mb: Option<u64>,
 
         /// CPUs for the temporary build sandbox
         #[arg(long)]
@@ -800,7 +800,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     name,
                     cpus,
                     memory,
-                    disk,
+                    disk_mb,
                     timeout,
                     entrypoint,
                     snapshot,
@@ -812,13 +812,6 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     network_allow,
                     network_deny,
                 } => {
-                    let disk_mb = disk
-                        .map(|value| {
-                            value.checked_mul(1024).ok_or_else(|| {
-                                CliError::usage("--disk is too large to convert to MiB")
-                            })
-                        })
-                        .transpose()?;
                     commands::sbx::create::run(
                         ctx,
                         commands::sbx::create::CreateArgs {
@@ -973,7 +966,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     ImageCommands::Create {
                         dockerfile_path,
                         registered_name,
-                        disk,
+                        disk_mb,
                         cpus,
                         memory,
                         public,
@@ -982,7 +975,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             ctx,
                             &dockerfile_path,
                             registered_name.as_deref(),
-                            disk,
+                            disk_mb,
                             cpus,
                             memory,
                             public,
@@ -1036,6 +1029,27 @@ mod tests {
     }
 
     #[test]
+    fn sbx_create_parses_disk_mb_override() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "create",
+            "--disk_mb",
+            "30720",
+            "--image",
+            "tensorlake/ubuntu-minimal",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Create { disk_mb, .. }) => {
+                assert_eq!(disk_mb, Some(30720));
+            }
+            _ => panic!("expected sbx create command"),
+        }
+    }
+
+    #[test]
     fn image_create_parses_cpu_memory_and_disk_overrides() {
         let cli = Cli::try_parse_from([
             "tl",
@@ -1047,18 +1061,18 @@ mod tests {
             "3.5",
             "--memory",
             "8192",
-            "--disk",
-            "30",
+            "--disk_mb",
+            "30720",
         ])
         .unwrap();
 
         match cli.command {
             Commands::Sbx(SbxCommands::Image(ImageCommands::Create {
-                cpus, memory, disk, ..
+                cpus, memory, disk_mb, ..
             })) => {
                 assert_eq!(cpus, Some(3.5));
                 assert_eq!(memory, Some(8192));
-                assert_eq!(disk, Some(30));
+                assert_eq!(disk_mb, Some(30720));
             }
             _ => panic!("expected sbx image create command"),
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.2"
+version = "0.5.3"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.1",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.1",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -1093,30 +1093,30 @@ export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {
       name: { type: "string", short: "n" },
       cpus: { type: "string" },
       memory: { type: "string" },
-      disk: { type: "string" },
+      disk_mb: { type: "string" },
       public: { type: "boolean", default: false },
     },
   });
 
   const dockerfilePath = parsed.positionals[0];
   if (!dockerfilePath) {
-    throw new Error("Usage: tensorlake-create-sandbox-image <dockerfile_path> [--name NAME] [--cpus N] [--memory MB] [--disk GB] [--public]");
+    throw new Error("Usage: tensorlake-create-sandbox-image <dockerfile_path> [--name NAME] [--cpus N] [--memory MB] [--disk_mb MB] [--public]");
   }
 
   const cpus =
     parsed.values.cpus != null ? Number(parsed.values.cpus) : undefined;
   const memoryMb =
     parsed.values.memory != null ? Number(parsed.values.memory) : undefined;
-  const diskGb =
-    parsed.values.disk != null ? Number(parsed.values.disk) : undefined;
+  const diskMb =
+    parsed.values.disk_mb != null ? Number(parsed.values.disk_mb) : undefined;
   if (cpus != null && !Number.isFinite(cpus)) {
     throw new Error(`Invalid --cpus value: ${parsed.values.cpus}`);
   }
   if (memoryMb != null && !Number.isInteger(memoryMb)) {
     throw new Error(`Invalid --memory value: ${parsed.values.memory}`);
   }
-  if (diskGb != null && !Number.isInteger(diskGb)) {
-    throw new Error(`Invalid --disk value: ${parsed.values.disk}`);
+  if (diskMb != null && !Number.isInteger(diskMb)) {
+    throw new Error(`Invalid --disk_mb value: ${parsed.values.disk_mb}`);
   }
 
   await createSandboxImage(
@@ -1125,7 +1125,7 @@ export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {
       registeredName: parsed.values.name,
       cpus,
       memoryMb,
-      diskMb: diskGb != null ? diskGb * 1024 : undefined,
+      diskMb,
       isPublic: parsed.values.public,
     },
     { emit: ndjsonStdoutEmit },


### PR DESCRIPTION
## Summary
- rename Rust CLI sandbox create flag from `--disk` to `--disk_mb` as the primary public flag
- add hidden Rust CLI legacy alias `--disk` (GB) for backward compatibility, converted to MB at dispatch time
- rename Rust CLI image build flag from `--disk` to `--disk_mb` as the primary public flag
- add hidden Rust CLI image-build legacy alias `--disk` (GB), converted to MB at dispatch time
- rename TypeScript sandbox-image CLI flag from `--disk` to `--disk_mb` and update usage/error text
- update CLI help text to include `(default: 10240 for new sandboxes)` for `--disk_mb`
- bump release versions to `0.5.3` for Rust workspace/CLI, Python package, and TypeScript package metadata

## Validation
- `cargo test -p tensorlake-cli sbx_create_parses_disk_mb_override -- --nocapture`
- `cargo test -p tensorlake-cli sbx_create_parses_hidden_disk_gb_override -- --nocapture`
- `cargo test -p tensorlake-cli image_create_parses_cpu_memory_and_disk_overrides -- --nocapture`
- `cargo test -p tensorlake-cli image_create_parses_hidden_disk_gb_override -- --nocapture`
- `cargo run -p tensorlake-cli --bin tl -- --version` (`tl 0.5.3`)
- `python3` read of `pyproject.toml` project version (`0.5.3`)
- `node -p "require('./typescript/package.json').version"` (`0.5.3`)
- `npm run typecheck` (typescript/)
- `npm run test -- tests/sandbox-image.test.ts` (typescript/)
