### PR TITLE
fix(sdk): wait for VNC port readiness in connectDesktop (Rust + TS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,7 +2798,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "bytes",
  "chrono",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2878,7 +2878,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.5"
+version = "0.5.6"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/sandboxes/desktop.rs
+++ b/crates/cloud-sdk/src/sandboxes/desktop.rs
@@ -4,9 +4,12 @@ use std::time::Duration;
 
 use des::Des;
 use des::cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray};
+use eventsource_stream::Eventsource;
 use futures::{SinkExt, StreamExt};
 use png::{BitDepth, ColorType};
-use reqwest::header::{HOST, HeaderMap};
+use reqwest::Method;
+use reqwest::header::{ACCEPT, HOST, HeaderMap};
+use serde_json::json;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio::time::{Instant, sleep, timeout};
@@ -15,6 +18,17 @@ use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 use url::Url;
 
 use crate::{Client, error::SdkError};
+
+/// How long each individual `bash`-builtin port probe is allowed to run inside
+/// the sandbox before the daemon kills it. Two seconds comfortably covers a
+/// successful TCP connect on a healthy port and bounds the cost of each retry
+/// when the port is still refusing connections.
+const PORT_PROBE_PROCESS_TIMEOUT_SECS: u64 = 2;
+
+/// Pause between port-probe attempts. The probe itself is cheap (~5–10 ms when
+/// the port is up), so the cap on probe rate is more about avoiding daemon
+/// chatter than throughput.
+const PORT_PROBE_RETRY_INTERVAL: Duration = Duration::from_millis(250);
 
 const SECURITY_TYPE_NONE: u8 = 1;
 const SECURITY_TYPE_VNC_AUTH: u8 = 2;
@@ -40,7 +54,16 @@ impl SandboxDesktopClient {
         shared: bool,
         connect_timeout: Duration,
     ) -> Result<Self, SdkError> {
+        // Wait for the VNC port to be reachable inside the sandbox before
+        // attempting the WebSocket tunnel handshake. Without this, freshly
+        // created sandboxes (where the in-VM `vncserver` systemd unit is
+        // still starting) race the tunnel: the dataplane gets `Connection
+        // refused` on 127.0.0.1:<port> and the proxy returns 502 before
+        // VNC has had a chance to bind. The wait is bounded by
+        // `connect_timeout` along with the WS handshake and VNC negotiation
+        // that follow — total wall-clock is what the caller asked for.
         let session = timeout(connect_timeout, async move {
+            wait_for_port_ready(&client, port).await?;
             let transport = TunnelConnection::connect(client, host_override, port).await?;
             DesktopSession::connect(transport, password, shared).await
         })
@@ -142,6 +165,66 @@ impl SandboxDesktopClient {
         let session = self.session.lock().await;
         Ok((session.width, session.height))
     }
+}
+
+/// Poll the in-sandbox daemon until the requested port accepts a TCP connection
+/// from `127.0.0.1`. The probe runs `bash -c 'exec 3<>/dev/tcp/127.0.0.1/<port>'`
+/// via the daemon's `/api/v1/processes/run` endpoint; bash's `/dev/tcp` builtin
+/// returns exit 0 when the connect succeeds and non-zero on `Connection
+/// refused` / timeout. `bash` is present on every sandbox image we ship.
+///
+/// Loops forever; the caller is expected to wrap this in an outer
+/// `tokio::time::timeout` (see [`SandboxDesktopClient::connect`]). Treats
+/// transient errors (e.g. SSE stream hiccups) as "not ready yet" and retries;
+/// only persistent SDK errors that bubble out of the underlying request will
+/// surface here.
+async fn wait_for_port_ready(client: &Client, port: u16) -> Result<(), SdkError> {
+    loop {
+        match probe_port_once(client, port).await {
+            Ok(true) => return Ok(()),
+            Ok(false) | Err(_) => sleep(PORT_PROBE_RETRY_INTERVAL).await,
+        }
+    }
+}
+
+/// One probe attempt. Returns `Ok(true)` if `bash`'s `/dev/tcp` connect
+/// succeeded (exit 0), `Ok(false)` otherwise. Errors are returned for
+/// non-process-level failures (transport, JSON shape) so the caller can decide
+/// whether to retry.
+async fn probe_port_once(client: &Client, port: u16) -> Result<bool, SdkError> {
+    let payload = json!({
+        "command": "/bin/bash",
+        "args": ["-c", format!("exec 3<>/dev/tcp/127.0.0.1/{port}")],
+        "timeout_secs": PORT_PROBE_PROCESS_TIMEOUT_SECS,
+    });
+    let req = client
+        .request(Method::POST, "/api/v1/processes/run")
+        .header(ACCEPT, "text/event-stream")
+        .json(&payload)
+        .build()?;
+    let response = client.execute(req).await?;
+    let mut stream = response.bytes_stream().eventsource();
+    while let Some(event) = stream.next().await {
+        let msg = match event {
+            Ok(m) => m,
+            // Mid-stream transport errors should not be fatal — treat as
+            // "not ready, try again".
+            Err(_) => return Ok(false),
+        };
+        let parsed: serde_json::Value = match serde_json::from_str(&msg.data) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if let Some(exit_code) = parsed.get("exit_code").and_then(|v| v.as_i64()) {
+            return Ok(exit_code == 0);
+        }
+        if parsed.get("signal").is_some() {
+            // Killed by signal (e.g. SIGTERM from timeout) — treat as not ready.
+            return Ok(false);
+        }
+    }
+    // Stream ended without an Exited event — daemon hiccup, retry.
+    Ok(false)
 }
 
 struct TunnelConnection {

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.5"
+version = "0.5.6"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.5"
+version = "0.5.6"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.3",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.3",
+      "version": "0.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",
@@ -1225,7 +1225,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1532,7 +1531,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1587,7 +1585,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2308,7 +2305,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2358,7 +2354,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2796,7 +2791,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2844,7 +2838,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -865,14 +865,69 @@ export class Sandbox {
 
   /** Connect to a sandbox VNC session for programmatic desktop control. */
   async connectDesktop(options?: ConnectDesktopOptions): Promise<Desktop> {
+    const port = options?.port ?? 5901;
+    const connectTimeout = options?.connectTimeout ?? 10;
+
+    // Wait for the VNC port to be reachable inside the sandbox before
+    // attempting the WebSocket tunnel handshake. Without this, freshly
+    // created sandboxes (where the in-VM `vncserver` systemd unit is
+    // still starting) race the tunnel: the dataplane gets `Connection
+    // refused` on 127.0.0.1:<port> and the proxy returns 502 before
+    // VNC has had a chance to bind. The wait is bounded by
+    // `connectTimeout` along with the WS handshake and VNC negotiation
+    // that follow — total wall-clock is what the caller asked for.
+    const startMs = Date.now();
+    const deadlineMs = startMs + connectTimeout * 1000;
+    await this.waitForPortReady(port, deadlineMs);
+    const remainingSecs = Math.max(0.1, (deadlineMs - Date.now()) / 1000);
+
     return Desktop.connect({
       baseUrl: this.baseUrl,
       wsHeaders: this.wsHeaders,
-      port: options?.port,
+      port,
       password: options?.password,
       shared: options?.shared,
-      connectTimeout: options?.connectTimeout,
+      connectTimeout: remainingSecs,
     });
+  }
+
+  /**
+   * Poll the in-sandbox daemon until `127.0.0.1:port` accepts a TCP connection.
+   * Uses `bash`'s `/dev/tcp` builtin via `processes/run` — no extra deps in
+   * the sandbox image. `bash` is present on every image we ship.
+   */
+  private async waitForPortReady(
+    port: number,
+    deadlineMs: number,
+  ): Promise<void> {
+    const probeIntervalMs = 250;
+    const probeProcessTimeoutSecs = 2;
+    let lastError: unknown;
+
+    while (Date.now() < deadlineMs) {
+      try {
+        const result = await this.run("/bin/bash", {
+          args: ["-c", `exec 3<>/dev/tcp/127.0.0.1/${port}`],
+          timeout: probeProcessTimeoutSecs,
+        });
+        if (result.exitCode === 0) {
+          return;
+        }
+      } catch (error) {
+        lastError = error;
+      }
+      const remainingMs = deadlineMs - Date.now();
+      if (remainingMs <= 0) break;
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(probeIntervalMs, remainingMs)),
+      );
+    }
+
+    const detail =
+      lastError instanceof Error ? `: ${lastError.message}` : "";
+    throw new SandboxError(
+      `port ${port} did not become reachable inside sandbox within the connect timeout${detail}`,
+    );
   }
 
   ptyWsUrl(sessionId: string, token: string): string {

--- a/typescript/tests/desktop.test.ts
+++ b/typescript/tests/desktop.test.ts
@@ -243,6 +243,15 @@ describe("DesktopSession", () => {
     vi.resetModules();
     ({ DesktopSession } = await import("../src/desktop.js"));
     ({ Sandbox } = await import("../src/sandbox.js"));
+    // `connectDesktop` probes the in-sandbox VNC port via `Sandbox.run`
+    // before opening the WebSocket tunnel. Tests don't have a real daemon
+    // behind `sandbox.tensorlake.ai` (only the `ws` module is mocked), so
+    // short-circuit the probe to return "port is ready" immediately.
+    vi.spyOn(Sandbox.prototype, "run").mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

`Sandbox.create()` returns when the in-VM container daemon is up (~1 s after VM resume from snapshot), but image-specific systemd units like `vncserver-tl-user.service` start a few seconds later. The current `connectDesktop` immediately opens a WebSocket to `/api/v1/tunnels/tcp?port=5901`. The dataplane sees `Connection refused (os error 111)` on `127.0.0.1:5901` and the proxy returns **502 Bad Gateway** — surfacing to the user as `desktop tunnel websocket handshake failed with HTTP 502`.

This adds a port-readiness probe in both the Rust core (used by Python via the PyO3 wrapper) and the standalone TypeScript implementation. The probe runs `bash -c 'exec 3<>/dev/tcp/127.0.0.1/<port>'` via the existing `POST /api/v1/processes/run` daemon endpoint, retrying every 250 ms until the TCP connect succeeds. The whole probe is bounded by the caller's `connect_timeout` along with the WS handshake and VNC negotiation that follow — total wall-clock matches what the caller asked for. `bash`'s `/dev/tcp` builtin is present on every sandbox image we ship, so no extra image dependency.

## Verified end-to-end

```python
sandbox = Sandbox.create(image="ubuntu-vnc")
with sandbox.connect_desktop(password="tensorlake") as desktop:
    print(desktop.width, desktop.height)
# Connected. 1280x800
# elapsed=2s
```

Same flow before this patch returned `502 Bad Gateway` in ~50 ms.

## Why not fix the snapshot baker instead

The longer-term fix is per-image readiness in `indexify/crates/dataplane/src/service.rs:2336` — today the global presnap waits only on container-daemon connect, so the snapshot captures the VM mid-boot. The right fix is a per-image readiness probe (e.g. `tcp_listen 5901` for `ubuntu-vnc`) before snapshot capture. That's a separate change in the dataplane repo. This SDK probe keeps users unblocked today and stays useful afterward as a defensive bound on any cold-start jitter that survives a smarter baker.

## Architecture note

The Python SDK uses the Rust core via PyO3 (`crates/cloud-sdk` → `crates/rust-cloud-sdk-py`). The TypeScript SDK has its own implementation. So the same logical fix is implemented twice in this PR. We discussed (separately) whether to consolidate TS onto the Rust core via napi-rs — staying split for now; this divergence is the cost.

## Test plan

- [x] `cargo build -p tensorlake --tests` with `RUSTFLAGS="-D warnings"`: clean
- [x] `npm run typecheck`: clean
- [x] `npm test`: 132/132 pass (added a `vi.spyOn(Sandbox.prototype, "run")` short-circuit in the desktop tests so the probe doesn't try to hit `sandbox.tensorlake.ai` for a fake sandbox id)
- [x] Live: rebuilt the PyO3 wheel locally, ran `Sandbox.create("ubuntu-vnc")` + `connect_desktop()` against prod — 2 s total, no 502, returns desktop dimensions cleanly.

Note: `package-lock.json` had drifted (`0.5.3` vs. `package.json`'s `0.5.5`); `npm install` synced it in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)