### PR TITLE
Add snapshot/checkpoint type flag

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -118,6 +118,15 @@ jobs:
       - name: Build and lint tensorlake
         run: make build && make check
 
+      - name: Run sandbox/image SDK unit tests
+        env:
+          PYTHONPATH: src
+        run: |
+          poetry run python -m unittest \
+            tests.sandbox.test_client_rust_backend \
+            tests.sandbox.test_sandbox_rust_backend \
+            tests.image.test_sandbox_builder
+
       - name: Set up Docker
         uses: docker/setup-docker-action@v4
 

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -53,6 +53,9 @@ jobs:
       - name: Run unit tests
         run: npm test
 
+      - name: Run snapshot-focused SDK unit tests
+        run: npm test -- tests/client.test.ts tests/sandbox-image.test.ts
+
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/clone.rs
+++ b/crates/cli/src/commands/sbx/clone.rs
@@ -14,7 +14,7 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, timeout: f64, times: usize)
         eprintln!("Cloning sandbox {} into {} copies...", sandbox_id, times);
     }
 
-    let snapshot_id = snapshot::create_snapshot(ctx, sandbox_id, timeout, None).await?;
+    let snapshot_id = snapshot::create_snapshot(ctx, sandbox_id, timeout, Some("memory")).await?;
 
     if times > 1 {
         eprintln!(

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -1185,6 +1185,7 @@ mod tests {
                     snapshot_uri: None,
                     size_bytes: None,
                     rootfs_disk_bytes: None,
+                    content_mode: None,
                     created_at: None,
                 })
             }

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -12,8 +12,7 @@ use tensorlake::{
     sandboxes::{
         SandboxProxyClient, SandboxesClient,
         models::{
-            CreateSandboxRequest, CreateSandboxResources, ProcessInfo, SnapshotContentMode,
-            SnapshotInfo,
+            CreateSandboxRequest, CreateSandboxResources, ProcessInfo, SnapshotInfo, SnapshotType,
         },
     },
 };
@@ -166,7 +165,7 @@ async fn create_snapshot_and_wait(
     sandbox_id: &str,
 ) -> Result<SnapshotRegistrationMetadata> {
     let snapshot = sandboxes
-        .snapshot(sandbox_id, Some(SnapshotContentMode::FilesystemOnly))
+        .snapshot(sandbox_id, Some(SnapshotType::Filesystem))
         .await?;
     let snapshot_id = snapshot.snapshot_id.clone();
 
@@ -1185,7 +1184,7 @@ mod tests {
                     snapshot_uri: None,
                     size_bytes: None,
                     rootfs_disk_bytes: None,
-                    content_mode: None,
+                    snapshot_type: None,
                     created_at: None,
                 })
             }

--- a/crates/cli/src/commands/sbx/snapshot.rs
+++ b/crates/cli/src/commands/sbx/snapshot.rs
@@ -41,7 +41,7 @@ pub async fn create_snapshot_with_details(
     ctx: &CliContext,
     sandbox_id: &str,
     timeout: f64,
-    content_mode: Option<&str>,
+    snapshot_type: Option<&str>,
 ) -> Result<SnapshotDetails> {
     let client = ctx.client()?;
 
@@ -49,9 +49,9 @@ pub async fn create_snapshot_with_details(
 
     let url = sandbox_endpoint(ctx, &format!("sandboxes/{}/snapshot", sandbox_id));
     let request = client.post(url);
-    let resp = if let Some(mode) = content_mode {
+    let resp = if let Some(t) = snapshot_type {
         request
-            .json(&serde_json::json!({"snapshot_content_mode": mode}))
+            .json(&serde_json::json!({"snapshot_type": t}))
             .send()
             .await
             .map_err(CliError::Http)?
@@ -146,10 +146,10 @@ pub async fn create_snapshot(
     ctx: &CliContext,
     sandbox_id: &str,
     timeout: f64,
-    content_mode: Option<&str>,
+    snapshot_type: Option<&str>,
 ) -> Result<String> {
     Ok(
-        create_snapshot_with_details(ctx, sandbox_id, timeout, content_mode)
+        create_snapshot_with_details(ctx, sandbox_id, timeout, snapshot_type)
             .await?
             .snapshot_id,
     )
@@ -159,9 +159,9 @@ pub async fn run(
     ctx: &CliContext,
     sandbox_id: &str,
     timeout: f64,
-    content_mode: Option<&str>,
+    snapshot_type: Option<&str>,
 ) -> Result<()> {
-    let snapshot_id = create_snapshot(ctx, sandbox_id, timeout, content_mode).await?;
+    let snapshot_id = create_snapshot(ctx, sandbox_id, timeout, snapshot_type).await?;
     println!("{}", snapshot_id);
     Ok(())
 }

--- a/crates/cli/src/commands/sbx/snapshot.rs
+++ b/crates/cli/src/commands/sbx/snapshot.rs
@@ -155,8 +155,13 @@ pub async fn create_snapshot(
     )
 }
 
-pub async fn run(ctx: &CliContext, sandbox_id: &str, timeout: f64) -> Result<()> {
-    let snapshot_id = create_snapshot(ctx, sandbox_id, timeout, None).await?;
+pub async fn run(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    timeout: f64,
+    content_mode: Option<&str>,
+) -> Result<()> {
+    let snapshot_id = create_snapshot(ctx, sandbox_id, timeout, content_mode).await?;
     println!("{}", snapshot_id);
     Ok(())
 }

--- a/crates/cli/src/commands/sbx/snapshot_ls.rs
+++ b/crates/cli/src/commands/sbx/snapshot_ls.rs
@@ -43,6 +43,7 @@ pub async fn run(ctx: &CliContext) -> Result<()> {
     let mut table = new_table(&[
         "ID",
         "Status",
+        "Content Mode",
         "Sandbox ID",
         "Base Image",
         "Size",
@@ -59,6 +60,7 @@ pub async fn run(ctx: &CliContext) -> Result<()> {
             .get("status")
             .and_then(|v| v.as_str())
             .unwrap_or("-");
+        let content_mode = format_content_mode(snapshot);
         let sandbox_id = snapshot
             .get("sandbox_id")
             .and_then(|v| v.as_str())
@@ -73,6 +75,7 @@ pub async fn run(ctx: &CliContext) -> Result<()> {
         table.add_row(vec![
             Cell::new(snapshot_id),
             Cell::new(status),
+            Cell::new(content_mode),
             Cell::new(sandbox_id),
             Cell::new(base_image),
             Cell::new(size),
@@ -98,5 +101,50 @@ fn format_size(size_bytes: Option<&serde_json::Value>) -> String {
         format!("{:.1} KB", size_bytes as f64 / 1024.0)
     } else {
         format!("{} B", size_bytes)
+    }
+}
+
+fn format_content_mode(snapshot: &serde_json::Value) -> String {
+    let raw_mode = snapshot
+        .get("content_mode")
+        .or_else(|| snapshot.get("snapshot_content_mode"))
+        .and_then(|v| v.as_str());
+
+    match raw_mode {
+        Some("filesystem") => "filesystem_only".to_string(),
+        Some("memory") => "full".to_string(),
+        Some(mode) => mode.to_string(),
+        None => "-".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_content_mode;
+
+    #[test]
+    fn format_content_mode_uses_content_mode_field() {
+        let snapshot = serde_json::json!({"content_mode": "filesystem_only"});
+        assert_eq!(format_content_mode(&snapshot), "filesystem_only");
+    }
+
+    #[test]
+    fn format_content_mode_uses_legacy_snapshot_content_mode_field() {
+        let snapshot = serde_json::json!({"snapshot_content_mode": "full"});
+        assert_eq!(format_content_mode(&snapshot), "full");
+    }
+
+    #[test]
+    fn format_content_mode_normalizes_alias_values() {
+        let filesystem_snapshot = serde_json::json!({"content_mode": "filesystem"});
+        let memory_snapshot = serde_json::json!({"content_mode": "memory"});
+        assert_eq!(format_content_mode(&filesystem_snapshot), "filesystem_only");
+        assert_eq!(format_content_mode(&memory_snapshot), "full");
+    }
+
+    #[test]
+    fn format_content_mode_handles_missing_mode() {
+        let snapshot = serde_json::json!({});
+        assert_eq!(format_content_mode(&snapshot), "-");
     }
 }

--- a/crates/cli/src/commands/sbx/snapshot_ls.rs
+++ b/crates/cli/src/commands/sbx/snapshot_ls.rs
@@ -43,7 +43,7 @@ pub async fn run(ctx: &CliContext) -> Result<()> {
     let mut table = new_table(&[
         "ID",
         "Status",
-        "Content Mode",
+        "Type",
         "Sandbox ID",
         "Base Image",
         "Size",
@@ -60,7 +60,7 @@ pub async fn run(ctx: &CliContext) -> Result<()> {
             .get("status")
             .and_then(|v| v.as_str())
             .unwrap_or("-");
-        let content_mode = format_content_mode(snapshot);
+        let snapshot_type = format_snapshot_type(snapshot);
         let sandbox_id = snapshot
             .get("sandbox_id")
             .and_then(|v| v.as_str())
@@ -75,7 +75,7 @@ pub async fn run(ctx: &CliContext) -> Result<()> {
         table.add_row(vec![
             Cell::new(snapshot_id),
             Cell::new(status),
-            Cell::new(content_mode),
+            Cell::new(snapshot_type),
             Cell::new(sandbox_id),
             Cell::new(base_image),
             Cell::new(size),
@@ -104,47 +104,33 @@ fn format_size(size_bytes: Option<&serde_json::Value>) -> String {
     }
 }
 
-fn format_content_mode(snapshot: &serde_json::Value) -> String {
-    let raw_mode = snapshot
-        .get("content_mode")
-        .or_else(|| snapshot.get("snapshot_content_mode"))
-        .and_then(|v| v.as_str());
-
-    match raw_mode {
-        Some("filesystem") => "filesystem_only".to_string(),
-        Some("memory") => "full".to_string(),
-        Some(mode) => mode.to_string(),
-        None => "-".to_string(),
-    }
+fn format_snapshot_type(snapshot: &serde_json::Value) -> String {
+    snapshot
+        .get("snapshot_type")
+        .and_then(|v| v.as_str())
+        .map(|t| t.to_string())
+        .unwrap_or_else(|| "-".to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::format_content_mode;
+    use super::format_snapshot_type;
 
     #[test]
-    fn format_content_mode_uses_content_mode_field() {
-        let snapshot = serde_json::json!({"content_mode": "filesystem_only"});
-        assert_eq!(format_content_mode(&snapshot), "filesystem_only");
+    fn format_snapshot_type_uses_snapshot_type_field() {
+        let snapshot = serde_json::json!({"snapshot_type": "filesystem"});
+        assert_eq!(format_snapshot_type(&snapshot), "filesystem");
     }
 
     #[test]
-    fn format_content_mode_uses_legacy_snapshot_content_mode_field() {
-        let snapshot = serde_json::json!({"snapshot_content_mode": "full"});
-        assert_eq!(format_content_mode(&snapshot), "full");
+    fn format_snapshot_type_handles_memory() {
+        let snapshot = serde_json::json!({"snapshot_type": "memory"});
+        assert_eq!(format_snapshot_type(&snapshot), "memory");
     }
 
     #[test]
-    fn format_content_mode_normalizes_alias_values() {
-        let filesystem_snapshot = serde_json::json!({"content_mode": "filesystem"});
-        let memory_snapshot = serde_json::json!({"content_mode": "memory"});
-        assert_eq!(format_content_mode(&filesystem_snapshot), "filesystem_only");
-        assert_eq!(format_content_mode(&memory_snapshot), "full");
-    }
-
-    #[test]
-    fn format_content_mode_handles_missing_mode() {
+    fn format_snapshot_type_handles_missing_field() {
         let snapshot = serde_json::json!({});
-        assert_eq!(format_content_mode(&snapshot), "-");
+        assert_eq!(format_snapshot_type(&snapshot), "-");
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -603,6 +603,26 @@ struct SnapshotArgs {
     /// Max seconds to wait
     #[arg(short, long, default_value = "300", requires = "sandbox_id")]
     timeout: f64,
+
+    /// Snapshot content mode. Defaults to `filesystem` when omitted. `full` captures VM memory + filesystem state, `filesystem` captures filesystem only.
+    #[arg(long, value_enum, requires = "sandbox_id")]
+    content_mode: Option<SnapshotContentModeArg>,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+enum SnapshotContentModeArg {
+    Full,
+    #[value(alias = "filesystem_only")]
+    Filesystem,
+}
+
+impl SnapshotContentModeArg {
+    fn as_wire_value(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Filesystem => "filesystem_only",
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -900,7 +920,15 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 "checkpoint requires a sandbox ID or the 'ls' subcommand",
                             )
                         })?;
-                        commands::sbx::snapshot::run(ctx, &sandbox_id, snapshot_args.timeout).await
+                        commands::sbx::snapshot::run(
+                            ctx,
+                            &sandbox_id,
+                            snapshot_args.timeout,
+                            snapshot_args
+                                .content_mode
+                                .map(SnapshotContentModeArg::as_wire_value),
+                        )
+                        .await
                     }
                 },
                 SbxCommands::Clone {
@@ -1067,17 +1095,88 @@ mod tests {
     }
 
     #[test]
-    fn sbx_run_parses_disk_mb_override() {
+    fn snapshot_content_mode_maps_to_wire_values() {
+        assert_eq!(SnapshotContentModeArg::Full.as_wire_value(), "full");
+        assert_eq!(
+            SnapshotContentModeArg::Filesystem.as_wire_value(),
+            "filesystem_only"
+        );
+    }
+
+    #[test]
+    fn sbx_checkpoint_parses_full_content_mode() {
         let cli = Cli::try_parse_from([
             "tl",
             "sbx",
-            "run",
-            "--disk_mb",
-            "30720",
-            "echo",
-            "hello",
+            "checkpoint",
+            "sbx-123",
+            "--content-mode",
+            "full",
         ])
         .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Checkpoint(SnapshotArgs {
+                sandbox_id,
+                content_mode,
+                ..
+            })) => {
+                assert_eq!(sandbox_id.as_deref(), Some("sbx-123"));
+                assert_eq!(content_mode, Some(SnapshotContentModeArg::Full));
+            }
+            _ => panic!("expected sbx checkpoint command"),
+        }
+    }
+
+    #[test]
+    fn sbx_checkpoint_parses_filesystem_content_mode() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "checkpoint",
+            "sbx-123",
+            "--content-mode",
+            "filesystem",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Checkpoint(SnapshotArgs {
+                sandbox_id,
+                content_mode,
+                ..
+            })) => {
+                assert_eq!(sandbox_id.as_deref(), Some("sbx-123"));
+                assert_eq!(content_mode, Some(SnapshotContentModeArg::Filesystem));
+            }
+            _ => panic!("expected sbx checkpoint command"),
+        }
+    }
+
+    #[test]
+    fn sbx_checkpoint_accepts_filesystem_only_content_mode_alias() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "checkpoint",
+            "sbx-123",
+            "--content-mode",
+            "filesystem_only",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Checkpoint(SnapshotArgs { content_mode, .. })) => {
+                assert_eq!(content_mode, Some(SnapshotContentModeArg::Filesystem));
+            }
+            _ => panic!("expected sbx checkpoint command"),
+        }
+    }
+
+    #[test]
+    fn sbx_run_parses_disk_mb_override() {
+        let cli = Cli::try_parse_from(["tl", "sbx", "run", "--disk_mb", "30720", "echo", "hello"])
+            .unwrap();
 
         match cli.command {
             Commands::Sbx(SbxCommands::Run { disk_mb, .. }) => {
@@ -1151,7 +1250,10 @@ mod tests {
 
         match cli.command {
             Commands::Sbx(SbxCommands::Image(ImageCommands::Create {
-                cpus, memory, disk_mb, ..
+                cpus,
+                memory,
+                disk_mb,
+                ..
             })) => {
                 assert_eq!(cpus, Some(3.5));
                 assert_eq!(memory, Some(8192));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -604,7 +604,7 @@ struct SnapshotArgs {
     #[arg(short, long, default_value = "300", requires = "sandbox_id")]
     timeout: f64,
 
-    /// Snapshot type. Defaults to `filesystem` when omitted. `memory` captures VM memory + filesystem state, `filesystem` captures filesystem only.
+    /// Optional snapshot type. When omitted, the client sends no `snapshot_type` and the server applies its default (currently `filesystem`). `memory` captures VM memory + filesystem state, `filesystem` captures filesystem only.
     #[arg(long, value_enum, requires = "sandbox_id")]
     snapshot_type: Option<SnapshotTypeArg>,
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -604,23 +604,22 @@ struct SnapshotArgs {
     #[arg(short, long, default_value = "300", requires = "sandbox_id")]
     timeout: f64,
 
-    /// Snapshot content mode. Defaults to `filesystem` when omitted. `full` captures VM memory + filesystem state, `filesystem` captures filesystem only.
+    /// Snapshot type. Defaults to `filesystem` when omitted. `memory` captures VM memory + filesystem state, `filesystem` captures filesystem only.
     #[arg(long, value_enum, requires = "sandbox_id")]
-    content_mode: Option<SnapshotContentModeArg>,
+    snapshot_type: Option<SnapshotTypeArg>,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-enum SnapshotContentModeArg {
-    Full,
-    #[value(alias = "filesystem_only")]
+enum SnapshotTypeArg {
+    Memory,
     Filesystem,
 }
 
-impl SnapshotContentModeArg {
+impl SnapshotTypeArg {
     fn as_wire_value(self) -> &'static str {
         match self {
-            Self::Full => "full",
-            Self::Filesystem => "filesystem_only",
+            Self::Memory => "memory",
+            Self::Filesystem => "filesystem",
         }
     }
 }
@@ -925,8 +924,8 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             &sandbox_id,
                             snapshot_args.timeout,
                             snapshot_args
-                                .content_mode
-                                .map(SnapshotContentModeArg::as_wire_value),
+                                .snapshot_type
+                                .map(SnapshotTypeArg::as_wire_value),
                         )
                         .await
                     }
@@ -1095,47 +1094,44 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_content_mode_maps_to_wire_values() {
-        assert_eq!(SnapshotContentModeArg::Full.as_wire_value(), "full");
-        assert_eq!(
-            SnapshotContentModeArg::Filesystem.as_wire_value(),
-            "filesystem_only"
-        );
+    fn snapshot_type_maps_to_wire_values() {
+        assert_eq!(SnapshotTypeArg::Memory.as_wire_value(), "memory");
+        assert_eq!(SnapshotTypeArg::Filesystem.as_wire_value(), "filesystem");
     }
 
     #[test]
-    fn sbx_checkpoint_parses_full_content_mode() {
+    fn sbx_checkpoint_parses_memory_snapshot_type() {
         let cli = Cli::try_parse_from([
             "tl",
             "sbx",
             "checkpoint",
             "sbx-123",
-            "--content-mode",
-            "full",
+            "--snapshot-type",
+            "memory",
         ])
         .unwrap();
 
         match cli.command {
             Commands::Sbx(SbxCommands::Checkpoint(SnapshotArgs {
                 sandbox_id,
-                content_mode,
+                snapshot_type,
                 ..
             })) => {
                 assert_eq!(sandbox_id.as_deref(), Some("sbx-123"));
-                assert_eq!(content_mode, Some(SnapshotContentModeArg::Full));
+                assert_eq!(snapshot_type, Some(SnapshotTypeArg::Memory));
             }
             _ => panic!("expected sbx checkpoint command"),
         }
     }
 
     #[test]
-    fn sbx_checkpoint_parses_filesystem_content_mode() {
+    fn sbx_checkpoint_parses_filesystem_snapshot_type() {
         let cli = Cli::try_parse_from([
             "tl",
             "sbx",
             "checkpoint",
             "sbx-123",
-            "--content-mode",
+            "--snapshot-type",
             "filesystem",
         ])
         .unwrap();
@@ -1143,31 +1139,11 @@ mod tests {
         match cli.command {
             Commands::Sbx(SbxCommands::Checkpoint(SnapshotArgs {
                 sandbox_id,
-                content_mode,
+                snapshot_type,
                 ..
             })) => {
                 assert_eq!(sandbox_id.as_deref(), Some("sbx-123"));
-                assert_eq!(content_mode, Some(SnapshotContentModeArg::Filesystem));
-            }
-            _ => panic!("expected sbx checkpoint command"),
-        }
-    }
-
-    #[test]
-    fn sbx_checkpoint_accepts_filesystem_only_content_mode_alias() {
-        let cli = Cli::try_parse_from([
-            "tl",
-            "sbx",
-            "checkpoint",
-            "sbx-123",
-            "--content-mode",
-            "filesystem_only",
-        ])
-        .unwrap();
-
-        match cli.command {
-            Commands::Sbx(SbxCommands::Checkpoint(SnapshotArgs { content_mode, .. })) => {
-                assert_eq!(content_mode, Some(SnapshotContentModeArg::Filesystem));
+                assert_eq!(snapshot_type, Some(SnapshotTypeArg::Filesystem));
             }
             _ => panic!("expected sbx checkpoint command"),
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -604,9 +604,9 @@ struct SnapshotArgs {
     #[arg(short, long, default_value = "300", requires = "sandbox_id")]
     timeout: f64,
 
-    /// Optional snapshot type. When omitted, the client sends no `snapshot_type` and the server applies its default (currently `filesystem`). `memory` captures VM memory + filesystem state, `filesystem` captures filesystem only.
+    /// Optional checkpoint type. When omitted, the client sends no `snapshot_type` and the server applies its default (currently `filesystem`). `memory` captures VM memory + filesystem state, `filesystem` captures filesystem only.
     #[arg(long, value_enum, requires = "sandbox_id")]
-    snapshot_type: Option<SnapshotTypeArg>,
+    checkpoint_type: Option<SnapshotTypeArg>,
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -924,7 +924,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             &sandbox_id,
                             snapshot_args.timeout,
                             snapshot_args
-                                .snapshot_type
+                                .checkpoint_type
                                 .map(SnapshotTypeArg::as_wire_value),
                         )
                         .await
@@ -1094,19 +1094,19 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_type_maps_to_wire_values() {
+    fn checkpoint_type_maps_to_wire_values() {
         assert_eq!(SnapshotTypeArg::Memory.as_wire_value(), "memory");
         assert_eq!(SnapshotTypeArg::Filesystem.as_wire_value(), "filesystem");
     }
 
     #[test]
-    fn sbx_checkpoint_parses_memory_snapshot_type() {
+    fn sbx_checkpoint_parses_memory_checkpoint_type() {
         let cli = Cli::try_parse_from([
             "tl",
             "sbx",
             "checkpoint",
             "sbx-123",
-            "--snapshot-type",
+            "--checkpoint-type",
             "memory",
         ])
         .unwrap();
@@ -1114,24 +1114,24 @@ mod tests {
         match cli.command {
             Commands::Sbx(SbxCommands::Checkpoint(SnapshotArgs {
                 sandbox_id,
-                snapshot_type,
+                checkpoint_type,
                 ..
             })) => {
                 assert_eq!(sandbox_id.as_deref(), Some("sbx-123"));
-                assert_eq!(snapshot_type, Some(SnapshotTypeArg::Memory));
+                assert_eq!(checkpoint_type, Some(SnapshotTypeArg::Memory));
             }
             _ => panic!("expected sbx checkpoint command"),
         }
     }
 
     #[test]
-    fn sbx_checkpoint_parses_filesystem_snapshot_type() {
+    fn sbx_checkpoint_parses_filesystem_checkpoint_type() {
         let cli = Cli::try_parse_from([
             "tl",
             "sbx",
             "checkpoint",
             "sbx-123",
-            "--snapshot-type",
+            "--checkpoint-type",
             "filesystem",
         ])
         .unwrap();
@@ -1139,11 +1139,11 @@ mod tests {
         match cli.command {
             Commands::Sbx(SbxCommands::Checkpoint(SnapshotArgs {
                 sandbox_id,
-                snapshot_type,
+                checkpoint_type,
                 ..
             })) => {
                 assert_eq!(sandbox_id.as_deref(), Some("sbx-123"));
-                assert_eq!(snapshot_type, Some(SnapshotTypeArg::Filesystem));
+                assert_eq!(checkpoint_type, Some(SnapshotTypeArg::Filesystem));
             }
             _ => panic!("expected sbx checkpoint command"),
         }

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -18,8 +18,7 @@ use models::{
     CreateSnapshotResponse, DaemonInfo, HealthResponse, ListDirectoryResponse,
     ListProcessesResponse, ListSandboxPoolsResponse, ListSandboxesResponse, ListSnapshotsResponse,
     OutputEvent, OutputResponse, ProcessInfo, RunProcessEvent, SandboxInfo, SandboxPoolInfo,
-    SandboxPoolRequest, SendSignalResponse, SnapshotContentMode, SnapshotInfo,
-    UpdateSandboxRequest,
+    SandboxPoolRequest, SendSignalResponse, SnapshotInfo, SnapshotType, UpdateSandboxRequest,
 };
 
 /// A client for managing sandbox lifecycle, pool, and snapshot APIs.
@@ -125,17 +124,15 @@ impl SandboxesClient {
     pub async fn snapshot(
         &self,
         sandbox_id: &str,
-        content_mode: Option<SnapshotContentMode>,
+        snapshot_type: Option<SnapshotType>,
     ) -> Result<Traced<CreateSnapshotResponse>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/snapshot"));
-        let req = if content_mode.is_some() {
-            let body = CreateSnapshotRequest {
-                snapshot_content_mode: content_mode,
-            };
+        let req = if snapshot_type.is_some() {
+            let body = CreateSnapshotRequest { snapshot_type };
             self.client
                 .build_post_json_request(Method::POST, &uri, &body)?
         } else {
-            // Preserve today's wire shape (no body) for callers that don't set a content mode.
+            // Preserve today's wire shape (no body) for callers that don't set a snapshot type.
             self.client.request(Method::POST, &uri).build()?
         };
         self.client.execute_json(req).await

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -218,6 +218,8 @@ pub struct SnapshotInfo {
     pub size_bytes: Option<i64>,
     #[serde(default)]
     pub rootfs_disk_bytes: Option<u64>,
+    #[serde(default, alias = "snapshot_content_mode")]
+    pub content_mode: Option<SnapshotContentMode>,
     #[serde(default)]
     pub created_at: Option<serde_json::Value>,
 }
@@ -398,5 +400,31 @@ mod tests {
             serde_json::to_string(&body).unwrap(),
             r#"{"snapshot_content_mode":"filesystem_only"}"#
         );
+    }
+
+    #[test]
+    fn snapshot_info_deserializes_content_mode() {
+        let json = r#"{
+            "id":"snap-1",
+            "namespace":"default",
+            "sandbox_id":"sbx-1",
+            "status":"completed",
+            "content_mode":"filesystem_only"
+        }"#;
+        let info: SnapshotInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.content_mode, Some(SnapshotContentMode::FilesystemOnly));
+    }
+
+    #[test]
+    fn snapshot_info_deserializes_legacy_snapshot_content_mode_alias() {
+        let json = r#"{
+            "id":"snap-1",
+            "namespace":"default",
+            "sandbox_id":"sbx-1",
+            "status":"completed",
+            "snapshot_content_mode":"full"
+        }"#;
+        let info: SnapshotInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.content_mode, Some(SnapshotContentMode::Full));
     }
 }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -184,15 +184,15 @@ pub struct ListSandboxPoolsResponse {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum SnapshotContentMode {
-    Full,
-    FilesystemOnly,
+pub enum SnapshotType {
+    Memory,
+    Filesystem,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CreateSnapshotRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub snapshot_content_mode: Option<SnapshotContentMode>,
+    pub snapshot_type: Option<SnapshotType>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -218,8 +218,8 @@ pub struct SnapshotInfo {
     pub size_bytes: Option<i64>,
     #[serde(default)]
     pub rootfs_disk_bytes: Option<u64>,
-    #[serde(default, alias = "snapshot_content_mode")]
-    pub content_mode: Option<SnapshotContentMode>,
+    #[serde(default)]
+    pub snapshot_type: Option<SnapshotType>,
     #[serde(default)]
     pub created_at: Option<serde_json::Value>,
 }
@@ -326,21 +326,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn snapshot_content_mode_serializes_as_snake_case() {
+    fn snapshot_type_serializes_as_snake_case() {
         assert_eq!(
-            serde_json::to_string(&SnapshotContentMode::Full).unwrap(),
-            "\"full\""
+            serde_json::to_string(&SnapshotType::Memory).unwrap(),
+            "\"memory\""
         );
         assert_eq!(
-            serde_json::to_string(&SnapshotContentMode::FilesystemOnly).unwrap(),
-            "\"filesystem_only\""
+            serde_json::to_string(&SnapshotType::Filesystem).unwrap(),
+            "\"filesystem\""
         );
     }
 
     #[test]
-    fn create_snapshot_request_skips_none_content_mode() {
+    fn create_snapshot_request_skips_none_snapshot_type() {
         let body = CreateSnapshotRequest {
-            snapshot_content_mode: None,
+            snapshot_type: None,
         };
         assert_eq!(serde_json::to_string(&body).unwrap(), "{}");
     }
@@ -392,39 +392,26 @@ mod tests {
     }
 
     #[test]
-    fn create_snapshot_request_serializes_filesystem_only() {
+    fn create_snapshot_request_serializes_filesystem() {
         let body = CreateSnapshotRequest {
-            snapshot_content_mode: Some(SnapshotContentMode::FilesystemOnly),
+            snapshot_type: Some(SnapshotType::Filesystem),
         };
         assert_eq!(
             serde_json::to_string(&body).unwrap(),
-            r#"{"snapshot_content_mode":"filesystem_only"}"#
+            r#"{"snapshot_type":"filesystem"}"#
         );
     }
 
     #[test]
-    fn snapshot_info_deserializes_content_mode() {
+    fn snapshot_info_deserializes_snapshot_type() {
         let json = r#"{
             "id":"snap-1",
             "namespace":"default",
             "sandbox_id":"sbx-1",
             "status":"completed",
-            "content_mode":"filesystem_only"
+            "snapshot_type":"filesystem"
         }"#;
         let info: SnapshotInfo = serde_json::from_str(json).unwrap();
-        assert_eq!(info.content_mode, Some(SnapshotContentMode::FilesystemOnly));
-    }
-
-    #[test]
-    fn snapshot_info_deserializes_legacy_snapshot_content_mode_alias() {
-        let json = r#"{
-            "id":"snap-1",
-            "namespace":"default",
-            "sandbox_id":"sbx-1",
-            "status":"completed",
-            "snapshot_content_mode":"full"
-        }"#;
-        let info: SnapshotInfo = serde_json::from_str(json).unwrap();
-        assert_eq!(info.content_mode, Some(SnapshotContentMode::Full));
+        assert_eq!(info.snapshot_type, Some(SnapshotType::Filesystem));
     }
 }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -23,7 +23,7 @@ use tensorlake::images::models::{
     ApplicationBuildContext, CreateApplicationBuildRequest,
 };
 use tensorlake::sandboxes::models::{
-    CreateSandboxRequest, SandboxPoolRequest, SnapshotContentMode, UpdateSandboxRequest,
+    CreateSandboxRequest, SandboxPoolRequest, SnapshotType, UpdateSandboxRequest,
 };
 use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
@@ -672,26 +672,26 @@ impl CloudSandboxClient {
         })
     }
 
-    #[pyo3(signature = (sandbox_id, content_mode=None))]
+    #[pyo3(signature = (sandbox_id, snapshot_type=None))]
     fn create_snapshot(
         &self,
         sandbox_id: String,
-        content_mode: Option<String>,
+        snapshot_type: Option<String>,
     ) -> PyResult<(String, String)> {
-        let parsed_mode = match content_mode.as_deref() {
+        let parsed_type = match snapshot_type.as_deref() {
             None => None,
-            Some("full") => Some(SnapshotContentMode::Full),
-            Some("filesystem_only") => Some(SnapshotContentMode::FilesystemOnly),
+            Some("memory") => Some(SnapshotType::Memory),
+            Some("filesystem") => Some(SnapshotType::Filesystem),
             Some(other) => {
                 return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                    "invalid snapshot content_mode '{other}': expected 'full' or 'filesystem_only'"
+                    "invalid snapshot_type '{other}': expected 'memory' or 'filesystem'"
                 )));
             }
         };
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
             async move {
-                let traced = client.snapshot(&sandbox_id, parsed_mode).await?;
+                let traced = client.snapshot(&sandbox_id, parsed_type).await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
                 Ok((trace_id, json))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.3"
+version = "0.5.4"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -25,7 +25,7 @@ import httpx
 from tensorlake._tracing import USER_AGENT, inject_traceparent
 from tensorlake.cli._common import Context
 from tensorlake.sandbox import Sandbox, SandboxClient
-from tensorlake.sandbox.models import ProcessStatus, SnapshotContentMode
+from tensorlake.sandbox.models import ProcessStatus, SnapshotType
 
 from ._dockerfile import image_to_dockerfile, render_op_line
 from .image import Image
@@ -774,7 +774,7 @@ def _run_plan(
         emit({"type": "status", "message": "Creating snapshot..."})
         snapshot = sandbox_client.snapshot_and_wait(
             sandbox.sandbox_id,
-            content_mode=SnapshotContentMode.FILESYSTEM_ONLY,
+            snapshot_type=SnapshotType.FILESYSTEM,
         )
         emit(
             {

--- a/src/tensorlake/sandbox/__init__.py
+++ b/src/tensorlake/sandbox/__init__.py
@@ -33,9 +33,9 @@ from .models import (
     SandboxPortAccess,
     SandboxStatus,
     SendSignalResponse,
-    SnapshotContentMode,
     SnapshotInfo,
     SnapshotStatus,
+    SnapshotType,
     StdinMode,
 )
 from .pty import Pty
@@ -60,7 +60,7 @@ __all__ = [
     "NetworkConfig",
     # Snapshot models
     "SnapshotStatus",
-    "SnapshotContentMode",
+    "SnapshotType",
     "SnapshotInfo",
     "CreateSnapshotResponse",
     # Command result

--- a/src/tensorlake/sandbox/__init__.py
+++ b/src/tensorlake/sandbox/__init__.py
@@ -12,6 +12,7 @@ from .exceptions import (
     SandboxNotFoundError,
 )
 from .models import (
+    CheckpointType,
     CommandResult,
     ContainerResourcesInfo,
     CreateSandboxPoolResponse,
@@ -62,6 +63,7 @@ __all__ = [
     "SnapshotStatus",
     "SnapshotType",
     "SnapshotInfo",
+    "CheckpointType",
     "CreateSnapshotResponse",
     # Command result
     "CommandResult",

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -34,9 +34,9 @@ from .models import (
     SandboxPoolRequest,
     SandboxPortAccess,
     SandboxStatus,
-    SnapshotContentMode,
     SnapshotInfo,
     SnapshotStatus,
+    SnapshotType,
     UpdateSandboxRequest,
 )
 
@@ -692,7 +692,7 @@ class SandboxClient:
     def snapshot(
         self,
         sandbox_id: str,
-        content_mode: SnapshotContentMode | None = None,
+        snapshot_type: SnapshotType | None = None,
     ) -> Traced[CreateSnapshotResponse]:
         """Create a snapshot of a running sandbox's filesystem.
 
@@ -701,11 +701,11 @@ class SandboxClient:
 
         Args:
             sandbox_id: ID of the running sandbox to snapshot.
-            content_mode: Optional content mode for the snapshot. When
-                ``None`` (default) the server picks its default. Use
-                :attr:`SnapshotContentMode.FILESYSTEM_ONLY` for snapshots
-                that should be cold-booted by sandboxes restoring from
-                them (e.g. sandbox image builds).
+            snapshot_type: Optional snapshot type. When ``None`` (default)
+                the server picks its default. Use
+                :attr:`SnapshotType.FILESYSTEM` for snapshots that should be
+                cold-booted by sandboxes restoring from them (e.g. sandbox
+                image builds).
 
         Returns:
             Traced[CreateSnapshotResponse] with snapshot_id, status, and trace_id
@@ -718,7 +718,9 @@ class SandboxClient:
         try:
             trace_id, response_json = self._rust_client.create_snapshot(
                 sandbox_id=sandbox_id,
-                content_mode=content_mode.value if content_mode is not None else None,
+                snapshot_type=(
+                    snapshot_type.value if snapshot_type is not None else None
+                ),
             )
             return Traced(
                 trace_id, CreateSnapshotResponse.model_validate_json(response_json)
@@ -787,7 +789,7 @@ class SandboxClient:
         sandbox_id: str,
         timeout: float = 300,
         poll_interval: float = 1.0,
-        content_mode: SnapshotContentMode | None = None,
+        snapshot_type: SnapshotType | None = None,
     ) -> Traced[SnapshotInfo]:
         """Create a snapshot and wait for it to complete.
 
@@ -795,8 +797,8 @@ class SandboxClient:
             sandbox_id: ID of the running sandbox to snapshot
             timeout: Max seconds to wait for completion (default 300)
             poll_interval: Seconds between status polls (default 1)
-            content_mode: Optional content mode for the snapshot. See
-                :meth:`snapshot` for details.
+            snapshot_type: Optional snapshot type. See :meth:`snapshot` for
+                details.
 
         Returns:
             Traced[SnapshotInfo] with completed snapshot details and trace_id
@@ -804,7 +806,7 @@ class SandboxClient:
         Raises:
             SandboxError: If snapshot fails or times out
         """
-        traced_create = self.snapshot(sandbox_id, content_mode=content_mode)
+        traced_create = self.snapshot(sandbox_id, snapshot_type=snapshot_type)
         deadline = time.time() + timeout
         while time.time() < deadline:
             traced_info = self.get_snapshot(traced_create.snapshot_id)

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -64,6 +64,20 @@ class SnapshotType(str, Enum):
     FILESYSTEM = "filesystem"
 
 
+class CheckpointType(str, Enum):
+    """Checkpoint type for :meth:`Sandbox.checkpoint`.
+
+    - ``MEMORY``: Capture VM memory + filesystem state. Sandboxes
+      restored from this checkpoint warm-restore VM memory and running
+      processes.
+    - ``FILESYSTEM``: Capture filesystem state only. Sandboxes restored
+      from this checkpoint cold-boot from the snapshot tarball.
+    """
+
+    MEMORY = "memory"
+    FILESYSTEM = "filesystem"
+
+
 class ContainerResourcesInfo(BaseModel):
     """Container resource configuration."""
 

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Annotated, Any
 
-from pydantic import BaseModel, BeforeValidator, Field
+from pydantic import AliasChoices, BaseModel, BeforeValidator, Field
 
 
 def _parse_timestamp(v: int | float | datetime | None) -> datetime | None:
@@ -278,6 +278,10 @@ class SnapshotInfo(BaseModel):
     sandbox_id: str
     base_image: str | None = None
     status: SnapshotStatus
+    content_mode: SnapshotContentMode | None = Field(
+        default=None,
+        validation_alias=AliasChoices("content_mode", "snapshot_content_mode"),
+    )
     error: str | None = None
     snapshot_uri: str | None = None
     size_bytes: int | None = None

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Annotated, Any
 
-from pydantic import AliasChoices, BaseModel, BeforeValidator, Field
+from pydantic import BaseModel, BeforeValidator, Field
 
 
 def _parse_timestamp(v: int | float | datetime | None) -> datetime | None:
@@ -49,19 +49,19 @@ class SnapshotStatus(str, Enum):
     FAILED = "failed"
 
 
-class SnapshotContentMode(str, Enum):
-    """Content mode for snapshot creation.
+class SnapshotType(str, Enum):
+    """User-facing snapshot type for sandbox snapshot creation.
 
-    - ``FULL``: Full VM snapshot (memory + filesystem state). Sandboxes
+    - ``MEMORY``: Capture VM memory + filesystem state. Sandboxes
       restored from this snapshot warm-restore VM memory.
-    - ``FILESYSTEM_ONLY``: Filesystem-only snapshot. Sandboxes restored
+    - ``FILESYSTEM``: Capture filesystem state only. Sandboxes restored
       from this snapshot cold-boot from the snapshot tarball instead of
       warm-restoring VM state. Use this for sandbox image builds so that
       the restored sandbox bypasses Firecracker's overlay-path constraints.
     """
 
-    FULL = "full"
-    FILESYSTEM_ONLY = "filesystem_only"
+    MEMORY = "memory"
+    FILESYSTEM = "filesystem"
 
 
 class ContainerResourcesInfo(BaseModel):
@@ -278,10 +278,7 @@ class SnapshotInfo(BaseModel):
     sandbox_id: str
     base_image: str | None = None
     status: SnapshotStatus
-    content_mode: SnapshotContentMode | None = Field(
-        default=None,
-        validation_alias=AliasChoices("content_mode", "snapshot_content_mode"),
-    )
+    snapshot_type: SnapshotType | None = None
     error: str | None = None
     snapshot_uri: str | None = None
     size_bytes: int | None = None

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -30,8 +30,8 @@ from .models import (
     SandboxInfo,
     SandboxStatus,
     SendSignalResponse,
-    SnapshotContentMode,
     SnapshotInfo,
+    SnapshotType,
     StdinMode,
 )
 
@@ -467,7 +467,7 @@ class Sandbox:
         wait: bool = True,
         timeout: float = 300,
         poll_interval: float = 1.0,
-        content_mode: SnapshotContentMode | None = None,
+        snapshot_type: SnapshotType | None = None,
     ) -> SnapshotInfo | None:
         """Create a snapshot of this sandbox's filesystem.
 
@@ -479,7 +479,7 @@ class Sandbox:
             wait: If True (default), poll until the snapshot is committed.
             timeout: Max seconds to wait when wait=True (default 300).
             poll_interval: Seconds between polls when wait=True (default 1.0).
-            content_mode: Optional content mode for the snapshot.
+            snapshot_type: Optional snapshot type.
 
         Returns:
             Completed SnapshotInfo when wait=True; None when wait=False.
@@ -489,13 +489,15 @@ class Sandbox:
         """
         self._require_lifecycle_client("checkpoint")
         if not wait:
-            self._lifecycle_client.snapshot(self.sandbox_id, content_mode=content_mode)
+            self._lifecycle_client.snapshot(
+                self.sandbox_id, snapshot_type=snapshot_type
+            )
             return None
         return self._lifecycle_client.snapshot_and_wait(
             self.sandbox_id,
             timeout=timeout,
             poll_interval=poll_interval,
-            content_mode=content_mode,
+            snapshot_type=snapshot_type,
         ).value
 
     def list_snapshots(self) -> TracedIterator[SnapshotInfo]:

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -18,6 +18,7 @@ from .exceptions import (
     SandboxError,
 )
 from .models import (
+    CheckpointType,
     CommandResult,
     DaemonInfo,
     HealthResponse,
@@ -467,7 +468,7 @@ class Sandbox:
         wait: bool = True,
         timeout: float = 300,
         poll_interval: float = 1.0,
-        checkpoint_type: SnapshotType | None = None,
+        checkpoint_type: CheckpointType | None = None,
     ) -> SnapshotInfo | None:
         """Create a snapshot of this sandbox's filesystem.
 
@@ -488,16 +489,19 @@ class Sandbox:
             SandboxError: If the snapshot fails or times out.
         """
         self._require_lifecycle_client("checkpoint")
+        snapshot_type = (
+            SnapshotType(checkpoint_type.value) if checkpoint_type is not None else None
+        )
         if not wait:
             self._lifecycle_client.snapshot(
-                self.sandbox_id, snapshot_type=checkpoint_type
+                self.sandbox_id, snapshot_type=snapshot_type
             )
             return None
         return self._lifecycle_client.snapshot_and_wait(
             self.sandbox_id,
             timeout=timeout,
             poll_interval=poll_interval,
-            snapshot_type=checkpoint_type,
+            snapshot_type=snapshot_type,
         ).value
 
     def list_snapshots(self) -> TracedIterator[SnapshotInfo]:

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -467,7 +467,7 @@ class Sandbox:
         wait: bool = True,
         timeout: float = 300,
         poll_interval: float = 1.0,
-        snapshot_type: SnapshotType | None = None,
+        checkpoint_type: SnapshotType | None = None,
     ) -> SnapshotInfo | None:
         """Create a snapshot of this sandbox's filesystem.
 
@@ -479,7 +479,7 @@ class Sandbox:
             wait: If True (default), poll until the snapshot is committed.
             timeout: Max seconds to wait when wait=True (default 300).
             poll_interval: Seconds between polls when wait=True (default 1.0).
-            snapshot_type: Optional snapshot type.
+            checkpoint_type: Optional checkpoint type.
 
         Returns:
             Completed SnapshotInfo when wait=True; None when wait=False.
@@ -490,14 +490,14 @@ class Sandbox:
         self._require_lifecycle_client("checkpoint")
         if not wait:
             self._lifecycle_client.snapshot(
-                self.sandbox_id, snapshot_type=snapshot_type
+                self.sandbox_id, snapshot_type=checkpoint_type
             )
             return None
         return self._lifecycle_client.snapshot_and_wait(
             self.sandbox_id,
             timeout=timeout,
             poll_interval=poll_interval,
-            snapshot_type=snapshot_type,
+            snapshot_type=checkpoint_type,
         ).value
 
     def list_snapshots(self) -> TracedIterator[SnapshotInfo]:

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -91,7 +91,10 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
         sandbox.sandbox_id = "sbx-1"
         snapshot = SimpleNamespace(
             snapshot_id="snap-1",
+            sandbox_id="sbx-1",
             snapshot_uri="s3://snapshots/snap-1.tar.zst",
+            size_bytes=1234,
+            rootfs_disk_bytes=25 * 1024 * 1024 * 1024,
         )
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -136,7 +139,10 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             "sandbox-image",
             dockerfile_text + "\n",
             "snap-1",
+            "sbx-1",
             "s3://snapshots/snap-1.tar.zst",
+            1234,
+            25 * 1024 * 1024 * 1024,
             False,
         )
         sandbox.terminate.assert_called_once_with()
@@ -155,7 +161,10 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
         sandbox.sandbox_id = "sbx-1"
         snapshot = SimpleNamespace(
             snapshot_id="snap-1",
+            sandbox_id="sbx-1",
             snapshot_uri="s3://snapshots/snap-1.tar.zst",
+            size_bytes=1234,
+            rootfs_disk_bytes=25 * 1024 * 1024 * 1024,
         )
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -192,7 +201,10 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             "custom-name",
             dockerfile_text,
             "snap-1",
+            "sbx-1",
             "s3://snapshots/snap-1.tar.zst",
+            1234,
+            25 * 1024 * 1024 * 1024,
             True,
         )
 
@@ -208,7 +220,10 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
         sandbox.sandbox_id = "sbx-1"
         snapshot = SimpleNamespace(
             snapshot_id="snap-1",
+            sandbox_id="sbx-1",
             snapshot_uri="s3://snapshots/snap-1.tar.zst",
+            size_bytes=1234,
+            rootfs_disk_bytes=25 * 1024 * 1024 * 1024,
         )
 
         build_ctx, execute, register_image, sandbox_client_cls = _make_build_patches(

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from tensorlake.image import Image
 from tensorlake.image import sandbox_builder as sbm
-from tensorlake.sandbox.models import SnapshotContentMode
+from tensorlake.sandbox.models import SnapshotType
 
 BUILD_CPUS = 2.0
 BUILD_MEMORY_MB = 4096
@@ -146,7 +146,7 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
         # and broke `tl sbx new --image`).
         sandbox_client.snapshot_and_wait.assert_called_once_with(
             "sbx-1",
-            content_mode=SnapshotContentMode.FILESYSTEM_ONLY,
+            snapshot_type=SnapshotType.FILESYSTEM,
         )
 
     def test_public_flag_and_registered_name(self):
@@ -263,7 +263,7 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
 
         sandbox_client.snapshot_and_wait.assert_called_once_with(
             "sbx-1",
-            content_mode=SnapshotContentMode.FILESYSTEM_ONLY,
+            snapshot_type=SnapshotType.FILESYSTEM,
         )
 
     def test_registered_name_overrides_image_name(self):

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -37,6 +37,7 @@ class _FakeRustClient:
         return (
             '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
             '"base_image":"python:3.12","status":"completed",'
+            '"content_mode":"filesystem_only",'
             '"snapshot_uri":"s3://snap-1.tar.zst"}'
         )
 
@@ -390,6 +391,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(sandbox_id, "sbx-1")
         self.assertEqual(content_mode, "filesystem_only")
         self.assertEqual(info.snapshot_id, "snap-1")
+        self.assertEqual(info.content_mode, SnapshotContentMode.FILESYSTEM_ONLY)
 
     def test_snapshot_omits_content_mode_when_none(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
@@ -401,6 +403,22 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(len(fake.create_snapshot_calls), 1)
         _, content_mode = fake.create_snapshot_calls[0]
         self.assertIsNone(content_mode)
+
+    def test_get_snapshot_accepts_legacy_snapshot_content_mode_alias(self):
+        class _LegacySnapshotModeRustClient(_FakeRustClient):
+            def get_snapshot_json(self, snapshot_id):
+                return (
+                    '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
+                    '"base_image":"python:3.12","status":"completed",'
+                    '"snapshot_content_mode":"full",'
+                    '"snapshot_uri":"s3://snap-1.tar.zst"}'
+                )
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _LegacySnapshotModeRustClient()
+
+        traced = client.get_snapshot("snap-1")
+        self.assertEqual(traced.content_mode, SnapshotContentMode.FULL)
 
 
 if __name__ == "__main__":

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -47,10 +47,12 @@ class _FakeRustClient:
 
     def create_sandbox(self, request_json):
         self.create_request_json = request_json
-        return '{"sandbox_id":"sbx-1","status":"pending"}'
+        return ("trace-create-sandbox", '{"sandbox_id":"sbx-1","status":"pending"}')
 
     def list_sandboxes_json(self):
-        return """
+        return (
+            "trace-list-sandboxes",
+            """
 {
   "sandboxes": [
     {
@@ -66,11 +68,14 @@ class _FakeRustClient:
     }
   ]
 }
-"""
+""",
+        )
 
     def get_sandbox_json(self, sandbox_id):
         self.last_get_sandbox_id = sandbox_id
-        return """
+        return (
+            "trace-get-sandbox",
+            """
 {
   "id": "sbx-1",
   "namespace": "default",
@@ -85,7 +90,8 @@ class _FakeRustClient:
   "exposed_ports": [8080],
   "sandbox_url": "https://sbx-1.sandbox.tensorlake.ai"
 }
-"""
+""",
+        )
 
     def update_sandbox(self, sandbox_id, request_json):
         self.last_get_sandbox_id = sandbox_id
@@ -108,7 +114,7 @@ class _FakeRustClient:
             "exposed_ports": payload.get("exposed_ports", []),
             "sandbox_url": f"https://{sandbox_id}.sandbox.tensorlake.ai",
         }
-        return json.dumps(response)
+        return ("trace-update-sandbox", json.dumps(response))
 
 
 class TestSandboxClientRustBackend(unittest.TestCase):
@@ -158,7 +164,9 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         class _StartupFailureRustClient(_FakeRustClient):
             def get_sandbox_json(self, sandbox_id):
                 self.last_get_sandbox_id = sandbox_id
-                return """
+                return (
+                    "trace-get-sandbox",
+                    """
 {
   "id": "sbx-1",
   "namespace": "default",
@@ -173,7 +181,8 @@ class TestSandboxClientRustBackend(unittest.TestCase):
     "message": "failed to pull image tensorlake/missing-image"
   }
 }
-"""
+""",
+                )
 
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         client._rust_client = _StartupFailureRustClient()
@@ -189,10 +198,11 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         client._rust_client = _FakeRustClient()
 
         sandboxes = client.list()
+        sandboxes_list = list(sandboxes)
 
-        self.assertEqual(len(sandboxes), 1)
-        self.assertEqual(sandboxes[0].sandbox_id, "sbx-1")
-        self.assertEqual(sandboxes[0].status, "running")
+        self.assertEqual(len(sandboxes_list), 1)
+        self.assertEqual(sandboxes_list[0].sandbox_id, "sbx-1")
+        self.assertEqual(sandboxes_list[0].status, "running")
 
     def test_update_sandbox_sends_port_access_fields(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
@@ -263,7 +273,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         fake = _FakeRustClient()
         client._rust_client = fake
 
-        client.suspend("my-env")
+        client.suspend("my-env", wait=False)
 
         self.assertEqual(fake.suspend_calls, ["my-env"])
         self.assertEqual(fake.resume_calls, [])
@@ -273,7 +283,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         fake = _FakeRustClient()
         client._rust_client = fake
 
-        client.resume("my-env")
+        client.resume("my-env", wait=False)
 
         self.assertEqual(fake.resume_calls, ["my-env"])
         self.assertEqual(fake.suspend_calls, [])

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from tensorlake.sandbox import (
     PoolInUseError,
     SandboxNotFoundError,
-    SnapshotContentMode,
+    SnapshotType,
 )
 from tensorlake.sandbox.client import SandboxClient
 from tensorlake.sandbox.exceptions import SandboxError
@@ -29,16 +29,20 @@ class _FakeRustClient:
     def resume_sandbox(self, sandbox_id):
         self.resume_calls.append(sandbox_id)
 
-    def create_snapshot(self, sandbox_id, content_mode=None):
-        self.create_snapshot_calls.append((sandbox_id, content_mode))
-        return '{"snapshot_id":"snap-1","status":"in_progress"}'
+    def create_snapshot(self, sandbox_id, snapshot_type=None):
+        self.create_snapshot_calls.append((sandbox_id, snapshot_type))
+        return (
+            "trace-create",
+            '{"snapshot_id":"snap-1","status":"in_progress"}',
+        )
 
     def get_snapshot_json(self, snapshot_id):
         return (
+            "trace-get",
             '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
             '"base_image":"python:3.12","status":"completed",'
-            '"content_mode":"filesystem_only",'
-            '"snapshot_uri":"s3://snap-1.tar.zst"}'
+            '"snapshot_type":"filesystem",'
+            '"snapshot_uri":"s3://snap-1.tar.zst"}',
         )
 
     def create_sandbox(self, request_json):
@@ -376,24 +380,24 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         finally:
             sandbox_client_module.RustCloudSandboxClientError = previous
 
-    def test_snapshot_threads_content_mode_to_rust_backend(self):
+    def test_snapshot_threads_snapshot_type_to_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         fake = _FakeRustClient()
         client._rust_client = fake
 
         info = client.snapshot_and_wait(
             "sbx-1",
-            content_mode=SnapshotContentMode.FILESYSTEM_ONLY,
+            snapshot_type=SnapshotType.FILESYSTEM,
         )
 
         self.assertEqual(len(fake.create_snapshot_calls), 1)
-        sandbox_id, content_mode = fake.create_snapshot_calls[0]
+        sandbox_id, snapshot_type = fake.create_snapshot_calls[0]
         self.assertEqual(sandbox_id, "sbx-1")
-        self.assertEqual(content_mode, "filesystem_only")
+        self.assertEqual(snapshot_type, "filesystem")
         self.assertEqual(info.snapshot_id, "snap-1")
-        self.assertEqual(info.content_mode, SnapshotContentMode.FILESYSTEM_ONLY)
+        self.assertEqual(info.snapshot_type, SnapshotType.FILESYSTEM)
 
-    def test_snapshot_omits_content_mode_when_none(self):
+    def test_snapshot_omits_snapshot_type_when_none(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         fake = _FakeRustClient()
         client._rust_client = fake
@@ -401,24 +405,8 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         client.snapshot_and_wait("sbx-1")
 
         self.assertEqual(len(fake.create_snapshot_calls), 1)
-        _, content_mode = fake.create_snapshot_calls[0]
-        self.assertIsNone(content_mode)
-
-    def test_get_snapshot_accepts_legacy_snapshot_content_mode_alias(self):
-        class _LegacySnapshotModeRustClient(_FakeRustClient):
-            def get_snapshot_json(self, snapshot_id):
-                return (
-                    '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
-                    '"base_image":"python:3.12","status":"completed",'
-                    '"snapshot_content_mode":"full",'
-                    '"snapshot_uri":"s3://snap-1.tar.zst"}'
-                )
-
-        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
-        client._rust_client = _LegacySnapshotModeRustClient()
-
-        traced = client.get_snapshot("snap-1")
-        self.assertEqual(traced.content_mode, SnapshotContentMode.FULL)
+        _, snapshot_type = fake.create_snapshot_calls[0]
+        self.assertIsNone(snapshot_type)
 
 
 if __name__ == "__main__":

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -28,6 +28,18 @@ import {
 import { Sandbox } from "./sandbox.js";
 import { isLocalhost, lifecyclePath, resolveProxyUrl } from "./url.js";
 
+type SnapshotInfoWithLegacyMode = SnapshotInfo & {
+  snapshotContentMode?: SnapshotInfo["contentMode"];
+};
+
+function normalizeSnapshotInfo(snapshot: SnapshotInfoWithLegacyMode): SnapshotInfo {
+  if (snapshot.contentMode == null && snapshot.snapshotContentMode != null) {
+    snapshot.contentMode = snapshot.snapshotContentMode;
+  }
+  delete (snapshot as { snapshotContentMode?: SnapshotInfo["contentMode"] }).snapshotContentMode;
+  return snapshot;
+}
+
 /**
  * Client for managing TensorLake sandboxes, pools, and snapshots.
  *
@@ -352,7 +364,7 @@ export class SandboxClient {
       "GET",
       this.path(`snapshots/${snapshotId}`),
     );
-    return fromSnakeKeys(raw, "snapshotId") as SnapshotInfo;
+    return normalizeSnapshotInfo(fromSnakeKeys(raw, "snapshotId") as SnapshotInfoWithLegacyMode);
   }
 
   /** List all snapshots in the namespace. */
@@ -362,7 +374,7 @@ export class SandboxClient {
       this.path("snapshots"),
     );
     const snapshots = (raw.snapshots ?? []).map(
-      (s) => fromSnakeKeys(s, "snapshotId") as SnapshotInfo,
+      (s) => normalizeSnapshotInfo(fromSnakeKeys(s, "snapshotId") as SnapshotInfoWithLegacyMode),
     );
     return Object.assign(snapshots, { traceId: raw.traceId });
   }

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -28,18 +28,6 @@ import {
 import { Sandbox } from "./sandbox.js";
 import { isLocalhost, lifecyclePath, resolveProxyUrl } from "./url.js";
 
-type SnapshotInfoWithLegacyMode = SnapshotInfo & {
-  snapshotContentMode?: SnapshotInfo["contentMode"];
-};
-
-function normalizeSnapshotInfo(snapshot: SnapshotInfoWithLegacyMode): SnapshotInfo {
-  if (snapshot.contentMode == null && snapshot.snapshotContentMode != null) {
-    snapshot.contentMode = snapshot.snapshotContentMode;
-  }
-  delete (snapshot as { snapshotContentMode?: SnapshotInfo["contentMode"] }).snapshotContentMode;
-  return snapshot;
-}
-
 /**
  * Client for managing TensorLake sandboxes, pools, and snapshots.
  *
@@ -338,17 +326,17 @@ export class SandboxClient {
    * status — the snapshot is created asynchronously. Poll `getSnapshot()` until
    * `completed` or `failed`, or use `snapshotAndWait()` to block automatically.
    *
-   * @param options.contentMode - `"filesystem_only"` for cold-boot snapshots (e.g. image builds).
-   *   Omit to use the server default (full VM snapshot).
+   * @param options.snapshotType - `"filesystem"` for cold-boot snapshots (e.g. image builds).
+   *   Omit to use the server default (`filesystem`).
    */
   async snapshot(
     sandboxId: string,
     options?: SnapshotOptions,
   ): Promise<CreateSnapshotResponse> {
-    // Preserve today's wire shape (no body) when contentMode is not set.
+    // Preserve today's wire shape (no body) when snapshotType is not set.
     const requestOptions =
-      options?.contentMode != null
-        ? { body: { snapshot_content_mode: options.contentMode } }
+      options?.snapshotType != null
+        ? { body: { snapshot_type: options.snapshotType } }
         : undefined;
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "POST",
@@ -364,7 +352,7 @@ export class SandboxClient {
       "GET",
       this.path(`snapshots/${snapshotId}`),
     );
-    return normalizeSnapshotInfo(fromSnakeKeys(raw, "snapshotId") as SnapshotInfoWithLegacyMode);
+    return fromSnakeKeys(raw, "snapshotId") as SnapshotInfo;
   }
 
   /** List all snapshots in the namespace. */
@@ -374,7 +362,7 @@ export class SandboxClient {
       this.path("snapshots"),
     );
     const snapshots = (raw.snapshots ?? []).map(
-      (s) => normalizeSnapshotInfo(fromSnakeKeys(s, "snapshotId") as SnapshotInfoWithLegacyMode),
+      (s) => fromSnakeKeys(s, "snapshotId") as SnapshotInfo,
     );
     return Object.assign(snapshots, { traceId: raw.traceId });
   }
@@ -397,7 +385,7 @@ export class SandboxClient {
    * @param sandboxId - ID of the running sandbox to snapshot.
    * @param options.timeout - Max seconds to wait (default 300).
    * @param options.pollInterval - Seconds between status polls (default 1).
-   * @param options.contentMode - Content mode passed through to `snapshot()`.
+   * @param options.snapshotType - Snapshot type passed through to `snapshot()`.
    * @throws {SandboxError} If the snapshot fails or `timeout` elapses.
    */
   async snapshotAndWait(
@@ -408,7 +396,7 @@ export class SandboxClient {
     const pollInterval = options?.pollInterval ?? 1;
 
     const result = await this.snapshot(sandboxId, {
-      contentMode: options?.contentMode,
+      snapshotType: options?.snapshotType,
     });
     const deadline = Date.now() + timeout * 1000;
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -50,7 +50,7 @@ export {
   ContainerState,
 } from "./models.js";
 
-export type { SnapshotContentMode, SnapshotOptions } from "./models.js";
+export type { SnapshotType, SnapshotOptions } from "./models.js";
 
 export type {
   BinaryPayload,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -50,7 +50,7 @@ export {
   ContainerState,
 } from "./models.js";
 
-export type { SnapshotType, SnapshotOptions } from "./models.js";
+export type { CheckpointType, SnapshotType, SnapshotOptions } from "./models.js";
 
 export type {
   BinaryPayload,

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -355,7 +355,7 @@ export interface SuspendResumeOptions {
 }
 
 export interface CheckpointOptions extends SuspendResumeOptions {
-  snapshotType?: SnapshotType;
+  checkpointType?: SnapshotType;
 }
 
 export interface ConnectOptions {

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -143,6 +143,7 @@ export interface SnapshotInfo {
   sandboxId: string;
   baseImage: string;
   status: SnapshotStatus;
+  contentMode?: SnapshotContentMode;
   error?: string;
   snapshotUri?: string;
   sizeBytes?: number;

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -27,6 +27,16 @@ export enum SnapshotStatus {
  */
 export type SnapshotType = "memory" | "filesystem";
 
+/**
+ * Checkpoint type for {@link Sandbox.checkpoint}.
+ *
+ * - `"memory"`: Capture VM memory + filesystem state. Sandboxes restored
+ *   from this checkpoint warm-restore VM memory and running processes.
+ * - `"filesystem"`: Capture filesystem state only. Sandboxes restored from
+ *   this checkpoint cold-boot from the snapshot tarball.
+ */
+export type CheckpointType = "memory" | "filesystem";
+
 export enum ProcessStatus {
   RUNNING = "running",
   EXITED = "exited",
@@ -355,7 +365,7 @@ export interface SuspendResumeOptions {
 }
 
 export interface CheckpointOptions extends SuspendResumeOptions {
-  checkpointType?: SnapshotType;
+  checkpointType?: CheckpointType;
 }
 
 export interface ConnectOptions {

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -16,16 +16,16 @@ export enum SnapshotStatus {
 }
 
 /**
- * Content mode for snapshot creation.
+ * Snapshot type for sandbox snapshot creation.
  *
- * - `"full"`: Full VM snapshot (memory + filesystem state). Sandboxes
- *   restored from this snapshot warm-restore VM memory.
- * - `"filesystem_only"`: Filesystem-only snapshot. Sandboxes restored from
+ * - `"memory"`: Capture VM memory + filesystem state. Sandboxes restored
+ *   from this snapshot warm-restore VM memory.
+ * - `"filesystem"`: Capture filesystem state only. Sandboxes restored from
  *   this snapshot cold-boot from the snapshot tarball instead of warm-
  *   restoring VM state. Use this for sandbox image builds so that the
  *   restored sandbox bypasses Firecracker's overlay-path constraints.
  */
-export type SnapshotContentMode = "full" | "filesystem_only";
+export type SnapshotType = "memory" | "filesystem";
 
 export enum ProcessStatus {
   RUNNING = "running",
@@ -143,7 +143,7 @@ export interface SnapshotInfo {
   sandboxId: string;
   baseImage: string;
   status: SnapshotStatus;
-  contentMode?: SnapshotContentMode;
+  snapshotType?: SnapshotType;
   error?: string;
   snapshotUri?: string;
   sizeBytes?: number;
@@ -153,11 +153,11 @@ export interface SnapshotInfo {
 
 export interface SnapshotOptions {
   /**
-   * Optional content mode for the snapshot. When omitted the server picks
-   * its default. Use `"filesystem_only"` for snapshots intended for sandbox
-   * image builds so that restored sandboxes cold-boot.
+   * Optional snapshot type. When omitted the server picks its default. Use
+   * `"filesystem"` for snapshots intended for sandbox image builds so that
+   * restored sandboxes cold-boot.
    */
-  contentMode?: SnapshotContentMode;
+  snapshotType?: SnapshotType;
 }
 
 export interface SnapshotAndWaitOptions extends SnapshotOptions {
@@ -355,7 +355,7 @@ export interface SuspendResumeOptions {
 }
 
 export interface CheckpointOptions extends SuspendResumeOptions {
-  contentMode?: SnapshotContentMode;
+  snapshotType?: SnapshotType;
 }
 
 export interface ConnectOptions {

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -4,8 +4,8 @@ import { parseArgs } from "node:util";
 import {
   type CommandResult,
   type ProcessInfo,
-  type SnapshotContentMode,
   type SnapshotInfo,
+  type SnapshotType,
 } from "./models.js";
 import { type OutputResponse, ProcessStatus } from "./models.js";
 import { SandboxClient } from "./client.js";
@@ -108,7 +108,7 @@ interface BuildClient {
     options?: {
       timeout?: number;
       pollInterval?: number;
-      contentMode?: SnapshotContentMode;
+      snapshotType?: SnapshotType;
     },
   ): Promise<SnapshotInfo>;
   close(): void;
@@ -1026,7 +1026,7 @@ export async function createSandboxImage(
 
     emit({ type: "status", message: "Creating snapshot..." });
     const snapshot = await client.snapshotAndWait(sandbox.sandboxId, {
-      contentMode: "filesystem_only",
+      snapshotType: "filesystem",
     });
     emit({
       type: "snapshot_created",

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -490,13 +490,13 @@ export class Sandbox {
   async checkpoint(options?: CheckpointOptions): Promise<SnapshotInfo | undefined> {
     const client = this.requireLifecycleClient("checkpoint");
     if (options?.wait === false) {
-      await client.snapshot(this.lifecycleIdentifier, { snapshotType: options.snapshotType });
+      await client.snapshot(this.lifecycleIdentifier, { snapshotType: options.checkpointType });
       return undefined;
     }
     return client.snapshotAndWait(this.lifecycleIdentifier, {
       timeout: options?.timeout,
       pollInterval: options?.pollInterval,
-      snapshotType: options?.snapshotType,
+      snapshotType: options?.checkpointType,
     });
   }
 

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -490,13 +490,13 @@ export class Sandbox {
   async checkpoint(options?: CheckpointOptions): Promise<SnapshotInfo | undefined> {
     const client = this.requireLifecycleClient("checkpoint");
     if (options?.wait === false) {
-      await client.snapshot(this.lifecycleIdentifier, { contentMode: options.contentMode });
+      await client.snapshot(this.lifecycleIdentifier, { snapshotType: options.snapshotType });
       return undefined;
     }
     return client.snapshotAndWait(this.lifecycleIdentifier, {
       timeout: options?.timeout,
       pollInterval: options?.pollInterval,
-      contentMode: options?.contentMode,
+      snapshotType: options?.snapshotType,
     });
   }
 

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -648,6 +648,7 @@ describe("SandboxClient", () => {
             sandbox_id: "sbx-1",
             base_image: "python:3.12",
             status: "completed",
+            content_mode: "filesystem_only",
             created_at: 1700000000,
           }),
           { status: 200 },
@@ -659,6 +660,29 @@ describe("SandboxClient", () => {
       expect(info.snapshotId).toBe("snap-1");
       expect(info.baseImage).toBe("python:3.12");
       expect(info.status).toBe(SnapshotStatus.COMPLETED);
+      expect(info.contentMode).toBe("filesystem_only");
+      client.close();
+    });
+
+    it("normalizes legacy snapshot_content_mode alias in snapshot info", async () => {
+      mockFetch(() =>
+        new Response(
+          JSON.stringify({
+            id: "snap-1",
+            namespace: "default",
+            sandbox_id: "sbx-1",
+            base_image: "python:3.12",
+            status: "completed",
+            snapshot_content_mode: "full",
+            created_at: 1700000000,
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const client = SandboxClient.forLocalhost();
+      const info = await client.getSnapshot("snap-1");
+      expect(info.contentMode).toBe("full");
       client.close();
     });
 

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -601,7 +601,7 @@ describe("SandboxClient", () => {
     });
 
     it("omits request body when no snapshot options are provided", async () => {
-      // Pins down backwards compatibility: when contentMode is unset we
+      // Pins down backwards compatibility: when snapshotType is unset we
       // must not change the wire shape for existing callers.
       mockFetch((_url, init) => {
         expect(init?.method).toBe("POST");
@@ -617,14 +617,14 @@ describe("SandboxClient", () => {
       client.close();
     });
 
-    it("sends snapshot_content_mode in body when contentMode is provided", async () => {
-      // Regression: sandbox image builds MUST pass `filesystem_only` so
-      // that restored sandboxes cold-boot (see PR #583 for the original
+    it("sends snapshot_type in body when snapshotType is provided", async () => {
+      // Regression: sandbox image builds MUST pass `filesystem` so that
+      // restored sandboxes cold-boot (see PR #583 for the original
       // regression that broke `tl sbx new --image`).
       mockFetch((_url, init) => {
         expect(init?.method).toBe("POST");
         const body = JSON.parse(String(init?.body ?? "{}"));
-        expect(body.snapshot_content_mode).toBe("filesystem_only");
+        expect(body.snapshot_type).toBe("filesystem");
         return new Response(
           JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
           { status: 200 },
@@ -633,7 +633,7 @@ describe("SandboxClient", () => {
 
       const client = SandboxClient.forLocalhost();
       const result = await client.snapshot("sbx-1", {
-        contentMode: "filesystem_only",
+        snapshotType: "filesystem",
       });
       expect(result.snapshotId).toBe("snap-1");
       client.close();
@@ -648,7 +648,7 @@ describe("SandboxClient", () => {
             sandbox_id: "sbx-1",
             base_image: "python:3.12",
             status: "completed",
-            content_mode: "filesystem_only",
+            snapshot_type: "filesystem",
             created_at: 1700000000,
           }),
           { status: 200 },
@@ -660,29 +660,7 @@ describe("SandboxClient", () => {
       expect(info.snapshotId).toBe("snap-1");
       expect(info.baseImage).toBe("python:3.12");
       expect(info.status).toBe(SnapshotStatus.COMPLETED);
-      expect(info.contentMode).toBe("filesystem_only");
-      client.close();
-    });
-
-    it("normalizes legacy snapshot_content_mode alias in snapshot info", async () => {
-      mockFetch(() =>
-        new Response(
-          JSON.stringify({
-            id: "snap-1",
-            namespace: "default",
-            sandbox_id: "sbx-1",
-            base_image: "python:3.12",
-            status: "completed",
-            snapshot_content_mode: "full",
-            created_at: 1700000000,
-          }),
-          { status: 200 },
-        ),
-      );
-
-      const client = SandboxClient.forLocalhost();
-      const info = await client.getSnapshot("snap-1");
-      expect(info.contentMode).toBe("full");
+      expect(info.snapshotType).toBe("filesystem");
       client.close();
     });
 

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -213,7 +213,7 @@ describe("sandbox image helpers", () => {
     // snapshot so restored sandboxes cold-boot (see PR #583).
     expect(client.snapshotAndWait).toHaveBeenCalledWith(
       "sbx-1",
-      expect.objectContaining({ contentMode: "filesystem_only" }),
+      expect.objectContaining({ snapshotType: "filesystem" }),
     );
     expect(registerImage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -305,7 +305,7 @@ describe("sandbox image helpers", () => {
     });
     expect(client.snapshotAndWait).toHaveBeenCalledWith(
       "sbx-1",
-      expect.objectContaining({ contentMode: "filesystem_only" }),
+      expect.objectContaining({ snapshotType: "filesystem" }),
     );
     expect(writeFileMock).toHaveBeenCalledWith(
       "/workspace/hello.txt",
@@ -461,7 +461,7 @@ describe("sandbox image helpers", () => {
     });
     expect(client.snapshotAndWait).toHaveBeenCalledWith(
       "sbx-1",
-      expect.objectContaining({ contentMode: "filesystem_only" }),
+      expect.objectContaining({ snapshotType: "filesystem" }),
     );
     expect(registerImage).toHaveBeenCalledWith(
       expect.anything(),


### PR DESCRIPTION
## Summary
- rename snapshot API/SDK surface to `snapshot_type` with values `filesystem | memory`
- update Rust CLI checkpoint flag to `--snapshot-type <filesystem|memory>`
- thread `snapshot_type` through CLI -> SDK -> HTTP request payload
- update snapshot response handling and models to expose `snapshot_type`
- align SDKs and tests (Rust/Python/TypeScript) to the new field/value names
- add targeted CI coverage for snapshot-related SDK tests:
  - Python: `tests.sandbox.test_client_rust_backend`, `tests.sandbox.test_sandbox_rust_backend`, `tests.image.test_sandbox_builder`
  - TypeScript: `tests/client.test.ts`, `tests/sandbox-image.test.ts`

## Validation
- `cargo test -p tensorlake-cli snapshot_type -- --nocapture`
- `cargo test -p tensorlake snapshot_type -- --nocapture`
- `PYTHONPATH=src poetry run python -m unittest tests.sandbox.test_client_rust_backend tests.sandbox.test_sandbox_rust_backend tests.image.test_sandbox_builder`
- `npm test -- tests/client.test.ts tests/sandbox-image.test.ts`
- `npm run typecheck`
- live smoke-tested create -> exec -> snapshot -> restore flows and verified logs for `filesystem` vs `memory` behavior
