### PR TITLE
feat(sandbox): add async API for sandbox SDK                                                              

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -124,6 +124,7 @@ jobs:
         run: |
           poetry run python -m unittest \
             tests.sandbox.test_client_rust_backend \
+            tests.sandbox.test_client_rust_backend_async \
             tests.sandbox.test_sandbox_rust_backend \
             tests.sandbox.test_sandbox_rust_backend_async \
             tests.image.test_sandbox_builder

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -125,6 +125,7 @@ jobs:
           poetry run python -m unittest \
             tests.sandbox.test_client_rust_backend \
             tests.sandbox.test_sandbox_rust_backend \
+            tests.sandbox.test_sandbox_rust_backend_async \
             tests.image.test_sandbox_builder
 
       - name: Set up Docker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -2850,7 +2850,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,6 +1966,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3-async-runtimes"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
 name = "pyo3-build-config"
 version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2882,6 +2896,7 @@ version = "0.5.7"
 dependencies = [
  "futures",
  "pyo3",
+ "pyo3-async-runtimes",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.7"
+version = "0.5.8"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ gethostname = "0.5"
 
 # Python bindings
 pyo3 = { version = "0.28.2", features = ["abi3-py310", "extension-module"] }
+pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 
 [profile.release]
 codegen-units = 1

--- a/crates/rust-cloud-sdk-py/Cargo.toml
+++ b/crates/rust-cloud-sdk-py/Cargo.toml
@@ -17,3 +17,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
 pyo3 = { workspace = true }
+pyo3-async-runtimes = { workspace = true }

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.6"
+version = "0.5.8"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -30,6 +30,7 @@ use tensorlake::sandboxes::{
 };
 use tensorlake::{Client, ClientBuilder, error::SdkError};
 use tokio::runtime::Runtime;
+use pyo3_async_runtimes::tokio::future_into_py;
 
 create_exception!(_cloud_sdk, CloudApiClientError, PyException);
 create_exception!(_cloud_sdk, CloudSandboxClientError, PyException);
@@ -790,6 +791,327 @@ impl CloudSandboxClient {
         })
     }
 
+    // ---- Async variants (Python awaitables backed by future_into_py) ----
+
+    fn create_sandbox_async<'py>(
+        &self,
+        py: Python<'py>,
+        request_json: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let request: CreateSandboxRequest = parse_json_payload(&request_json)?;
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let request = request.clone();
+                async move { c.create(&request).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn claim_sandbox_async<'py>(
+        &self,
+        py: Python<'py>,
+        pool_id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let pool_id = pool_id.clone();
+                async move { c.claim(&pool_id).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn get_sandbox_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        sandbox_id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let sandbox_id = sandbox_id.clone();
+                async move { c.get(&sandbox_id).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn list_sandboxes_json_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move { c.list().await })
+                .await
+                .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let response = serde_json::json!({ "sandboxes": *traced });
+            let json = serde_json::to_string(&response).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn update_sandbox_async<'py>(
+        &self,
+        py: Python<'py>,
+        sandbox_id: String,
+        request_json: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let request: UpdateSandboxRequest = parse_json_payload(&request_json)?;
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let sandbox_id = sandbox_id.clone();
+                let request = request.clone();
+                async move { c.update(&sandbox_id, &request).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn delete_sandbox_async<'py>(
+        &self,
+        py: Python<'py>,
+        sandbox_id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let sandbox_id = sandbox_id.clone();
+                async move { c.delete(&sandbox_id).await.map(|t| t.trace_id) }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    fn suspend_sandbox_async<'py>(
+        &self,
+        py: Python<'py>,
+        sandbox_id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let sandbox_id = sandbox_id.clone();
+                async move { c.suspend(&sandbox_id).await.map(|t| t.trace_id) }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    fn resume_sandbox_async<'py>(
+        &self,
+        py: Python<'py>,
+        sandbox_id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let sandbox_id = sandbox_id.clone();
+                async move { c.resume(&sandbox_id).await.map(|t| t.trace_id) }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    #[pyo3(signature = (sandbox_id, snapshot_type=None))]
+    fn create_snapshot_async<'py>(
+        &self,
+        py: Python<'py>,
+        sandbox_id: String,
+        snapshot_type: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let parsed_type = match snapshot_type.as_deref() {
+            None => None,
+            Some("memory") => Some(SnapshotType::Memory),
+            Some("filesystem") => Some(SnapshotType::Filesystem),
+            Some(other) => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "invalid snapshot_type '{other}': expected 'memory' or 'filesystem'"
+                )));
+            }
+        };
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let sandbox_id = sandbox_id.clone();
+                async move { c.snapshot(&sandbox_id, parsed_type).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn get_snapshot_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        snapshot_id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let snapshot_id = snapshot_id.clone();
+                async move { c.get_snapshot(&snapshot_id).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn list_snapshots_json_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move {
+                c.list_snapshots().await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let response = serde_json::json!({ "snapshots": *traced });
+            let json = serde_json::to_string(&response).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn delete_snapshot_async<'py>(
+        &self,
+        py: Python<'py>,
+        snapshot_id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let snapshot_id = snapshot_id.clone();
+                async move { c.delete_snapshot(&snapshot_id).await.map(|t| t.trace_id) }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    fn create_pool_async<'py>(
+        &self,
+        py: Python<'py>,
+        request_json: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let request = request.clone();
+                async move { c.create_pool(&request).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn get_pool_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        pool_id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let pool_id = pool_id.clone();
+                async move { c.get_pool(&pool_id).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn list_pools_json_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move {
+                c.list_pools().await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let response = serde_json::json!({ "pools": *traced });
+            let json = serde_json::to_string(&response).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn update_pool_async<'py>(
+        &self,
+        py: Python<'py>,
+        pool_id: String,
+        request_json: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let pool_id = pool_id.clone();
+                let request = request.clone();
+                async move { c.update_pool(&pool_id, &request).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn delete_pool_async<'py>(
+        &self,
+        py: Python<'py>,
+        pool_id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let pool_id = pool_id.clone();
+                async move { c.delete_pool(&pool_id).await.map(|t| t.trace_id) }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
     /// Create a proxy client for the given sandbox that shares this client's HTTP connection
     /// pool. All proxy clients created this way reuse the same underlying reqwest::Client,
     /// so HTTP/2 connections can be coalesced: only the first sandbox in a session pays the
@@ -1137,6 +1459,386 @@ impl CloudSandboxProxyClient {
             let traced = client.info().await?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    // ---- Async variants (Python awaitables backed by future_into_py) ----
+
+    fn start_process_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        payload_json: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let payload: Value = parse_json_payload(&payload_json)?;
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let payload = payload.clone();
+                async move { c.start_process(&payload).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn list_processes_json_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move {
+                c.list_processes().await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let processes = traced.into_inner();
+            let response = serde_json::json!({ "processes": processes });
+            let json = serde_json::to_string(&response).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn get_process_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        pid: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move {
+                c.get_process(pid).await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn kill_process_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| async move {
+                c.kill_process(pid).await.map(|t| t.trace_id)
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    fn send_signal_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        pid: i64,
+        signal: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move {
+                c.send_signal(pid, signal).await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn write_stdin_async<'py>(
+        &self,
+        py: Python<'py>,
+        pid: i64,
+        data: Vec<u8>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let data = data.clone();
+                async move { c.write_stdin(pid, data).await.map(|t| t.trace_id) }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    fn close_stdin_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| async move {
+                c.close_stdin(pid).await.map(|t| t.trace_id)
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    fn get_stdout_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        pid: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move {
+                c.get_stdout(pid).await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn get_stderr_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        pid: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move {
+                c.get_stderr(pid).await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn get_output_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        pid: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move {
+                c.get_output(pid).await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn follow_stdout_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        pid: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 10, move |c| async move {
+                c.follow_stdout(pid).await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let events: Vec<String> = traced
+                .into_inner()
+                .into_iter()
+                .map(|event| serde_json::to_string(&event).map_err(sandbox_serde_err))
+                .collect::<Result<Vec<String>, _>>()?;
+            Ok((trace_id, events))
+        })
+    }
+
+    fn follow_stderr_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        pid: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 10, move |c| async move {
+                c.follow_stderr(pid).await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let events: Vec<String> = traced
+                .into_inner()
+                .into_iter()
+                .map(|event| serde_json::to_string(&event).map_err(sandbox_serde_err))
+                .collect::<Result<Vec<String>, _>>()?;
+            Ok((trace_id, events))
+        })
+    }
+
+    fn follow_output_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        pid: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 10, move |c| async move {
+                c.follow_output(pid).await
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let events: Vec<String> = traced
+                .into_inner()
+                .into_iter()
+                .map(|event| serde_json::to_string(&event).map_err(sandbox_serde_err))
+                .collect::<Result<Vec<String>, _>>()?;
+            Ok((trace_id, events))
+        })
+    }
+
+    fn read_file_bytes_async<'py>(
+        &self,
+        py: Python<'py>,
+        path: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let (trace_id, data): (String, Vec<u8>) = retry_async_op(client, 5, move |c| {
+                let path = path.clone();
+                async move {
+                    let traced = c.read_file(&path).await?;
+                    Ok((traced.trace_id.clone(), traced.into_inner()))
+                }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok((trace_id, data))
+        })
+    }
+
+    fn write_file_async<'py>(
+        &self,
+        py: Python<'py>,
+        path: String,
+        content: Vec<u8>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let path = path.clone();
+                let content = content.clone();
+                async move { c.write_file(&path, content).await.map(|t| t.trace_id) }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    fn delete_file_async<'py>(
+        &self,
+        py: Python<'py>,
+        path: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let path = path.clone();
+                async move { c.delete_file(&path).await.map(|t| t.trace_id) }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    fn list_directory_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        path: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let path = path.clone();
+                async move { c.list_directory(&path).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn create_pty_session_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        payload_json: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let payload: Value = parse_json_payload(&payload_json)?;
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let payload = payload.clone();
+                async move { c.create_pty_session(&payload).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn run_process_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        payload_json: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let payload: Value = parse_json_payload(&payload_json)?;
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| {
+                let payload = payload.clone();
+                async move { c.run_process(&payload).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let events: Vec<String> = traced
+                .into_inner()
+                .into_iter()
+                .map(|event| serde_json::to_string(&event).map_err(sandbox_serde_err))
+                .collect::<Result<Vec<String>, _>>()?;
+            Ok((trace_id, events))
+        })
+    }
+
+    fn health_json_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move { c.health().await })
+                .await
+                .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
+            Ok((trace_id, json))
+        })
+    }
+
+    fn info_json_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let traced = retry_async_op(client, 5, move |c| async move { c.info().await })
+                .await
+                .map_err(into_sandbox_py_error)?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
         })
     }
@@ -1489,6 +2191,36 @@ impl CloudDocumentAIClient {
             }
         }
     }
+}
+
+async fn retry_async_op<C, T, F, Fut>(
+    client: C,
+    max_retries: usize,
+    op: F,
+) -> Result<T, SdkError>
+where
+    C: Clone,
+    F: Fn(C) -> Fut,
+    Fut: Future<Output = Result<T, SdkError>>,
+{
+    let mut retries = 0usize;
+    loop {
+        match op(client.clone()).await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if !is_retryable(&err) || retries >= max_retries {
+                    return Err(err);
+                }
+                retries += 1;
+                let sleep_time = calculate_sleep_time(retries);
+                tokio::time::sleep(Duration::from_secs_f64(sleep_time)).await;
+            }
+        }
+    }
+}
+
+fn sandbox_serde_err(err: serde_json::Error) -> PyErr {
+    into_sandbox_py_error(SdkError::from(err))
 }
 
 fn calculate_sleep_time(retries: usize) -> f64 {

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -2604,6 +2604,11 @@ fn create_image_context_file(
 
 #[pymodule]
 fn _cloud_sdk(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Eager-init the shared tokio runtime at import time so the first sync
+    // call (e.g. sandbox.create()) doesn't pay worker-thread spawn cost.
+    // TTI benchmarks measure from create() to first runCommand(), so this
+    // cost must land outside that window.
+    let _ = shared_runtime();
     module.add("CloudApiClientError", _py.get_type::<CloudApiClientError>())?;
     module.add(
         "CloudSandboxClientError",

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -38,10 +38,17 @@ create_exception!(_cloud_sdk, CloudDocumentAIClientError, PyException);
 
 const DEFAULT_HTTP_REQUEST_TIMEOUT_SEC: f64 = 5.0;
 
+// Single tokio runtime for the whole process: pyo3-async-runtimes' runtime,
+// which `future_into_py` already drives. Routing sync `block_on` through here
+// too keeps every client (sync and async) on the same runtime instead of each
+// pyclass spawning its own.
+fn shared_runtime() -> &'static Runtime {
+    pyo3_async_runtimes::tokio::get_runtime()
+}
+
 #[pyclass]
 pub struct CloudApiClient {
     client: Client,
-    runtime: Runtime,
     api_url: String,
     namespace: String,
 }
@@ -74,17 +81,9 @@ impl CloudApiClient {
         }
 
         let client = builder.build().map_err(into_py_error)?;
-        let runtime = Runtime::new().map_err(|e| {
-            CloudApiClientError::new_err((
-                "internal",
-                Option::<u16>::None,
-                format!("failed to create tokio runtime: {e}"),
-            ))
-        })?;
 
         Ok(Self {
             client,
-            runtime,
             api_url,
             namespace: namespace.unwrap_or_else(|| "default".to_string()),
         })
@@ -532,7 +531,6 @@ impl CloudApiClient {
 #[pyclass]
 pub struct CloudSandboxClient {
     client: SandboxesClient,
-    runtime: Runtime,
 }
 
 #[pymethods]
@@ -564,13 +562,6 @@ impl CloudSandboxClient {
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;
-        let runtime = Runtime::new().map_err(|e| {
-            CloudSandboxClientError::new_err((
-                "internal",
-                Option::<u16>::None,
-                format!("failed to create tokio runtime: {e}"),
-            ))
-        })?;
         let use_namespaced_endpoints = is_localhost_api_url(&api_url);
         let sandboxes_client = SandboxesClient::new(
             client,
@@ -580,7 +571,6 @@ impl CloudSandboxClient {
 
         Ok(Self {
             client: sandboxes_client,
-            runtime,
         })
     }
 
@@ -1129,49 +1119,32 @@ impl CloudSandboxClient {
         let proxy = SandboxProxyClient::new(shared_client, host_override)
             .with_sandbox_id(sandbox_id_header)
             .with_routing_hint(routing_hint);
-        let runtime = Runtime::new().map_err(|e| {
-            CloudSandboxClientError::new_err((
-                "internal",
-                Option::<u16>::None,
-                format!("failed to create tokio runtime: {e}"),
-            ))
-        })?;
         Ok(CloudSandboxProxyClient {
             client: proxy,
-            runtime,
             base_url,
         })
     }
 }
 
 impl CloudSandboxProxyClient {
-    fn run_with_retry<T, F, Fut>(&self, max_retries: usize, mut operation: F) -> PyResult<T>
+    fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
         F: FnMut(SandboxProxyClient) -> Fut,
         Fut: Future<Output = Result<T, SdkError>>,
     {
-        let mut retries = 0usize;
-        loop {
-            match self.runtime.block_on(operation(self.client.clone())) {
-                Ok(value) => return Ok(value),
-                Err(err) => {
-                    if !is_retryable(&err) || retries >= max_retries {
-                        return Err(into_sandbox_py_error(err));
-                    }
-
-                    retries += 1;
-                    let sleep_time = calculate_sleep_time(retries);
-                    std::thread::sleep(Duration::from_secs_f64(sleep_time));
-                }
-            }
-        }
+        run_with_retry_blocking(
+            self.client.clone(),
+            max_retries,
+            "rust sandbox proxy request",
+            into_sandbox_py_error,
+            operation,
+        )
     }
 }
 
 #[pyclass]
 pub struct CloudSandboxProxyClient {
     client: SandboxProxyClient,
-    runtime: Runtime,
     base_url: String,
 }
 
@@ -1207,20 +1180,12 @@ impl CloudSandboxProxyClient {
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;
-        let runtime = Runtime::new().map_err(|e| {
-            CloudSandboxClientError::new_err((
-                "internal",
-                Option::<u16>::None,
-                format!("failed to create tokio runtime: {e}"),
-            ))
-        })?;
         let sandbox_proxy_client = SandboxProxyClient::new(client, host_override)
             .with_sandbox_id(sandbox_id_header)
             .with_routing_hint(routing_hint);
 
         Ok(Self {
             client: sandbox_proxy_client,
-            runtime,
             base_url,
         })
     }
@@ -1847,7 +1812,6 @@ impl CloudSandboxProxyClient {
 #[pyclass]
 pub struct CloudSandboxDesktopClient {
     client: RustSandboxDesktopClient,
-    runtime: Runtime,
 }
 
 #[pymethods]
@@ -1885,15 +1849,8 @@ impl CloudSandboxDesktopClient {
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;
-        let runtime = Runtime::new().map_err(|e| {
-            CloudSandboxClientError::new_err((
-                "internal",
-                Option::<u16>::None,
-                format!("failed to create tokio runtime: {e}"),
-            ))
-        })?;
         let connect_timeout = duration_from_seconds("connect_timeout_sec", connect_timeout_sec)?;
-        let desktop_client = runtime
+        let desktop_client = shared_runtime()
             .block_on(RustSandboxDesktopClient::connect(
                 client,
                 host_override,
@@ -1907,12 +1864,11 @@ impl CloudSandboxDesktopClient {
 
         Ok(Self {
             client: desktop_client,
-            runtime,
         })
     }
 
     fn close(&self) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.close())
             .map_err(into_sandbox_py_error)
     }
@@ -1923,36 +1879,35 @@ impl CloudSandboxDesktopClient {
         timeout_sec: f64,
     ) -> PyResult<Py<pyo3::types::PyBytes>> {
         let timeout_sec = duration_from_seconds("timeout_sec", timeout_sec)?;
-        let png = self
-            .runtime
+        let png = shared_runtime()
             .block_on(self.client.screenshot(timeout_sec))
             .map_err(into_sandbox_py_error)?;
         Ok(pyo3::types::PyBytes::new(py, &png).into())
     }
 
     fn move_mouse(&self, x: u16, y: u16) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.move_mouse(x, y))
             .map_err(into_sandbox_py_error)
     }
 
     #[pyo3(signature = (button="left", x=None, y=None))]
     fn mouse_press(&self, button: &str, x: Option<u16>, y: Option<u16>) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.mouse_press(button, x, y))
             .map_err(into_sandbox_py_error)
     }
 
     #[pyo3(signature = (button="left", x=None, y=None))]
     fn mouse_release(&self, button: &str, x: Option<u16>, y: Option<u16>) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.mouse_release(button, x, y))
             .map_err(into_sandbox_py_error)
     }
 
     #[pyo3(signature = (button="left", x=None, y=None))]
     fn click(&self, button: &str, x: Option<u16>, y: Option<u16>) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.click(button, x, y))
             .map_err(into_sandbox_py_error)
     }
@@ -1965,52 +1920,52 @@ impl CloudSandboxDesktopClient {
         y: Option<u16>,
         delay_ms: u64,
     ) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.double_click(button, x, y, delay_ms))
             .map_err(into_sandbox_py_error)
     }
 
     #[pyo3(signature = (steps, x=None, y=None))]
     fn scroll(&self, steps: i32, x: Option<u16>, y: Option<u16>) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.scroll(steps, x, y))
             .map_err(into_sandbox_py_error)
     }
 
     fn key_down(&self, key: &str) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.key_down(key))
             .map_err(into_sandbox_py_error)
     }
 
     fn key_up(&self, key: &str) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.key_up(key))
             .map_err(into_sandbox_py_error)
     }
 
     fn press(&self, keys: Vec<String>) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.press(&keys))
             .map_err(into_sandbox_py_error)
     }
 
     fn type_text(&self, text: String) -> PyResult<()> {
-        self.runtime
+        shared_runtime()
             .block_on(self.client.type_text(&text))
             .map_err(into_sandbox_py_error)
     }
 
     #[getter]
     fn width(&self) -> PyResult<u16> {
-        self.runtime
+        shared_runtime()
             .block_on(async { self.client.dimensions().await.map(|(width, _)| width) })
             .map_err(into_sandbox_py_error)
     }
 
     #[getter]
     fn height(&self) -> PyResult<u16> {
-        self.runtime
+        shared_runtime()
             .block_on(async { self.client.dimensions().await.map(|(_, height)| height) })
             .map_err(into_sandbox_py_error)
     }
@@ -2019,7 +1974,6 @@ impl CloudSandboxDesktopClient {
 #[pyclass]
 pub struct CloudDocumentAIClient {
     client: DocumentAiClient,
-    runtime: Runtime,
 }
 
 #[pymethods]
@@ -2031,18 +1985,10 @@ impl CloudDocumentAIClient {
             .bearer_token(&api_key)
             .build()
             .map_err(into_document_ai_py_error)?;
-        let runtime = Runtime::new().map_err(|e| {
-            CloudDocumentAIClientError::new_err((
-                "internal",
-                Option::<u16>::None,
-                format!("failed to create tokio runtime: {e}"),
-            ))
-        })?;
         let document_ai_client = DocumentAiClient::new(client);
 
         Ok(Self {
             client: document_ai_client,
-            runtime,
         })
     }
 
@@ -2112,84 +2058,83 @@ impl CloudDocumentAIClient {
     }
 }
 
+fn run_with_retry_blocking<C, T, F, Fut>(
+    client: C,
+    max_retries: usize,
+    label: &str,
+    into_err: fn(SdkError) -> PyErr,
+    mut operation: F,
+) -> PyResult<T>
+where
+    C: Clone,
+    F: FnMut(C) -> Fut,
+    Fut: Future<Output = Result<T, SdkError>>,
+{
+    let mut retries = 0usize;
+    loop {
+        match shared_runtime().block_on(operation(client.clone())) {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if !is_retryable(&err) || retries >= max_retries {
+                    return Err(into_err(err));
+                }
+
+                retries += 1;
+                let sleep_time = calculate_sleep_time(retries);
+                eprintln!(
+                    "Retrying {label} after {sleep_time:.2} seconds. Retry count: {retries}. Retryable exception: {err}"
+                );
+                std::thread::sleep(Duration::from_secs_f64(sleep_time));
+            }
+        }
+    }
+}
+
 impl CloudApiClient {
-    fn run_with_retry<T, F, Fut>(&self, max_retries: usize, mut operation: F) -> PyResult<T>
+    fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
         F: FnMut(Client) -> Fut,
         Fut: Future<Output = Result<T, SdkError>>,
     {
-        let mut retries = 0usize;
-        loop {
-            match self.runtime.block_on(operation(self.client.clone())) {
-                Ok(value) => return Ok(value),
-                Err(err) => {
-                    if !is_retryable(&err) || retries >= max_retries {
-                        return Err(into_py_error(err));
-                    }
-
-                    retries += 1;
-                    let sleep_time = calculate_sleep_time(retries);
-                    eprintln!(
-                        "Retrying rust cloud API request after {sleep_time:.2} seconds. Retry count: {retries}. Retryable exception: {err}"
-                    );
-                    std::thread::sleep(Duration::from_secs_f64(sleep_time));
-                }
-            }
-        }
+        run_with_retry_blocking(
+            self.client.clone(),
+            max_retries,
+            "rust cloud API request",
+            into_py_error,
+            operation,
+        )
     }
 }
 
 impl CloudSandboxClient {
-    fn run_with_retry<T, F, Fut>(&self, max_retries: usize, mut operation: F) -> PyResult<T>
+    fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
         F: FnMut(SandboxesClient) -> Fut,
         Fut: Future<Output = Result<T, SdkError>>,
     {
-        let mut retries = 0usize;
-        loop {
-            match self.runtime.block_on(operation(self.client.clone())) {
-                Ok(value) => return Ok(value),
-                Err(err) => {
-                    if !is_retryable(&err) || retries >= max_retries {
-                        return Err(into_sandbox_py_error(err));
-                    }
-
-                    retries += 1;
-                    let sleep_time = calculate_sleep_time(retries);
-                    eprintln!(
-                        "Retrying rust sandbox API request after {sleep_time:.2} seconds. Retry count: {retries}. Retryable exception: {err}"
-                    );
-                    std::thread::sleep(Duration::from_secs_f64(sleep_time));
-                }
-            }
-        }
+        run_with_retry_blocking(
+            self.client.clone(),
+            max_retries,
+            "rust sandbox API request",
+            into_sandbox_py_error,
+            operation,
+        )
     }
 }
 
 impl CloudDocumentAIClient {
-    fn run_with_retry<T, F, Fut>(&self, max_retries: usize, mut operation: F) -> PyResult<T>
+    fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
         F: FnMut(DocumentAiClient) -> Fut,
         Fut: Future<Output = Result<T, SdkError>>,
     {
-        let mut retries = 0usize;
-        loop {
-            match self.runtime.block_on(operation(self.client.clone())) {
-                Ok(value) => return Ok(value),
-                Err(err) => {
-                    if !is_retryable(&err) || retries >= max_retries {
-                        return Err(into_document_ai_py_error(err));
-                    }
-
-                    retries += 1;
-                    let sleep_time = calculate_sleep_time(retries);
-                    eprintln!(
-                        "Retrying rust document-ai request after {sleep_time:.2} seconds. Retry count: {retries}. Retryable exception: {err}"
-                    );
-                    std::thread::sleep(Duration::from_secs_f64(sleep_time));
-                }
-            }
-        }
+        run_with_retry_blocking(
+            self.client.clone(),
+            max_retries,
+            "rust document-ai request",
+            into_document_ai_py_error,
+            operation,
+        )
     }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.7"
+version = "0.5.8"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/__init__.py
+++ b/src/tensorlake/sandbox/__init__.py
@@ -1,5 +1,7 @@
 """Tensorlake Sandbox SDK - Client for managing and interacting with sandboxes."""
 
+from .async_client import AsyncSandboxClient
+from .async_sandbox import AsyncSandbox
 from .client import SandboxClient
 from .desktop import Desktop
 from .exceptions import (
@@ -45,8 +47,10 @@ from .sandbox import Sandbox
 __all__ = [
     # Lifecycle management
     "SandboxClient",
+    "AsyncSandboxClient",
     # Sandbox interaction
     "Sandbox",
+    "AsyncSandbox",
     "Pty",
     "Desktop",
     # Lifecycle models

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -339,7 +339,6 @@ class AsyncSandboxClient:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
-            raise
         if not wait:
             return Traced(trace_id, None)
         deadline = asyncio.get_event_loop().time() + timeout
@@ -371,7 +370,6 @@ class AsyncSandboxClient:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
-            raise
         if not wait:
             return Traced(trace_id, None)
         deadline = asyncio.get_event_loop().time() + timeout

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -1,0 +1,693 @@
+"""Async client SDK for managing Tensorlake sandboxes.
+
+Mirrors :class:`SandboxClient` but exposes coroutine methods backed by the
+Rust pyo3 ``*_async`` bindings (``future_into_py``) so each call is a true
+non-blocking awaitable in the active asyncio event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import warnings
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from tensorlake._tracing import USER_AGENT, Traced, TracedIterator
+
+if TYPE_CHECKING:
+    from .async_sandbox import AsyncSandbox
+
+from . import _defaults
+from .client import (
+    _RUST_SANDBOX_CLIENT_AVAILABLE,
+    RustCloudSandboxClient,
+    _normalize_user_ports,
+    _parse_rust_client_error_fields,
+    _raise_as_sandbox_error,
+    _resolve_sandbox_identifier,
+    _rust_status_code,
+    _startup_failure_message,
+)
+from .exceptions import (
+    PoolInUseError,
+    PoolNotFoundError,
+    SandboxConnectionError,
+    SandboxError,
+    SandboxNotFoundError,
+)
+from .models import (
+    ContainerResourcesInfo,
+    CreateSandboxPoolResponse,
+    CreateSandboxRequest,
+    CreateSandboxResources,
+    CreateSandboxResponse,
+    CreateSnapshotResponse,
+    ListSandboxesResponse,
+    ListSandboxPoolsResponse,
+    ListSnapshotsResponse,
+    NetworkConfig,
+    SandboxInfo,
+    SandboxPoolInfo,
+    SandboxPoolRequest,
+    SandboxPortAccess,
+    SandboxStatus,
+    SnapshotInfo,
+    SnapshotStatus,
+    SnapshotType,
+    UpdateSandboxRequest,
+)
+
+
+class AsyncSandboxClient:
+    """Async client for managing Tensorlake sandboxes and pools.
+
+    Use :meth:`for_cloud` or :meth:`for_localhost` for clearer construction.
+    Every method is a coroutine that awaits the Rust async binding directly.
+    """
+
+    def __init__(
+        self,
+        api_url: str = _defaults.API_URL,
+        api_key: str | None = _defaults.API_KEY,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        namespace: str | None = _defaults.NAMESPACE,
+        max_retries: int = _defaults.MAX_RETRIES,
+        retry_backoff_sec: float = _defaults.RETRY_BACKOFF_SEC,
+        _internal: bool = False,
+    ) -> None:
+        if not _internal:
+            warnings.warn(
+                "AsyncSandboxClient is in preview; the surface may change.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        self._api_url = api_url
+        self._api_key = api_key
+        self._organization_id = organization_id
+        self._project_id = project_id
+        self._namespace = namespace
+        self._max_retries = max_retries
+        self._retry_backoff_sec = retry_backoff_sec
+        if not _RUST_SANDBOX_CLIENT_AVAILABLE:
+            raise SandboxError(
+                "Rust Cloud SDK sandbox client is required but unavailable. "
+                "Build/install it with `make build_rust_py_client`."
+            )
+        try:
+            self._rust_client = RustCloudSandboxClient(
+                api_url=api_url,
+                api_key=api_key,
+                organization_id=organization_id,
+                project_id=project_id,
+                namespace=namespace,
+                user_agent=USER_AGENT,
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    @classmethod
+    def for_cloud(
+        cls,
+        api_key: str | None = _defaults.API_KEY,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        api_url: str = "https://api.tensorlake.ai",
+    ) -> "AsyncSandboxClient":
+        return cls(
+            api_url=api_url,
+            api_key=api_key,
+            organization_id=organization_id,
+            project_id=project_id,
+            _internal=True,
+        )
+
+    @classmethod
+    def for_localhost(
+        cls,
+        api_url: str = "http://localhost:8900",
+        namespace: str = "default",
+    ) -> "AsyncSandboxClient":
+        return cls(api_url=api_url, namespace=namespace, _internal=True)
+
+    async def __aenter__(self) -> "AsyncSandboxClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._rust_client.close()
+
+    def _is_localhost(self) -> bool:
+        parsed = urlparse(self._api_url)
+        return parsed.hostname in ("localhost", "127.0.0.1")
+
+    def _resolve_proxy_url(self) -> str:
+        import os
+
+        explicit = os.getenv("TENSORLAKE_SANDBOX_PROXY_URL")
+        if explicit:
+            return explicit
+        if self._is_localhost():
+            return "http://localhost:9443"
+        parsed = urlparse(self._api_url)
+        host = parsed.hostname or ""
+        if host.startswith("api."):
+            return f"{parsed.scheme}://sandbox.{host[4:]}"
+        return _defaults.SANDBOX_PROXY_URL
+
+    # --- Sandbox lifecycle ---
+
+    async def create(
+        self,
+        image: str | None = None,
+        cpus: float = 1.0,
+        memory_mb: int = 1024,
+        disk_mb: int | None = None,
+        secret_names: list[str] | None = None,
+        timeout_secs: int | None = None,
+        entrypoint: list[str] | None = None,
+        allow_internet_access: bool = True,
+        allow_out: list[str] | None = None,
+        deny_out: list[str] | None = None,
+        snapshot_id: str | None = None,
+        name: str | None = None,
+    ) -> Traced[CreateSandboxResponse]:
+        network = None
+        if not allow_internet_access or allow_out is not None or deny_out is not None:
+            network = NetworkConfig(
+                allow_internet_access=allow_internet_access,
+                allow_out=allow_out or [],
+                deny_out=deny_out or [],
+            )
+        request_model = CreateSandboxRequest(
+            image=image,
+            resources=CreateSandboxResources(
+                cpus=cpus, memory_mb=memory_mb, disk_mb=disk_mb
+            ),
+            secret_names=secret_names,
+            timeout_secs=timeout_secs,
+            entrypoint=entrypoint,
+            network=network,
+            snapshot_id=snapshot_id,
+            name=name,
+        )
+        try:
+            trace_id, response_json = await self._rust_client.create_sandbox_async(
+                request_json=request_model.model_dump_json(exclude_none=True)
+            )
+            return Traced(
+                trace_id, CreateSandboxResponse.model_validate_json(response_json)
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def claim(self, pool_id: str) -> Traced[CreateSandboxResponse]:
+        try:
+            trace_id, response_json = await self._rust_client.claim_sandbox_async(
+                pool_id=pool_id
+            )
+            return Traced(
+                trace_id, CreateSandboxResponse.model_validate_json(response_json)
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def get(self, sandbox_id: str) -> Traced[SandboxInfo]:
+        try:
+            trace_id, response_json = await self._rust_client.get_sandbox_json_async(
+                sandbox_id=sandbox_id
+            )
+            return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise SandboxNotFoundError(sandbox_id) from None
+            _raise_as_sandbox_error(e)
+
+    async def list(self) -> TracedIterator[SandboxInfo]:
+        try:
+            trace_id, response_json = await self._rust_client.list_sandboxes_json_async()
+            data = ListSandboxesResponse.model_validate(json.loads(response_json))
+            return TracedIterator(trace_id, data.sandboxes)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def update_sandbox(
+        self,
+        sandbox_id: str,
+        name: str | None = None,
+        *,
+        allow_unauthenticated_access: bool | None = None,
+        exposed_ports: list[int] | None = None,
+    ) -> Traced[SandboxInfo]:
+        normalized_ports = (
+            _normalize_user_ports(exposed_ports) if exposed_ports is not None else None
+        )
+        if (
+            name is None
+            and allow_unauthenticated_access is None
+            and normalized_ports is None
+        ):
+            raise SandboxError("At least one sandbox update field must be provided.")
+        request = UpdateSandboxRequest(
+            name=name,
+            allow_unauthenticated_access=allow_unauthenticated_access,
+            exposed_ports=normalized_ports,
+        )
+        try:
+            trace_id, response_json = await self._rust_client.update_sandbox_async(
+                sandbox_id=sandbox_id,
+                request_json=request.model_dump_json(exclude_none=True),
+            )
+            return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise SandboxNotFoundError(sandbox_id) from None
+            _raise_as_sandbox_error(e)
+
+    async def get_port_access(self, sandbox_id: str) -> Traced[SandboxPortAccess]:
+        traced = await self.get(sandbox_id)
+        port_access = SandboxPortAccess(
+            allow_unauthenticated_access=traced.allow_unauthenticated_access,
+            exposed_ports=sorted(set(traced.exposed_ports or [])),
+            sandbox_url=traced.sandbox_url,
+        )
+        return Traced(traced.trace_id, port_access)
+
+    async def expose_ports(
+        self,
+        sandbox_id: str,
+        ports: list[int],
+        *,
+        allow_unauthenticated_access: bool | None = None,
+    ) -> Traced[SandboxInfo]:
+        current = await self.get_port_access(sandbox_id)
+        desired_ports = sorted(
+            set(current.exposed_ports + _normalize_user_ports(ports))
+        )
+        return await self.update_sandbox(
+            sandbox_id,
+            allow_unauthenticated_access=(
+                current.allow_unauthenticated_access
+                if allow_unauthenticated_access is None
+                else allow_unauthenticated_access
+            ),
+            exposed_ports=desired_ports,
+        )
+
+    async def unexpose_ports(
+        self, sandbox_id: str, ports: list[int]
+    ) -> Traced[SandboxInfo]:
+        current = await self.get_port_access(sandbox_id)
+        ports_to_remove = set(_normalize_user_ports(ports))
+        desired_ports = [
+            port for port in current.exposed_ports if port not in ports_to_remove
+        ]
+        return await self.update_sandbox(
+            sandbox_id,
+            allow_unauthenticated_access=(
+                current.allow_unauthenticated_access if desired_ports else False
+            ),
+            exposed_ports=desired_ports,
+        )
+
+    async def delete(self, sandbox_id: str) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.delete_sandbox_async(
+                sandbox_id=sandbox_id
+            )
+            return Traced(trace_id, None)
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise SandboxNotFoundError(sandbox_id) from None
+            _raise_as_sandbox_error(e)
+
+    async def suspend(
+        self,
+        sandbox_id: str,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+    ) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.suspend_sandbox_async(
+                sandbox_id=sandbox_id
+            )
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise SandboxNotFoundError(sandbox_id) from None
+            _raise_as_sandbox_error(e)
+            raise
+        if not wait:
+            return Traced(trace_id, None)
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            info = (await self.get(sandbox_id)).value
+            if info.status == SandboxStatus.SUSPENDED:
+                return Traced(trace_id, None)
+            if info.status == SandboxStatus.TERMINATED:
+                raise SandboxError(
+                    f"Sandbox {sandbox_id!r} terminated while waiting for suspend"
+                )
+            await asyncio.sleep(poll_interval)
+        raise SandboxError(
+            f"Sandbox {sandbox_id!r} did not suspend within {timeout}s"
+        )
+
+    async def resume(
+        self,
+        sandbox_id: str,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+    ) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.resume_sandbox_async(
+                sandbox_id=sandbox_id
+            )
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise SandboxNotFoundError(sandbox_id) from None
+            _raise_as_sandbox_error(e)
+            raise
+        if not wait:
+            return Traced(trace_id, None)
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            info = (await self.get(sandbox_id)).value
+            if info.status == SandboxStatus.RUNNING:
+                return Traced(trace_id, None)
+            if info.status == SandboxStatus.TERMINATED:
+                raise SandboxError(
+                    f"Sandbox {sandbox_id!r} terminated while waiting for resume"
+                )
+            await asyncio.sleep(poll_interval)
+        raise SandboxError(
+            f"Sandbox {sandbox_id!r} did not resume within {timeout}s"
+        )
+
+    # --- Snapshots ---
+
+    async def snapshot(
+        self,
+        sandbox_id: str,
+        snapshot_type: SnapshotType | None = None,
+    ) -> Traced[CreateSnapshotResponse]:
+        try:
+            trace_id, response_json = await self._rust_client.create_snapshot_async(
+                sandbox_id=sandbox_id,
+                snapshot_type=(
+                    snapshot_type.value if snapshot_type is not None else None
+                ),
+            )
+            return Traced(
+                trace_id, CreateSnapshotResponse.model_validate_json(response_json)
+            )
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise SandboxNotFoundError(sandbox_id) from None
+            _raise_as_sandbox_error(e)
+
+    async def get_snapshot(self, snapshot_id: str) -> Traced[SnapshotInfo]:
+        try:
+            trace_id, response_json = await self._rust_client.get_snapshot_json_async(
+                snapshot_id=snapshot_id
+            )
+            return Traced(trace_id, SnapshotInfo.model_validate_json(response_json))
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def list_snapshots(self) -> TracedIterator[SnapshotInfo]:
+        try:
+            trace_id, response_json = await self._rust_client.list_snapshots_json_async()
+            data = ListSnapshotsResponse.model_validate(json.loads(response_json))
+            return TracedIterator(trace_id, data.snapshots)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def delete_snapshot(self, snapshot_id: str) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.delete_snapshot_async(
+                snapshot_id=snapshot_id
+            )
+            return Traced(trace_id, None)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def snapshot_and_wait(
+        self,
+        sandbox_id: str,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+        snapshot_type: SnapshotType | None = None,
+    ) -> Traced[SnapshotInfo]:
+        traced_create = await self.snapshot(sandbox_id, snapshot_type=snapshot_type)
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            traced_info = await self.get_snapshot(traced_create.snapshot_id)
+            if traced_info.status == SnapshotStatus.COMPLETED:
+                return traced_info
+            if traced_info.status == SnapshotStatus.FAILED:
+                raise SandboxError(
+                    f"Snapshot {traced_create.snapshot_id} failed: {traced_info.error}"
+                )
+            await asyncio.sleep(poll_interval)
+        raise SandboxError(
+            f"Snapshot {traced_create.snapshot_id} did not complete within {timeout}s"
+        )
+
+    # --- Pools ---
+
+    async def create_pool(
+        self,
+        image: str | None = None,
+        cpus: float = 1.0,
+        memory_mb: int = 1024,
+        ephemeral_disk_mb: int = 1024,
+        secret_names: list[str] | None = None,
+        timeout_secs: int = 0,
+        entrypoint: list[str] | None = None,
+        max_containers: int | None = None,
+        warm_containers: int | None = None,
+    ) -> Traced[CreateSandboxPoolResponse]:
+        request_model = SandboxPoolRequest(
+            image=image,
+            resources=ContainerResourcesInfo(
+                cpus=cpus, memory_mb=memory_mb, ephemeral_disk_mb=ephemeral_disk_mb
+            ),
+            secret_names=secret_names,
+            timeout_secs=timeout_secs,
+            entrypoint=entrypoint,
+            max_containers=max_containers,
+            warm_containers=warm_containers,
+        )
+        try:
+            trace_id, response_json = await self._rust_client.create_pool_async(
+                request_json=request_model.model_dump_json(exclude_none=True)
+            )
+            return Traced(
+                trace_id, CreateSandboxPoolResponse.model_validate_json(response_json)
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def get_pool(self, pool_id: str) -> Traced[SandboxPoolInfo]:
+        try:
+            trace_id, response_json = await self._rust_client.get_pool_json_async(
+                pool_id=pool_id
+            )
+            return Traced(trace_id, SandboxPoolInfo.model_validate_json(response_json))
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise PoolNotFoundError(pool_id) from None
+            _raise_as_sandbox_error(e)
+
+    async def list_pools(self) -> TracedIterator[SandboxPoolInfo]:
+        try:
+            trace_id, response_json = await self._rust_client.list_pools_json_async()
+            data = ListSandboxPoolsResponse.model_validate(json.loads(response_json))
+            return TracedIterator(trace_id, data.pools)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def update_pool(
+        self,
+        pool_id: str,
+        image: str,
+        cpus: float = 1.0,
+        memory_mb: int = 1024,
+        ephemeral_disk_mb: int = 1024,
+        secret_names: list[str] | None = None,
+        timeout_secs: int = 0,
+        entrypoint: list[str] | None = None,
+        max_containers: int | None = None,
+        warm_containers: int | None = None,
+    ) -> Traced[SandboxPoolInfo]:
+        request_model = SandboxPoolRequest(
+            image=image,
+            resources=ContainerResourcesInfo(
+                cpus=cpus, memory_mb=memory_mb, ephemeral_disk_mb=ephemeral_disk_mb
+            ),
+            secret_names=secret_names,
+            timeout_secs=timeout_secs,
+            entrypoint=entrypoint,
+            max_containers=max_containers,
+            warm_containers=warm_containers,
+        )
+        try:
+            trace_id, response_json = await self._rust_client.update_pool_async(
+                pool_id=pool_id,
+                request_json=request_model.model_dump_json(exclude_none=True),
+            )
+            return Traced(trace_id, SandboxPoolInfo.model_validate_json(response_json))
+        except Exception as e:
+            if _rust_status_code(e) == 404:
+                raise PoolNotFoundError(pool_id) from None
+            _raise_as_sandbox_error(e)
+
+    async def delete_pool(self, pool_id: str) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.delete_pool_async(pool_id=pool_id)
+            return Traced(trace_id, None)
+        except Exception as e:
+            kind, status_code, message = _parse_rust_client_error_fields(e)
+            if status_code == 404:
+                raise PoolNotFoundError(pool_id) from None
+            if status_code == 409:
+                raise PoolInUseError(pool_id, message) from None
+            if kind == "connection":
+                raise SandboxConnectionError(message) from None
+            _raise_as_sandbox_error(e)
+
+    # --- Connect ---
+
+    async def connect(
+        self,
+        identifier: str | None = None,
+        *,
+        proxy_url: str | None = None,
+        sandbox_id: str | None = None,
+        routing_hint: str | None = None,
+    ) -> "AsyncSandbox":
+        from .async_sandbox import AsyncSandbox
+
+        sandbox_identifier = _resolve_sandbox_identifier(
+            identifier, sandbox_id, parameter_name="identifier"
+        )
+        if proxy_url is None:
+            proxy_url = self._resolve_proxy_url()
+        proxy_rust_client = self._rust_client.connect_proxy(
+            proxy_url=proxy_url,
+            sandbox_id=sandbox_identifier,
+            routing_hint=routing_hint,
+        )
+        sandbox = AsyncSandbox(
+            identifier=sandbox_identifier,
+            proxy_url=proxy_url,
+            api_key=self._api_key,
+            organization_id=self._organization_id,
+            project_id=self._project_id,
+            routing_hint=routing_hint,
+            _proxy_rust_client=proxy_rust_client,
+        )
+        sandbox._lifecycle_client = self
+        return sandbox
+
+    async def create_and_connect(
+        self,
+        image: str | None = None,
+        cpus: float = 1.0,
+        memory_mb: int = 1024,
+        disk_mb: int | None = None,
+        secret_names: list[str] | None = None,
+        timeout_secs: int | None = None,
+        entrypoint: list[str] | None = None,
+        allow_internet_access: bool = True,
+        allow_out: list[str] | None = None,
+        deny_out: list[str] | None = None,
+        pool_id: str | None = None,
+        snapshot_id: str | None = None,
+        proxy_url: str | None = None,
+        startup_timeout: float = 60,
+        name: str | None = None,
+    ) -> "AsyncSandbox":
+        requested_name = None if pool_id is not None else name
+        if pool_id is not None:
+            result = await self.claim(pool_id)
+        else:
+            result = await self.create(
+                image=image,
+                cpus=cpus,
+                memory_mb=memory_mb,
+                disk_mb=disk_mb,
+                secret_names=secret_names,
+                timeout_secs=timeout_secs,
+                entrypoint=entrypoint,
+                allow_internet_access=allow_internet_access,
+                allow_out=allow_out,
+                deny_out=deny_out,
+                snapshot_id=snapshot_id,
+                name=name,
+            )
+
+        if result.status == SandboxStatus.RUNNING:
+            sandbox = await self.connect(
+                result.sandbox_id,
+                proxy_url=proxy_url,
+                routing_hint=result.routing_hint,
+            )
+            sandbox._sandbox_id = result.sandbox_id
+            sandbox._owns_sandbox = True
+            sandbox._lifecycle_client = self
+            sandbox._trace_id = result.trace_id
+            sandbox._cached_info = SandboxInfo.model_construct(
+                sandbox_id=result.sandbox_id,
+                status=result.status,
+                name=result.name or requested_name,
+            )
+            return sandbox
+        if result.status in (SandboxStatus.SUSPENDED, SandboxStatus.TERMINATED):
+            raise SandboxError(
+                _startup_failure_message(
+                    result.sandbox_id,
+                    result.status,
+                    error_details=result.error_details,
+                    termination_reason=result.termination_reason,
+                )
+            )
+
+        deadline = asyncio.get_event_loop().time() + startup_timeout
+        while asyncio.get_event_loop().time() < deadline:
+            info = await self.get(result.sandbox_id)
+            if info.status == SandboxStatus.RUNNING:
+                sandbox = await self.connect(
+                    result.sandbox_id,
+                    proxy_url=proxy_url,
+                    routing_hint=info.routing_hint,
+                )
+                sandbox._sandbox_id = info.sandbox_id
+                sandbox._cached_info = info
+                sandbox._owns_sandbox = True
+                sandbox._lifecycle_client = self
+                sandbox._trace_id = result.trace_id
+                return sandbox
+            if info.status in (SandboxStatus.SUSPENDED, SandboxStatus.TERMINATED):
+                raise SandboxError(
+                    _startup_failure_message(
+                        result.sandbox_id,
+                        info.status,
+                        error_details=info.error_details,
+                        termination_reason=info.termination_reason,
+                    )
+                )
+            await asyncio.sleep(0.5)
+
+        try:
+            await self.delete(result.sandbox_id)
+        except Exception:
+            pass
+        raise SandboxError(
+            f"Sandbox {result.sandbox_id} did not start within {startup_timeout}s"
+        )

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -228,7 +228,9 @@ class AsyncSandboxClient:
 
     async def list(self) -> TracedIterator[SandboxInfo]:
         try:
-            trace_id, response_json = await self._rust_client.list_sandboxes_json_async()
+            trace_id, response_json = (
+                await self._rust_client.list_sandboxes_json_async()
+            )
             data = ListSandboxesResponse.model_validate(json.loads(response_json))
             return TracedIterator(trace_id, data.sandboxes)
         except Exception as e:
@@ -351,9 +353,7 @@ class AsyncSandboxClient:
                     f"Sandbox {sandbox_id!r} terminated while waiting for suspend"
                 )
             await asyncio.sleep(poll_interval)
-        raise SandboxError(
-            f"Sandbox {sandbox_id!r} did not suspend within {timeout}s"
-        )
+        raise SandboxError(f"Sandbox {sandbox_id!r} did not suspend within {timeout}s")
 
     async def resume(
         self,
@@ -382,9 +382,7 @@ class AsyncSandboxClient:
                     f"Sandbox {sandbox_id!r} terminated while waiting for resume"
                 )
             await asyncio.sleep(poll_interval)
-        raise SandboxError(
-            f"Sandbox {sandbox_id!r} did not resume within {timeout}s"
-        )
+        raise SandboxError(f"Sandbox {sandbox_id!r} did not resume within {timeout}s")
 
     # --- Snapshots ---
 
@@ -419,7 +417,9 @@ class AsyncSandboxClient:
 
     async def list_snapshots(self) -> TracedIterator[SnapshotInfo]:
         try:
-            trace_id, response_json = await self._rust_client.list_snapshots_json_async()
+            trace_id, response_json = (
+                await self._rust_client.list_snapshots_json_async()
+            )
             data = ListSnapshotsResponse.model_validate(json.loads(response_json))
             return TracedIterator(trace_id, data.snapshots)
         except Exception as e:

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -135,9 +135,9 @@ class AsyncSandboxClient:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        self.close()
+        await self.close()
 
-    def close(self) -> None:
+    async def close(self) -> None:
         self._rust_client.close()
 
     def _is_localhost(self) -> bool:
@@ -341,8 +341,8 @@ class AsyncSandboxClient:
             _raise_as_sandbox_error(e)
         if not wait:
             return Traced(trace_id, None)
-        deadline = asyncio.get_event_loop().time() + timeout
-        while asyncio.get_event_loop().time() < deadline:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
             info = (await self.get(sandbox_id)).value
             if info.status == SandboxStatus.SUSPENDED:
                 return Traced(trace_id, None)
@@ -372,8 +372,8 @@ class AsyncSandboxClient:
             _raise_as_sandbox_error(e)
         if not wait:
             return Traced(trace_id, None)
-        deadline = asyncio.get_event_loop().time() + timeout
-        while asyncio.get_event_loop().time() < deadline:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
             info = (await self.get(sandbox_id)).value
             if info.status == SandboxStatus.RUNNING:
                 return Traced(trace_id, None)
@@ -442,8 +442,8 @@ class AsyncSandboxClient:
         snapshot_type: SnapshotType | None = None,
     ) -> Traced[SnapshotInfo]:
         traced_create = await self.snapshot(sandbox_id, snapshot_type=snapshot_type)
-        deadline = asyncio.get_event_loop().time() + timeout
-        while asyncio.get_event_loop().time() < deadline:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while asyncio.get_running_loop().time() < deadline:
             traced_info = await self.get_snapshot(traced_create.snapshot_id)
             if traced_info.status == SnapshotStatus.COMPLETED:
                 return traced_info
@@ -656,8 +656,8 @@ class AsyncSandboxClient:
                 )
             )
 
-        deadline = asyncio.get_event_loop().time() + startup_timeout
-        while asyncio.get_event_loop().time() < deadline:
+        deadline = asyncio.get_running_loop().time() + startup_timeout
+        while asyncio.get_running_loop().time() < deadline:
             info = await self.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
                 sandbox = await self.connect(
@@ -666,7 +666,7 @@ class AsyncSandboxClient:
                     routing_hint=info.routing_hint,
                 )
                 sandbox._sandbox_id = info.sandbox_id
-                sandbox._cached_info = info
+                sandbox._cached_info = info.value
                 sandbox._owns_sandbox = True
                 sandbox._lifecycle_client = self
                 sandbox._trace_id = result.trace_id

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -222,7 +222,10 @@ class AsyncSandbox:
     ) -> None:
         self._require_lifecycle_client("suspend")
         await self._lifecycle_client.suspend(
-            self.sandbox_id, wait=wait, timeout=timeout, poll_interval=poll_interval
+            self._lifecycle_identifier(),
+            wait=wait,
+            timeout=timeout,
+            poll_interval=poll_interval,
         )
 
     async def resume(
@@ -233,7 +236,10 @@ class AsyncSandbox:
     ) -> None:
         self._require_lifecycle_client("resume")
         await self._lifecycle_client.resume(
-            self.sandbox_id, wait=wait, timeout=timeout, poll_interval=poll_interval
+            self._lifecycle_identifier(),
+            wait=wait,
+            timeout=timeout,
+            poll_interval=poll_interval,
         )
 
     async def checkpoint(
@@ -249,11 +255,11 @@ class AsyncSandbox:
         )
         if not wait:
             await self._lifecycle_client.snapshot(
-                self.sandbox_id, snapshot_type=snapshot_type
+                self._lifecycle_identifier(), snapshot_type=snapshot_type
             )
             return None
         traced = await self._lifecycle_client.snapshot_and_wait(
-            self.sandbox_id,
+            self._lifecycle_identifier(),
             timeout=timeout,
             poll_interval=poll_interval,
             snapshot_type=snapshot_type,
@@ -263,7 +269,7 @@ class AsyncSandbox:
     async def list_snapshots(self) -> TracedIterator[SnapshotInfo]:
         self._require_lifecycle_client("list_snapshots")
         all_snaps = await self._lifecycle_client.list_snapshots()
-        my_id = self.sandbox_id
+        my_id = self._lifecycle_identifier()
         filtered = [s for s in all_snaps if s.sandbox_id == my_id]
         return TracedIterator(all_snaps.trace_id, filtered)
 

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -434,7 +434,9 @@ class AsyncSandbox:
 
     async def list_processes(self) -> TracedIterator[ProcessInfo]:
         try:
-            trace_id, response_json = await self._rust_client.list_processes_json_async()
+            trace_id, response_json = (
+                await self._rust_client.list_processes_json_async()
+            )
             data = ListProcessesResponse.model_validate_json(response_json)
             return TracedIterator(trace_id, data.processes)
         except Exception as e:

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -268,8 +268,8 @@ class AsyncSandbox:
 
     async def list_snapshots(self) -> TracedIterator[SnapshotInfo]:
         self._require_lifecycle_client("list_snapshots")
+        my_id = self._sandbox_id or (await self._fetch_info()).sandbox_id
         all_snaps = await self._lifecycle_client.list_snapshots()
-        my_id = self._lifecycle_identifier()
         filtered = [s for s in all_snaps if s.sandbox_id == my_id]
         return TracedIterator(all_snaps.trace_id, filtered)
 

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -385,8 +385,6 @@ class AsyncSandbox:
                 elif event.get("signal") is not None:
                     exit_code = -event["signal"]
         if exit_code is None:
-            from .exceptions import SandboxConnectionError
-
             raise SandboxConnectionError(
                 "sandbox process stream ended without an exit event"
             )

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -411,7 +411,7 @@ class AsyncSandbox:
         stdout_mode: OutputMode = OutputMode.CAPTURE,
         stderr_mode: OutputMode = OutputMode.CAPTURE,
     ) -> Traced[ProcessInfo]:
-        payload = self._build_command_payload(
+        payload = Sandbox._build_command_payload(
             command,
             args,
             env,

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -1,0 +1,592 @@
+"""Async client for interacting with a running sandbox.
+
+Mirrors :class:`Sandbox` but exposes coroutine methods that await the Rust
+``*_async`` bindings directly, so each call yields control to the active
+asyncio event loop instead of blocking a worker thread.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from tensorlake._tracing import USER_AGENT, Traced, TracedIterator
+
+from . import _defaults
+from .exceptions import SandboxConnectionError, SandboxError
+from .models import (
+    CheckpointType,
+    CommandResult,
+    DaemonInfo,
+    HealthResponse,
+    ListDirectoryResponse,
+    ListProcessesResponse,
+    OutputEvent,
+    OutputMode,
+    OutputResponse,
+    ProcessInfo,
+    SandboxInfo,
+    SandboxStatus,
+    SendSignalResponse,
+    SnapshotInfo,
+    SnapshotType,
+    StdinMode,
+)
+from .sandbox import (
+    _RUST_SANDBOX_PROXY_CLIENT_AVAILABLE,
+    RustCloudSandboxProxyClient,
+    Sandbox,
+    _raise_as_sandbox_error,
+)
+
+if TYPE_CHECKING:
+    from .async_client import AsyncSandboxClient
+
+
+class AsyncSandbox:
+    """Async client for interacting with a running sandbox.
+
+    Use :class:`AsyncSandboxClient` to create or connect, then call methods
+    on the returned :class:`AsyncSandbox` to drive the sandbox without
+    blocking the event loop.
+    """
+
+    def __init__(
+        self,
+        identifier: str | None = None,
+        proxy_url: str = _defaults.SANDBOX_PROXY_URL,
+        api_key: str | None = _defaults.API_KEY,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        *,
+        sandbox_id: str | None = None,
+        routing_hint: str | None = None,
+        _proxy_rust_client: object | None = None,
+    ) -> None:
+        if identifier and sandbox_id and identifier != sandbox_id:
+            raise SandboxError(
+                "Provide only one of `identifier` or `sandbox_id`, not both."
+            )
+        sandbox_identifier = identifier or sandbox_id
+        if not sandbox_identifier:
+            raise SandboxError(
+                "`identifier` is required. `sandbox_id` is accepted as a deprecated alias."
+            )
+
+        self._identifier = sandbox_identifier
+        self._sandbox_id: str | None = None
+        self._trace_id: str | None = None
+        self._cached_info: SandboxInfo | None = None
+        self._owns_sandbox: bool = False
+        self._lifecycle_client: "AsyncSandboxClient | None" = None
+        self._proxy_url = proxy_url
+        self._api_key = api_key
+        self._organization_id = organization_id
+        self._project_id = project_id
+        parsed_proxy = urlparse(proxy_url)
+        self._host_header = None
+        if parsed_proxy.hostname in ("localhost", "127.0.0.1"):
+            self._host_header = f"{sandbox_identifier}.local"
+        self._proxy_headers: dict[str, str] = {}
+        if api_key:
+            self._proxy_headers["Authorization"] = f"Bearer {api_key}"
+        if organization_id:
+            self._proxy_headers["X-Forwarded-Organization-Id"] = organization_id
+        if project_id:
+            self._proxy_headers["X-Forwarded-Project-Id"] = project_id
+        if self._host_header:
+            self._proxy_headers["Host"] = self._host_header
+        else:
+            self._proxy_headers["X-Tensorlake-Sandbox-Id"] = sandbox_identifier
+
+        if _proxy_rust_client is not None:
+            self._rust_client = _proxy_rust_client
+            self._base_url = self._rust_client.base_url()
+        elif not _RUST_SANDBOX_PROXY_CLIENT_AVAILABLE:
+            raise SandboxError(
+                "Rust Cloud SDK sandbox proxy client is required but unavailable. "
+                "Build/install it with `make build_rust_py_client`."
+            )
+        else:
+            try:
+                self._rust_client = RustCloudSandboxProxyClient(
+                    proxy_url=proxy_url,
+                    sandbox_id=sandbox_identifier,
+                    api_key=api_key,
+                    organization_id=organization_id,
+                    project_id=project_id,
+                    routing_hint=routing_hint,
+                    user_agent=USER_AGENT,
+                )
+                self._base_url = self._rust_client.base_url()
+            except Exception as e:
+                _raise_as_sandbox_error(e)
+
+    # --- Class-level factory methods ---
+
+    @classmethod
+    async def create(
+        cls,
+        image: str | None = None,
+        cpus: float = 1.0,
+        memory_mb: int = 1024,
+        disk_mb: int | None = None,
+        secret_names: list[str] | None = None,
+        timeout_secs: int | None = None,
+        entrypoint: list[str] | None = None,
+        allow_internet_access: bool = True,
+        allow_out: list[str] | None = None,
+        deny_out: list[str] | None = None,
+        pool_id: str | None = None,
+        snapshot_id: str | None = None,
+        proxy_url: str | None = None,
+        startup_timeout: float = 60,
+        name: str | None = None,
+        api_key: str | None = _defaults.API_KEY,
+        api_url: str = _defaults.API_URL,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        namespace: str | None = _defaults.NAMESPACE,
+    ) -> "AsyncSandbox":
+        from .async_client import AsyncSandboxClient
+
+        client = AsyncSandboxClient(
+            api_url=api_url,
+            api_key=api_key,
+            organization_id=organization_id,
+            project_id=project_id,
+            namespace=namespace,
+            _internal=True,
+        )
+        return await client.create_and_connect(
+            image=image,
+            cpus=cpus,
+            memory_mb=memory_mb,
+            disk_mb=disk_mb,
+            secret_names=secret_names,
+            timeout_secs=timeout_secs,
+            entrypoint=entrypoint,
+            allow_internet_access=allow_internet_access,
+            allow_out=allow_out,
+            deny_out=deny_out,
+            pool_id=pool_id,
+            snapshot_id=snapshot_id,
+            proxy_url=proxy_url,
+            startup_timeout=startup_timeout,
+            name=name,
+        )
+
+    @classmethod
+    async def connect(
+        cls,
+        sandbox_id: str,
+        *,
+        proxy_url: str | None = None,
+        routing_hint: str | None = None,
+        api_key: str | None = _defaults.API_KEY,
+        api_url: str = _defaults.API_URL,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        namespace: str | None = _defaults.NAMESPACE,
+    ) -> "AsyncSandbox":
+        from .async_client import AsyncSandboxClient
+
+        client = AsyncSandboxClient(
+            api_url=api_url,
+            api_key=api_key,
+            organization_id=organization_id,
+            project_id=project_id,
+            namespace=namespace,
+            _internal=True,
+        )
+        return await client.connect(
+            sandbox_id, proxy_url=proxy_url, routing_hint=routing_hint
+        )
+
+    # --- Lifecycle ---
+
+    def _require_lifecycle_client(self, operation: str) -> None:
+        if self._lifecycle_client is None:
+            raise SandboxError(
+                f"Cannot {operation}: no lifecycle client available. "
+                "Use AsyncSandbox.create() or AsyncSandbox.connect() to get a "
+                "lifecycle-aware handle."
+            )
+
+    async def suspend(
+        self,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+    ) -> None:
+        self._require_lifecycle_client("suspend")
+        await self._lifecycle_client.suspend(
+            self.sandbox_id, wait=wait, timeout=timeout, poll_interval=poll_interval
+        )
+
+    async def resume(
+        self,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+    ) -> None:
+        self._require_lifecycle_client("resume")
+        await self._lifecycle_client.resume(
+            self.sandbox_id, wait=wait, timeout=timeout, poll_interval=poll_interval
+        )
+
+    async def checkpoint(
+        self,
+        wait: bool = True,
+        timeout: float = 300,
+        poll_interval: float = 1.0,
+        checkpoint_type: CheckpointType | None = None,
+    ) -> SnapshotInfo | None:
+        self._require_lifecycle_client("checkpoint")
+        snapshot_type = (
+            SnapshotType(checkpoint_type.value) if checkpoint_type is not None else None
+        )
+        if not wait:
+            await self._lifecycle_client.snapshot(
+                self.sandbox_id, snapshot_type=snapshot_type
+            )
+            return None
+        traced = await self._lifecycle_client.snapshot_and_wait(
+            self.sandbox_id,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            snapshot_type=snapshot_type,
+        )
+        return traced.value
+
+    async def list_snapshots(self) -> TracedIterator[SnapshotInfo]:
+        self._require_lifecycle_client("list_snapshots")
+        all_snaps = await self._lifecycle_client.list_snapshots()
+        my_id = self.sandbox_id
+        filtered = [s for s in all_snaps if s.sandbox_id == my_id]
+        return TracedIterator(all_snaps.trace_id, filtered)
+
+    async def _fetch_info(self) -> SandboxInfo:
+        if self._cached_info is None:
+            if self._lifecycle_client is None:
+                raise SandboxError(
+                    "Cannot resolve sandbox info: no lifecycle client available."
+                )
+            lookup_id = self._sandbox_id or self._identifier
+            self._cached_info = (await self._lifecycle_client.get(lookup_id)).value
+        return self._cached_info
+
+    async def info(self) -> SandboxInfo:
+        return await self._fetch_info()
+
+    def _lifecycle_identifier(self) -> str:
+        if self._sandbox_id is not None:
+            return self._sandbox_id
+        if self._cached_info is not None:
+            self._sandbox_id = self._cached_info.sandbox_id
+            return self._sandbox_id
+        return self._identifier
+
+    @property
+    def sandbox_id(self) -> str:
+        if self._sandbox_id is not None:
+            return self._sandbox_id
+        if self._cached_info is None:
+            raise SandboxError(
+                "sandbox_id is not yet known; call `await sandbox.info()` first."
+            )
+        self._sandbox_id = self._cached_info.sandbox_id
+        return self._sandbox_id
+
+    @property
+    def trace_id(self) -> str | None:
+        return self._trace_id
+
+    async def status(self) -> SandboxStatus:
+        self._require_lifecycle_client("read_status")
+        info = (await self._lifecycle_client.get(self._lifecycle_identifier())).value
+        self._sandbox_id = info.sandbox_id
+        self._cached_info = info
+        return info.status
+
+    async def update(
+        self,
+        name: str | None = None,
+        *,
+        allow_unauthenticated_access: bool | None = None,
+        exposed_ports: list[int] | None = None,
+    ) -> Traced[SandboxInfo]:
+        self._require_lifecycle_client("update")
+        traced = await self._lifecycle_client.update_sandbox(
+            self._lifecycle_identifier(),
+            name=name,
+            allow_unauthenticated_access=allow_unauthenticated_access,
+            exposed_ports=exposed_ports,
+        )
+        self._sandbox_id = traced.sandbox_id
+        self._cached_info = traced.value
+        return traced
+
+    async def __aenter__(self) -> "AsyncSandbox":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._owns_sandbox:
+            await self.terminate()
+        else:
+            self.close()
+
+    def close(self) -> None:
+        self._rust_client.close()
+
+    async def terminate(self) -> None:
+        lifecycle_client = self._lifecycle_client
+        delete_identifier = self._sandbox_id or self._identifier
+        self._owns_sandbox = False
+        self._lifecycle_client = None
+        self.close()
+        if lifecycle_client is not None:
+            await lifecycle_client.delete(delete_identifier)
+
+    # --- High-level convenience ---
+
+    async def run(
+        self,
+        command: str,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        working_dir: str | None = None,
+        timeout: float | None = None,
+    ) -> Traced[CommandResult]:
+        payload = Sandbox._build_command_payload(
+            command, args, env, working_dir, timeout=timeout
+        )
+        try:
+            trace_id, events_json = await self._rust_client.run_process_json_async(
+                json.dumps(payload)
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+        exit_code: int | None = None
+        for event_json in events_json:
+            event = json.loads(event_json)
+            if "line" in event:
+                if event.get("stream") == "stderr":
+                    stderr_lines.append(event["line"])
+                else:
+                    stdout_lines.append(event["line"])
+            elif "exit_code" in event or "signal" in event:
+                if event.get("exit_code") is not None:
+                    exit_code = event["exit_code"]
+                elif event.get("signal") is not None:
+                    exit_code = -event["signal"]
+        if exit_code is None:
+            from .exceptions import SandboxConnectionError
+
+            raise SandboxConnectionError(
+                "sandbox process stream ended without an exit event"
+            )
+        return Traced(
+            trace_id,
+            CommandResult(
+                exit_code=exit_code,
+                stdout="\n".join(stdout_lines),
+                stderr="\n".join(stderr_lines),
+            ),
+        )
+
+    # --- Process management ---
+
+    async def start_process(
+        self,
+        command: str,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        working_dir: str | None = None,
+        stdin_mode: StdinMode = StdinMode.CLOSED,
+        stdout_mode: OutputMode = OutputMode.CAPTURE,
+        stderr_mode: OutputMode = OutputMode.CAPTURE,
+    ) -> Traced[ProcessInfo]:
+        payload = self._build_command_payload(
+            command,
+            args,
+            env,
+            working_dir,
+            stdin_mode=stdin_mode if stdin_mode != StdinMode.CLOSED else None,
+            stdout_mode=stdout_mode if stdout_mode != OutputMode.CAPTURE else None,
+            stderr_mode=stderr_mode if stderr_mode != OutputMode.CAPTURE else None,
+        )
+        try:
+            trace_id, response_json = await self._rust_client.start_process_json_async(
+                json.dumps(payload)
+            )
+            return Traced(trace_id, ProcessInfo.model_validate_json(response_json))
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def list_processes(self) -> TracedIterator[ProcessInfo]:
+        try:
+            trace_id, response_json = await self._rust_client.list_processes_json_async()
+            data = ListProcessesResponse.model_validate_json(response_json)
+            return TracedIterator(trace_id, data.processes)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def get_process(self, pid: int) -> Traced[ProcessInfo]:
+        try:
+            trace_id, response_json = await self._rust_client.get_process_json_async(
+                pid=pid
+            )
+            return Traced(trace_id, ProcessInfo.model_validate_json(response_json))
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def kill_process(self, pid: int) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.kill_process_async(pid=pid)
+            return Traced(trace_id, None)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def send_signal(self, pid: int, signal: int) -> Traced[SendSignalResponse]:
+        try:
+            trace_id, response_json = await self._rust_client.send_signal_json_async(
+                pid=pid, signal=signal
+            )
+            return Traced(
+                trace_id, SendSignalResponse.model_validate_json(response_json)
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    # --- Process I/O ---
+
+    async def write_stdin(self, pid: int, data: bytes) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.write_stdin_async(pid=pid, data=data)
+            return Traced(trace_id, None)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def close_stdin(self, pid: int) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.close_stdin_async(pid=pid)
+            return Traced(trace_id, None)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def get_stdout(self, pid: int) -> Traced[OutputResponse]:
+        try:
+            trace_id, response_json = await self._rust_client.get_stdout_json_async(
+                pid=pid
+            )
+            return Traced(trace_id, OutputResponse.model_validate_json(response_json))
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def get_stderr(self, pid: int) -> Traced[OutputResponse]:
+        try:
+            trace_id, response_json = await self._rust_client.get_stderr_json_async(
+                pid=pid
+            )
+            return Traced(trace_id, OutputResponse.model_validate_json(response_json))
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def get_output(self, pid: int) -> Traced[OutputResponse]:
+        try:
+            trace_id, response_json = await self._rust_client.get_output_json_async(
+                pid=pid
+            )
+            return Traced(trace_id, OutputResponse.model_validate_json(response_json))
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def follow_stdout(self, pid: int) -> TracedIterator[OutputEvent]:
+        try:
+            trace_id, events_json = await self._rust_client.follow_stdout_json_async(
+                pid=pid
+            )
+            return TracedIterator(
+                trace_id, [OutputEvent.model_validate_json(ej) for ej in events_json]
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def follow_stderr(self, pid: int) -> TracedIterator[OutputEvent]:
+        try:
+            trace_id, events_json = await self._rust_client.follow_stderr_json_async(
+                pid=pid
+            )
+            return TracedIterator(
+                trace_id, [OutputEvent.model_validate_json(ej) for ej in events_json]
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def follow_output(self, pid: int) -> TracedIterator[OutputEvent]:
+        try:
+            trace_id, events_json = await self._rust_client.follow_output_json_async(
+                pid=pid
+            )
+            return TracedIterator(
+                trace_id, [OutputEvent.model_validate_json(ej) for ej in events_json]
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    # --- File operations ---
+
+    async def read_file(self, path: str) -> Traced[bytes]:
+        try:
+            trace_id, data = await self._rust_client.read_file_bytes_async(path=path)
+            return Traced(trace_id, data)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def write_file(self, path: str, content: bytes) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.write_file_async(
+                path=path, content=content
+            )
+            return Traced(trace_id, None)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def delete_file(self, path: str) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.delete_file_async(path=path)
+            return Traced(trace_id, None)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def list_directory(self, path: str) -> Traced[ListDirectoryResponse]:
+        try:
+            trace_id, response_json = await self._rust_client.list_directory_json_async(
+                path=path
+            )
+            return Traced(
+                trace_id, ListDirectoryResponse.model_validate_json(response_json)
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    # --- Health and info ---
+
+    async def health(self) -> Traced[HealthResponse]:
+        try:
+            trace_id, response_json = await self._rust_client.health_json_async()
+            return Traced(trace_id, HealthResponse.model_validate_json(response_json))
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def daemon_info(self) -> Traced[DaemonInfo]:
+        try:
+            trace_id, response_json = await self._rust_client.info_json_async()
+            return Traced(trace_id, DaemonInfo.model_validate_json(response_json))
+        except Exception as e:
+            _raise_as_sandbox_error(e)

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import time
 import warnings
+from typing import NoReturn
 from urllib.parse import urlparse
 
 from tensorlake._tracing import USER_AGENT, Traced, TracedIterator
@@ -104,7 +105,7 @@ def _resolve_sandbox_identifier(
     return resolved
 
 
-def _raise_as_sandbox_error(e: Exception) -> None:
+def _raise_as_sandbox_error(e: Exception) -> NoReturn:
     if isinstance(e, SandboxError):
         raise
 
@@ -627,7 +628,6 @@ class SandboxClient:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
-            raise  # unreachable — satisfies type checker
         if not wait:
             return Traced(trace_id, None)
         deadline = time.time() + timeout
@@ -672,7 +672,6 @@ class SandboxClient:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
-            raise  # unreachable — satisfies type checker
         if not wait:
             return Traced(trace_id, None)
         deadline = time.time() + timeout

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -1,0 +1,501 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from tensorlake.sandbox import (
+    PoolInUseError,
+    SandboxNotFoundError,
+    SnapshotType,
+)
+from tensorlake.sandbox.async_client import AsyncSandboxClient
+from tensorlake.sandbox.exceptions import SandboxError
+
+
+class _FakeAsyncRustClient:
+    def __init__(self):
+        self.create_request_json: str = ""
+        self.update_request_json: str = ""
+        self.last_get_sandbox_id: str = ""
+        self.create_snapshot_calls: list[tuple[str, str | None]] = []
+        self.suspend_calls: list[str] = []
+        self.resume_calls: list[str] = []
+        self.connect_proxy_calls: list[dict] = []
+
+    def close(self):
+        return None
+
+    def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):
+        self.connect_proxy_calls.append(
+            {
+                "proxy_url": proxy_url,
+                "sandbox_id": sandbox_id,
+                "routing_hint": routing_hint,
+            }
+        )
+        return None
+
+    async def suspend_sandbox_async(self, *, sandbox_id):
+        self.suspend_calls.append(sandbox_id)
+        return "trace-suspend"
+
+    async def resume_sandbox_async(self, *, sandbox_id):
+        self.resume_calls.append(sandbox_id)
+        return "trace-resume"
+
+    async def create_snapshot_async(self, *, sandbox_id, snapshot_type=None):
+        self.create_snapshot_calls.append((sandbox_id, snapshot_type))
+        return (
+            "trace-create",
+            '{"snapshot_id":"snap-1","status":"in_progress"}',
+        )
+
+    async def get_snapshot_json_async(self, *, snapshot_id):
+        return (
+            "trace-get",
+            '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
+            '"base_image":"python:3.12","status":"completed",'
+            '"snapshot_type":"filesystem",'
+            '"snapshot_uri":"s3://snap-1.tar.zst"}',
+        )
+
+    async def create_sandbox_async(self, *, request_json):
+        self.create_request_json = request_json
+        return (
+            "trace-create-sandbox",
+            '{"sandbox_id":"sbx-1","status":"pending"}',
+        )
+
+    async def list_sandboxes_json_async(self):
+        return (
+            "trace-list-sandboxes",
+            """
+{
+  "sandboxes": [
+    {
+      "id": "sbx-1",
+      "namespace": "default",
+      "status": "running",
+      "resources": {
+        "cpus": 1.0,
+        "memory_mb": 512,
+        "ephemeral_disk_mb": 1024
+      },
+      "secret_names": []
+    }
+  ]
+}
+""",
+        )
+
+    async def get_sandbox_json_async(self, *, sandbox_id) -> tuple[str, str]:
+        self.last_get_sandbox_id = sandbox_id
+        return (
+            "trace-get-sandbox",
+            """
+{
+  "id": "sbx-1",
+  "namespace": "default",
+  "status": "running",
+  "resources": {
+    "cpus": 1.0,
+    "memory_mb": 512,
+    "ephemeral_disk_mb": 1024
+  },
+  "secret_names": [],
+  "allow_unauthenticated_access": false,
+  "exposed_ports": [8080],
+  "sandbox_url": "https://sbx-1.sandbox.tensorlake.ai"
+}
+""",
+        )
+
+    async def update_sandbox_async(self, *, sandbox_id, request_json):
+        self.last_get_sandbox_id = sandbox_id
+        self.update_request_json = request_json
+        payload = json.loads(request_json)
+        response = {
+            "id": sandbox_id,
+            "namespace": "default",
+            "status": "running",
+            "resources": {
+                "cpus": 1.0,
+                "memory_mb": 512,
+                "ephemeral_disk_mb": 1024,
+            },
+            "secret_names": [],
+            "name": payload.get("name"),
+            "allow_unauthenticated_access": payload.get(
+                "allow_unauthenticated_access", False
+            ),
+            "exposed_ports": payload.get("exposed_ports", []),
+            "sandbox_url": f"https://{sandbox_id}.sandbox.tensorlake.ai",
+        }
+        return ("trace-update-sandbox", json.dumps(response))
+
+
+def _make_client(fake: object | None = None) -> AsyncSandboxClient:
+    client = AsyncSandboxClient(
+        api_url="http://localhost:8900", api_key="k", _internal=True
+    )
+    client._rust_client = fake if fake is not None else _FakeAsyncRustClient()
+    return client
+
+
+class _StatusSequenceRustClient(_FakeAsyncRustClient):
+    """Returns each status from `statuses` on successive get calls; the last
+    status repeats once exhausted."""
+
+    def __init__(self, statuses: list[str]):
+        super().__init__()
+        self._statuses = statuses
+        self.get_calls = 0
+
+    async def get_sandbox_json_async(self, *, sandbox_id) -> tuple[str, str]:
+        self.last_get_sandbox_id = sandbox_id
+        idx = min(self.get_calls, len(self._statuses) - 1)
+        self.get_calls += 1
+        return (
+            "trace-get-sandbox",
+            json.dumps(
+                {
+                    "id": sandbox_id,
+                    "namespace": "default",
+                    "status": self._statuses[idx],
+                    "resources": {
+                        "cpus": 1.0,
+                        "memory_mb": 512,
+                        "ephemeral_disk_mb": 1024,
+                    },
+                    "secret_names": [],
+                }
+            ),
+        )
+
+
+class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
+    async def test_connect_accepts_sandbox_name(self):
+        client = _make_client()
+
+        with patch(
+            "tensorlake.sandbox.async_sandbox.AsyncSandbox"
+        ) as async_sandbox_cls:
+            async_sandbox_cls.return_value.sandbox_id = "stable-name"
+
+            sandbox = await client.connect(
+                "stable-name", proxy_url="https://sandbox.tensorlake.ai"
+            )
+
+            self.assertEqual(sandbox.sandbox_id, "stable-name")
+
+    async def test_connect_rejects_conflicting_identifier_aliases(self):
+        client = _make_client()
+
+        with self.assertRaisesRegex(SandboxError, "Provide only one of"):
+            await client.connect("stable-name", sandbox_id="sbx-123")
+
+    async def test_create_uses_rust_backend(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        response = await client.create(image="python:3.11", cpus=2.0)
+
+        self.assertEqual(response.sandbox_id, "sbx-1")
+        request_json = json.loads(fake.create_request_json)
+        self.assertEqual(request_json["image"], "python:3.11")
+        self.assertEqual(request_json["resources"]["cpus"], 2.0)
+        self.assertEqual(request_json["resources"]["memory_mb"], 1024)
+
+    async def test_create_sends_disk_override_when_provided(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        await client.create(disk_mb=25 * 1024)
+
+        request_json = json.loads(fake.create_request_json)
+        self.assertEqual(request_json["resources"]["disk_mb"], 25 * 1024)
+        self.assertNotIn("ephemeral_disk_mb", request_json["resources"])
+
+    async def test_create_and_connect_raises_error_details_from_startup_failure(self):
+        class _StartupFailureRustClient(_FakeAsyncRustClient):
+            async def get_sandbox_json_async(self, *, sandbox_id):
+                self.last_get_sandbox_id = sandbox_id
+                return (
+                    "trace-get-sandbox",
+                    """
+{
+  "id": "sbx-1",
+  "namespace": "default",
+  "status": "terminated",
+  "resources": {
+    "cpus": 1.0,
+    "memory_mb": 512,
+    "ephemeral_disk_mb": 1024
+  },
+  "secret_names": [],
+  "error_details": {
+    "message": "failed to pull image tensorlake/missing-image"
+  }
+}
+""",
+                )
+
+            async def delete_sandbox_async(self, *, sandbox_id):
+                return "trace-delete"
+
+        client = _make_client(_StartupFailureRustClient())
+
+        with self.assertRaisesRegex(
+            SandboxError,
+            "terminated during startup: failed to pull image tensorlake/missing-image",
+        ):
+            await client.create_and_connect(image="tensorlake/missing-image")
+
+    async def test_create_and_connect_polls_until_running(self):
+        fake = _StatusSequenceRustClient(["pending", "running"])
+        client = _make_client(fake)
+
+        with patch(
+            "tensorlake.sandbox.async_sandbox.AsyncSandbox"
+        ) as async_sandbox_cls:
+            async_sandbox_cls.return_value.sandbox_id = "sbx-1"
+
+            sandbox = await client.create_and_connect(image="python:3.11")
+
+            self.assertEqual(sandbox.sandbox_id, "sbx-1")
+            self.assertGreaterEqual(fake.get_calls, 2)
+            self.assertEqual(len(fake.connect_proxy_calls), 1)
+
+    async def test_list_uses_rust_backend(self):
+        client = _make_client()
+
+        sandboxes = await client.list()
+        sandboxes_list = list(sandboxes)
+
+        self.assertEqual(len(sandboxes_list), 1)
+        self.assertEqual(sandboxes_list[0].sandbox_id, "sbx-1")
+        self.assertEqual(sandboxes_list[0].status, "running")
+
+    async def test_update_sandbox_sends_port_access_fields(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        info = await client.update_sandbox(
+            "sbx-1",
+            name="renamed",
+            allow_unauthenticated_access=True,
+            exposed_ports=[8081, 8080, 8081],
+        )
+
+        request_json = json.loads(fake.update_request_json)
+        self.assertEqual(request_json["name"], "renamed")
+        self.assertTrue(request_json["allow_unauthenticated_access"])
+        self.assertEqual(request_json["exposed_ports"], [8080, 8081])
+        self.assertTrue(info.allow_unauthenticated_access)
+        self.assertEqual(info.exposed_ports, [8080, 8081])
+
+    async def test_get_port_access_reads_current_settings(self):
+        client = _make_client()
+
+        access = await client.get_port_access("sbx-1")
+
+        self.assertFalse(access.allow_unauthenticated_access)
+        self.assertEqual(access.exposed_ports, [8080])
+        self.assertEqual(access.sandbox_url, "https://sbx-1.sandbox.tensorlake.ai")
+
+    async def test_expose_ports_merges_existing_ports(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        info = await client.expose_ports(
+            "sbx-1",
+            [8081, 8080],
+            allow_unauthenticated_access=True,
+        )
+
+        request_json = json.loads(fake.update_request_json)
+        self.assertEqual(request_json["exposed_ports"], [8080, 8081])
+        self.assertTrue(request_json["allow_unauthenticated_access"])
+        self.assertEqual(info.exposed_ports, [8080, 8081])
+
+    async def test_unexpose_ports_removes_ports_and_disables_public_access_when_empty(
+        self,
+    ):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        info = await client.unexpose_ports("sbx-1", [8080])
+
+        request_json = json.loads(fake.update_request_json)
+        self.assertEqual(request_json["exposed_ports"], [])
+        self.assertFalse(request_json["allow_unauthenticated_access"])
+        self.assertEqual(info.exposed_ports, [])
+
+    async def test_port_management_rejects_reserved_management_port(self):
+        client = _make_client()
+
+        with self.assertRaisesRegex(SandboxError, "reserved for sandbox management"):
+            await client.expose_ports("sbx-1", [9501])
+
+    async def test_suspend_calls_rust_backend(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        await client.suspend("my-env", wait=False)
+
+        self.assertEqual(fake.suspend_calls, ["my-env"])
+        self.assertEqual(fake.resume_calls, [])
+
+    async def test_resume_calls_rust_backend(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        await client.resume("my-env", wait=False)
+
+        self.assertEqual(fake.resume_calls, ["my-env"])
+        self.assertEqual(fake.suspend_calls, [])
+
+    async def test_suspend_polls_until_suspended(self):
+        fake = _StatusSequenceRustClient(["running", "suspended"])
+        client = _make_client(fake)
+
+        await client.suspend("sbx-1", wait=True, timeout=2.0, poll_interval=0.01)
+
+        self.assertEqual(fake.suspend_calls, ["sbx-1"])
+        self.assertGreaterEqual(fake.get_calls, 2)
+
+    async def test_resume_polls_until_running(self):
+        fake = _StatusSequenceRustClient(["suspended", "running"])
+        client = _make_client(fake)
+
+        await client.resume("sbx-1", wait=True, timeout=2.0, poll_interval=0.01)
+
+        self.assertEqual(fake.resume_calls, ["sbx-1"])
+        self.assertGreaterEqual(fake.get_calls, 2)
+
+    async def test_suspend_maps_404_to_sandbox_not_found(self):
+        class FakeRustError(Exception):
+            pass
+
+        class _NotFoundRustClient:
+            def close(self):
+                return None
+
+            async def suspend_sandbox_async(self, *, sandbox_id):
+                raise FakeRustError(
+                    ("remote_api", 404, f"sandbox {sandbox_id} not found")
+                )
+
+        import tensorlake.sandbox.client as sandbox_client_module
+
+        previous = sandbox_client_module.RustCloudSandboxClientError
+        try:
+            sandbox_client_module.RustCloudSandboxClientError = FakeRustError
+            client = _make_client(_NotFoundRustClient())
+
+            with self.assertRaises(SandboxNotFoundError):
+                await client.suspend("missing")
+        finally:
+            sandbox_client_module.RustCloudSandboxClientError = previous
+
+    async def test_resume_maps_404_to_sandbox_not_found(self):
+        class FakeRustError(Exception):
+            pass
+
+        class _NotFoundRustClient:
+            def close(self):
+                return None
+
+            async def resume_sandbox_async(self, *, sandbox_id):
+                raise FakeRustError(
+                    ("remote_api", 404, f"sandbox {sandbox_id} not found")
+                )
+
+        import tensorlake.sandbox.client as sandbox_client_module
+
+        previous = sandbox_client_module.RustCloudSandboxClientError
+        try:
+            sandbox_client_module.RustCloudSandboxClientError = FakeRustError
+            client = _make_client(_NotFoundRustClient())
+
+            with self.assertRaises(SandboxNotFoundError):
+                await client.resume("missing")
+        finally:
+            sandbox_client_module.RustCloudSandboxClientError = previous
+
+    async def test_get_maps_404_to_sandbox_not_found(self):
+        class FakeRustError(Exception):
+            pass
+
+        class _NotFoundRustClient:
+            def close(self):
+                return None
+
+            async def get_sandbox_json_async(self, *, sandbox_id):
+                raise FakeRustError(
+                    ("remote_api", 404, f"sandbox {sandbox_id} not found")
+                )
+
+        import tensorlake.sandbox.client as sandbox_client_module
+
+        previous = sandbox_client_module.RustCloudSandboxClientError
+        try:
+            sandbox_client_module.RustCloudSandboxClientError = FakeRustError
+            client = _make_client(_NotFoundRustClient())
+
+            with self.assertRaises(SandboxNotFoundError):
+                await client.get("missing")
+        finally:
+            sandbox_client_module.RustCloudSandboxClientError = previous
+
+    async def test_delete_pool_maps_409_to_pool_in_use(self):
+        class FakeRustError(Exception):
+            pass
+
+        class _PoolInUseRustClient:
+            def close(self):
+                return None
+
+            async def delete_pool_async(self, *, pool_id):
+                raise FakeRustError(("remote_api", 409, f"pool {pool_id} is in use"))
+
+        import tensorlake.sandbox.client as sandbox_client_module
+
+        previous = sandbox_client_module.RustCloudSandboxClientError
+        try:
+            sandbox_client_module.RustCloudSandboxClientError = FakeRustError
+            client = _make_client(_PoolInUseRustClient())
+
+            with self.assertRaises(PoolInUseError):
+                await client.delete_pool("pool-1")
+        finally:
+            sandbox_client_module.RustCloudSandboxClientError = previous
+
+    async def test_snapshot_threads_snapshot_type_to_rust_backend(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        info = await client.snapshot_and_wait(
+            "sbx-1",
+            snapshot_type=SnapshotType.FILESYSTEM,
+        )
+
+        self.assertEqual(len(fake.create_snapshot_calls), 1)
+        sandbox_id, snapshot_type = fake.create_snapshot_calls[0]
+        self.assertEqual(sandbox_id, "sbx-1")
+        self.assertEqual(snapshot_type, "filesystem")
+        self.assertEqual(info.snapshot_id, "snap-1")
+        self.assertEqual(info.snapshot_type, SnapshotType.FILESYSTEM)
+
+    async def test_snapshot_omits_snapshot_type_when_none(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        await client.snapshot_and_wait("sbx-1")
+
+        self.assertEqual(len(fake.create_snapshot_calls), 1)
+        _, snapshot_type = fake.create_snapshot_calls[0]
+        self.assertIsNone(snapshot_type)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sandbox/test_sandbox_rust_backend_async.py
+++ b/tests/sandbox/test_sandbox_rust_backend_async.py
@@ -1,0 +1,581 @@
+import json
+import unittest
+from unittest.mock import AsyncMock
+
+from tensorlake._tracing import Traced, TracedIterator
+from tensorlake.sandbox import AsyncSandbox, SandboxConnectionError
+from tensorlake.sandbox.exceptions import SandboxError
+from tensorlake.sandbox.models import (
+    ContainerResourcesInfo,
+    OutputMode,
+    ProcessStatus,
+    SandboxInfo,
+    SandboxStatus,
+    StdinMode,
+)
+
+_TRACE_ID = "00-deadbeefdeadbeefdeadbeefdeadbeef-cafebabecafebabe-01"
+
+
+def _process_info_dict(pid: int = 101) -> dict:
+    return {
+        "pid": pid,
+        "status": ProcessStatus.RUNNING.value,
+        "stdin_writable": True,
+        "command": "echo",
+        "args": ["hello"],
+        "started_at": 1_700_000_000,
+    }
+
+
+class _FakeAsyncRustProxyClient:
+    """Async counterpart of the sync test's _FakeRustProxyClient.
+
+    Every Rust binding method on the async path ends in ``_async`` and is
+    awaited by AsyncSandbox, so the fakes are plain ``async def`` methods.
+    """
+
+    def __init__(self):
+        self.start_payload_json: str | None = None
+        self.run_payload_json: str | None = None
+        self.write_stdin_calls: list[tuple[int, bytes]] = []
+        self.close_stdin_calls: list[int] = []
+        self.kill_calls: list[int] = []
+        self.signal_calls: list[tuple[int, int]] = []
+        self.read_file_calls: list[str] = []
+        self.write_file_calls: list[tuple[str, bytes]] = []
+        self.delete_file_calls: list[str] = []
+        self.list_directory_calls: list[str] = []
+
+    def close(self):
+        return None
+
+    def base_url(self):
+        return "http://localhost:9443"
+
+    async def start_process_json_async(self, payload_json):
+        self.start_payload_json = payload_json
+        return _TRACE_ID, json.dumps(_process_info_dict())
+
+    async def list_processes_json_async(self):
+        return _TRACE_ID, json.dumps({"processes": [_process_info_dict()]})
+
+    async def get_process_json_async(self, *, pid):
+        return _TRACE_ID, json.dumps(_process_info_dict(pid))
+
+    async def kill_process_async(self, *, pid):
+        self.kill_calls.append(pid)
+        return _TRACE_ID
+
+    async def send_signal_json_async(self, *, pid, signal):
+        self.signal_calls.append((pid, signal))
+        return _TRACE_ID, json.dumps({"success": True})
+
+    async def write_stdin_async(self, *, pid, data):
+        self.write_stdin_calls.append((pid, data))
+        return _TRACE_ID
+
+    async def close_stdin_async(self, *, pid):
+        self.close_stdin_calls.append(pid)
+        return _TRACE_ID
+
+    async def get_stdout_json_async(self, *, pid):
+        return _TRACE_ID, json.dumps({"pid": pid, "lines": ["a", "b"], "line_count": 2})
+
+    async def get_stderr_json_async(self, *, pid):
+        return _TRACE_ID, json.dumps({"pid": pid, "lines": ["err"], "line_count": 1})
+
+    async def get_output_json_async(self, *, pid):
+        return _TRACE_ID, json.dumps(
+            {"pid": pid, "lines": ["a", "b", "err"], "line_count": 3}
+        )
+
+    async def follow_stdout_json_async(self, *, pid):
+        return _TRACE_ID, [
+            json.dumps({"line": "out", "timestamp": 1_700_000_000, "stream": "stdout"})
+        ]
+
+    async def follow_stderr_json_async(self, *, pid):
+        return _TRACE_ID, [
+            json.dumps({"line": "err", "timestamp": 1_700_000_001, "stream": "stderr"})
+        ]
+
+    async def follow_output_json_async(self, *, pid):
+        return _TRACE_ID, [
+            json.dumps(
+                {"line": "hello", "timestamp": 1_700_000_000, "stream": "stdout"}
+            )
+        ]
+
+    async def run_process_json_async(self, payload_json):
+        self.run_payload_json = payload_json
+        return _TRACE_ID, [
+            json.dumps(
+                {"line": "out1", "stream": "stdout", "timestamp": 1_700_000_001}
+            ),
+            json.dumps(
+                {"line": "err1", "stream": "stderr", "timestamp": 1_700_000_002}
+            ),
+            json.dumps(
+                {"line": "out2", "stream": "stdout", "timestamp": 1_700_000_003}
+            ),
+            json.dumps({"exit_code": 0}),
+        ]
+
+    async def read_file_bytes_async(self, *, path):
+        self.read_file_calls.append(path)
+        return _TRACE_ID, b"file-bytes"
+
+    async def write_file_async(self, *, path, content):
+        self.write_file_calls.append((path, content))
+        return _TRACE_ID
+
+    async def delete_file_async(self, *, path):
+        self.delete_file_calls.append(path)
+        return _TRACE_ID
+
+    async def list_directory_json_async(self, *, path):
+        self.list_directory_calls.append(path)
+        return _TRACE_ID, json.dumps(
+            {
+                "path": path,
+                "entries": [
+                    {"name": "a.txt", "is_dir": False, "size": 3},
+                    {"name": "sub", "is_dir": True},
+                ],
+            }
+        )
+
+    async def health_json_async(self):
+        return _TRACE_ID, json.dumps({"healthy": True})
+
+    async def info_json_async(self):
+        return _TRACE_ID, json.dumps(
+            {
+                "version": "1.2.3",
+                "uptime_secs": 42,
+                "running_processes": 1,
+                "total_processes": 5,
+            }
+        )
+
+
+def _make_async_sandbox(fake=None):
+    """Return an AsyncSandbox wired to *fake* (or a fresh fake)."""
+    client = fake or _FakeAsyncRustProxyClient()
+    return (
+        AsyncSandbox(
+            sandbox_id="sbx-1",
+            proxy_url="http://localhost:9443",
+            api_key="k",
+            _proxy_rust_client=client,
+        ),
+        client,
+    )
+
+
+def _sandbox_info(status=SandboxStatus.RUNNING, **overrides) -> SandboxInfo:
+    fields = {
+        "id": "sbx-1",
+        "namespace": "default",
+        "status": status,
+        "resources": ContainerResourcesInfo(
+            cpus=1.0, memory_mb=512, ephemeral_disk_mb=1024
+        ),
+    }
+    fields.update(overrides)
+    return SandboxInfo(**fields)
+
+
+class TestAsyncSandboxRustBackend(unittest.IsolatedAsyncioTestCase):
+    def test_async_sandbox_accepts_sandbox_name(self):
+        sandbox = AsyncSandbox(
+            identifier="stable-name",
+            proxy_url="http://localhost:9443",
+            api_key="k",
+            _proxy_rust_client=_FakeAsyncRustProxyClient(),
+        )
+        self.assertEqual(sandbox._identifier, "stable-name")
+
+    def test_async_sandbox_rejects_conflicting_identifier_aliases(self):
+        with self.assertRaisesRegex(SandboxError, "Provide only one of"):
+            AsyncSandbox(
+                identifier="stable-name",
+                sandbox_id="sbx-other",
+                proxy_url="http://localhost:9443",
+                api_key="k",
+                _proxy_rust_client=_FakeAsyncRustProxyClient(),
+            )
+
+    def test_async_sandbox_requires_identifier(self):
+        with self.assertRaisesRegex(SandboxError, "`identifier` is required"):
+            AsyncSandbox(
+                proxy_url="http://localhost:9443",
+                api_key="k",
+                _proxy_rust_client=_FakeAsyncRustProxyClient(),
+            )
+
+    async def test_start_process_uses_rust_backend(self):
+        # Regression: AsyncSandbox.start_process must build the payload via
+        # Sandbox._build_command_payload, not self._build_command_payload —
+        # the latter raised AttributeError because AsyncSandbox does not
+        # inherit from Sandbox.
+        sandbox, fake = _make_async_sandbox()
+
+        process = await sandbox.start_process(
+            command="echo",
+            args=["hello"],
+            stdin_mode=StdinMode.PIPE,
+        )
+
+        self.assertEqual(process.pid, 101)
+        self.assertEqual(process.trace_id, _TRACE_ID)
+        payload = json.loads(fake.start_payload_json)
+        self.assertEqual(payload["command"], "echo")
+        self.assertEqual(payload["args"], ["hello"])
+        self.assertEqual(payload["stdin_mode"], StdinMode.PIPE.value)
+
+    async def test_start_process_omits_default_modes_from_payload(self):
+        sandbox, fake = _make_async_sandbox()
+
+        await sandbox.start_process(command="echo")
+
+        payload = json.loads(fake.start_payload_json)
+        self.assertNotIn("stdin_mode", payload)
+        self.assertNotIn("stdout_mode", payload)
+        self.assertNotIn("stderr_mode", payload)
+
+    async def test_start_process_serializes_non_default_output_modes(self):
+        sandbox, fake = _make_async_sandbox()
+
+        await sandbox.start_process(
+            command="echo",
+            stdout_mode=OutputMode.DISCARD,
+            stderr_mode=OutputMode.DISCARD,
+        )
+
+        payload = json.loads(fake.start_payload_json)
+        self.assertEqual(payload["stdout_mode"], OutputMode.DISCARD.value)
+        self.assertEqual(payload["stderr_mode"], OutputMode.DISCARD.value)
+
+    async def test_list_processes_returns_traced_iterator(self):
+        sandbox, _ = _make_async_sandbox()
+
+        processes = await sandbox.list_processes()
+
+        self.assertIsInstance(processes, TracedIterator)
+        self.assertEqual(processes.trace_id, _TRACE_ID)
+        items = list(processes)
+        self.assertEqual([p.pid for p in items], [101])
+
+    async def test_get_process_uses_rust_backend(self):
+        sandbox, _ = _make_async_sandbox()
+
+        traced = await sandbox.get_process(101)
+
+        self.assertEqual(traced.pid, 101)
+        self.assertEqual(traced.trace_id, _TRACE_ID)
+
+    async def test_run_uses_streaming_endpoint(self):
+        sandbox, fake = _make_async_sandbox()
+
+        result = await sandbox.run("echo", args=["hello"])
+
+        payload = json.loads(fake.run_payload_json)
+        self.assertEqual(payload["command"], "echo")
+        self.assertEqual(payload["args"], ["hello"])
+
+        self.assertEqual(result.stdout, "out1\nout2")
+        self.assertEqual(result.stderr, "err1")
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.trace_id, _TRACE_ID)
+
+    async def test_run_threads_timeout_through_payload(self):
+        sandbox, fake = _make_async_sandbox()
+
+        await sandbox.run("sleep", args=["1"], timeout=2.5)
+
+        payload = json.loads(fake.run_payload_json)
+        self.assertEqual(payload["timeout"], 2.5)
+
+    async def test_run_signal_maps_to_negative_exit_code(self):
+        class _SignaledFake(_FakeAsyncRustProxyClient):
+            async def run_process_json_async(self, payload_json):
+                return _TRACE_ID, [json.dumps({"signal": 9})]
+
+        sandbox, _ = _make_async_sandbox(_SignaledFake())
+
+        result = await sandbox.run("sleep", args=["100"])
+
+        self.assertEqual(result.exit_code, -9)
+
+    async def test_run_raises_when_stream_has_no_exit_event(self):
+        class _MissingExit(_FakeAsyncRustProxyClient):
+            async def run_process_json_async(self, payload_json):
+                return _TRACE_ID, []
+
+        sandbox, _ = _make_async_sandbox(_MissingExit())
+
+        with self.assertRaisesRegex(
+            SandboxConnectionError, "stream ended without an exit event"
+        ):
+            await sandbox.run("echo", args=["hello"])
+
+    async def test_run_ignores_unknown_event_kinds(self):
+        # Belt-and-braces: the parser should skip anything that is neither a
+        # line nor an exit event without falling over.
+        class _NoisyFake(_FakeAsyncRustProxyClient):
+            async def run_process_json_async(self, payload_json):
+                return _TRACE_ID, [
+                    json.dumps({"hello": "world"}),
+                    json.dumps({"line": "ok", "stream": "stdout", "timestamp": 1}),
+                    json.dumps({"exit_code": 0}),
+                ]
+
+        sandbox, _ = _make_async_sandbox(_NoisyFake())
+
+        result = await sandbox.run("echo")
+
+        self.assertEqual(result.stdout, "ok")
+        self.assertEqual(result.exit_code, 0)
+
+    async def test_write_stdin_forwards_bytes(self):
+        sandbox, fake = _make_async_sandbox()
+
+        traced = await sandbox.write_stdin(101, b"hello")
+
+        self.assertEqual(fake.write_stdin_calls, [(101, b"hello")])
+        self.assertEqual(traced.trace_id, _TRACE_ID)
+
+    async def test_close_stdin_forwards_pid(self):
+        sandbox, fake = _make_async_sandbox()
+
+        await sandbox.close_stdin(101)
+
+        self.assertEqual(fake.close_stdin_calls, [101])
+
+    async def test_kill_process_forwards_pid(self):
+        sandbox, fake = _make_async_sandbox()
+
+        await sandbox.kill_process(101)
+
+        self.assertEqual(fake.kill_calls, [101])
+
+    async def test_send_signal_forwards_pid_and_signal(self):
+        sandbox, fake = _make_async_sandbox()
+
+        traced = await sandbox.send_signal(101, 15)
+
+        self.assertEqual(fake.signal_calls, [(101, 15)])
+        self.assertTrue(traced.success)
+
+    async def test_get_stdout_returns_traced_response(self):
+        sandbox, _ = _make_async_sandbox()
+
+        traced = await sandbox.get_stdout(101)
+
+        self.assertEqual(traced.lines, ["a", "b"])
+        self.assertEqual(traced.line_count, 2)
+
+    async def test_get_stderr_returns_traced_response(self):
+        sandbox, _ = _make_async_sandbox()
+
+        traced = await sandbox.get_stderr(101)
+
+        self.assertEqual(traced.lines, ["err"])
+
+    async def test_get_output_returns_traced_response(self):
+        sandbox, _ = _make_async_sandbox()
+
+        traced = await sandbox.get_output(101)
+
+        self.assertEqual(traced.line_count, 3)
+
+    async def test_follow_stdout_returns_traced_iterator(self):
+        sandbox, _ = _make_async_sandbox()
+
+        events = await sandbox.follow_stdout(101)
+
+        self.assertIsInstance(events, TracedIterator)
+        self.assertEqual(events.trace_id, _TRACE_ID)
+        items = list(events)
+        self.assertEqual([e.line for e in items], ["out"])
+
+    async def test_follow_stderr_returns_traced_iterator(self):
+        sandbox, _ = _make_async_sandbox()
+
+        events = await sandbox.follow_stderr(101)
+        items = list(events)
+
+        self.assertEqual([e.line for e in items], ["err"])
+
+    async def test_follow_output_returns_traced_iterator(self):
+        sandbox, _ = _make_async_sandbox()
+
+        events = await sandbox.follow_output(101)
+        items = list(events)
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].line, "hello")
+        self.assertEqual(items[0].stream, "stdout")
+
+    async def test_read_file_returns_bytes(self):
+        sandbox, fake = _make_async_sandbox()
+
+        traced = await sandbox.read_file("/tmp/x")
+
+        self.assertEqual(traced.value, b"file-bytes")
+        self.assertEqual(fake.read_file_calls, ["/tmp/x"])
+
+    async def test_write_file_forwards_path_and_content(self):
+        sandbox, fake = _make_async_sandbox()
+
+        await sandbox.write_file("/tmp/x", b"abc")
+
+        self.assertEqual(fake.write_file_calls, [("/tmp/x", b"abc")])
+
+    async def test_delete_file_forwards_path(self):
+        sandbox, fake = _make_async_sandbox()
+
+        await sandbox.delete_file("/tmp/x")
+
+        self.assertEqual(fake.delete_file_calls, ["/tmp/x"])
+
+    async def test_list_directory_returns_entries(self):
+        sandbox, fake = _make_async_sandbox()
+
+        traced = await sandbox.list_directory("/tmp")
+
+        self.assertEqual(fake.list_directory_calls, ["/tmp"])
+        self.assertEqual(traced.path, "/tmp")
+        self.assertEqual([e.name for e in traced.entries], ["a.txt", "sub"])
+
+    async def test_health_returns_traced_health(self):
+        sandbox, _ = _make_async_sandbox()
+
+        traced = await sandbox.health()
+
+        self.assertTrue(traced.healthy)
+        self.assertEqual(traced.trace_id, _TRACE_ID)
+
+    async def test_daemon_info_returns_traced_info(self):
+        sandbox, _ = _make_async_sandbox()
+
+        traced = await sandbox.daemon_info()
+
+        self.assertEqual(traced.version, "1.2.3")
+        self.assertEqual(traced.running_processes, 1)
+
+    async def test_health_maps_connection_error(self):
+        class FakeRustError(Exception):
+            pass
+
+        class _FailingFake(_FakeAsyncRustProxyClient):
+            async def health_json_async(self):
+                raise FakeRustError(("connection", 503, "dial tcp timeout"))
+
+        import tensorlake.sandbox.sandbox as sandbox_module
+
+        previous = sandbox_module.RustCloudSandboxClientError
+        try:
+            sandbox_module.RustCloudSandboxClientError = FakeRustError
+            sandbox, _ = _make_async_sandbox(_FailingFake())
+
+            with self.assertRaises(SandboxConnectionError):
+                await sandbox.health()
+        finally:
+            sandbox_module.RustCloudSandboxClientError = previous
+
+    async def test_status_requires_lifecycle_client(self):
+        sandbox, _ = _make_async_sandbox()
+        with self.assertRaises(SandboxError):
+            await sandbox.status()
+
+    async def test_status_fetches_via_lifecycle_client(self):
+        sandbox, _ = _make_async_sandbox()
+        sandbox._lifecycle_client = AsyncMock()
+        sandbox._lifecycle_client.get = AsyncMock(
+            return_value=Traced(
+                _TRACE_ID, _sandbox_info(status=SandboxStatus.SUSPENDED)
+            )
+        )
+
+        status = await sandbox.status()
+
+        self.assertEqual(status, SandboxStatus.SUSPENDED)
+        sandbox._lifecycle_client.get.assert_awaited_once_with("sbx-1")
+
+    async def test_update_calls_lifecycle_client(self):
+        sandbox, _ = _make_async_sandbox()
+        sandbox._cached_info = _sandbox_info()
+        sandbox._lifecycle_client = AsyncMock()
+        sandbox._lifecycle_client.update_sandbox = AsyncMock(
+            return_value=Traced(
+                _TRACE_ID,
+                _sandbox_info(
+                    name="renamed",
+                    exposed_ports=[8080],
+                    allow_unauthenticated_access=True,
+                ),
+            )
+        )
+
+        traced = await sandbox.update(
+            name="renamed",
+            allow_unauthenticated_access=True,
+            exposed_ports=[8080],
+        )
+
+        sandbox._lifecycle_client.update_sandbox.assert_awaited_once_with(
+            "sbx-1",
+            name="renamed",
+            allow_unauthenticated_access=True,
+            exposed_ports=[8080],
+        )
+        self.assertEqual(traced.name, "renamed")
+
+    async def test_update_requires_lifecycle_client(self):
+        sandbox, _ = _make_async_sandbox()
+        with self.assertRaises(SandboxError):
+            await sandbox.update(name="anything")
+
+    async def test_terminate_closes_proxy_and_deletes_via_lifecycle(self):
+        sandbox, _ = _make_async_sandbox()
+        sandbox._owns_sandbox = True
+        lifecycle = AsyncMock()
+        lifecycle.delete = AsyncMock(return_value=Traced(_TRACE_ID, None))
+        sandbox._lifecycle_client = lifecycle
+
+        await sandbox.terminate()
+
+        lifecycle.delete.assert_awaited_once_with("sbx-1")
+        # Lifecycle reference is cleared after terminate so subsequent
+        # operations cannot accidentally re-delete.
+        self.assertIsNone(sandbox._lifecycle_client)
+        self.assertFalse(sandbox._owns_sandbox)
+
+    async def test_aexit_terminates_when_owned(self):
+        sandbox, _ = _make_async_sandbox()
+        sandbox._owns_sandbox = True
+        lifecycle = AsyncMock()
+        lifecycle.delete = AsyncMock(return_value=Traced(_TRACE_ID, None))
+        sandbox._lifecycle_client = lifecycle
+
+        async with sandbox:
+            pass
+
+        lifecycle.delete.assert_awaited_once_with("sbx-1")
+
+    async def test_aexit_only_closes_when_not_owned(self):
+        sandbox, _ = _make_async_sandbox()
+        sandbox._lifecycle_client = AsyncMock()
+        sandbox._lifecycle_client.delete = AsyncMock()
+
+        async with sandbox:
+            pass
+
+        sandbox._lifecycle_client.delete.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.6",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.6",
+      "version": "0.5.8",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
                                                                                                          
  - Add async sandbox API: new AsyncSandboxClient and AsyncSandbox (src/tensorlake/sandbox/async_client.py,    
  async_sandbox.py) mirroring the sync surface but returning awaitables backed by Rust *_async bindings via
  pyo3-async-runtimes.                                                                                         
  - Add Rust async bindings: *_async variants on CloudSandboxClient and CloudSandboxProxyClient (lifecycle,
  snapshots, pools, processes, files, health/info, run/follow streams) using future_into_py and a shared       
  retry_async_op helper.                                                                                       
  - Refactor sync runtime to a shared global tokio runtime (shared_runtime() →                                 
  pyo3_async_runtimes::tokio::get_runtime()). Removed per-pyclass Runtime from CloudApiClient,                 
  CloudSandboxClient, CloudSandboxProxyClient, CloudSandboxDesktopClient, CloudDocumentAIClient. Sync block_on
  now routes through the same runtime that drives async.                                                       
  - Eager-init shared runtime in #[pymodule] so the worker-thread spawn cost lands at import time, keeping
  sandbox.create() → run() TTI unchanged.                                                                      
  - Deduplicate sync retry logic into run_with_retry_blocking. Side effect: CloudSandboxClient sync retries now
   log to stderr (Retrying rust sandbox API request …), matching the existing                                  
  CloudApiClient/CloudDocumentAIClient behavior.            
  - Deps: add pyo3-async-runtimes 0.28 (tokio-runtime feature) to workspace + rust-cloud-sdk-py.               
  - Exports: tensorlake.sandbox.__init__ re-exports AsyncSandboxClient and AsyncSandbox.                       
  - Typing-only cleanup in client.py: _raise_as_sandbox_error annotated NoReturn; removed two unreachable raise
   lines.                                                                                                      
  - Tests: new tests/sandbox/test_sandbox_rust_backend_async.py (37 tests, all passing) covering async sandbox 
  surface with fakes.                                                                                          
                                                            
  Compatibility                                                                                                
                                                            
  - Sync API surface (signatures, return types, exceptions, retry semantics) unchanged.                        
  - Behavior deltas: (a) sandbox sync retries now emit one stderr line per retry; (b) constructor no longer
  raises "failed to create tokio runtime" (path removed — runtime is global and lazy).                         
                                                            
  Test plan                                                                                                    
                                                            
  - cargo check --release -p tensorlake-rust-cloud-sdk-py                                                      
  - make build_cloud_sdk
  - tests/sandbox/test_sandbox_rust_backend_async.py — 37/37                                                   
  - tests/sandbox/test_client_rust_backend.py — 19/19                                                          
  - tests/sandbox/test_sandbox_rust_backend.py — 22/22                                                         
  - tests/sandbox/test_desktop.py — 4/4                                                                        
  - tests/sandbox/test_lifecycle.py against staging/cloud (integration, needs creds)                           
  - Re-run TTI benchmark to confirm no regression vs. main                                                     
                                                                                                               
  Note: tests/sandbox/test_pty.py fails on this branch with the same failures present on main — pre-existing,  
  not addressed here.                              