### PR TITLE
feat(sandbox-pools): Python SDK + CLI gap closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,23 +112,48 @@ with client.create_and_connect(snapshot_id=snapshot.snapshot_id) as sandbox:
 
 ### Sandbox Pools
 
-Pre-warm containers for fast startup:
+Pre-warm containers for fast startup. Pool-level network and proxy settings
+are inherited by every claimed sandbox.
 
 ```python
-# Create a pool with warm containers
+from tensorlake.sandbox import NetworkConfig
+
+# Create a pool with warm containers, exposed ports, and an outbound network policy
 pool = client.create_pool(
     image="tensorlake/ubuntu-minimal",
     warm_containers=3,
+    max_containers=10,
+    allow_unauthenticated_access=True,
+    exposed_ports=[8080],
+    network=NetworkConfig(
+        allow_internet_access=False,
+        allow_out=["10.0.0.0/8"],
+    ),
 )
 
 # Claim a sandbox instantly from the pool
 resp = client.claim(pool.pool_id)
 sandbox = client.connect(resp.sandbox_id)
 
-# Named sandboxes can be reconnected later by name
-named = client.create(image="tensorlake/ubuntu-minimal", name="stable-name")
-sandbox = client.connect("stable-name")
+# Patch-merge update — pass only the fields you want to change
+client.update_pool(pool.pool_id, warm_containers=5)
+
+# Force-delete to terminate active sandboxes alongside the pool
+client.delete_pool(pool.pool_id, force=True)
 ```
+
+From the CLI:
+
+```bash
+tl sbx pool create --image tensorlake/ubuntu-minimal --warm-containers 3 --max-containers 10
+tl sbx pool ls
+tl sbx pool claim <pool-id>            # waits for the sandbox to be running
+tl sbx pool update <pool-id> --warm-containers 5
+tl sbx pool rm <pool-id> --force       # terminates active sandboxes too
+```
+
+See [docs/sandbox-pools-cli-reference.md](docs/sandbox-pools-cli-reference.md)
+for the full CLI reference.
 
 ---
 

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -5,6 +5,7 @@ pub mod exec;
 pub mod image;
 pub mod ls;
 pub mod name;
+pub mod pool;
 pub mod port;
 pub mod resume;
 pub mod run;

--- a/crates/cli/src/commands/sbx/pool/claim.rs
+++ b/crates/cli/src/commands/sbx/pool/claim.rs
@@ -1,0 +1,60 @@
+use crate::auth::context::CliContext;
+use crate::commands::sbx::{
+    DEFAULT_SANDBOX_WAIT_TIMEOUT, sandbox_endpoint, wait_for_sandbox_status,
+};
+use crate::error::{CliError, Result};
+
+pub async fn run(ctx: &CliContext, pool_id: &str, wait: bool) -> Result<()> {
+    let client = ctx.client()?;
+    let url = sandbox_endpoint(ctx, &format!("sandbox-pools/{pool_id}/sandboxes"));
+    let resp = client
+        .post(&url)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to claim sandbox from pool {} (HTTP {}): {}",
+            pool_id,
+            status,
+            body
+        )));
+    }
+
+    let result: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
+    let sandbox_id = result
+        .get("sandbox_id")
+        .or_else(|| result.get("id"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!("claim response missing sandbox_id"))
+        })?
+        .to_string();
+    let status = result
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    if wait && status != "running" {
+        wait_for_sandbox_status(
+            ctx,
+            &sandbox_id,
+            "Waiting for sandbox to start",
+            "running",
+            DEFAULT_SANDBOX_WAIT_TIMEOUT,
+        )
+        .await?;
+    }
+
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    if is_tty {
+        eprintln!("Sandbox {} claimed from pool {}.", sandbox_id, pool_id);
+    } else {
+        println!("{}", sandbox_id);
+    }
+    Ok(())
+}

--- a/crates/cli/src/commands/sbx/pool/create.rs
+++ b/crates/cli/src/commands/sbx/pool/create.rs
@@ -1,0 +1,94 @@
+use crate::auth::context::CliContext;
+use crate::commands::sbx::pool::{PoolBodyArgs, build_pool_create_body};
+use crate::commands::sbx::sandbox_endpoint;
+use crate::error::{CliError, Result};
+
+pub struct CreateArgs<'a> {
+    pub image: Option<&'a str>,
+    pub cpus: Option<f64>,
+    pub memory: Option<i64>,
+    pub disk_mb: Option<u64>,
+    pub timeout: Option<i64>,
+    pub entrypoint: &'a [String],
+    pub max_containers: Option<i64>,
+    pub warm_containers: Option<i64>,
+    pub ports: &'a [u16],
+    pub allow_unauthenticated_access: bool,
+    pub no_internet: bool,
+    pub network_allow: &'a [String],
+    pub network_deny: &'a [String],
+}
+
+pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
+    let CreateArgs {
+        image,
+        cpus,
+        memory,
+        disk_mb,
+        timeout,
+        entrypoint,
+        max_containers,
+        warm_containers,
+        ports,
+        allow_unauthenticated_access,
+        no_internet,
+        network_allow,
+        network_deny,
+    } = args;
+
+    let body = build_pool_create_body(&PoolBodyArgs {
+        image,
+        cpus,
+        memory_mb: memory,
+        disk_mb,
+        timeout,
+        entrypoint,
+        max_containers,
+        warm_containers,
+        ports,
+        allow_unauthenticated_access,
+        no_internet,
+        network_allow,
+        network_deny,
+    });
+
+    let client = ctx.client()?;
+    let url = sandbox_endpoint(ctx, "sandbox-pools");
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to create sandbox pool (HTTP {}): {}",
+            status,
+            text
+        )));
+    }
+
+    let result: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
+    let pool_id = result
+        .get("pool_id")
+        .or_else(|| result.get("id"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!("create response missing pool_id"))
+        })?;
+
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    if is_tty {
+        eprintln!("Pool {} created.", pool_id);
+        eprintln!();
+        eprintln!("Claim a sandbox from this pool:");
+        eprintln!("  tl sbx pool claim {pool_id}");
+    } else {
+        println!("{}", pool_id);
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/sbx/pool/get.rs
+++ b/crates/cli/src/commands/sbx/pool/get.rs
@@ -1,0 +1,150 @@
+use comfy_table::Cell;
+
+use crate::auth::context::CliContext;
+use crate::commands::sbx::{format_created_at, sandbox_endpoint};
+use crate::error::{CliError, Result};
+use crate::output::table::new_table;
+
+pub async fn run(ctx: &CliContext, pool_id: &str) -> Result<()> {
+    let pool = fetch_pool(ctx, pool_id).await?;
+
+    let id = pool
+        .get("pool_id")
+        .or_else(|| pool.get("id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(pool_id);
+    let namespace = pool.get("namespace").and_then(|v| v.as_str()).unwrap_or("-");
+    let image = pool.get("image").and_then(|v| v.as_str()).unwrap_or("-");
+    let resources = pool.get("resources");
+    let cpus = resources
+        .and_then(|r| r.get("cpus"))
+        .and_then(|v| v.as_f64())
+        .map(|v| format!("{}", v))
+        .unwrap_or_else(|| "-".to_string());
+    let memory = resources
+        .and_then(|r| r.get("memory_mb"))
+        .and_then(|v| v.as_i64())
+        .map(|v| format!("{} MB", v))
+        .unwrap_or_else(|| "-".to_string());
+    let disk = resources
+        .and_then(|r| r.get("ephemeral_disk_mb"))
+        .and_then(|v| v.as_i64())
+        .map(|v| format!("{} MB", v))
+        .unwrap_or_else(|| "-".to_string());
+    let warm = pool
+        .get("warm_containers")
+        .and_then(|v| v.as_i64())
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let max = pool
+        .get("max_containers")
+        .and_then(|v| v.as_i64())
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let min = pool
+        .get("min_containers")
+        .and_then(|v| v.as_i64())
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let timeout = pool
+        .get("timeout_secs")
+        .and_then(|v| v.as_i64())
+        .map(|v| if v == 0 { "—".to_string() } else { format!("{}s", v) })
+        .unwrap_or_else(|| "-".to_string());
+    let created_at = format_created_at(pool.get("created_at"));
+    let updated_at = format_created_at(pool.get("updated_at"));
+    let allow_unauth = pool
+        .get("allow_unauthenticated_access")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let exposed_ports = pool
+        .get("exposed_ports")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_u64().map(|p| p.to_string()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+
+    println!("Pool: {}", id);
+    println!("  Namespace:                       {}", namespace);
+    println!("  Image:                           {}", image);
+    println!("  CPUs:                            {}", cpus);
+    println!("  Memory:                          {}", memory);
+    println!("  Ephemeral disk:                  {}", disk);
+    println!("  Warm containers:                 {}", warm);
+    println!("  Min containers:                  {}", min);
+    println!("  Max containers:                  {}", max);
+    println!("  Timeout:                         {}", timeout);
+    println!("  Allow unauthenticated access:    {}", allow_unauth);
+    if !exposed_ports.is_empty() {
+        println!("  Exposed ports:                   {}", exposed_ports);
+    }
+    if let Some(net) = pool.get("network_policy") {
+        let internet = net
+            .get("allow_internet_access")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        println!("  Internet access:                 {}", internet);
+        if let Some(allow_out) = net.get("allow_out").and_then(|v| v.as_array())
+            && !allow_out.is_empty()
+        {
+            let list: Vec<&str> = allow_out.iter().filter_map(|v| v.as_str()).collect();
+            println!("  Network allow:                   {}", list.join(", "));
+        }
+        if let Some(deny_out) = net.get("deny_out").and_then(|v| v.as_array())
+            && !deny_out.is_empty()
+        {
+            let list: Vec<&str> = deny_out.iter().filter_map(|v| v.as_str()).collect();
+            println!("  Network deny:                    {}", list.join(", "));
+        }
+    }
+    println!("  Created:                         {}", created_at);
+    if updated_at != "-" {
+        println!("  Updated:                         {}", updated_at);
+    }
+
+    let containers = pool
+        .get("containers")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if containers.is_empty() {
+        println!();
+        println!("No containers in this pool yet.");
+    } else {
+        println!();
+        let mut table = new_table(&["Container ID", "State", "Sandbox ID", "Executor"]);
+        for c in &containers {
+            let cid = c.get("id").and_then(|v| v.as_str()).unwrap_or("-");
+            let state = c.get("state").and_then(|v| v.as_str()).unwrap_or("-");
+            let sid = c.get("sandbox_id").and_then(|v| v.as_str()).unwrap_or("");
+            let exec = c.get("executor_id").and_then(|v| v.as_str()).unwrap_or("-");
+            table.add_row(vec![Cell::new(cid), Cell::new(state), Cell::new(sid), Cell::new(exec)]);
+        }
+        println!("{table}");
+    }
+
+    Ok(())
+}
+
+/// Fetch full pool detail (including containers). Shared with `update` and
+/// `rm` so they can branch on current state without an extra round-trip.
+pub async fn fetch_pool(ctx: &CliContext, pool_id: &str) -> Result<serde_json::Value> {
+    let client = ctx.client()?;
+    let url = sandbox_endpoint(ctx, &format!("sandbox-pools/{pool_id}"));
+    let resp = client.get(&url).send().await.map_err(CliError::Http)?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to fetch sandbox pool {} (HTTP {}): {}",
+            pool_id,
+            status,
+            body
+        )));
+    }
+    resp.json::<serde_json::Value>().await.map_err(CliError::Http)
+}

--- a/crates/cli/src/commands/sbx/pool/ls.rs
+++ b/crates/cli/src/commands/sbx/pool/ls.rs
@@ -1,0 +1,118 @@
+use comfy_table::Cell;
+
+use crate::auth::context::CliContext;
+use crate::commands::sbx::{created_at_sort_key, format_created_at, sandbox_endpoint};
+use crate::error::{CliError, Result};
+use crate::output::table::new_table;
+
+pub async fn run(ctx: &CliContext, quiet: bool) -> Result<()> {
+    let client = ctx.client()?;
+    let url = sandbox_endpoint(ctx, "sandbox-pools");
+
+    let resp = client.get(&url).send().await.map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to list sandbox pools (HTTP {}): {}",
+            status,
+            body
+        )));
+    }
+
+    let body: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
+    let mut pools = body
+        .get("pools")
+        .or_else(|| body.get("items"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    pools.sort_by(|a, b| {
+        let a_at = created_at_sort_key(a.get("created_at"));
+        let b_at = created_at_sort_key(b.get("created_at"));
+        b_at.cmp(&a_at)
+    });
+
+    if quiet {
+        for p in &pools {
+            let id = p
+                .get("pool_id")
+                .or_else(|| p.get("id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("-");
+            println!("{}", id);
+        }
+        return Ok(());
+    }
+
+    if pools.is_empty() {
+        println!("No sandbox pools found.");
+        return Ok(());
+    }
+
+    let mut table = new_table(&[
+        "Pool ID",
+        "Image",
+        "CPUs",
+        "Memory",
+        "Warm",
+        "Max",
+        "Timeout",
+        "Created At",
+    ]);
+
+    for p in &pools {
+        let id = p
+            .get("pool_id")
+            .or_else(|| p.get("id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("-");
+        let image = p.get("image").and_then(|v| v.as_str()).unwrap_or("-");
+        let resources = p.get("resources");
+        let cpus = resources
+            .and_then(|r| r.get("cpus"))
+            .and_then(|v| v.as_f64())
+            .map(|v| format!("{}", v))
+            .unwrap_or_else(|| "-".to_string());
+        let memory = resources
+            .and_then(|r| r.get("memory_mb"))
+            .and_then(|v| v.as_i64())
+            .map(|v| format!("{} MB", v))
+            .unwrap_or_else(|| "-".to_string());
+        let warm = p
+            .get("warm_containers")
+            .and_then(|v| v.as_i64())
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let max = p
+            .get("max_containers")
+            .and_then(|v| v.as_i64())
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let timeout = p
+            .get("timeout_secs")
+            .and_then(|v| v.as_i64())
+            .map(|v| if v == 0 { "—".to_string() } else { format!("{}s", v) })
+            .unwrap_or_else(|| "-".to_string());
+        let created_at = format_created_at(p.get("created_at"));
+
+        table.add_row(vec![
+            Cell::new(id),
+            Cell::new(image),
+            Cell::new(&cpus),
+            Cell::new(&memory),
+            Cell::new(&warm),
+            Cell::new(&max),
+            Cell::new(&timeout),
+            Cell::new(created_at),
+        ]);
+    }
+
+    println!("{table}");
+    let count = pools.len();
+    println!("{} pool{}", count, if count != 1 { "s" } else { "" });
+
+    Ok(())
+}

--- a/crates/cli/src/commands/sbx/pool/mod.rs
+++ b/crates/cli/src/commands/sbx/pool/mod.rs
@@ -1,0 +1,286 @@
+pub mod claim;
+pub mod create;
+pub mod get;
+pub mod ls;
+pub mod rm;
+pub mod update;
+
+use crate::commands::sbx::apply_proxy_access_settings;
+
+pub const DEFAULT_POOL_CPUS: f64 = 1.0;
+pub const DEFAULT_POOL_MEMORY_MB: i64 = 1024;
+pub const DEFAULT_POOL_DISK_MB: u64 = 1024;
+
+/// Shared resource arguments that flow into create / update bodies.
+///
+/// Fields are `Option<_>` so the same builder can serve `create` (where `None`
+/// means "use default") and `update` (where `None` means "don't change"). The
+/// caller decides how to interpret `None`.
+#[derive(Default, Clone)]
+pub struct PoolBodyArgs<'a> {
+    pub image: Option<&'a str>,
+    pub cpus: Option<f64>,
+    pub memory_mb: Option<i64>,
+    pub disk_mb: Option<u64>,
+    pub timeout: Option<i64>,
+    pub entrypoint: &'a [String],
+    pub max_containers: Option<i64>,
+    pub warm_containers: Option<i64>,
+    pub ports: &'a [u16],
+    pub allow_unauthenticated_access: bool,
+    pub no_internet: bool,
+    pub network_allow: &'a [String],
+    pub network_deny: &'a [String],
+}
+
+/// Build a fresh pool create body, falling back to library defaults for
+/// resource fields. Used by `tl sbx pool create`.
+pub fn build_pool_create_body(args: &PoolBodyArgs<'_>) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "resources": {
+            "cpus": args.cpus.unwrap_or(DEFAULT_POOL_CPUS),
+            "memory_mb": args.memory_mb.unwrap_or(DEFAULT_POOL_MEMORY_MB),
+            "ephemeral_disk_mb": args.disk_mb.unwrap_or(DEFAULT_POOL_DISK_MB),
+        },
+    });
+
+    if let Some(image) = args.image {
+        body["image"] = serde_json::Value::String(image.to_string());
+    }
+    if let Some(t) = args.timeout {
+        body["timeout_secs"] = serde_json::Value::Number(t.into());
+    }
+    if !args.entrypoint.is_empty() {
+        body["entrypoint"] = serde_json::json!(args.entrypoint);
+    }
+    if let Some(m) = args.max_containers {
+        body["max_containers"] = serde_json::Value::Number(m.into());
+    }
+    if let Some(w) = args.warm_containers {
+        body["warm_containers"] = serde_json::Value::Number(w.into());
+    }
+
+    apply_proxy_access_settings(&mut body, args.ports, args.allow_unauthenticated_access);
+
+    let has_network = args.no_internet || !args.network_allow.is_empty() || !args.network_deny.is_empty();
+    if has_network {
+        let mut network = serde_json::json!({});
+        if args.no_internet {
+            network["allow_internet_access"] = serde_json::Value::Bool(false);
+        }
+        if !args.network_allow.is_empty() {
+            network["allow_out"] = serde_json::json!(args.network_allow);
+        }
+        if !args.network_deny.is_empty() {
+            network["deny_out"] = serde_json::json!(args.network_deny);
+        }
+        body["network"] = network;
+    }
+
+    body
+}
+
+/// Apply the user's update overrides on top of a body parsed from the current
+/// pool's `GET` response, producing a full `PUT` body. Only scalar/list
+/// fields are exposed in `tl sbx pool update`; network/proxy access are
+/// preserved as-is from the current state. The current state's
+/// `network_policy` (response field) is renamed to `network` (request field).
+pub fn merge_pool_update_body(
+    current: &serde_json::Value,
+    overrides: &PoolBodyArgs<'_>,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({});
+
+    let image = overrides
+        .image
+        .map(str::to_string)
+        .or_else(|| {
+            current
+                .get("image")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        });
+    if let Some(image) = image {
+        body["image"] = serde_json::Value::String(image);
+    }
+
+    let current_resources = current
+        .get("resources")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+    let mut resources = serde_json::json!({
+        "cpus": overrides
+            .cpus
+            .or_else(|| current_resources.get("cpus").and_then(|v| v.as_f64()))
+            .unwrap_or(DEFAULT_POOL_CPUS),
+        "memory_mb": overrides
+            .memory_mb
+            .or_else(|| current_resources.get("memory_mb").and_then(|v| v.as_i64()))
+            .unwrap_or(DEFAULT_POOL_MEMORY_MB),
+    });
+    let disk = overrides
+        .disk_mb
+        .map(|v| v as i64)
+        .or_else(|| {
+            current_resources
+                .get("ephemeral_disk_mb")
+                .and_then(|v| v.as_i64())
+        });
+    if let Some(d) = disk {
+        resources["ephemeral_disk_mb"] = serde_json::Value::Number(d.into());
+    }
+    body["resources"] = resources;
+
+    let timeout = overrides.timeout.or_else(|| {
+        current.get("timeout_secs").and_then(|v| v.as_i64())
+    });
+    if let Some(t) = timeout {
+        body["timeout_secs"] = serde_json::Value::Number(t.into());
+    }
+
+    let entrypoint: Vec<String> = if !overrides.entrypoint.is_empty() {
+        overrides.entrypoint.to_vec()
+    } else {
+        current
+            .get("entrypoint")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    if !entrypoint.is_empty() {
+        body["entrypoint"] = serde_json::json!(entrypoint);
+    }
+
+    let max_containers = overrides.max_containers.or_else(|| {
+        current.get("max_containers").and_then(|v| v.as_i64())
+    });
+    if let Some(m) = max_containers {
+        body["max_containers"] = serde_json::Value::Number(m.into());
+    }
+
+    let warm_containers = overrides.warm_containers.or_else(|| {
+        current.get("warm_containers").and_then(|v| v.as_i64())
+    });
+    if let Some(w) = warm_containers {
+        body["warm_containers"] = serde_json::Value::Number(w.into());
+    }
+
+    if let Some(secret_names) = current.get("secret_names").cloned() {
+        body["secret_names"] = secret_names;
+    }
+    if let Some(true) = current
+        .get("allow_unauthenticated_access")
+        .and_then(|v| v.as_bool())
+    {
+        body["allow_unauthenticated_access"] = serde_json::Value::Bool(true);
+    }
+    if let Some(ports) = current.get("exposed_ports").cloned() {
+        body["exposed_ports"] = ports;
+    }
+    if let Some(network) = current.get("network_policy").cloned() {
+        body["network"] = network;
+    }
+
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_body_uses_defaults_when_unspecified() {
+        let body = build_pool_create_body(&PoolBodyArgs {
+            image: Some("alpine"),
+            entrypoint: &[],
+            ports: &[],
+            network_allow: &[],
+            network_deny: &[],
+            ..Default::default()
+        });
+        assert_eq!(body["image"], "alpine");
+        assert_eq!(body["resources"]["cpus"], 1.0);
+        assert_eq!(body["resources"]["memory_mb"], 1024);
+        assert_eq!(body["resources"]["ephemeral_disk_mb"], 1024);
+        assert!(body.get("max_containers").is_none());
+        assert!(body.get("network").is_none());
+    }
+
+    #[test]
+    fn create_body_includes_proxy_and_network_when_set() {
+        let body = build_pool_create_body(&PoolBodyArgs {
+            image: Some("alpine"),
+            entrypoint: &[],
+            ports: &[8080],
+            allow_unauthenticated_access: true,
+            no_internet: true,
+            network_allow: &["10.0.0.0/8".to_string()],
+            network_deny: &[],
+            ..Default::default()
+        });
+        assert_eq!(body["exposed_ports"], serde_json::json!([8080]));
+        assert_eq!(body["allow_unauthenticated_access"], true);
+        assert_eq!(body["network"]["allow_internet_access"], false);
+        assert_eq!(body["network"]["allow_out"], serde_json::json!(["10.0.0.0/8"]));
+    }
+
+    #[test]
+    fn merge_update_body_preserves_unspecified_fields() {
+        let current = serde_json::json!({
+            "image": "alpine",
+            "resources": {"cpus": 0.5, "memory_mb": 256, "ephemeral_disk_mb": 512},
+            "timeout_secs": 60,
+            "entrypoint": ["bash"],
+            "max_containers": 10,
+            "warm_containers": 3,
+            "allow_unauthenticated_access": true,
+            "exposed_ports": [8080],
+            "network_policy": {"allow_internet_access": false, "allow_out": [], "deny_out": []},
+            "secret_names": ["A"],
+        });
+        let overrides = PoolBodyArgs {
+            warm_containers: Some(5),
+            entrypoint: &[],
+            ports: &[],
+            network_allow: &[],
+            network_deny: &[],
+            ..Default::default()
+        };
+        let body = merge_pool_update_body(&current, &overrides);
+        assert_eq!(body["image"], "alpine");
+        assert_eq!(body["resources"]["cpus"], 0.5);
+        assert_eq!(body["resources"]["memory_mb"], 256);
+        assert_eq!(body["resources"]["ephemeral_disk_mb"], 512);
+        assert_eq!(body["timeout_secs"], 60);
+        assert_eq!(body["entrypoint"], serde_json::json!(["bash"]));
+        assert_eq!(body["max_containers"], 10);
+        assert_eq!(body["warm_containers"], 5);
+        assert_eq!(body["allow_unauthenticated_access"], true);
+        assert_eq!(body["exposed_ports"], serde_json::json!([8080]));
+        assert_eq!(body["network"]["allow_internet_access"], false);
+        assert_eq!(body["secret_names"], serde_json::json!(["A"]));
+    }
+
+    #[test]
+    fn merge_update_body_renames_network_policy_to_network() {
+        let current = serde_json::json!({
+            "image": "alpine",
+            "resources": {"cpus": 0.5, "memory_mb": 256},
+            "network_policy": {"allow_internet_access": false, "allow_out": ["1.2.3.4/32"], "deny_out": []},
+        });
+        let overrides = PoolBodyArgs {
+            entrypoint: &[],
+            ports: &[],
+            network_allow: &[],
+            network_deny: &[],
+            ..Default::default()
+        };
+        let body = merge_pool_update_body(&current, &overrides);
+        assert_eq!(body["network"]["allow_out"], serde_json::json!(["1.2.3.4/32"]));
+        assert!(body.get("network_policy").is_none());
+    }
+}

--- a/crates/cli/src/commands/sbx/pool/mod.rs
+++ b/crates/cli/src/commands/sbx/pool/mod.rs
@@ -266,6 +266,48 @@ mod tests {
     }
 
     #[test]
+    fn create_body_setting_port_implicitly_allows_unauthenticated() {
+        // apply_proxy_access_settings forces allow_unauthenticated_access=true
+        // whenever any port is exposed, so ports work end-to-end without an
+        // extra flag.
+        let body = build_pool_create_body(&PoolBodyArgs {
+            image: Some("alpine"),
+            entrypoint: &[],
+            ports: &[8080],
+            allow_unauthenticated_access: false,
+            network_allow: &[],
+            network_deny: &[],
+            ..Default::default()
+        });
+        assert_eq!(body["exposed_ports"], serde_json::json!([8080]));
+        assert_eq!(body["allow_unauthenticated_access"], true);
+    }
+
+    #[test]
+    fn merge_update_body_handles_pool_without_optional_fields() {
+        // Minimal current state — pool was created without entrypoint,
+        // network policy, ports, etc. Update should still succeed.
+        let current = serde_json::json!({
+            "image": "alpine",
+            "resources": {"cpus": 1.0, "memory_mb": 1024, "ephemeral_disk_mb": 1024},
+        });
+        let overrides = PoolBodyArgs {
+            warm_containers: Some(2),
+            entrypoint: &[],
+            ports: &[],
+            network_allow: &[],
+            network_deny: &[],
+            ..Default::default()
+        };
+        let body = merge_pool_update_body(&current, &overrides);
+        assert_eq!(body["image"], "alpine");
+        assert_eq!(body["warm_containers"], 2);
+        assert!(body.get("entrypoint").is_none());
+        assert!(body.get("network").is_none());
+        assert!(body.get("exposed_ports").is_none());
+    }
+
+    #[test]
     fn merge_update_body_renames_network_policy_to_network() {
         let current = serde_json::json!({
             "image": "alpine",

--- a/crates/cli/src/commands/sbx/pool/rm.rs
+++ b/crates/cli/src/commands/sbx/pool/rm.rs
@@ -1,0 +1,86 @@
+use crate::auth::context::CliContext;
+use crate::commands::sbx::pool::get::fetch_pool;
+use crate::commands::sbx::sandbox_endpoint;
+use crate::error::{CliError, Result};
+
+pub async fn run(ctx: &CliContext, pool_id: &str, force: bool) -> Result<()> {
+    let active = active_sandbox_count(ctx, pool_id).await?;
+
+    if active > 0 {
+        let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+        if !force {
+            if !is_tty {
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "pool {} has {} active sandbox{}; pass --force to terminate them",
+                    pool_id,
+                    active,
+                    if active == 1 { "" } else { "es" }
+                )));
+            }
+
+            let prompt = format!(
+                "Pool {} has {} active sandbox{}. Terminate them and delete the pool?",
+                pool_id,
+                active,
+                if active == 1 { "" } else { "es" }
+            );
+            let confirmed = dialoguer::Confirm::new()
+                .with_prompt(prompt)
+                .default(false)
+                .interact()
+                .map_err(|_| CliError::Cancelled)?;
+            if !confirmed {
+                return Err(CliError::Cancelled);
+            }
+        }
+    }
+
+    let force_flag = force || active > 0;
+    let client = ctx.client()?;
+    let suffix = if force_flag {
+        format!("sandbox-pools/{pool_id}?force=true")
+    } else {
+        format!("sandbox-pools/{pool_id}")
+    };
+    let url = sandbox_endpoint(ctx, &suffix);
+    let resp = client.delete(&url).send().await.map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to delete sandbox pool {} (HTTP {}): {}",
+            pool_id,
+            status,
+            body
+        )));
+    }
+
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    if is_tty {
+        eprintln!("Deleted sandbox pool {}", pool_id);
+    } else {
+        println!("{}", pool_id);
+    }
+    Ok(())
+}
+
+/// Count containers in the pool that have been claimed (have a sandbox_id).
+/// Used to decide whether to prompt the user before deletion.
+async fn active_sandbox_count(ctx: &CliContext, pool_id: &str) -> Result<usize> {
+    let pool = fetch_pool(ctx, pool_id).await?;
+    Ok(pool
+        .get("containers")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|c| {
+                    c.get("sandbox_id")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .is_some()
+                })
+                .count()
+        })
+        .unwrap_or(0))
+}

--- a/crates/cli/src/commands/sbx/pool/update.rs
+++ b/crates/cli/src/commands/sbx/pool/update.rs
@@ -1,0 +1,80 @@
+use crate::auth::context::CliContext;
+use crate::commands::sbx::pool::get::fetch_pool;
+use crate::commands::sbx::pool::{PoolBodyArgs, merge_pool_update_body};
+use crate::commands::sbx::sandbox_endpoint;
+use crate::error::{CliError, Result};
+
+pub struct UpdateArgs<'a> {
+    pub pool_id: &'a str,
+    pub image: Option<&'a str>,
+    pub cpus: Option<f64>,
+    pub memory: Option<i64>,
+    pub disk_mb: Option<u64>,
+    pub timeout: Option<i64>,
+    pub entrypoint: &'a [String],
+    pub max_containers: Option<i64>,
+    pub warm_containers: Option<i64>,
+}
+
+pub async fn run(ctx: &CliContext, args: UpdateArgs<'_>) -> Result<()> {
+    let UpdateArgs {
+        pool_id,
+        image,
+        cpus,
+        memory,
+        disk_mb,
+        timeout,
+        entrypoint,
+        max_containers,
+        warm_containers,
+    } = args;
+
+    let current = fetch_pool(ctx, pool_id).await?;
+
+    let body = merge_pool_update_body(
+        &current,
+        &PoolBodyArgs {
+            image,
+            cpus,
+            memory_mb: memory,
+            disk_mb,
+            timeout,
+            entrypoint,
+            max_containers,
+            warm_containers,
+            ports: &[],
+            allow_unauthenticated_access: false,
+            no_internet: false,
+            network_allow: &[],
+            network_deny: &[],
+        },
+    );
+
+    let client = ctx.client()?;
+    let url = sandbox_endpoint(ctx, &format!("sandbox-pools/{pool_id}"));
+    let resp = client
+        .put(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to update sandbox pool {} (HTTP {}): {}",
+            pool_id,
+            status,
+            text
+        )));
+    }
+
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
+    if is_tty {
+        eprintln!("Pool {} updated.", pool_id);
+    } else {
+        println!("{}", pool_id);
+    }
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -555,6 +555,141 @@ enum SbxCommands {
     /// Manage sandbox images
     #[command(subcommand)]
     Image(ImageCommands),
+
+    /// Manage sandbox pools (warm-container fleets)
+    #[command(subcommand)]
+    Pool(PoolCommands),
+}
+
+#[derive(Subcommand)]
+enum PoolCommands {
+    /// Create a new sandbox pool
+    Create {
+        /// Sandbox image name to boot from (registered image name or e.g. tensorlake/ubuntu-minimal)
+        #[arg(short, long)]
+        image: Option<String>,
+
+        /// Number of CPUs per container (default: 1.0)
+        #[arg(short, long)]
+        cpus: Option<f64>,
+
+        /// Memory in MB per container (default: 1024)
+        #[arg(short, long)]
+        memory: Option<i64>,
+
+        /// Ephemeral disk size in MB per container (default: 1024)
+        #[arg(long = "disk_mb")]
+        disk_mb: Option<u64>,
+
+        /// Per-sandbox timeout in seconds (0 or omitted = no timeout)
+        #[arg(short, long)]
+        timeout: Option<i64>,
+
+        /// Entrypoint command parts
+        #[arg(short, long)]
+        entrypoint: Vec<String>,
+
+        /// Maximum total containers allowed in this pool
+        #[arg(long)]
+        max_containers: Option<i64>,
+
+        /// Number of warm containers to keep ready
+        #[arg(long)]
+        warm_containers: Option<i64>,
+
+        /// Expose a port via the sandbox proxy on every claimed sandbox (can be repeated)
+        #[arg(short = 'x', long = "expose", value_parser = parse_user_port)]
+        ports: Vec<u16>,
+
+        /// Allow unauthenticated proxy access on claimed sandboxes
+        #[arg(long, hide = true)]
+        allow_unauthenticated_access: bool,
+
+        /// Block all outbound internet access on claimed sandboxes
+        #[arg(short = 'N', long)]
+        no_internet: bool,
+
+        /// Allow outbound traffic to this IP or CIDR (can be repeated)
+        #[arg(short = 'A', long = "network-allow")]
+        network_allow: Vec<String>,
+
+        /// Deny outbound traffic to this IP or CIDR (can be repeated)
+        #[arg(short = 'D', long = "network-deny")]
+        network_deny: Vec<String>,
+    },
+
+    /// List sandbox pools
+    Ls {
+        /// Print only pool IDs, one per line
+        #[arg(short, long)]
+        quiet: bool,
+    },
+
+    /// Show pool detail and current containers
+    Get {
+        /// Pool ID
+        pool_id: String,
+    },
+
+    /// Update a sandbox pool. Only provided flags are changed; others are
+    /// preserved. Network and proxy access settings are not yet exposed
+    /// here — recreate the pool to change those.
+    Update {
+        /// Pool ID
+        pool_id: String,
+
+        /// Sandbox image name
+        #[arg(short, long)]
+        image: Option<String>,
+
+        /// Number of CPUs per container
+        #[arg(short, long)]
+        cpus: Option<f64>,
+
+        /// Memory in MB per container
+        #[arg(short, long)]
+        memory: Option<i64>,
+
+        /// Ephemeral disk size in MB per container
+        #[arg(long = "disk_mb")]
+        disk_mb: Option<u64>,
+
+        /// Per-sandbox timeout in seconds
+        #[arg(short, long)]
+        timeout: Option<i64>,
+
+        /// Entrypoint command parts (replaces existing when non-empty)
+        #[arg(short, long)]
+        entrypoint: Vec<String>,
+
+        /// Maximum total containers allowed in this pool
+        #[arg(long)]
+        max_containers: Option<i64>,
+
+        /// Number of warm containers to keep ready
+        #[arg(long)]
+        warm_containers: Option<i64>,
+    },
+
+    /// Delete a sandbox pool
+    Rm {
+        /// Pool ID
+        pool_id: String,
+
+        /// Skip confirmation prompt and terminate active sandboxes
+        #[arg(short, long)]
+        force: bool,
+    },
+
+    /// Claim a sandbox from the pool
+    Claim {
+        /// Pool ID
+        pool_id: String,
+
+        /// Return immediately with the sandbox ID instead of waiting for it to be running
+        #[arg(long)]
+        no_wait: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1094,6 +1229,82 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     remote_port,
                     listen_port,
                 } => commands::sbx::tunnel::run(ctx, &sandbox_id, remote_port, listen_port).await,
+                SbxCommands::Pool(pool_cmd) => match pool_cmd {
+                    PoolCommands::Create {
+                        image,
+                        cpus,
+                        memory,
+                        disk_mb,
+                        timeout,
+                        entrypoint,
+                        max_containers,
+                        warm_containers,
+                        ports,
+                        allow_unauthenticated_access,
+                        no_internet,
+                        network_allow,
+                        network_deny,
+                    } => {
+                        commands::sbx::pool::create::run(
+                            ctx,
+                            commands::sbx::pool::create::CreateArgs {
+                                image: image.as_deref(),
+                                cpus,
+                                memory,
+                                disk_mb,
+                                timeout,
+                                entrypoint: &entrypoint,
+                                max_containers,
+                                warm_containers,
+                                ports: &ports,
+                                allow_unauthenticated_access,
+                                no_internet,
+                                network_allow: &network_allow,
+                                network_deny: &network_deny,
+                            },
+                        )
+                        .await
+                    }
+                    PoolCommands::Ls { quiet } => {
+                        commands::sbx::pool::ls::run(ctx, quiet).await
+                    }
+                    PoolCommands::Get { pool_id } => {
+                        commands::sbx::pool::get::run(ctx, &pool_id).await
+                    }
+                    PoolCommands::Update {
+                        pool_id,
+                        image,
+                        cpus,
+                        memory,
+                        disk_mb,
+                        timeout,
+                        entrypoint,
+                        max_containers,
+                        warm_containers,
+                    } => {
+                        commands::sbx::pool::update::run(
+                            ctx,
+                            commands::sbx::pool::update::UpdateArgs {
+                                pool_id: &pool_id,
+                                image: image.as_deref(),
+                                cpus,
+                                memory,
+                                disk_mb,
+                                timeout,
+                                entrypoint: &entrypoint,
+                                max_containers,
+                                warm_containers,
+                            },
+                        )
+                        .await
+                    }
+                    PoolCommands::Rm { pool_id, force } => {
+                        commands::sbx::pool::rm::run(ctx, &pool_id, force).await
+                    }
+                    PoolCommands::Claim { pool_id, no_wait } => {
+                        commands::sbx::pool::claim::run(ctx, &pool_id, !no_wait).await
+                    }
+                },
             }
         }
     }

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -199,8 +199,20 @@ impl SandboxesClient {
         self.client.execute_json(req).await
     }
 
-    pub async fn delete_pool(&self, pool_id: &str) -> Result<Traced<()>, SdkError> {
-        let uri = self.endpoint(&format!("sandbox-pools/{pool_id}"));
+    /// Delete a sandbox pool. When `force` is true, the server terminates any
+    /// active sandboxes claimed from the pool (`?force=true`). Without
+    /// `force`, the server returns 409 if the pool still has active sandboxes.
+    pub async fn delete_pool(
+        &self,
+        pool_id: &str,
+        force: bool,
+    ) -> Result<Traced<()>, SdkError> {
+        let path = if force {
+            format!("sandbox-pools/{pool_id}?force=true")
+        } else {
+            format!("sandbox-pools/{pool_id}")
+        };
+        let uri = self.endpoint(&path);
         let req = self.client.request(Method::DELETE, &uri).build()?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -76,6 +76,12 @@ pub struct SandboxPoolRequest {
     pub max_containers: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warm_containers: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_unauthenticated_access: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exposed_ports: Option<Vec<u16>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<NetworkConfig>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -169,6 +175,15 @@ pub struct SandboxPoolInfo {
     pub max_containers: Option<i64>,
     #[serde(default)]
     pub warm_containers: Option<i64>,
+    /// Server-derived; not configurable on create/update.
+    #[serde(default)]
+    pub min_containers: Option<i64>,
+    #[serde(default)]
+    pub allow_unauthenticated_access: bool,
+    #[serde(default)]
+    pub exposed_ports: Option<Vec<u16>>,
+    #[serde(default)]
+    pub network_policy: Option<NetworkConfig>,
     #[serde(default)]
     pub containers: Option<Vec<PoolContainerInfo>>,
     #[serde(default)]
@@ -400,6 +415,99 @@ mod tests {
             serde_json::to_string(&body).unwrap(),
             r#"{"snapshot_type":"filesystem"}"#
         );
+    }
+
+    #[test]
+    fn sandbox_pool_request_skips_new_optional_fields_when_none() {
+        let body = SandboxPoolRequest {
+            image: Some("alpine".into()),
+            resources: ContainerResourcesInfo {
+                cpus: 0.5,
+                memory_mb: 512,
+                ephemeral_disk_mb: 0,
+            },
+            secret_names: None,
+            timeout_secs: 0,
+            entrypoint: None,
+            max_containers: None,
+            warm_containers: None,
+            allow_unauthenticated_access: None,
+            exposed_ports: None,
+            network: None,
+        };
+        let json = serde_json::to_string(&body).unwrap();
+        assert!(!json.contains("allow_unauthenticated_access"));
+        assert!(!json.contains("exposed_ports"));
+        assert!(!json.contains("network"));
+    }
+
+    #[test]
+    fn sandbox_pool_request_serializes_new_fields_when_set() {
+        let body = SandboxPoolRequest {
+            image: Some("alpine".into()),
+            resources: ContainerResourcesInfo {
+                cpus: 0.5,
+                memory_mb: 512,
+                ephemeral_disk_mb: 0,
+            },
+            secret_names: None,
+            timeout_secs: 0,
+            entrypoint: None,
+            max_containers: None,
+            warm_containers: None,
+            allow_unauthenticated_access: Some(true),
+            exposed_ports: Some(vec![8080, 9000]),
+            network: Some(NetworkConfig {
+                allow_internet_access: false,
+                allow_out: vec!["10.0.0.0/8".into()],
+                deny_out: vec![],
+            }),
+        };
+        let value: serde_json::Value = serde_json::to_value(&body).unwrap();
+        assert_eq!(value["allow_unauthenticated_access"], true);
+        assert_eq!(value["exposed_ports"], serde_json::json!([8080, 9000]));
+        assert_eq!(value["network"]["allow_internet_access"], false);
+        assert_eq!(value["network"]["allow_out"], serde_json::json!(["10.0.0.0/8"]));
+    }
+
+    #[test]
+    fn sandbox_pool_info_deserializes_new_fields() {
+        let json = r#"{
+            "id": "pool-1",
+            "namespace": "default",
+            "image": "alpine",
+            "resources": {"cpus": 0.5, "memory_mb": 512, "ephemeral_disk_mb": 0},
+            "min_containers": 1,
+            "allow_unauthenticated_access": true,
+            "exposed_ports": [8080],
+            "network_policy": {
+                "allow_internet_access": false,
+                "allow_out": [],
+                "deny_out": ["1.2.3.4/32"]
+            }
+        }"#;
+        let info: SandboxPoolInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.min_containers, Some(1));
+        assert!(info.allow_unauthenticated_access);
+        assert_eq!(info.exposed_ports, Some(vec![8080]));
+        let net = info.network_policy.expect("network_policy");
+        assert!(!net.allow_internet_access);
+        assert_eq!(net.deny_out, vec!["1.2.3.4/32"]);
+    }
+
+    #[test]
+    fn sandbox_pool_info_defaults_when_new_fields_absent() {
+        let json = r#"{
+            "id": "pool-1",
+            "namespace": "default",
+            "image": "alpine",
+            "resources": {"cpus": 0.5, "memory_mb": 512, "ephemeral_disk_mb": 0}
+        }"#;
+        let info: SandboxPoolInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.min_containers, None);
+        assert!(!info.allow_unauthenticated_access);
+        assert_eq!(info.exposed_ports, None);
+        assert!(info.network_policy.is_none());
     }
 
     #[test]

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -782,10 +782,16 @@ impl CloudSandboxClient {
         })
     }
 
-    fn delete_pool(&self, pool_id: String) -> PyResult<String> {
+    #[pyo3(signature = (pool_id, force=false))]
+    fn delete_pool(&self, pool_id: String, force: bool) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
-            async move { client.delete_pool(&pool_id).await.map(|t| t.trace_id) }
+            async move {
+                client
+                    .delete_pool(&pool_id, force)
+                    .await
+                    .map(|t| t.trace_id)
+            }
         })
     }
 

--- a/docs/sandbox-pools-cli-reference.md
+++ b/docs/sandbox-pools-cli-reference.md
@@ -1,0 +1,195 @@
+# Sandbox Pools CLI Reference
+
+Manage warm-container fleets backing fast sandbox claims using the
+`tl sbx pool` subcommand group.
+
+---
+
+## Authentication
+
+All `tl sbx pool` commands require authentication. Either:
+
+- Run `tl login` once — credentials are saved to `~/.config/tensorlake/credentials.toml`
+- Or set `TENSORLAKE_API_KEY=<your-key>` in your environment
+
+---
+
+## Concepts
+
+A **sandbox pool** keeps a configurable number of pre-built containers warm
+so that calling `tl sbx pool claim` returns a running sandbox in
+sub-second time on the warm path. Network and proxy access settings are
+applied at the pool level and inherited by every claimed sandbox.
+
+| Concept | What it does |
+|---|---|
+| `warm_containers` | How many idle containers to keep ready at all times. The scheduler refills this count after each claim. |
+| `max_containers` | Hard cap on total containers (warm + claimed). Once reached, claims wait until a slot opens. |
+| `min_containers` | Server-derived (read-only). Reflects the floor the scheduler maintains internally. |
+| Pool deletion with `--force` | Terminates every claimed sandbox before removing the pool. Without `--force`, the API returns 409 if the pool still has active sandboxes. |
+
+---
+
+## Commands
+
+### `tl sbx pool create`
+
+Create a new sandbox pool.
+
+```
+tl sbx pool create [OPTIONS]
+```
+
+**Options**
+
+| Option | Description |
+|---|---|
+| `-i, --image <IMAGE>` | Sandbox image name (e.g. `tensorlake/ubuntu-minimal` or a registered image) |
+| `-c, --cpus <N>` | CPUs per container (default: `1.0`) |
+| `-m, --memory <MB>` | Memory in MB per container (default: `1024`) |
+| `--disk_mb <MB>` | Ephemeral disk in MB per container (default: `1024`) |
+| `-t, --timeout <SECS>` | Per-sandbox timeout (`0` or omitted = no timeout) |
+| `-e, --entrypoint <PART>` | Entrypoint command parts (repeatable) |
+| `--max-containers <N>` | Total-container cap |
+| `--warm-containers <N>` | Number of warm containers to maintain |
+| `-x, --expose <PORT>` | Expose a TCP port (>9501) on every claimed sandbox (repeatable) |
+| `-N, --no-internet` | Block all outbound internet access |
+| `-A, --network-allow <CIDR>` | Allow outbound traffic to this IP/CIDR (repeatable) |
+| `-D, --network-deny <CIDR>` | Deny outbound traffic to this IP/CIDR (repeatable) |
+
+> Setting any `--expose` port implicitly enables unauthenticated proxy access
+> for those ports — there's no way to expose a port and still require auth.
+
+**Example**
+
+```bash
+tl sbx pool create \
+  --image tensorlake/ubuntu-minimal \
+  --warm-containers 3 \
+  --max-containers 10 \
+  --expose 8080 \
+  --no-internet \
+  --network-allow 10.0.0.0/8
+```
+
+Prints the new `pool_id` on success.
+
+---
+
+### `tl sbx pool ls`
+
+List pools in the current namespace.
+
+```
+tl sbx pool ls [--quiet]
+```
+
+| Option | Description |
+|---|---|
+| `-q, --quiet` | Print only pool IDs, one per line (no table formatting) |
+
+The default table shows pool ID, image, CPUs, memory, warm/max counts,
+timeout, and creation time.
+
+---
+
+### `tl sbx pool get`
+
+Show full pool detail and the current container list (warm + claimed).
+
+```
+tl sbx pool get <POOL_ID>
+```
+
+Containers are rendered in a table with their state (`Idle` or `Running`),
+the claiming sandbox ID (if any), and the executor ID hosting them.
+
+---
+
+### `tl sbx pool update`
+
+Patch-like update — only fields you pass are changed. The CLI fetches the
+current pool state, merges your overrides, and `PUT`s the full body, so
+you don't need to repeat unchanged fields.
+
+```
+tl sbx pool update <POOL_ID> [OPTIONS]
+```
+
+| Option | Description |
+|---|---|
+| `-i, --image <IMAGE>` | Replace the pool image |
+| `-c, --cpus <N>` | Change CPUs per container |
+| `-m, --memory <MB>` | Change memory per container |
+| `--disk_mb <MB>` | Change ephemeral disk per container |
+| `-t, --timeout <SECS>` | Change per-sandbox timeout |
+| `-e, --entrypoint <PART>` | Replace entrypoint (only when at least one part is passed) |
+| `--max-containers <N>` | Change the total-container cap |
+| `--warm-containers <N>` | Change the warm-container target |
+
+> Network and proxy access settings (`--no-internet`, `--allow-unauthenticated-access`,
+> `--expose`, `--network-allow`/`-deny`) are not exposed on `update` in v1
+> because clap bare-flag args can only flip to true. To change those, recreate
+> the pool with the new settings, or use the Python SDK's `update_pool()`
+> kwargs.
+
+**Example**
+
+```bash
+tl sbx pool update <pool-id> --warm-containers 5
+```
+
+---
+
+### `tl sbx pool rm`
+
+Delete a sandbox pool.
+
+```
+tl sbx pool rm <POOL_ID> [--force]
+```
+
+| Option | Description |
+|---|---|
+| `-f, --force` | Skip the confirmation prompt and terminate any sandboxes still claimed from this pool |
+
+Behavior:
+
+- **Empty pool**: deletes immediately, no prompt.
+- **Active sandboxes, TTY**: prompts before deletion. Choose `y` to terminate them along with the pool.
+- **Active sandboxes, non-TTY** (CI, scripts): exits with an error if `--force` is missing, instead of hanging on a prompt.
+- **`--force`**: terminates active sandboxes and deletes the pool unconditionally.
+
+---
+
+### `tl sbx pool claim`
+
+Claim a sandbox from the pool. The warm path is sub-second; if no warm
+container is available, the scheduler creates one on demand.
+
+```
+tl sbx pool claim <POOL_ID> [--no-wait]
+```
+
+| Option | Description |
+|---|---|
+| `--no-wait` | Return immediately with the sandbox ID rather than blocking until it transitions to `running` |
+
+By default `claim` waits for the sandbox to reach `running` before
+returning, so the printed ID is always usable for follow-up commands.
+This differs from `tl sbx create`, where `--wait` is opt-in — pools
+exist for fast claims, so blocking briefly is the expected mode.
+
+**Example**
+
+```bash
+sandbox_id=$(tl sbx pool claim <pool-id>)
+tl sbx ssh "$sandbox_id"
+```
+
+---
+
+## See also
+
+- [`tl sbx create`](../crates/cli/src/commands/sbx/create.rs) — create individual sandboxes (no pool)
+- [Python SDK](../src/tensorlake/sandbox/client.py) — `client.create_pool()`, `client.claim()`, etc.

--- a/docs/sandbox-pools-plan.md
+++ b/docs/sandbox-pools-plan.md
@@ -66,10 +66,10 @@ Three patterns, all of which already exist — no new infrastructure.
 
 ### 5. Documentation updates (last step of the change)
 
-- Python SDK reference (sandbox client + models)
-- CLI reference (new `tl sbx pool` group)
-- docs.tensorlake.ai sandbox guide — add Python pool examples alongside the
-  existing TS examples
+- Python SDK docstrings on `create_pool` / `update_pool` / `delete_pool`
+- CLI `--help` text on each `tl sbx pool` subcommand
+- README's Sandbox Pools section — Python + CLI examples
+- New `docs/sandbox-pools-cli-reference.md` for the full CLI surface
 
 ## Backend / cross-team gaps (NOT in this change)
 
@@ -135,14 +135,7 @@ cannot name the resulting sandbox — the API takes an empty body.
   `POST /sandbox-pools/{id}/sandboxes`. Low priority; users can rename via
   `tl sbx name` afterward.
 
-### 6. docs.tensorlake.ai sandbox guide
-
-The public docs site lives in a separate repo. The Sandbox Pools section
-there currently has TypeScript examples only; the Python equivalents need
-to be added in a parallel PR against that repo, mirroring the README and
-the new `docs/sandbox-pools-cli-reference.md` in this PR.
-
-### 7. `tl sbx create --pool <id>` as an alias for claim?
+### 6. `tl sbx create --pool <id>` as an alias for claim?
 
 Considered and deferred. TS SDK uses `Sandbox.create({poolId})` as the only
 surface; Python SDK has both `Sandbox.create()` and `client.claim()`. Keeping

--- a/docs/sandbox-pools-plan.md
+++ b/docs/sandbox-pools-plan.md
@@ -1,0 +1,143 @@
+# Sandbox Pools — Python SDK + CLI Gap Closure
+
+Status doc for the Sandbox Pools effort. Captures the current state, what this
+change adds, and gaps that depend on backend or other-team work.
+
+## State of the world today
+
+| Layer | Pool support | Notes |
+|---|---|---|
+| HTTP API (`compute-engine-internal`) | Full CRUD + claim | Some fields not yet exposed (see backend gaps) |
+| Rust core SDK (`crates/cloud-sdk`) | Full CRUD + claim | Missing several fields the API supports |
+| Rust→Py bridge (`crates/rust-cloud-sdk-py`) | Full passthrough | |
+| Python SDK (`src/tensorlake/sandbox`) | Full CRUD + claim | Missing several fields the API supports |
+| TypeScript SDK (`typescript/src`) | Full CRUD + claim | Same field gaps as Python |
+| **CLI (`tl`)** | **None** | No pool subcommands at all |
+
+## What this change does
+
+### 1. Field gap-fill across Rust core SDK + Python SDK
+
+Adds these fields to `SandboxPoolRequest` and `SandboxPoolInfo` in both layers
+(they exist in the HTTP API today but neither SDK exposes them):
+
+- `allow_unauthenticated_access: bool`
+- `exposed_ports: list[int]`
+- `network: NetworkAccessControl` (`allow_internet_access`, `allow_out`, `deny_out`)
+- `min_containers: int` — read-only on `SandboxPoolInfo` only (see backend gap)
+
+Adds `force: bool` parameter to `delete_pool` (maps to `?force=true` query
+param) so callers can delete pools that still have active sandboxes.
+
+`update_pool` becomes patch-like: callers pass only the fields they want to
+change; the SDK fetches current state, merges, and PUTs.
+
+### 2. CLI: new `tl sbx pool` subcommand group
+
+| Command | Behavior |
+|---|---|
+| `tl sbx pool create --image ... --cpus 1.0 --memory-mb 1024 --warm-containers N --max-containers N --timeout S --port P --allow-unauthenticated-access --no-internet --network-allow CIDR --network-deny CIDR --entrypoint ...` | Creates pool. Defaults match `tl sbx create` (cpus=1.0, memory=1024). |
+| `tl sbx pool ls [--quiet]` | Lists pools. Columns: ID, Image, Warm, Max, Timeout, Created. |
+| `tl sbx pool get <pool-id>` | Shows pool detail + container table. |
+| `tl sbx pool update <pool-id> [any subset of create flags]` | Patch-like: fetch-merge-put. |
+| `tl sbx pool rm <pool-id> [--force]` | Confirmation prompt if pool has active sandboxes; `--force` skips prompt and terminates them. |
+| `tl sbx pool claim <pool-id> [--no-wait]` | Claims a sandbox from the pool. **Waits for `running` status by default**; `--no-wait` returns immediately with `pending`. |
+
+Defaults and conventions:
+- All flag names match `tl sbx create` exactly (e.g. `--memory-mb`, `--cpus`,
+  `--port`, `--network-allow/deny`, `--no-internet`).
+- `tl sbx pool claim` waits by default because pools exist for fast claims —
+  inconsistent with `tl sbx create`'s opt-in `--wait`, but defensible because
+  the warm-container path is sub-second. Consider matching this default later
+  if `tl sbx create` ever gets warm-pool fallback.
+- `tl sbx pool rm` confirms only when sandboxes are active. No prompt for empty
+  pools.
+- `tl sbx pool claim` does NOT support per-claim flags (`--name`, `--ports`,
+  etc.) — the API takes an empty body. Proxy/network/access settings are
+  inherited from the pool.
+
+### 3. Tests
+
+Three patterns, all of which already exist — no new infrastructure.
+
+- **Python SDK unit tests** ([tests/sandbox/test_client_rust_backend.py](tests/sandbox/test_client_rust_backend.py)) — uses `_FakeRustClient` mock. Extend with cases that capture the create/update JSON payload and assert the new fields (`allow_unauthenticated_access`, `exposed_ports`, `network`, `min_containers`) round-trip through the Python models. Add a unit test for `update_pool` patch-merge: only-passed fields override, untouched fields preserved.
+- **Python SDK integration tests** ([tests/sandbox/test_lifecycle.py:190 `TestPoolLifecycle`](tests/sandbox/test_lifecycle.py:190)) — already runs full pool CRUD against a live server. Extend `test_1_create_pool` to set the new fields, extend `test_2_get_pool` to assert they read back, add a `test_N_update_pool_partial` that exercises the patch-merge path, and add a `test_N_delete_pool_force` for the force flag.
+- **Rust CLI command-level unit tests** — match the inline `#[test]` pattern used in [crates/cli/src/commands/sbx/ls.rs](crates/cli/src/commands/sbx/ls.rs), [tunnel.rs](crates/cli/src/commands/sbx/tunnel.rs), [exec.rs](crates/cli/src/commands/sbx/exec.rs). For each pool command, add inline tests for body construction (`build_pool_create_body` etc.) and the merge logic in `update`. No end-to-end binary tests — that infra doesn't exist for any sbx command and is out of scope.
+
+### 5. Documentation updates (last step of the change)
+
+- Python SDK reference (sandbox client + models)
+- CLI reference (new `tl sbx pool` group)
+- docs.tensorlake.ai sandbox guide — add Python pool examples alongside the
+  existing TS examples
+
+## Backend / cross-team gaps (NOT in this change)
+
+These need separate work outside the SDK + CLI:
+
+### 1. `min_containers` is not configurable
+
+The HTTP API exposes `min_containers` on `GET` responses (read-only) but does
+NOT accept it on `POST` or `PUT`. The value is server-derived from internal
+`ContainerPool.min_containers` state.
+
+- **Source**: `indexify/crates/server/src/routes/sandbox_pools.rs` lines 115–146
+  (CreateSandboxPoolRequest), 151–182 (UpdateSandboxPoolRequest), 203–223
+  (SandboxPoolInfo)
+- **Ask**: add `min_containers: Option<u32>` to both request structs and wire
+  it through to the underlying pool config.
+- **Until then**: SDK exposes `min_containers` on read only; pool create/update
+  cannot set it.
+
+### 2. `claim` response gives no warm-vs-cold hint
+
+`POST /sandbox-pools/{id}/sandboxes` always returns
+`status="pending", pending_reason="scheduling"`, regardless of whether a warm
+container was assigned. Clients must poll `GET /sandboxes/{id}` to discover
+running state.
+
+- **Source**: `indexify/crates/server/src/routes/sandbox_pools.rs` lines
+  576–606 (`create_pool_sandbox` handler), lines 601–605 (hardcoded response)
+- **Ask**: have the response distinguish warm-claim (status="running" or
+  pending_reason="warm_assigned") from cold-claim (pending_reason="scheduling")
+  so clients can skip polling on the fast path.
+- **Until then**: every `claim` does at least one extra round-trip to confirm
+  running state. Acceptable but wasteful for the warm path.
+
+### 3. `secret_names` on pools — drop or wire up?
+
+Both Python and Rust SDKs accept `secret_names: list[str]` on `SandboxPoolRequest`
+and surface it on `SandboxPoolInfo`. The API route handler does **not** appear
+to read this field (no mention in the Create/Update request structs in
+`sandbox_pools.rs`).
+
+- **Action needed**: backend confirms whether `secret_names` is silently
+  dropped or actually wired through. If dropped: remove from SDK request
+  models. If wired: leave as-is and add CLI `--secret` flag to
+  `tl sbx pool create`.
+- **Until confirmed**: this change leaves Python SDK's `secret_names` alone
+  and does NOT add a `--secret` flag to `tl sbx pool create`.
+
+### 4. GPU support on pools
+
+`gpu_configs` exists on `CreateSandboxPoolRequest` in the API. Neither
+`tl sbx create` nor the Python `Sandbox.create()` API expose GPU flags today.
+
+- **Action**: defer pool-level GPU until individual-sandbox GPU lands. When
+  it does, mirror the same flags to `tl sbx pool create`.
+
+### 5. Per-claim sandbox naming
+
+`tl sbx create --name foo` works for individual sandboxes. `tl sbx pool claim`
+cannot name the resulting sandbox — the API takes an empty body.
+
+- **Ask**: optional API change to accept `{ "name": "..." }` on
+  `POST /sandbox-pools/{id}/sandboxes`. Low priority; users can rename via
+  `tl sbx name` afterward.
+
+### 6. `tl sbx create --pool <id>` as an alias for claim?
+
+Considered and deferred. TS SDK uses `Sandbox.create({poolId})` as the only
+surface; Python SDK has both `Sandbox.create()` and `client.claim()`. Keeping
+the CLI to one obvious entry point (`tl sbx pool claim`) for now; can add
+`tl sbx create --pool` later if discoverability complaints come in.

--- a/docs/sandbox-pools-plan.md
+++ b/docs/sandbox-pools-plan.md
@@ -135,7 +135,14 @@ cannot name the resulting sandbox — the API takes an empty body.
   `POST /sandbox-pools/{id}/sandboxes`. Low priority; users can rename via
   `tl sbx name` afterward.
 
-### 6. `tl sbx create --pool <id>` as an alias for claim?
+### 6. docs.tensorlake.ai sandbox guide
+
+The public docs site lives in a separate repo. The Sandbox Pools section
+there currently has TypeScript examples only; the Python equivalents need
+to be added in a parallel PR against that repo, mirroring the README and
+the new `docs/sandbox-pools-cli-reference.md` in this PR.
+
+### 7. `tl sbx create --pool <id>` as an alias for claim?
 
 Considered and deferred. TS SDK uses `Sandbox.create({poolId})` as the only
 surface; Python SDK has both `Sandbox.create()` and `client.claim()`. Keeping

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -834,6 +834,9 @@ class SandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
+        allow_unauthenticated_access: bool | None = None,
+        exposed_ports: list[int] | None = None,
+        network: NetworkConfig | None = None,
     ) -> Traced[CreateSandboxPoolResponse]:
         """Create a new sandbox pool.
 
@@ -848,6 +851,13 @@ class SandboxClient:
             entrypoint: Custom entrypoint command (optional)
             max_containers: Maximum number of containers in pool
             warm_containers: Number of warm containers to maintain
+            allow_unauthenticated_access: When True, sandboxes claimed from
+                this pool accept unauthenticated proxy traffic on exposed
+                ports. Required for public-facing services.
+            exposed_ports: TCP ports (>9501) to expose through the proxy on
+                every claimed sandbox.
+            network: Outbound network policy applied to every claimed
+                sandbox.
 
         Returns:
             CreateSandboxPoolResponse with pool_id and namespace
@@ -866,6 +876,9 @@ class SandboxClient:
             entrypoint=entrypoint,
             max_containers=max_containers,
             warm_containers=warm_containers,
+            allow_unauthenticated_access=allow_unauthenticated_access,
+            exposed_ports=exposed_ports,
+            network=network,
         )
 
         try:
@@ -920,17 +933,25 @@ class SandboxClient:
     def update_pool(
         self,
         pool_id: str,
-        image: str,
-        cpus: float = 1.0,
-        memory_mb: int = 1024,
-        ephemeral_disk_mb: int = 1024,
+        image: str | None = None,
+        cpus: float | None = None,
+        memory_mb: int | None = None,
+        ephemeral_disk_mb: int | None = None,
         secret_names: list[str] | None = None,
-        timeout_secs: int = 0,
+        timeout_secs: int | None = None,
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
+        allow_unauthenticated_access: bool | None = None,
+        exposed_ports: list[int] | None = None,
+        network: NetworkConfig | None = None,
     ) -> Traced[SandboxPoolInfo]:
         """Update a sandbox pool configuration.
+
+        Patch-like: only fields you pass are changed. The API requires a
+        full PUT body, so this method first fetches current pool state and
+        merges your overrides before sending. ``None`` for a field means
+        "don't change"; pass an explicit empty list / value to clear.
 
         Args:
             pool_id: ID of the pool to update
@@ -940,10 +961,16 @@ class SandboxClient:
             memory_mb: Memory in megabytes
             ephemeral_disk_mb: Ephemeral disk space in megabytes
             secret_names: List of secret names to inject
-            timeout_secs: Timeout in seconds (default: 0 = no timeout)
-            entrypoint: Custom entrypoint command (optional)
+            timeout_secs: Timeout in seconds (0 = no timeout)
+            entrypoint: Custom entrypoint command
             max_containers: Maximum number of containers in pool
             warm_containers: Number of warm containers to maintain
+            allow_unauthenticated_access: Whether claimed sandboxes accept
+                unauthenticated proxy traffic on exposed ports.
+            exposed_ports: TCP ports (>9501) to expose through the proxy on
+                every claimed sandbox.
+            network: Outbound network policy applied to every claimed
+                sandbox.
 
         Returns:
             SandboxPoolInfo with updated pool details
@@ -953,16 +980,49 @@ class SandboxClient:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
-        request_model = SandboxPoolRequest(
-            image=image,
-            resources=ContainerResourcesInfo(
-                cpus=cpus, memory_mb=memory_mb, ephemeral_disk_mb=ephemeral_disk_mb
+        current = self.get_pool(pool_id).value
+
+        merged_resources = ContainerResourcesInfo(
+            cpus=cpus if cpus is not None else current.resources.cpus,
+            memory_mb=(
+                memory_mb if memory_mb is not None else current.resources.memory_mb
             ),
-            secret_names=secret_names,
-            timeout_secs=timeout_secs,
-            entrypoint=entrypoint,
-            max_containers=max_containers,
-            warm_containers=warm_containers,
+            ephemeral_disk_mb=(
+                ephemeral_disk_mb
+                if ephemeral_disk_mb is not None
+                else current.resources.ephemeral_disk_mb
+            ),
+        )
+
+        request_model = SandboxPoolRequest(
+            image=image if image is not None else current.image,
+            resources=merged_resources,
+            secret_names=(
+                secret_names if secret_names is not None else current.secret_names
+            ),
+            timeout_secs=(
+                timeout_secs if timeout_secs is not None else current.timeout_secs
+            ),
+            entrypoint=entrypoint if entrypoint is not None else current.entrypoint,
+            max_containers=(
+                max_containers
+                if max_containers is not None
+                else current.max_containers
+            ),
+            warm_containers=(
+                warm_containers
+                if warm_containers is not None
+                else current.warm_containers
+            ),
+            allow_unauthenticated_access=(
+                allow_unauthenticated_access
+                if allow_unauthenticated_access is not None
+                else current.allow_unauthenticated_access
+            ),
+            exposed_ports=(
+                exposed_ports if exposed_ports is not None else current.exposed_ports
+            ),
+            network=network if network is not None else current.network_policy,
         )
 
         try:
@@ -976,20 +1036,24 @@ class SandboxClient:
                 raise PoolNotFoundError(pool_id) from None
             _raise_as_sandbox_error(e)
 
-    def delete_pool(self, pool_id: str) -> Traced[None]:
+    def delete_pool(self, pool_id: str, force: bool = False) -> Traced[None]:
         """Delete a sandbox pool.
 
         Args:
             pool_id: ID of the pool to delete
+            force: When True, terminates any sandboxes still claimed from
+                the pool before deleting it. When False (default), the API
+                returns 409 (raised as PoolInUseError) if the pool still
+                has active sandboxes.
 
         Raises:
             PoolNotFoundError: If pool doesn't exist
-            PoolInUseError: If pool has active containers
+            PoolInUseError: If pool has active containers and force=False
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            trace_id = self._rust_client.delete_pool(pool_id=pool_id)
+            trace_id = self._rust_client.delete_pool(pool_id=pool_id, force=force)
             return Traced(trace_id, None)
         except Exception as e:
             kind, status_code, message = _parse_rust_client_error_fields(e)

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -164,6 +164,9 @@ class SandboxPoolRequest(BaseModel):
     entrypoint: list[str] | None = None
     max_containers: int | None = None
     warm_containers: int | None = None
+    allow_unauthenticated_access: bool | None = None
+    exposed_ports: list[int] | None = None
+    network: NetworkConfig | None = None
 
 
 # --- Response models ---
@@ -261,6 +264,10 @@ class SandboxPoolInfo(BaseModel):
     entrypoint: list[str] | None = None
     max_containers: int | None = None
     warm_containers: int | None = None
+    min_containers: int | None = None
+    allow_unauthenticated_access: bool = False
+    exposed_ports: list[int] | None = None
+    network_policy: NetworkConfig | None = None
     containers: list[PoolContainerInfo] | None = None
     created_at: OptionalTimestamp = None
     updated_at: OptionalTimestamp = None

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -418,6 +418,124 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         _, snapshot_type = fake.create_snapshot_calls[0]
         self.assertIsNone(snapshot_type)
 
+    def test_create_pool_sends_new_proxy_and_network_fields(self):
+        from tensorlake.sandbox import NetworkConfig
+
+        captured: dict = {}
+
+        class _PoolFake:
+            def close(self):
+                return None
+
+            def create_pool(self, request_json):
+                captured["create"] = request_json
+                return ("trace-create-pool", '{"pool_id":"pool-1","namespace":"default"}')
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _PoolFake()
+
+        client.create_pool(
+            image="alpine",
+            cpus=0.5,
+            memory_mb=512,
+            ephemeral_disk_mb=0,
+            allow_unauthenticated_access=True,
+            exposed_ports=[8080],
+            network=NetworkConfig(
+                allow_internet_access=False,
+                allow_out=["10.0.0.0/8"],
+                deny_out=[],
+            ),
+        )
+
+        body = json.loads(captured["create"])
+        self.assertEqual(body["allow_unauthenticated_access"], True)
+        self.assertEqual(body["exposed_ports"], [8080])
+        self.assertEqual(body["network"]["allow_internet_access"], False)
+        self.assertEqual(body["network"]["allow_out"], ["10.0.0.0/8"])
+
+    def test_update_pool_patch_merges_with_current_state(self):
+        captured: dict = {}
+
+        class _PoolFake:
+            def close(self):
+                return None
+
+            def get_pool_json(self, pool_id):
+                captured["get"] = pool_id
+                response = {
+                    "id": pool_id,
+                    "namespace": "default",
+                    "image": "alpine",
+                    "resources": {
+                        "cpus": 0.5,
+                        "memory_mb": 256,
+                        "ephemeral_disk_mb": 1024,
+                    },
+                    "secret_names": [],
+                    "timeout_secs": 60,
+                    "entrypoint": ["bash"],
+                    "max_containers": 10,
+                    "warm_containers": 3,
+                    "allow_unauthenticated_access": True,
+                    "exposed_ports": [8080],
+                    "network_policy": {
+                        "allow_internet_access": False,
+                        "allow_out": ["10.0.0.0/8"],
+                        "deny_out": [],
+                    },
+                }
+                return ("trace-get-pool", json.dumps(response))
+
+            def update_pool(self, pool_id, request_json):
+                captured["update"] = request_json
+                response = {
+                    "id": pool_id,
+                    "namespace": "default",
+                    "image": "alpine",
+                    "resources": {"cpus": 0.5, "memory_mb": 256, "ephemeral_disk_mb": 1024},
+                    "warm_containers": 5,
+                }
+                return ("trace-update-pool", json.dumps(response))
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _PoolFake()
+
+        client.update_pool(pool_id="pool-1", warm_containers=5)
+
+        body = json.loads(captured["update"])
+        self.assertEqual(body["image"], "alpine")
+        self.assertEqual(body["resources"]["cpus"], 0.5)
+        self.assertEqual(body["resources"]["memory_mb"], 256)
+        self.assertEqual(body["timeout_secs"], 60)
+        self.assertEqual(body["entrypoint"], ["bash"])
+        self.assertEqual(body["max_containers"], 10)
+        self.assertEqual(body["warm_containers"], 5)
+        self.assertEqual(body["allow_unauthenticated_access"], True)
+        self.assertEqual(body["exposed_ports"], [8080])
+        self.assertEqual(body["network"]["allow_out"], ["10.0.0.0/8"])
+        self.assertNotIn("network_policy", body)
+
+    def test_delete_pool_threads_force_flag(self):
+        captured: dict = {}
+
+        class _PoolFake:
+            def close(self):
+                return None
+
+            def delete_pool(self, pool_id, force=False):
+                captured["pool_id"] = pool_id
+                captured["force"] = force
+                return "trace-delete-pool"
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _PoolFake()
+
+        client.delete_pool("pool-1", force=True)
+
+        self.assertEqual(captured["pool_id"], "pool-1")
+        self.assertEqual(captured["force"], True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -374,7 +374,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
             def close(self):
                 return None
 
-            def delete_pool(self, pool_id):
+            def delete_pool(self, pool_id, force=False):
                 raise FakeRustError(("remote_api", 409, f"pool {pool_id} is in use"))
 
         import tensorlake.sandbox.client as sandbox_client_module

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -208,6 +208,8 @@ class TestPoolLifecycle(BaseSandboxTest):
             memory_mb=_SANDBOX_MEMORY_MB,
             ephemeral_disk_mb=_SANDBOX_DISK_MB,
             entrypoint=["sleep", "300"],
+            allow_unauthenticated_access=True,
+            exposed_ports=[8080],
         )
         self.assertIsNotNone(resp.pool_id)
         self.__class__.pool_id = resp.pool_id
@@ -219,6 +221,8 @@ class TestPoolLifecycle(BaseSandboxTest):
         self.assertEqual(info.image, _SANDBOX_IMAGE)
         self.assertAlmostEqual(info.resources.cpus, _SANDBOX_CPUS, places=2)
         self.assertEqual(info.resources.memory_mb, _SANDBOX_MEMORY_MB)
+        self.assertTrue(info.allow_unauthenticated_access)
+        self.assertEqual(info.exposed_ports, [8080])
 
     def test_3_list_pools(self):
         self.assertIsNotNone(self.__class__.pool_id, "Depends on test_1")
@@ -226,18 +230,20 @@ class TestPoolLifecycle(BaseSandboxTest):
         ids = [p.pool_id for p in pools]
         self.assertIn(self.__class__.pool_id, ids)
 
-    def test_4_update_pool(self):
+    def test_4_update_pool_partial_preserves_unspecified_fields(self):
+        """Patch-merge: passing only warm_containers must not change image/resources."""
         self.assertIsNotNone(self.__class__.pool_id, "Depends on test_1")
         updated = self.client.update_pool(
             pool_id=self.__class__.pool_id,
-            image=_SANDBOX_IMAGE,
-            cpus=_SANDBOX_CPUS,
-            memory_mb=2048,
-            ephemeral_disk_mb=_SANDBOX_DISK_MB,
             warm_containers=1,
         )
-        self.assertEqual(updated.resources.memory_mb, 2048)
         self.assertEqual(updated.warm_containers, 1)
+        # Fields we did not pass must be preserved as-is.
+        self.assertEqual(updated.image, _SANDBOX_IMAGE)
+        self.assertAlmostEqual(updated.resources.cpus, _SANDBOX_CPUS, places=2)
+        self.assertEqual(updated.resources.memory_mb, _SANDBOX_MEMORY_MB)
+        self.assertTrue(updated.allow_unauthenticated_access)
+        self.assertEqual(updated.exposed_ports, [8080])
 
     def test_5_delete_pool(self):
         self.assertIsNotNone(self.__class__.pool_id, "Depends on test_1")
@@ -462,6 +468,72 @@ class TestWarmContainers(BaseSandboxTest):
             time.sleep(2)
             self.client.delete_pool(self.__class__.pool_id)
             self.__class__.pool_id = None
+
+
+# ---------------------------------------------------------------------------
+# TestPoolForceDelete
+# ---------------------------------------------------------------------------
+
+
+class TestPoolForceDelete(BaseSandboxTest):
+    """Force-delete a pool that still has an active claimed sandbox.
+
+    Verifies that delete_pool(force=True) succeeds and terminates the
+    sandbox in the same call, vs. the no-force path which raises
+    PoolInUseError (covered by TestPoolWithSandboxes.test_4).
+    """
+
+    pool_id: str | None = None
+    sandbox_id: str | None = None
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.sandbox_id:
+            try:
+                cls.client.delete(cls.sandbox_id)
+            except Exception:
+                pass
+        if cls.pool_id:
+            try:
+                cls.client.delete_pool(cls.pool_id, force=True)
+            except Exception:
+                pass
+        super().tearDownClass()
+
+    def test_1_create_pool_and_claim_sandbox(self):
+        resp = self.client.create_pool(
+            image=_SANDBOX_IMAGE,
+            cpus=_SANDBOX_CPUS,
+            memory_mb=_SANDBOX_MEMORY_MB,
+            ephemeral_disk_mb=_SANDBOX_DISK_MB,
+            entrypoint=["sleep", "300"],
+            warm_containers=1,
+        )
+        self.assertIsNotNone(resp.pool_id)
+        self.__class__.pool_id = resp.pool_id
+
+        claim = self.client.claim(resp.pool_id)
+        self.assertIsNotNone(claim.sandbox_id)
+        self.__class__.sandbox_id = claim.sandbox_id
+        _poll_sandbox_status(
+            self.client, claim.sandbox_id, SandboxStatus.RUNNING, timeout=60
+        )
+
+    def test_2_force_delete_succeeds_with_active_sandbox(self):
+        self.assertIsNotNone(self.__class__.pool_id, "Depends on test_1")
+        self.assertIsNotNone(self.__class__.sandbox_id, "Depends on test_1")
+
+        # Without force this would raise PoolInUseError; force=True must succeed.
+        self.client.delete_pool(self.__class__.pool_id, force=True)
+        self.__class__.pool_id = None
+
+        _poll_sandbox_status(
+            self.client,
+            self.__class__.sandbox_id,
+            SandboxStatus.TERMINATED,
+            timeout=30,
+        )
+        self.__class__.sandbox_id = None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the Sandbox Pools gap across the Rust core SDK, Python SDK, and `tl` CLI. The HTTP API already supports the full feature set; this PR brings the SDKs and CLI up to parity, then adds the missing `tl sbx pool` subcommand group.

Plan and rationale: [docs/sandbox-pools-plan.md](https://github.com/tensorlakeai/tensorlake/blob/feat/sandbox-pools-cli/docs/sandbox-pools-plan.md)

## Layered approach

- [x] **Layer 1** — Rust core SDK: pool fields (`allow_unauthenticated_access`, `exposed_ports`, `network` / `network_policy`, read-only `min_containers`) and `delete_pool(force)`. Bridge passthrough for `force` so workspace compiles.
- [x] Layer 2 — Python SDK: mirror new fields, patch-merge `update_pool`, `force` kwarg on `delete_pool`
- [x] Layer 3 — `tl sbx pool` subcommand group: `create`, `ls`, `get`, `update`, `rm`, `claim`
- [x] Layer 4 — Tests (Python unit + integration, inline Rust unit tests)
- [ ] Layer 5 — Docs

## Backend / cross-team gaps captured for separate work

`min_containers` is not configurable on POST/PUT (server-derived only). `claim` always returns `pending`/`scheduling` regardless of warm-vs-cold. `secret_names` may be silently dropped by the API. See [the doc](https://github.com/tensorlakeai/tensorlake/blob/feat/sandbox-pools-cli/docs/sandbox-pools-plan.md#backend--cross-team-gaps-not-in-this-change) for full list.

## Test plan
- [x] `cargo test -p tensorlake --lib sandboxes::models::tests` — 4 new serde round-trip tests pass
- [x] `cargo check -p tensorlake-rust-cloud-sdk-py -p tensorlake-cli` — workspace type-checks
- [ ] (Layer 4) Python SDK unit tests via `_FakeRustClient`
- [ ] (Layer 4) Python SDK integration tests in `TestPoolLifecycle` against live server
- [ ] (Layer 4) Inline `#[test]` blocks for new Rust CLI command bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)