### PR TITLE
Propagate snapshot format when registering sandbox images

### DIFF
--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -53,6 +53,7 @@ struct SnapshotRegistrationMetadata {
     snapshot_id: String,
     sandbox_id: String,
     snapshot_uri: String,
+    snapshot_format_version: Option<String>,
     snapshot_size_bytes: u64,
     rootfs_disk_bytes: u64,
 }
@@ -122,6 +123,7 @@ pub async fn run(
                 snapshot_id: snapshot.snapshot_id.clone(),
                 snapshot_sandbox_id: snapshot.sandbox_id.clone(),
                 snapshot_uri: snapshot.snapshot_uri.clone(),
+                snapshot_format_version: snapshot.snapshot_format_version.clone(),
                 snapshot_size_bytes: snapshot.snapshot_size_bytes,
                 rootfs_disk_bytes: snapshot.rootfs_disk_bytes,
                 public: is_public,
@@ -255,6 +257,7 @@ fn parse_completed_snapshot(info: &SnapshotInfo) -> Result<SnapshotRegistrationM
         snapshot_id: info.snapshot_id.clone(),
         sandbox_id: info.sandbox_id.clone(),
         snapshot_uri,
+        snapshot_format_version: info.snapshot_format_version.clone(),
         snapshot_size_bytes,
         rootfs_disk_bytes,
     })
@@ -1184,6 +1187,7 @@ mod tests {
                     status: "pending".to_string(),
                     error: None,
                     snapshot_uri: None,
+                    snapshot_format_version: None,
                     size_bytes: None,
                     rootfs_disk_bytes: None,
                     snapshot_type: None,

--- a/crates/cli/src/commands/sbx/image/register.rs
+++ b/crates/cli/src/commands/sbx/image/register.rs
@@ -7,6 +7,7 @@ use tensorlake::sandbox_templates::models::CreateSandboxTemplateRequest;
 struct SnapshotRegistrationMetadata {
     sandbox_id: String,
     snapshot_uri: String,
+    snapshot_format_version: Option<String>,
     snapshot_size_bytes: u64,
     rootfs_disk_bytes: u64,
 }
@@ -80,9 +81,17 @@ fn parse_snapshot_registration_metadata(
             ))
         })?;
 
+    let snapshot_format_version = info
+        .get("snapshot_format_version")
+        .or_else(|| info.get("snapshotFormatVersion"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+
     Ok(SnapshotRegistrationMetadata {
         sandbox_id,
         snapshot_uri,
+        snapshot_format_version,
         snapshot_size_bytes,
         rootfs_disk_bytes,
     })
@@ -110,6 +119,7 @@ pub async fn run(
             snapshot_id: snapshot_id.to_string(),
             snapshot_sandbox_id: snapshot.sandbox_id.clone(),
             snapshot_uri: snapshot.snapshot_uri.clone(),
+            snapshot_format_version: snapshot.snapshot_format_version.clone(),
             snapshot_size_bytes: snapshot.snapshot_size_bytes,
             rootfs_disk_bytes: snapshot.rootfs_disk_bytes,
             public: is_public,
@@ -146,6 +156,7 @@ mod tests {
                 "status": "in_progress",
                 "sandbox_id": "sbx-1",
                 "snapshot_uri": "s3://snapshots/snap-1.tar.zst",
+                "snapshot_format_version": "durable_archive_v1",
                 "size_bytes": 123,
                 "rootfs_disk_bytes": 10 * 1024 * 1024 * 1024_u64,
             }),
@@ -166,6 +177,7 @@ mod tests {
                 "status": "completed",
                 "sandbox_id": "sbx-1",
                 "snapshot_uri": "s3://snapshots/snap-1.tar.zst",
+                "snapshot_format_version": "durable_archive_v1",
                 "size_bytes": 123,
                 "rootfs_disk_bytes": 10 * 1024 * 1024 * 1024_u64,
             }),
@@ -174,6 +186,10 @@ mod tests {
 
         assert_eq!(metadata.sandbox_id, "sbx-1");
         assert_eq!(metadata.snapshot_uri, "s3://snapshots/snap-1.tar.zst");
+        assert_eq!(
+            metadata.snapshot_format_version.as_deref(),
+            Some("durable_archive_v1")
+        );
         assert_eq!(metadata.snapshot_size_bytes, 123);
         assert_eq!(metadata.rootfs_disk_bytes, 10 * 1024 * 1024 * 1024_u64);
     }

--- a/crates/cloud-sdk/src/sandbox_templates/models.rs
+++ b/crates/cloud-sdk/src/sandbox_templates/models.rs
@@ -8,6 +8,8 @@ pub struct CreateSandboxTemplateRequest {
     pub snapshot_id: String,
     pub snapshot_sandbox_id: String,
     pub snapshot_uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_format_version: Option<String>,
     pub snapshot_size_bytes: u64,
     pub rootfs_disk_bytes: u64,
     pub public: bool,
@@ -26,6 +28,8 @@ pub struct SandboxTemplate {
     pub snapshot_sandbox_id: Option<String>,
     #[serde(default)]
     pub snapshot_uri: Option<String>,
+    #[serde(default)]
+    pub snapshot_format_version: Option<String>,
     #[serde(default)]
     pub snapshot_size_bytes: Option<u64>,
     #[serde(default)]
@@ -46,6 +50,7 @@ mod tests {
             snapshot_id: "snap-1".to_string(),
             snapshot_sandbox_id: "sbx-1".to_string(),
             snapshot_uri: "s3://snapshots/snap-1".to_string(),
+            snapshot_format_version: Some("durable_archive_v1".to_string()),
             snapshot_size_bytes: 123,
             rootfs_disk_bytes: 456,
             public: true,
@@ -54,7 +59,7 @@ mod tests {
         let json = serde_json::to_string(&request).unwrap();
         assert_eq!(
             json,
-            r#"{"name":"image1","dockerfile":"FROM ubuntu:24.04\n","snapshotId":"snap-1","snapshotSandboxId":"sbx-1","snapshotUri":"s3://snapshots/snap-1","snapshotSizeBytes":123,"rootfsDiskBytes":456,"public":true}"#
+            r#"{"name":"image1","dockerfile":"FROM ubuntu:24.04\n","snapshotId":"snap-1","snapshotSandboxId":"sbx-1","snapshotUri":"s3://snapshots/snap-1","snapshotFormatVersion":"durable_archive_v1","snapshotSizeBytes":123,"rootfsDiskBytes":456,"public":true}"#
         );
     }
 }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -215,6 +215,8 @@ pub struct SnapshotInfo {
     #[serde(default)]
     pub snapshot_uri: Option<String>,
     #[serde(default)]
+    pub snapshot_format_version: Option<String>,
+    #[serde(default)]
     pub size_bytes: Option<i64>,
     #[serde(default)]
     pub rootfs_disk_bytes: Option<u64>,

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -692,6 +692,7 @@ def _register_image(
     snapshot_size_bytes: int,
     rootfs_disk_bytes: int,
     is_public: bool = False,
+    snapshot_format_version: str | None = None,
 ) -> dict:
     """POST to Platform API through the ingress to register the image."""
     org_id = ctx.organization_id
@@ -722,6 +723,8 @@ def _register_image(
         "rootfsDiskBytes": rootfs_disk_bytes,
         "public": is_public,
     }
+    if snapshot_format_version:
+        body["snapshotFormatVersion"] = snapshot_format_version
     resp = httpx.post(url, json=body, headers=inject_traceparent(headers), timeout=30.0)
     resp.raise_for_status()
     return resp.json()
@@ -806,6 +809,7 @@ def _run_plan(
             snapshot.size_bytes,
             snapshot.rootfs_disk_bytes,
             is_public,
+            getattr(snapshot, "snapshot_format_version", None),
         )
         emit(
             {

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -295,6 +295,7 @@ class SnapshotInfo(BaseModel):
     snapshot_type: SnapshotType | None = None
     error: str | None = None
     snapshot_uri: str | None = None
+    snapshot_format_version: str | None = None
     size_bytes: int | None = None
     rootfs_disk_bytes: int | None = None
     created_at: OptionalTimestamp = None

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -93,6 +93,7 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             snapshot_id="snap-1",
             sandbox_id="sbx-1",
             snapshot_uri="s3://snapshots/snap-1.tar.zst",
+            snapshot_format_version="durable_archive_v1",
             size_bytes=1234,
             rootfs_disk_bytes=25 * 1024 * 1024 * 1024,
         )
@@ -144,6 +145,7 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             1234,
             25 * 1024 * 1024 * 1024,
             False,
+            "durable_archive_v1",
         )
         sandbox.terminate.assert_called_once_with()
         # Regression: sandbox image builds MUST request a filesystem-only
@@ -163,6 +165,7 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             snapshot_id="snap-1",
             sandbox_id="sbx-1",
             snapshot_uri="s3://snapshots/snap-1.tar.zst",
+            snapshot_format_version="durable_archive_v1",
             size_bytes=1234,
             rootfs_disk_bytes=25 * 1024 * 1024 * 1024,
         )
@@ -206,6 +209,7 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             1234,
             25 * 1024 * 1024 * 1024,
             True,
+            "durable_archive_v1",
         )
 
     def test_load_errors_raise_SandboxImageLoadError(self):
@@ -222,6 +226,7 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
             snapshot_id="snap-1",
             sandbox_id="sbx-1",
             snapshot_uri="s3://snapshots/snap-1.tar.zst",
+            snapshot_format_version="durable_archive_v1",
             size_bytes=1234,
             rootfs_disk_bytes=25 * 1024 * 1024 * 1024,
         )

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -156,6 +156,7 @@ export interface SnapshotInfo {
   snapshotType?: SnapshotType;
   error?: string;
   snapshotUri?: string;
+  snapshotFormatVersion?: string;
   sizeBytes?: number;
   rootfsDiskBytes?: number;
   createdAt?: Date;

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -127,6 +127,7 @@ interface CreateSandboxImageDeps {
     snapshotSizeBytes: number,
     rootfsDiskBytes: number,
     isPublic: boolean,
+    snapshotFormatVersion?: string,
   ) => Promise<Record<string, unknown>>;
   sleep?: (ms: number) => Promise<void>;
 }
@@ -927,6 +928,7 @@ async function registerImage(
   snapshotSizeBytes: number,
   rootfsDiskBytes: number,
   isPublic: boolean,
+  snapshotFormatVersion?: string,
 ): Promise<Record<string, unknown>> {
   if (!context.organizationId || !context.projectId) {
     throw new Error(
@@ -963,6 +965,7 @@ async function registerImage(
       snapshotId,
       snapshotSandboxId,
       snapshotUri,
+      ...(snapshotFormatVersion ? { snapshotFormatVersion } : {}),
       snapshotSizeBytes,
       rootfsDiskBytes,
       public: isPublic,
@@ -1063,6 +1066,7 @@ export async function createSandboxImage(
       snapshot.sizeBytes,
       snapshot.rootfsDiskBytes,
       options.isPublic ?? false,
+      snapshot.snapshotFormatVersion,
     );
 
     emit({

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -185,6 +185,7 @@ describe("sandbox image helpers", () => {
         snapshotId: "snap-1",
         sandboxId: "sbx-source-1",
         snapshotUri: "s3://snapshots/snap-1.tar.zst",
+        snapshotFormatVersion: "durable_archive_v1",
         sizeBytes: 123,
         rootfsDiskBytes: 10 * 1024 * 1024 * 1024,
       })),
@@ -228,6 +229,7 @@ describe("sandbox image helpers", () => {
       123,
       10 * 1024 * 1024 * 1024,
       false,
+      "durable_archive_v1",
     );
     expect(sandbox.terminate).toHaveBeenCalled();
     expect(writeFileMock).toHaveBeenCalled();
@@ -279,6 +281,7 @@ describe("sandbox image helpers", () => {
         snapshotId: "snap-1",
         sandboxId: "sbx-source-1",
         snapshotUri: "s3://snapshots/snap-1.tar.zst",
+        snapshotFormatVersion: "durable_archive_v1",
         sizeBytes: 123,
         rootfsDiskBytes: 10 * 1024 * 1024 * 1024,
       })),
@@ -329,6 +332,7 @@ describe("sandbox image helpers", () => {
       123,
       10 * 1024 * 1024 * 1024,
       false,
+      "durable_archive_v1",
     );
     expect(sandbox.terminate).toHaveBeenCalled();
   });
@@ -371,6 +375,7 @@ describe("sandbox image helpers", () => {
         snapshotId: "snap-1",
         sandboxId: "sbx-source-1",
         snapshotUri: "s3://snapshots/snap-1.tar.zst",
+        snapshotFormatVersion: "durable_archive_v1",
         sizeBytes: 123,
         rootfsDiskBytes: 10 * 1024 * 1024 * 1024,
       })),
@@ -436,6 +441,7 @@ describe("sandbox image helpers", () => {
         snapshotId: "snap-1",
         sandboxId: "sbx-source-1",
         snapshotUri: "s3://snapshots/snap-1.tar.zst",
+        snapshotFormatVersion: "durable_archive_v1",
         sizeBytes: 123,
         rootfsDiskBytes: 10 * 1024 * 1024 * 1024,
       })),
@@ -476,6 +482,7 @@ describe("sandbox image helpers", () => {
       123,
       10 * 1024 * 1024 * 1024,
       false,
+      "durable_archive_v1",
     );
   });
 


### PR DESCRIPTION
## Summary
- add snapshot format version to Rust/Python/TypeScript snapshot models
- pass snapshot format through sandbox image registration requests
- update CLI and SDK tests for the new Platform API field

## Related
- Requires/aligns with tensorlakeai/platform-api#493
- Aligns sandbox image registration with Indexify snapshot format metadata so rootfs-base snapshots are not registered as unknown-format snapshots.

## Validation
- PYTHONPATH=src poetry run python -m unittest tests.image.test_sandbox_builder
- cargo test -p tensorlake-cli sbx::image
- cargo test --workspace
- npm exec --package node@22 -- node node_modules/vitest/vitest.mjs run tests/sandbox-image.test.ts
- npm exec --package node@22 -- node node_modules/typescript/bin/tsc --noEmit
- cargo fmt --all -- --check
- PYTHONPATH=src poetry run black --check src/tensorlake tests/image/test_sandbox_builder.py --extend-exclude vendor
- PYTHONPATH=src poetry run isort --check src/tensorlake tests/image/test_sandbox_builder.py --profile black --extend-skip vendor

Note: local system node is v18, so TypeScript validation was run under Node 22 to match CI.