### PR TITLE
fix(sdk): route VNC port probe through SandboxProxyClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,6 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -158,7 +152,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -702,7 +696,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4193bd783c7bf560288cc72338b0934f699afbf9afd5dfb980e327f006fdfd7"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bollard",
  "directories",
  "docker_credential",
@@ -714,11 +708,11 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+checksum = "a4564c274ebf369f501de192b02a0b81a5c4bda375abfe526aa70fc702fa6fa0"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "serde",
  "serde_json",
 ]
@@ -1146,7 +1140,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1309,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1367,16 +1361,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-docker"
@@ -1491,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1534,7 +1518,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2114,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -2169,7 +2153,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2276,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -2581,11 +2565,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2600,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -2699,9 +2683,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2812,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -2850,10 +2834,10 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "bollard",
  "bytes",
  "chrono",
@@ -2892,7 +2876,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "futures",
  "pyo3",
@@ -2996,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -3116,20 +3100,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3348,9 +3332,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
@@ -3360,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3432,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3445,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3455,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3465,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3478,9 +3462,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3534,9 +3518,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.8"
+version = "0.5.9"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/describe.rs
+++ b/crates/cli/src/commands/sbx/describe.rs
@@ -19,7 +19,10 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str) -> Result<()> {
         )));
     }
 
-    let item = resp.json::<serde_json::Value>().await.map_err(CliError::Http)?;
+    let item = resp
+        .json::<serde_json::Value>()
+        .await
+        .map_err(CliError::Http)?;
     print_sandbox_details(&item);
     Ok(())
 }
@@ -87,9 +90,15 @@ fn print_sandbox_details(item: &serde_json::Value) {
         .and_then(|n| n.get("allow_internet_access"))
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
-    println!("Internet:        {}", if internet { "allowed" } else { "blocked" });
+    println!(
+        "Internet:        {}",
+        if internet { "allowed" } else { "blocked" }
+    );
 
-    println!("Created:         {}", format_created_at(item.get("created_at")));
+    println!(
+        "Created:         {}",
+        format_created_at(item.get("created_at"))
+    );
 
     // Optional fields
     let timeout = item
@@ -183,10 +192,7 @@ fn print_sandbox_details(item: &serde_json::Value) {
             .unwrap_or("");
         println!("Reason:          {}", reason);
 
-        let outcome = item
-            .get("outcome")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let outcome = item.get("outcome").and_then(|v| v.as_str()).unwrap_or("");
         println!("Outcome:         {}", outcome);
     }
 }

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -33,7 +33,11 @@ pub fn sandbox_endpoint(ctx: &CliContext, endpoint: &str) -> String {
             ctx.api_url, ctx.namespace, endpoint
         )
     } else {
-        format!("{}/{}", resolve_sandbox_lifecycle_url(&ctx.api_url), endpoint)
+        format!(
+            "{}/{}",
+            resolve_sandbox_lifecycle_url(&ctx.api_url),
+            endpoint
+        )
     }
 }
 

--- a/crates/cli/src/commands/sbx/ssh.rs
+++ b/crates/cli/src/commands/sbx/ssh.rs
@@ -114,7 +114,9 @@ pub async fn run(
         build_pty_create_payload(shell, shell_args, workdir, &term_val, rows, cols, env_dict)?;
 
     let pty_resp = with_sandbox_headers(
-        client.post(format!("{}/api/v1/pty", proxy_base)).json(&pty_payload),
+        client
+            .post(format!("{}/api/v1/pty", proxy_base))
+            .json(&pty_payload),
         sandbox_id,
         host_override.clone(),
     )

--- a/crates/cli/src/commands/ssh_keys.rs
+++ b/crates/cli/src/commands/ssh_keys.rs
@@ -123,9 +123,8 @@ pub async fn remove(ctx: &CliContext, key_ids: &[String]) -> Result<()> {
 
     let mut removed = 0_usize;
     for raw in key_ids {
-        let resolved = resolve_key_id(raw, &listing).ok_or_else(|| {
-            CliError::usage(format!("no ssh key matches \"{raw}\""))
-        })?;
+        let resolved = resolve_key_id(raw, &listing)
+            .ok_or_else(|| CliError::usage(format!("no ssh key matches \"{raw}\"")))?;
         let path = format!("{BASE_PATH}/{resolved}");
         let request = client
             .request(Method::DELETE, &path)
@@ -162,9 +161,8 @@ fn resolve_key_id(input: &str, listing: &[ApiSshKey]) -> Option<String> {
 fn read_public_key(arg: &str) -> Result<String> {
     let path = std::path::Path::new(arg);
     if path.is_file() {
-        std::fs::read_to_string(path).map_err(|e| {
-            CliError::usage(format!("failed to read {}: {e}", path.display()))
-        })
+        std::fs::read_to_string(path)
+            .map_err(|e| CliError::usage(format!("failed to read {}: {e}", path.display())))
     } else {
         Ok(arg.to_string())
     }
@@ -185,12 +183,10 @@ fn http_client(ctx: &CliContext) -> Result<Client> {
 
 fn map_sdk_error(error: SdkError) -> CliError {
     match error {
-        SdkError::Authentication(_) => {
-            CliError::auth("authentication failed; run 'tl login'")
+        SdkError::Authentication(_) => CliError::auth("authentication failed; run 'tl login'"),
+        SdkError::Authorization(_) => {
+            CliError::auth("permission denied; run 'tl login' or check your account permissions")
         }
-        SdkError::Authorization(_) => CliError::auth(
-            "permission denied; run 'tl login' or check your account permissions",
-        ),
         SdkError::ServerError { status, message } => {
             let code = status.as_u16();
             if (400..500).contains(&code) {
@@ -248,14 +244,23 @@ mod tests {
 
     #[test]
     fn resolve_id_matches_exact_id_first() {
-        let listing = vec![mk("ssh_key_aaa", "laptop"), mk("ssh_key_bbb", "ssh_key_aaa")];
-        assert_eq!(resolve_key_id("ssh_key_aaa", &listing).as_deref(), Some("ssh_key_aaa"));
+        let listing = vec![
+            mk("ssh_key_aaa", "laptop"),
+            mk("ssh_key_bbb", "ssh_key_aaa"),
+        ];
+        assert_eq!(
+            resolve_key_id("ssh_key_aaa", &listing).as_deref(),
+            Some("ssh_key_aaa")
+        );
     }
 
     #[test]
     fn resolve_id_matches_unique_name() {
         let listing = vec![mk("ssh_key_aaa", "laptop"), mk("ssh_key_bbb", "desktop")];
-        assert_eq!(resolve_key_id("desktop", &listing).as_deref(), Some("ssh_key_bbb"));
+        assert_eq!(
+            resolve_key_id("desktop", &listing).as_deref(),
+            Some("ssh_key_bbb")
+        );
     }
 
     #[test]

--- a/crates/cli/src/commands/whoami.rs
+++ b/crates/cli/src/commands/whoami.rs
@@ -97,7 +97,10 @@ pub async fn run(ctx: &mut CliContext, output_json: bool) -> Result<()> {
     println!("Endpoints");
     println!("  Dashboard   : {}", ctx.cloud_url);
     println!("  Cloud API   : {}", ctx.api_url);
-    println!("  Sandbox API : {}", resolve_sandbox_lifecycle_url(&ctx.api_url));
+    println!(
+        "  Sandbox API : {}",
+        resolve_sandbox_lifecycle_url(&ctx.api_url)
+    );
 
     if has_api_key || has_pat {
         println!();

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -153,7 +153,10 @@ impl Sdk {
         let client = ClientBuilder::new(base_url)
             .bearer_token(bearer_token)
             .build()?;
-        Ok(Self { client, api_url: base_url.to_string() })
+        Ok(Self {
+            client,
+            api_url: base_url.to_string(),
+        })
     }
 
     /// Create a new SDK instance using a client builder.
@@ -270,7 +273,9 @@ impl Sdk {
     /// * `use_namespaced_endpoints` - If true, use `/v1/namespaces/{namespace}/...`
     ///   paths. If false, use cloud-style top-level paths such as `/sandboxes`.
     pub fn sandboxes(&self, namespace: &str, use_namespaced_endpoints: bool) -> SandboxesClient {
-        let lifecycle_client = self.client.with_base_url(&resolve_sandbox_lifecycle_url(&self.api_url));
+        let lifecycle_client = self
+            .client
+            .with_base_url(&resolve_sandbox_lifecycle_url(&self.api_url));
         SandboxesClient::new(
             lifecycle_client,
             namespace.to_string(),

--- a/crates/cloud-sdk/src/sandboxes/desktop.rs
+++ b/crates/cloud-sdk/src/sandboxes/desktop.rs
@@ -15,8 +15,8 @@ use tokio_tungstenite::tungstenite::{self, Message, client::IntoClientRequest};
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 use url::Url;
 
-use crate::{Client, error::SdkError};
 use super::{SandboxProxyClient, models::RunProcessEvent};
+use crate::{Client, error::SdkError};
 
 /// How long each individual `bash`-builtin port probe is allowed to run inside
 /// the sandbox before the daemon kills it. Two seconds comfortably covers a
@@ -220,8 +220,11 @@ impl TunnelConnection {
         remote_port: u16,
     ) -> Result<Self, SdkError> {
         let ws_url = build_tunnel_url(client.base_url(), remote_port)?;
-        let headers =
-            build_tunnel_headers(client.default_headers(), host_override.as_deref(), sandbox_id)?;
+        let headers = build_tunnel_headers(
+            client.default_headers(),
+            host_override.as_deref(),
+            sandbox_id,
+        )?;
 
         let mut request = ws_url.into_client_request().map_err(|error| {
             SdkError::ClientError(format!("failed to build tunnel request: {error}"))

--- a/crates/cloud-sdk/src/sandboxes/desktop.rs
+++ b/crates/cloud-sdk/src/sandboxes/desktop.rs
@@ -4,11 +4,9 @@ use std::time::Duration;
 
 use des::Des;
 use des::cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray};
-use eventsource_stream::Eventsource;
 use futures::{SinkExt, StreamExt};
 use png::{BitDepth, ColorType};
-use reqwest::Method;
-use reqwest::header::{ACCEPT, HOST, HeaderMap};
+use reqwest::header::{HOST, HeaderMap};
 use serde_json::json;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
@@ -18,6 +16,7 @@ use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 use url::Url;
 
 use crate::{Client, error::SdkError};
+use super::{SandboxProxyClient, models::RunProcessEvent};
 
 /// How long each individual `bash`-builtin port probe is allowed to run inside
 /// the sandbox before the daemon kills it. Two seconds comfortably covers a
@@ -47,9 +46,7 @@ pub struct SandboxDesktopClient {
 
 impl SandboxDesktopClient {
     pub async fn connect(
-        client: Client,
-        host_override: Option<String>,
-        sandbox_id: Option<String>,
+        proxy_client: SandboxProxyClient,
         port: u16,
         password: Option<String>,
         shared: bool,
@@ -64,7 +61,11 @@ impl SandboxDesktopClient {
         // `connect_timeout` along with the WS handshake and VNC negotiation
         // that follow — total wall-clock is what the caller asked for.
         let session = timeout(connect_timeout, async move {
-            wait_for_port_ready(&client, port).await?;
+            wait_for_port_ready(&proxy_client, port).await?;
+            // Extract routing context before consuming proxy_client into the tunnel.
+            let host_override = proxy_client.host_override().map(str::to_string);
+            let sandbox_id = proxy_client.sandbox_id().map(str::to_string);
+            let client = proxy_client.http_client().clone();
             let transport =
                 TunnelConnection::connect(client, host_override, sandbox_id.as_deref(), port)
                     .await?;
@@ -178,55 +179,31 @@ impl SandboxDesktopClient {
 ///
 /// Loops forever; the caller is expected to wrap this in an outer
 /// `tokio::time::timeout` (see [`SandboxDesktopClient::connect`]). Treats
-/// transient errors (e.g. SSE stream hiccups) as "not ready yet" and retries;
-/// only persistent SDK errors that bubble out of the underlying request will
-/// surface here.
-async fn wait_for_port_ready(client: &Client, port: u16) -> Result<(), SdkError> {
+/// transient errors (e.g. SSE stream hiccups) as "not ready yet" and retries.
+async fn wait_for_port_ready(proxy_client: &SandboxProxyClient, port: u16) -> Result<(), SdkError> {
     loop {
-        match probe_port_once(client, port).await {
+        match probe_port_once(proxy_client, port).await {
             Ok(true) => return Ok(()),
             Ok(false) | Err(_) => sleep(PORT_PROBE_RETRY_INTERVAL).await,
         }
     }
 }
 
-/// One probe attempt. Returns `Ok(true)` if `bash`'s `/dev/tcp` connect
-/// succeeded (exit 0), `Ok(false)` otherwise. Errors are returned for
-/// non-process-level failures (transport, JSON shape) so the caller can decide
-/// whether to retry.
-async fn probe_port_once(client: &Client, port: u16) -> Result<bool, SdkError> {
+/// One probe attempt. Returns `Ok(true)` if bash's `/dev/tcp` connect succeeded
+/// (exit 0), `Ok(false)` otherwise. Uses `SandboxProxyClient::run_process` so
+/// sandbox routing headers are applied automatically.
+async fn probe_port_once(proxy_client: &SandboxProxyClient, port: u16) -> Result<bool, SdkError> {
     let payload = json!({
         "command": "/bin/bash",
         "args": ["-c", format!("exec 3<>/dev/tcp/127.0.0.1/{port}")],
         "timeout_secs": PORT_PROBE_PROCESS_TIMEOUT_SECS,
     });
-    let req = client
-        .request(Method::POST, "/api/v1/processes/run")
-        .header(ACCEPT, "text/event-stream")
-        .json(&payload)
-        .build()?;
-    let response = client.execute(req).await?;
-    let mut stream = response.bytes_stream().eventsource();
-    while let Some(event) = stream.next().await {
-        let msg = match event {
-            Ok(m) => m,
-            // Mid-stream transport errors should not be fatal — treat as
-            // "not ready, try again".
-            Err(_) => return Ok(false),
-        };
-        let parsed: serde_json::Value = match serde_json::from_str(&msg.data) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        if let Some(exit_code) = parsed.get("exit_code").and_then(|v| v.as_i64()) {
-            return Ok(exit_code == 0);
-        }
-        if parsed.get("signal").is_some() {
-            // Killed by signal (e.g. SIGTERM from timeout) — treat as not ready.
-            return Ok(false);
+    let events = proxy_client.run_process(&payload).await?.into_inner();
+    for event in events {
+        if let RunProcessEvent::Exited { exit_code, .. } = event {
+            return Ok(exit_code == Some(0));
         }
     }
-    // Stream ended without an Exited event — daemon hiccup, retry.
     Ok(false)
 }
 

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -235,6 +235,18 @@ impl SandboxProxyClient {
         self
     }
 
+    pub fn http_client(&self) -> &Client {
+        &self.client
+    }
+
+    pub fn host_override(&self) -> Option<&str> {
+        self.host_override.as_deref()
+    }
+
+    pub fn sandbox_id(&self) -> Option<&str> {
+        self.sandbox_id.as_deref()
+    }
+
     fn request(&self, method: Method, path: &str) -> reqwest_middleware::RequestBuilder {
         let mut request_builder = self.client.request(method, path);
         if let Some(host) = self.host_override.as_deref() {

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.8"
+version = "0.5.9"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -1849,12 +1849,12 @@ impl CloudSandboxDesktopClient {
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;
+        let proxy_client = SandboxProxyClient::new(client, host_override)
+            .with_sandbox_id(sandbox_id_header);
         let connect_timeout = duration_from_seconds("connect_timeout_sec", connect_timeout_sec)?;
         let desktop_client = shared_runtime()
             .block_on(RustSandboxDesktopClient::connect(
-                client,
-                host_override,
-                sandbox_id_header,
+                proxy_client,
                 port,
                 password,
                 shared,

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -13,15 +13,14 @@ use futures::StreamExt;
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
+use pyo3_async_runtimes::tokio::future_into_py;
 use reqwest::Method;
 use reqwest::multipart::{Form, Part};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tensorlake::document_ai::DocumentAiClient;
 use tensorlake::images::ImagesClient;
-use tensorlake::images::models::{
-    ApplicationBuildContext, CreateApplicationBuildRequest,
-};
+use tensorlake::images::models::{ApplicationBuildContext, CreateApplicationBuildRequest};
 use tensorlake::sandboxes::models::{
     CreateSandboxRequest, SandboxPoolRequest, SnapshotType, UpdateSandboxRequest,
 };
@@ -30,7 +29,6 @@ use tensorlake::sandboxes::{
 };
 use tensorlake::{Client, ClientBuilder, error::SdkError};
 use tokio::runtime::Runtime;
-use pyo3_async_runtimes::tokio::future_into_py;
 
 create_exception!(_cloud_sdk, CloudApiClientError, PyException);
 create_exception!(_cloud_sdk, CloudSandboxClientError, PyException);
@@ -980,11 +978,10 @@ impl CloudSandboxClient {
     fn list_snapshots_json_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move {
-                c.list_snapshots().await
-            })
-            .await
-            .map_err(into_sandbox_py_error)?;
+            let traced =
+                retry_async_op(client, 5, move |c| async move { c.list_snapshots().await })
+                    .await
+                    .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let response = serde_json::json!({ "snapshots": *traced });
             let json = serde_json::to_string(&response).map_err(sandbox_serde_err)?;
@@ -1051,11 +1048,9 @@ impl CloudSandboxClient {
     fn list_pools_json_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move {
-                c.list_pools().await
-            })
-            .await
-            .map_err(into_sandbox_py_error)?;
+            let traced = retry_async_op(client, 5, move |c| async move { c.list_pools().await })
+                .await
+                .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let response = serde_json::json!({ "pools": *traced });
             let json = serde_json::to_string(&response).map_err(sandbox_serde_err)?;
@@ -1453,11 +1448,10 @@ impl CloudSandboxProxyClient {
     fn list_processes_json_async<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move {
-                c.list_processes().await
-            })
-            .await
-            .map_err(into_sandbox_py_error)?;
+            let traced =
+                retry_async_op(client, 5, move |c| async move { c.list_processes().await })
+                    .await
+                    .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let processes = traced.into_inner();
             let response = serde_json::json!({ "processes": processes });
@@ -1473,11 +1467,10 @@ impl CloudSandboxProxyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move {
-                c.get_process(pid).await
-            })
-            .await
-            .map_err(into_sandbox_py_error)?;
+            let traced =
+                retry_async_op(client, 5, move |c| async move { c.get_process(pid).await })
+                    .await
+                    .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
@@ -1545,54 +1538,36 @@ impl CloudSandboxProxyClient {
         })
     }
 
-    fn get_stdout_json_async<'py>(
-        &self,
-        py: Python<'py>,
-        pid: i64,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn get_stdout_json_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move {
-                c.get_stdout(pid).await
-            })
-            .await
-            .map_err(into_sandbox_py_error)?;
+            let traced = retry_async_op(client, 5, move |c| async move { c.get_stdout(pid).await })
+                .await
+                .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
         })
     }
 
-    fn get_stderr_json_async<'py>(
-        &self,
-        py: Python<'py>,
-        pid: i64,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn get_stderr_json_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move {
-                c.get_stderr(pid).await
-            })
-            .await
-            .map_err(into_sandbox_py_error)?;
+            let traced = retry_async_op(client, 5, move |c| async move { c.get_stderr(pid).await })
+                .await
+                .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
         })
     }
 
-    fn get_output_json_async<'py>(
-        &self,
-        py: Python<'py>,
-        pid: i64,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn get_output_json_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move {
-                c.get_output(pid).await
-            })
-            .await
-            .map_err(into_sandbox_py_error)?;
+            let traced = retry_async_op(client, 5, move |c| async move { c.get_output(pid).await })
+                .await
+                .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
@@ -1606,9 +1581,11 @@ impl CloudSandboxProxyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 10, move |c| async move {
-                c.follow_stdout(pid).await
-            })
+            let traced = retry_async_op(
+                client,
+                10,
+                move |c| async move { c.follow_stdout(pid).await },
+            )
             .await
             .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
@@ -1628,9 +1605,11 @@ impl CloudSandboxProxyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 10, move |c| async move {
-                c.follow_stderr(pid).await
-            })
+            let traced = retry_async_op(
+                client,
+                10,
+                move |c| async move { c.follow_stderr(pid).await },
+            )
             .await
             .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
@@ -1650,9 +1629,11 @@ impl CloudSandboxProxyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 10, move |c| async move {
-                c.follow_output(pid).await
-            })
+            let traced = retry_async_op(
+                client,
+                10,
+                move |c| async move { c.follow_output(pid).await },
+            )
             .await
             .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
@@ -1704,11 +1685,7 @@ impl CloudSandboxProxyClient {
         })
     }
 
-    fn delete_file_async<'py>(
-        &self,
-        py: Python<'py>,
-        path: String,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn delete_file_async<'py>(&self, py: Python<'py>, path: String) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
             let trace_id = retry_async_op(client, 5, move |c| {
@@ -1849,8 +1826,8 @@ impl CloudSandboxDesktopClient {
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;
-        let proxy_client = SandboxProxyClient::new(client, host_override)
-            .with_sandbox_id(sandbox_id_header);
+        let proxy_client =
+            SandboxProxyClient::new(client, host_override).with_sandbox_id(sandbox_id_header);
         let connect_timeout = duration_from_seconds("connect_timeout_sec", connect_timeout_sec)?;
         let desktop_client = shared_runtime()
             .block_on(RustSandboxDesktopClient::connect(
@@ -2138,11 +2115,7 @@ impl CloudDocumentAIClient {
     }
 }
 
-async fn retry_async_op<C, T, F, Fut>(
-    client: C,
-    max_retries: usize,
-    op: F,
-) -> Result<T, SdkError>
+async fn retry_async_op<C, T, F, Fut>(client: C, max_retries: usize, op: F) -> Result<T, SdkError>
 where
     C: Clone,
     F: Fn(C) -> Fut,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.8"
+version = "0.5.9"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

PR #669 introduced a port-readiness probe that ran `bash`'s `/dev/tcp` trick via `POST /api/v1/processes/run`, but sent the request through the raw `Client` without the `Host` and `X-Tensorlake-Sandbox-Id` routing headers the dataplane requires to reach the correct sandbox. Every probe got a non-SSE error response, fell through to `Ok(false)`, and looped until `connect_timeout` fired — causing `connectDesktop` to **always** time out after #669.

## Root cause

```rust
// Before: raw client, no routing headers → dataplane can't identify the sandbox
let req = client
    .request(Method::POST, "/api/v1/processes/run")
    .header(ACCEPT, "text/event-stream")
    .json(&payload)
    .build()?;
```

`TunnelConnection::connect` correctly added `Host` and `X-Tensorlake-Sandbox-Id` via `build_tunnel_headers`, but `probe_port_once` bypassed all of that.

## Fix

`SandboxDesktopClient::connect` now accepts `SandboxProxyClient` instead of `Client + host_override + sandbox_id`. The probe calls `proxy_client.run_process()`, which applies routing headers automatically via `SandboxProxyClient::request()` and reuses the existing `RunProcessEvent` SSE parsing already used everywhere else.

- **`sandboxes/mod.rs`** — add `http_client()`, `host_override()`, `sandbox_id()` getters to `SandboxProxyClient`
- **`sandboxes/desktop.rs`** — accept `SandboxProxyClient`; probe uses `run_process()` (30 lines → 5); routing is structurally enforced — future HTTP calls in desktop.rs can't accidentally omit it
- **`rust-cloud-sdk-py/src/lib.rs`** — construct `SandboxProxyClient` in `CloudSandboxDesktopClient::new` and pass it through

## Test plan

- [x] `cargo build -p tensorlake`: clean
- [x] `cargo check -p tensorlake-rust-cloud-sdk-py`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)