### PR TITLE
Run offline rootfs builder for sandbox images

### DIFF
--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -4,11 +4,15 @@ use std::{
     time::Duration,
 };
 
+use serde::Deserialize;
 use serde_json::{Map, Value};
 use shlex::split as shlex_split;
 use tensorlake::{
     Client,
-    sandbox_templates::models::CreateSandboxTemplateRequest,
+    sandbox_templates::models::{
+        CompleteSandboxTemplateBuildRequest, CreateSandboxTemplateRequest,
+        PrepareSandboxTemplateBuildRequest, RootfsNodeKind, SandboxTemplateBuildPrepared,
+    },
     sandboxes::{
         SandboxProxyClient, SandboxesClient,
         models::{
@@ -26,6 +30,13 @@ use crate::{
 const BUILD_SANDBOX_PIP_ENV: &[(&str, &str)] = &[("PIP_BREAK_SYSTEM_PACKAGES", "1")];
 const DEFAULT_CPUS: f64 = 2.0;
 const DEFAULT_MEMORY_MB: i64 = 4096;
+const REMOTE_BUILD_SCRATCH_DIR: &str = "/tmp/tl-rootfs-build";
+const REMOTE_BUILD_SPEC_PATH: &str = "/tmp/tl-rootfs-build/build-spec.json";
+const REMOTE_BUILD_METADATA_PATH: &str = "/tmp/tl-rootfs-build/metadata.json";
+const REMOTE_BUILD_CONTEXT_DIR: &str = "/tmp/tl-rootfs-build/context";
+const REMOTE_ROOTFS_PATH: &str = "/dev/vda";
+const REMOTE_PARENT_ROOTFS_PATH: &str = "/tmp/tl-rootfs-build/parent-rootfs.img";
+const LEGACY_IMAGE_BUILD_ENV: &str = "TENSORLAKE_ENABLE_LEGACY_IMAGE_BUILD";
 const SNAPSHOT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const SNAPSHOT_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(300);
@@ -58,6 +69,18 @@ struct SnapshotRegistrationMetadata {
     rootfs_disk_bytes: u64,
 }
 
+#[derive(Debug, Deserialize)]
+struct RootfsBuildMetadata {
+    snapshot_id: String,
+    snapshot_uri: String,
+    snapshot_format_version: String,
+    rootfs_node_kind: RootfsNodeKind,
+    snapshot_size_bytes: u64,
+    rootfs_disk_bytes: u64,
+    #[serde(default)]
+    parent_manifest_uri: Option<String>,
+}
+
 pub async fn run(
     ctx: &CliContext,
     dockerfile_path: &str,
@@ -71,6 +94,152 @@ pub async fn run(
     let plan = load_dockerfile_plan(dockerfile_path, registered_name)?;
     eprintln!("⚙️  Selected image name: {}", plan.registered_name);
 
+    match run_offline_rootfs_builder(ctx, &plan, disk_mb, cpus, memory_mb, is_public).await {
+        Ok(()) => return Ok(()),
+        Err(error) if legacy_image_build_enabled() => {
+            eprintln!(
+                "⚠️  Offline rootfs builder failed; falling back to legacy filesystem snapshot flow because {LEGACY_IMAGE_BUILD_ENV}=1: {error}"
+            );
+        }
+        Err(error) => {
+            return Err(CliError::Other(anyhow::anyhow!(
+                "offline rootfs builder flow failed and legacy runtime snapshot image registration is disabled: {error}"
+            )));
+        }
+    }
+
+    run_legacy_filesystem_builder(ctx, &plan, disk_mb, cpus, memory_mb, is_public).await
+}
+
+async fn run_offline_rootfs_builder(
+    ctx: &CliContext,
+    plan: &DockerfileBuildPlan,
+    _disk_mb: Option<u64>,
+    _cpus: Option<f64>,
+    _memory_mb: Option<i64>,
+    is_public: bool,
+) -> Result<()> {
+    let client = super::sandbox_lifecycle_client(ctx)?;
+    let sandboxes = SandboxesClient::new(client.clone(), ctx.namespace.clone(), is_localhost(ctx));
+    let templates = super::sandbox_templates_client(ctx)?;
+    let prepared = templates
+        .prepare_build(&PrepareSandboxTemplateBuildRequest {
+            name: plan.registered_name.clone(),
+            dockerfile: plan.dockerfile_text.clone(),
+            base_image: Some(plan.base_image.clone()),
+            public: is_public,
+        })
+        .await?
+        .into_inner();
+
+    let resources = CreateSandboxResources {
+        cpus: prepared.builder.cpus,
+        memory_mb: prepared.builder.memory_mb,
+        disk_mb: Some(prepared.builder.disk_mb),
+    };
+
+    eprintln!(
+        "⚙️  Creating rootfs builder sandbox from {}...",
+        prepared.builder.image
+    );
+    let created = sandboxes
+        .create(&CreateSandboxRequest {
+            image: Some(prepared.builder.image.clone()),
+            resources,
+            secret_names: None,
+            timeout_secs: None,
+            entrypoint: None,
+            network: None,
+            snapshot_id: None,
+            name: None,
+        })
+        .await?;
+    let sandbox_id = created.sandbox_id.clone();
+    let routing_hint = created.routing_hint.clone();
+
+    let result = async {
+        wait_for_sandbox_status(
+            ctx,
+            &sandbox_id,
+            &format!("Waiting for rootfs builder sandbox {sandbox_id}"),
+            "running",
+            DEFAULT_SANDBOX_WAIT_TIMEOUT,
+        )
+        .await?;
+        eprintln!("⚙️  Rootfs builder sandbox {sandbox_id} is running");
+
+        let proxy = sandbox_proxy_client(ctx, &client, &sandbox_id, routing_hint)?;
+        upload_build_context(&proxy, &plan.context_dir).await?;
+        if prepared.rootfs_node_kind == RootfsNodeKind::Diff {
+            copy_parent_rootfs_for_diff(&proxy).await?;
+        }
+        execute_dockerfile_plan(&proxy, plan).await?;
+        let build_spec = build_remote_build_spec(&prepared, plan, is_public)?;
+        proxy
+            .write_file(REMOTE_BUILD_SPEC_PATH, build_spec)
+            .await
+            .map_err(CliError::from)?;
+
+        eprintln!("⚙️  Running rootfs builder...");
+        run_streaming_process(
+            &proxy,
+            &prepared.builder.command,
+            vec![
+                "--spec".to_string(),
+                REMOTE_BUILD_SPEC_PATH.to_string(),
+                "--metadata-out".to_string(),
+                REMOTE_BUILD_METADATA_PATH.to_string(),
+            ],
+            None,
+            Some(REMOTE_BUILD_SCRATCH_DIR.to_string()),
+        )
+        .await?;
+
+        let metadata = read_rootfs_build_metadata(&proxy).await?;
+        eprintln!("📸 Snapshot created: {}", metadata.snapshot_id);
+        eprintln!("⚙️  Registering image '{}'...", plan.registered_name);
+        let registered = templates
+            .complete_build(
+                &prepared.build_id,
+                &CompleteSandboxTemplateBuildRequest {
+                    snapshot_id: metadata.snapshot_id.clone(),
+                    snapshot_uri: metadata.snapshot_uri.clone(),
+                    snapshot_format_version: metadata.snapshot_format_version.clone(),
+                    snapshot_size_bytes: metadata.snapshot_size_bytes,
+                    rootfs_disk_bytes: metadata.rootfs_disk_bytes,
+                    rootfs_node_kind: metadata.rootfs_node_kind,
+                    parent_manifest_uri: metadata.parent_manifest_uri.clone(),
+                },
+            )
+            .await?;
+
+        let template_id = registered.id.as_deref().unwrap_or("-");
+        eprintln!(
+            "✅ Image '{}' registered ({})",
+            plan.registered_name, template_id
+        );
+        Ok(())
+    }
+    .await;
+
+    if let Err(error) = sandboxes.delete(&sandbox_id).await {
+        eprintln!(
+            "⚠️  Failed to terminate build sandbox {} during cleanup: {}",
+            sandbox_id, error
+        );
+    }
+
+    result
+}
+
+async fn run_legacy_filesystem_builder(
+    ctx: &CliContext,
+    plan: &DockerfileBuildPlan,
+    disk_mb: Option<u64>,
+    cpus: Option<f64>,
+    memory_mb: Option<i64>,
+    is_public: bool,
+) -> Result<()> {
     let client = super::sandbox_lifecycle_client(ctx)?;
     let sandboxes = SandboxesClient::new(client.clone(), ctx.namespace.clone(), is_localhost(ctx));
     let templates = super::sandbox_templates_client(ctx)?;
@@ -109,7 +278,7 @@ pub async fn run(
         eprintln!("⚙️  Build sandbox {sandbox_id} is running");
 
         let proxy = sandbox_proxy_client(ctx, &client, &sandbox_id, routing_hint)?;
-        execute_dockerfile_plan(&proxy, &plan).await?;
+        execute_dockerfile_plan(&proxy, plan).await?;
 
         eprintln!("⚙️  Creating snapshot...");
         let snapshot = create_snapshot_and_wait(&sandboxes, &sandbox_id).await?;
@@ -147,6 +316,110 @@ pub async fn run(
     }
 
     result
+}
+
+fn legacy_image_build_enabled() -> bool {
+    std::env::var(LEGACY_IMAGE_BUILD_ENV)
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false)
+}
+
+async fn upload_build_context(proxy: &SandboxProxyClient, context_dir: &Path) -> Result<()> {
+    run_streaming_process(
+        proxy,
+        "mkdir",
+        vec!["-p".to_string(), REMOTE_BUILD_CONTEXT_DIR.to_string()],
+        None,
+        None,
+    )
+    .await?;
+
+    for (full_path, relative_path) in collect_dir_files(context_dir, context_dir)? {
+        let remote_path = join_posix(REMOTE_BUILD_CONTEXT_DIR, &relative_path);
+        ensure_remote_parent_dir(proxy, &remote_path, &[]).await?;
+        let content = tokio::fs::read(&full_path).await.map_err(CliError::Io)?;
+        proxy.write_file(&remote_path, content).await?;
+    }
+
+    Ok(())
+}
+
+async fn copy_parent_rootfs_for_diff(proxy: &SandboxProxyClient) -> Result<()> {
+    eprintln!("⚙️  Capturing parent rootfs for offline diff...");
+    run_streaming_process(
+        proxy,
+        "sh",
+        vec![
+            "-c".to_string(),
+            format!(
+                "mkdir -p {scratch} && dd if={rootfs} of={parent} bs=16M conv=sparse status=none && sync",
+                scratch = shell_quote(REMOTE_BUILD_SCRATCH_DIR),
+                rootfs = shell_quote(REMOTE_ROOTFS_PATH),
+                parent = shell_quote(REMOTE_PARENT_ROOTFS_PATH),
+            ),
+        ],
+        None,
+        None,
+    )
+    .await
+}
+
+fn build_remote_build_spec(
+    prepared: &SandboxTemplateBuildPrepared,
+    plan: &DockerfileBuildPlan,
+    is_public: bool,
+) -> Result<Vec<u8>> {
+    let mut spec = serde_json::to_value(prepared)
+        .map_err(|error| CliError::Other(anyhow::anyhow!("failed to encode build spec: {error}")))?
+        .as_object()
+        .cloned()
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "prepared sandbox template build did not encode as an object"
+            ))
+        })?;
+    spec.insert(
+        "name".to_string(),
+        Value::String(plan.registered_name.clone()),
+    );
+    spec.insert(
+        "dockerfile".to_string(),
+        Value::String(plan.dockerfile_text.clone()),
+    );
+    spec.insert(
+        "baseImage".to_string(),
+        Value::String(plan.base_image.clone()),
+    );
+    spec.insert(
+        "contextDir".to_string(),
+        Value::String(REMOTE_BUILD_CONTEXT_DIR.to_string()),
+    );
+    spec.insert(
+        "rootfsPath".to_string(),
+        Value::String(REMOTE_ROOTFS_PATH.to_string()),
+    );
+    if prepared.rootfs_node_kind == RootfsNodeKind::Diff {
+        spec.insert(
+            "parentRootfsPath".to_string(),
+            Value::String(REMOTE_PARENT_ROOTFS_PATH.to_string()),
+        );
+    }
+    spec.insert("isPublic".to_string(), Value::Bool(is_public));
+
+    serde_json::to_vec(&Value::Object(spec)).map_err(|error| {
+        CliError::Other(anyhow::anyhow!("failed to serialize build spec: {error}"))
+    })
+}
+
+async fn read_rootfs_build_metadata(proxy: &SandboxProxyClient) -> Result<RootfsBuildMetadata> {
+    let bytes = proxy.read_file(REMOTE_BUILD_METADATA_PATH).await?;
+    serde_json::from_slice(bytes.as_slice()).map_err(|error| {
+        CliError::Other(anyhow::anyhow!(
+            "failed to parse rootfs builder metadata {}: {}",
+            REMOTE_BUILD_METADATA_PATH,
+            error
+        ))
+    })
 }
 
 fn sandbox_proxy_client(

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -36,6 +36,9 @@ const REMOTE_BUILD_METADATA_PATH: &str = "/tmp/tl-rootfs-build/metadata.json";
 const REMOTE_BUILD_CONTEXT_DIR: &str = "/tmp/tl-rootfs-build/context";
 const REMOTE_ROOTFS_PATH: &str = "/dev/vda";
 const REMOTE_PARENT_ROOTFS_PATH: &str = "/tmp/tl-rootfs-build/parent-rootfs.img";
+const ROOTFS_BUILDER_COMMAND_DIR: &str = "/usr/local/bin";
+const ROOTFS_BUILDER_DEFAULT_COMMAND: &str = "tl-rootfs-build";
+const ROOTFS_BUILDER_PATH: &str = "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const LEGACY_IMAGE_BUILD_ENV: &str = "TENSORLAKE_ENABLE_LEGACY_IMAGE_BUILD";
 const SNAPSHOT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const SNAPSHOT_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
@@ -181,16 +184,18 @@ async fn run_offline_rootfs_builder(
             .map_err(CliError::from)?;
 
         eprintln!("⚙️  Running rootfs builder...");
+        let builder_command = resolve_rootfs_builder_command(&prepared.builder.command);
+        let builder_env = vec![("PATH".to_string(), ROOTFS_BUILDER_PATH.to_string())];
         run_streaming_process(
             &proxy,
-            &prepared.builder.command,
+            &builder_command,
             vec![
                 "--spec".to_string(),
                 REMOTE_BUILD_SPEC_PATH.to_string(),
                 "--metadata-out".to_string(),
                 REMOTE_BUILD_METADATA_PATH.to_string(),
             ],
-            None,
+            Some(build_env_map(&builder_env)),
             Some(REMOTE_BUILD_SCRATCH_DIR.to_string()),
         )
         .await?;
@@ -230,6 +235,19 @@ async fn run_offline_rootfs_builder(
     }
 
     result
+}
+
+fn resolve_rootfs_builder_command(command: &str) -> String {
+    let command = if command.is_empty() {
+        ROOTFS_BUILDER_DEFAULT_COMMAND
+    } else {
+        command
+    };
+    if command.contains('/') {
+        command.to_string()
+    } else {
+        format!("{ROOTFS_BUILDER_COMMAND_DIR}/{command}")
+    }
 }
 
 async fn run_legacy_filesystem_builder(
@@ -1348,7 +1366,7 @@ mod tests {
     use super::{
         default_registered_name, load_dockerfile_plan, logical_dockerfile_lines, normalize_posix,
         parse_copy_like_values, parse_env_pairs, resolve_container_path,
-        resolve_context_source_path, wait_for_snapshot,
+        resolve_context_source_path, resolve_rootfs_builder_command, wait_for_snapshot,
     };
     use std::{cell::Cell, io::Write, time::Duration};
     use tensorlake::sandboxes::models::SnapshotInfo;
@@ -1410,6 +1428,22 @@ mod tests {
         assert_eq!(
             resolve_container_path("dst/", "/workspace"),
             "/workspace/dst/"
+        );
+    }
+
+    #[test]
+    fn resolve_rootfs_builder_command_prefers_usr_local_bin_for_bare_commands() {
+        assert_eq!(
+            resolve_rootfs_builder_command("tl-rootfs-build"),
+            "/usr/local/bin/tl-rootfs-build"
+        );
+        assert_eq!(
+            resolve_rootfs_builder_command("/opt/tl-rootfs-build"),
+            "/opt/tl-rootfs-build"
+        );
+        assert_eq!(
+            resolve_rootfs_builder_command(""),
+            "/usr/local/bin/tl-rootfs-build"
         );
     }
 

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -135,6 +135,13 @@ async fn run_offline_rootfs_builder(
         .await?
         .into_inner();
 
+    if requires_oci_base_import(&prepared, plan) {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "Platform API prepared this Dockerfile as a customer-owned rootfs base for OCI image {:?}, but this CLI cannot yet materialize OCI filesystems inside the offline rootfs builder. Use a registered Tensorlake rootfs base for now, or wait for the Docker export rootfs materializer.",
+            plan.base_image
+        )));
+    }
+
     let resources = CreateSandboxResources {
         cpus: prepared.builder.cpus,
         memory_mb: prepared.builder.memory_mb,
@@ -380,6 +387,13 @@ async fn copy_parent_rootfs_for_diff(proxy: &SandboxProxyClient) -> Result<()> {
         None,
     )
     .await
+}
+
+fn requires_oci_base_import(
+    prepared: &SandboxTemplateBuildPrepared,
+    plan: &DockerfileBuildPlan,
+) -> bool {
+    prepared.rootfs_node_kind == RootfsNodeKind::Base && prepared.builder.image != plan.base_image
 }
 
 fn build_remote_build_spec(
@@ -1364,12 +1378,15 @@ fn file_name_string(path: &Path) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        default_registered_name, load_dockerfile_plan, logical_dockerfile_lines, normalize_posix,
-        parse_copy_like_values, parse_env_pairs, resolve_container_path,
-        resolve_context_source_path, resolve_rootfs_builder_command, wait_for_snapshot,
+        DockerfileBuildPlan, default_registered_name, load_dockerfile_plan,
+        logical_dockerfile_lines, normalize_posix, parse_copy_like_values, parse_env_pairs,
+        requires_oci_base_import, resolve_container_path, resolve_context_source_path,
+        resolve_rootfs_builder_command, wait_for_snapshot,
     };
-    use std::{cell::Cell, io::Write, time::Duration};
-    use tensorlake::sandboxes::models::SnapshotInfo;
+    use std::{cell::Cell, io::Write, path::PathBuf, time::Duration};
+    use tensorlake::{
+        sandbox_templates::models::SandboxTemplateBuildPrepared, sandboxes::models::SnapshotInfo,
+    };
 
     #[test]
     fn default_registered_name_uses_parent_for_dockerfile() {
@@ -1445,6 +1462,46 @@ mod tests {
             resolve_rootfs_builder_command(""),
             "/usr/local/bin/tl-rootfs-build"
         );
+    }
+
+    #[test]
+    fn requires_oci_base_import_when_base_builder_differs_from_from_image() {
+        let plan = DockerfileBuildPlan {
+            context_dir: PathBuf::from("/tmp/context"),
+            registered_name: "alpine-custom".to_string(),
+            dockerfile_text: "FROM alpine:3.20\n".to_string(),
+            base_image: "alpine:3.20".to_string(),
+            instructions: vec![],
+        };
+        let prepared: SandboxTemplateBuildPrepared = serde_json::from_value(serde_json::json!({
+            "buildId": "build_1",
+            "snapshotId": "snap-base",
+            "snapshotUri": "s3://snapshots/base.tlsnap",
+            "rootfsNodeKind": "base",
+            "builder": {
+                "image": "tensorlake/rootfs-builder",
+                "command": "tl-rootfs-build",
+                "buildSpecVersion": "rootfs-build-spec-v1",
+                "cpus": 2.0,
+                "memoryMb": 4096,
+                "diskMb": 32768
+            },
+            "upload": {
+                "kind": "single_put",
+                "method": "PUT",
+                "url": "https://upload.example.test",
+                "headers": {},
+                "expiresAt": "2026-05-12T00:00:00.000Z"
+            },
+            "runtimeContract": {
+                "guestRuntimeLayout": "external-drive",
+                "guestRuntimeDriveFormat": "ext4",
+                "guestBootContract": "supervisor-init"
+            }
+        }))
+        .unwrap();
+
+        assert!(requires_oci_base_import(&prepared, &plan));
     }
 
     #[test]

--- a/crates/cloud-sdk/src/sandbox_templates/mod.rs
+++ b/crates/cloud-sdk/src/sandbox_templates/mod.rs
@@ -7,7 +7,10 @@ use crate::{
 
 pub mod models;
 
-use models::{CreateSandboxTemplateRequest, SandboxTemplate};
+use models::{
+    CompleteSandboxTemplateBuildRequest, CreateSandboxTemplateRequest,
+    PrepareSandboxTemplateBuildRequest, SandboxTemplate, SandboxTemplateBuildPrepared,
+};
 
 #[derive(Clone)]
 pub struct SandboxTemplatesClient {
@@ -36,6 +39,13 @@ impl SandboxTemplatesClient {
         )
     }
 
+    fn builds_endpoint(&self) -> String {
+        format!(
+            "/platform/v1/organizations/{}/projects/{}/sandbox-template-builds",
+            self.organization_id, self.project_id
+        )
+    }
+
     pub async fn create(
         &self,
         request: &CreateSandboxTemplateRequest,
@@ -43,6 +53,28 @@ impl SandboxTemplatesClient {
         let req = self
             .client
             .build_post_json_request(Method::POST, &self.endpoint(), request)?;
+        self.client.execute_json(req).await
+    }
+
+    pub async fn prepare_build(
+        &self,
+        request: &PrepareSandboxTemplateBuildRequest,
+    ) -> Result<Traced<SandboxTemplateBuildPrepared>, SdkError> {
+        let req =
+            self.client
+                .build_post_json_request(Method::POST, &self.builds_endpoint(), request)?;
+        self.client.execute_json(req).await
+    }
+
+    pub async fn complete_build(
+        &self,
+        build_id: &str,
+        request: &CompleteSandboxTemplateBuildRequest,
+    ) -> Result<Traced<SandboxTemplate>, SdkError> {
+        let uri = format!("{}/{build_id}/complete", self.builds_endpoint());
+        let req = self
+            .client
+            .build_post_json_request(Method::POST, &uri, request)?;
         self.client.execute_json(req).await
     }
 }

--- a/crates/cloud-sdk/src/sandbox_templates/models.rs
+++ b/crates/cloud-sdk/src/sandbox_templates/models.rs
@@ -1,5 +1,12 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RootfsNodeKind {
+    Base,
+    Diff,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateSandboxTemplateRequest {
@@ -13,6 +20,97 @@ pub struct CreateSandboxTemplateRequest {
     pub snapshot_size_bytes: u64,
     pub rootfs_disk_bytes: u64,
     pub public: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrepareSandboxTemplateBuildRequest {
+    pub name: String,
+    pub dockerfile: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_image: Option<String>,
+    pub public: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxTemplateBuildPrepared {
+    pub build_id: String,
+    pub snapshot_id: String,
+    pub snapshot_uri: String,
+    pub rootfs_node_kind: RootfsNodeKind,
+    pub builder: SandboxTemplateBuildBuilder,
+    pub upload: SandboxTemplateBuildUpload,
+    pub runtime_contract: SandboxTemplateBuildRuntimeContract,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<SandboxTemplateBuildParent>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxTemplateBuildBuilder {
+    pub image: String,
+    pub command: String,
+    pub build_spec_version: String,
+    pub cpus: f64,
+    pub memory_mb: i64,
+    pub disk_mb: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxTemplateBuildUpload {
+    pub kind: String,
+    pub method: String,
+    pub url: String,
+    #[serde(default)]
+    pub headers: std::collections::BTreeMap<String, String>,
+    pub expires_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxTemplateBuildRuntimeContract {
+    pub guest_runtime_layout: String,
+    pub guest_runtime_drive_format: String,
+    pub guest_boot_contract: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxTemplateBuildParent {
+    pub template_id: String,
+    pub name: String,
+    pub visibility: String,
+    pub snapshot_id: String,
+    pub snapshot_uri: String,
+    pub parent_manifest_uri: String,
+    pub rootfs_node_kind: RootfsNodeKind,
+    pub download: SandboxTemplateBuildDownload,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxTemplateBuildDownload {
+    pub kind: String,
+    pub method: String,
+    pub url: String,
+    #[serde(default)]
+    pub headers: std::collections::BTreeMap<String, String>,
+    pub expires_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompleteSandboxTemplateBuildRequest {
+    pub snapshot_id: String,
+    pub snapshot_uri: String,
+    pub snapshot_format_version: String,
+    pub snapshot_size_bytes: u64,
+    pub rootfs_disk_bytes: u64,
+    pub rootfs_node_kind: RootfsNodeKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_manifest_uri: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -40,7 +138,10 @@ pub struct SandboxTemplate {
 
 #[cfg(test)]
 mod tests {
-    use super::CreateSandboxTemplateRequest;
+    use super::{
+        CompleteSandboxTemplateBuildRequest, CreateSandboxTemplateRequest,
+        PrepareSandboxTemplateBuildRequest, RootfsNodeKind,
+    };
 
     #[test]
     fn create_sandbox_template_request_serializes_as_camel_case() {
@@ -60,6 +161,41 @@ mod tests {
         assert_eq!(
             json,
             r#"{"name":"image1","dockerfile":"FROM ubuntu:24.04\n","snapshotId":"snap-1","snapshotSandboxId":"sbx-1","snapshotUri":"s3://snapshots/snap-1","snapshotFormatVersion":"durable_archive_v1","snapshotSizeBytes":123,"rootfsDiskBytes":456,"public":true}"#
+        );
+    }
+
+    #[test]
+    fn prepare_sandbox_template_build_request_serializes_as_camel_case() {
+        let request = PrepareSandboxTemplateBuildRequest {
+            name: "image1".to_string(),
+            dockerfile: "FROM ubuntu:24.04\n".to_string(),
+            base_image: Some("ubuntu:24.04".to_string()),
+            public: false,
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert_eq!(
+            json,
+            r#"{"name":"image1","dockerfile":"FROM ubuntu:24.04\n","baseImage":"ubuntu:24.04","public":false}"#
+        );
+    }
+
+    #[test]
+    fn complete_sandbox_template_build_request_serializes_as_camel_case() {
+        let request = CompleteSandboxTemplateBuildRequest {
+            snapshot_id: "snap-1".to_string(),
+            snapshot_uri: "s3://snapshots/snap-1".to_string(),
+            snapshot_format_version: "durable_archive_v1".to_string(),
+            snapshot_size_bytes: 123,
+            rootfs_disk_bytes: 456,
+            rootfs_node_kind: RootfsNodeKind::Diff,
+            parent_manifest_uri: Some("s3://snapshots/parent".to_string()),
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert_eq!(
+            json,
+            r#"{"snapshotId":"snap-1","snapshotUri":"s3://snapshots/snap-1","snapshotFormatVersion":"durable_archive_v1","snapshotSizeBytes":123,"rootfsDiskBytes":456,"rootfsNodeKind":"diff","parentManifestUri":"s3://snapshots/parent"}"#
         );
     }
 }

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -50,6 +50,13 @@ _UNSUPPORTED_DOCKERFILE_INSTRUCTIONS = {
 }
 
 _DEFAULT_IMAGE_NAME = "default"
+_REMOTE_BUILD_SCRATCH_DIR = "/tmp/tl-rootfs-build"
+_REMOTE_BUILD_SPEC_PATH = "/tmp/tl-rootfs-build/build-spec.json"
+_REMOTE_BUILD_METADATA_PATH = "/tmp/tl-rootfs-build/metadata.json"
+_REMOTE_BUILD_CONTEXT_DIR = "/tmp/tl-rootfs-build/context"
+_REMOTE_ROOTFS_PATH = "/dev/vda"
+_REMOTE_PARENT_ROOTFS_PATH = "/tmp/tl-rootfs-build/parent-rootfs.img"
+_LEGACY_IMAGE_BUILD_ENV = "TENSORLAKE_ENABLE_LEGACY_IMAGE_BUILD"
 
 
 # --- Public exceptions ------------------------------------------------------
@@ -730,7 +737,239 @@ def _register_image(
     return resp.json()
 
 
-def _run_plan(
+def _prepare_offline_rootfs_build(
+    ctx: Context,
+    plan: DockerfileBuildPlan,
+    is_public: bool,
+) -> dict:
+    org_id = ctx.organization_id
+    proj_id = ctx.project_id
+    if not org_id or not proj_id:
+        raise RuntimeError(
+            "Organization ID and Project ID are required. Run 'tl login' and 'tl init'."
+        )
+
+    url = f"{ctx.api_url}/platform/v1/organizations/{org_id}/projects/{proj_id}/sandbox-template-builds"
+    bearer_token = ctx.api_key or ctx.personal_access_token
+    headers = {
+        "Authorization": f"Bearer {bearer_token}",
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    if ctx.personal_access_token and not ctx.api_key:
+        headers["X-Forwarded-Organization-Id"] = org_id
+        headers["X-Forwarded-Project-Id"] = proj_id
+
+    resp = httpx.post(
+        url,
+        json={
+            "name": plan.registered_name,
+            "dockerfile": plan.dockerfile_text,
+            "baseImage": plan.base_image,
+            "public": is_public,
+        },
+        headers=inject_traceparent(headers),
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _complete_offline_rootfs_build(
+    ctx: Context,
+    build_id: str,
+    metadata: dict,
+) -> dict:
+    org_id = ctx.organization_id
+    proj_id = ctx.project_id
+    if not org_id or not proj_id:
+        raise RuntimeError(
+            "Organization ID and Project ID are required. Run 'tl login' and 'tl init'."
+        )
+
+    url = f"{ctx.api_url}/platform/v1/organizations/{org_id}/projects/{proj_id}/sandbox-template-builds/{build_id}/complete"
+    bearer_token = ctx.api_key or ctx.personal_access_token
+    headers = {
+        "Authorization": f"Bearer {bearer_token}",
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+    }
+    if ctx.personal_access_token and not ctx.api_key:
+        headers["X-Forwarded-Organization-Id"] = org_id
+        headers["X-Forwarded-Project-Id"] = proj_id
+
+    body = {
+        "snapshotId": metadata["snapshot_id"],
+        "snapshotUri": metadata["snapshot_uri"],
+        "snapshotFormatVersion": metadata["snapshot_format_version"],
+        "snapshotSizeBytes": metadata["snapshot_size_bytes"],
+        "rootfsDiskBytes": metadata["rootfs_disk_bytes"],
+        "rootfsNodeKind": metadata["rootfs_node_kind"],
+    }
+    if metadata.get("parent_manifest_uri"):
+        body["parentManifestUri"] = metadata["parent_manifest_uri"]
+
+    resp = httpx.post(
+        url,
+        json=body,
+        headers=inject_traceparent(headers),
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _upload_build_context(
+    sandbox: Sandbox,
+    context_dir: str,
+    emit: EmitFn = _noop_emit,
+) -> None:
+    context_path = Path(context_dir)
+    if not context_path.exists():
+        return
+
+    _run_streaming(sandbox, "mkdir", ["-p", _REMOTE_BUILD_CONTEXT_DIR], emit=emit)
+    for local_path in context_path.rglob("*"):
+        if not local_path.is_file():
+            continue
+        rel = local_path.relative_to(context_path).as_posix()
+        remote_path = posixpath.join(_REMOTE_BUILD_CONTEXT_DIR, rel)
+        remote_parent = posixpath.dirname(remote_path)
+        _run_streaming(sandbox, "mkdir", ["-p", remote_parent], emit=emit)
+        sandbox.write_file(remote_path, local_path.read_bytes())
+
+
+def _copy_parent_rootfs_for_diff(
+    sandbox: Sandbox,
+    emit: EmitFn = _noop_emit,
+) -> None:
+    emit({"type": "status", "message": "Capturing parent rootfs for diff"})
+    _run_streaming(
+        sandbox,
+        "sh",
+        [
+            "-c",
+            (
+                f"mkdir -p {shlex.quote(_REMOTE_BUILD_SCRATCH_DIR)} "
+                f"&& dd if={shlex.quote(_REMOTE_ROOTFS_PATH)} "
+                f"of={shlex.quote(_REMOTE_PARENT_ROOTFS_PATH)} "
+                "bs=16M conv=sparse status=none && sync"
+            ),
+        ],
+        emit=emit,
+    )
+
+
+def _run_plan_remote_builder(
+    plan: DockerfileBuildPlan,
+    ctx: Context,
+    cpus: float,
+    memory_mb: int,
+    is_public: bool,
+    emit: EmitFn,
+    disk_mb: int | None,
+    prepared: dict,
+) -> dict:
+    builder = prepared["builder"]
+    build_id = prepared["buildId"]
+    sandbox_client = SandboxClient(
+        api_url=ctx.api_url,
+        api_key=ctx.api_key or ctx.personal_access_token,
+        organization_id=ctx.organization_id,
+        project_id=ctx.project_id,
+    )
+
+    sandbox = None
+    try:
+        emit({"type": "status", "message": "Starting rootfs builder sandbox..."})
+        builder_disk_mb = (
+            builder.get("diskMb", disk_mb)
+            if disk_mb is not None
+            else builder.get("diskMb")
+        )
+        sandbox = sandbox_client.create_and_connect(
+            image=builder["image"],
+            cpus=builder.get("cpus", cpus),
+            memory_mb=builder.get("memoryMb", memory_mb),
+            disk_mb=builder_disk_mb,
+        )
+        emit(
+            {
+                "type": "status",
+                "message": f"Builder sandbox {sandbox.sandbox_id} is running",
+            }
+        )
+
+        _upload_build_context(sandbox, plan.context_dir, emit=emit)
+        if prepared["rootfsNodeKind"] == "diff":
+            _copy_parent_rootfs_for_diff(sandbox, emit=emit)
+        _execute_dockerfile_plan(sandbox, plan, emit=emit)
+        build_spec = {
+            **prepared,
+            "name": plan.registered_name,
+            "dockerfile": plan.dockerfile_text,
+            "baseImage": plan.base_image,
+            "contextDir": _REMOTE_BUILD_CONTEXT_DIR,
+            "rootfsPath": _REMOTE_ROOTFS_PATH,
+            "isPublic": is_public,
+        }
+        if prepared["rootfsNodeKind"] == "diff":
+            build_spec["parentRootfsPath"] = _REMOTE_PARENT_ROOTFS_PATH
+        sandbox.write_file(
+            _REMOTE_BUILD_SPEC_PATH,
+            json.dumps(build_spec, separators=(",", ":")).encode("utf-8"),
+        )
+
+        emit({"type": "status", "message": "Running rootfs builder..."})
+        result = sandbox.run(
+            builder.get("command", "tl-rootfs-build"),
+            args=[
+                "--spec",
+                _REMOTE_BUILD_SPEC_PATH,
+                "--metadata-out",
+                _REMOTE_BUILD_METADATA_PATH,
+            ],
+            timeout=3600,
+            working_dir=_REMOTE_BUILD_SCRATCH_DIR,
+        )
+        if result.stdout:
+            emit({"type": "build_log", "stream": "stdout", "message": result.stdout})
+        if result.stderr:
+            emit({"type": "build_log", "stream": "stderr", "message": result.stderr})
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"Rootfs builder exited with code {result.exit_code}: {result.stderr}"
+            )
+
+        metadata = json.loads(
+            sandbox.read_file(_REMOTE_BUILD_METADATA_PATH).value.decode("utf-8")
+        )
+        emit(
+            {
+                "type": "snapshot_created",
+                "snapshot_id": metadata.get("snapshot_id", ""),
+            }
+        )
+        emit({"type": "status", "message": "Registering image..."})
+        registered = _complete_offline_rootfs_build(ctx, build_id, metadata)
+        emit(
+            {
+                "type": "image_registered",
+                "image_id": registered.get("id", ""),
+                "name": plan.registered_name,
+                "snapshot_id": metadata.get("snapshot_id", ""),
+            }
+        )
+        return registered
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.terminate()
+            except Exception:
+                pass
+
+
+def _run_plan_legacy(
     plan: DockerfileBuildPlan,
     ctx: Context,
     cpus: float,
@@ -826,6 +1065,48 @@ def _run_plan(
                 sandbox.terminate()
             except Exception:
                 pass
+
+
+def _run_plan(
+    plan: DockerfileBuildPlan,
+    ctx: Context,
+    cpus: float,
+    memory_mb: int,
+    is_public: bool,
+    emit: EmitFn,
+    disk_mb: int | None = None,
+) -> dict:
+    try:
+        prepared = _prepare_offline_rootfs_build(ctx, plan, is_public)
+    except Exception as exc:
+        if os.getenv(_LEGACY_IMAGE_BUILD_ENV, "").lower() not in {"1", "true", "yes"}:
+            raise RuntimeError(
+                "offline rootfs builder prepare failed and legacy runtime "
+                f"snapshot image registration is disabled: {exc}"
+            ) from exc
+        emit(
+            {
+                "type": "warning",
+                "message": (
+                    "Offline rootfs builder prepare failed; falling back to legacy "
+                    f"filesystem snapshot flow because {_LEGACY_IMAGE_BUILD_ENV}=1: {exc}"
+                ),
+            }
+        )
+        return _run_plan_legacy(
+            plan, ctx, cpus, memory_mb, is_public, emit=emit, disk_mb=disk_mb
+        )
+
+    return _run_plan_remote_builder(
+        plan,
+        ctx,
+        cpus,
+        memory_mb,
+        is_public,
+        emit,
+        disk_mb,
+        prepared,
+    )
 
 
 # --- Public API -----------------------------------------------------------

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -870,6 +870,16 @@ def _copy_parent_rootfs_for_diff(
     )
 
 
+def _requires_oci_base_import(prepared: dict, plan: DockerfileBuildPlan) -> bool:
+    builder = prepared.get("builder")
+    builder_image = builder.get("image") if isinstance(builder, dict) else None
+    return (
+        prepared.get("rootfsNodeKind") == "base"
+        and bool(plan.base_image)
+        and builder_image != plan.base_image
+    )
+
+
 def _run_plan_remote_builder(
     plan: DockerfileBuildPlan,
     ctx: Context,
@@ -882,6 +892,15 @@ def _run_plan_remote_builder(
 ) -> dict:
     builder = prepared["builder"]
     build_id = prepared["buildId"]
+    if _requires_oci_base_import(prepared, plan):
+        raise SandboxImageBuildError(
+            "Platform API prepared this Dockerfile as a customer-owned rootfs "
+            f"base for OCI image {plan.base_image!r}, but this SDK cannot yet "
+            "materialize OCI filesystems inside the offline rootfs builder. "
+            "Use a registered Tensorlake rootfs base for now, or wait for the "
+            "Docker export rootfs materializer."
+        )
+
     sandbox_client = SandboxClient(
         api_url=ctx.api_url,
         api_key=ctx.api_key or ctx.personal_access_token,

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -56,6 +56,9 @@ _REMOTE_BUILD_METADATA_PATH = "/tmp/tl-rootfs-build/metadata.json"
 _REMOTE_BUILD_CONTEXT_DIR = "/tmp/tl-rootfs-build/context"
 _REMOTE_ROOTFS_PATH = "/dev/vda"
 _REMOTE_PARENT_ROOTFS_PATH = "/tmp/tl-rootfs-build/parent-rootfs.img"
+_ROOTFS_BUILDER_COMMAND_DIR = "/usr/local/bin"
+_ROOTFS_BUILDER_DEFAULT_COMMAND = "tl-rootfs-build"
+_ROOTFS_BUILDER_ENV = {"PATH": "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 _LEGACY_IMAGE_BUILD_ENV = "TENSORLAKE_ENABLE_LEGACY_IMAGE_BUILD"
 
 
@@ -819,6 +822,13 @@ def _complete_offline_rootfs_build(
     return resp.json()
 
 
+def _resolve_rootfs_builder_command(command: str | None) -> str:
+    resolved = command or _ROOTFS_BUILDER_DEFAULT_COMMAND
+    if "/" in resolved:
+        return resolved
+    return posixpath.join(_ROOTFS_BUILDER_COMMAND_DIR, resolved)
+
+
 def _upload_build_context(
     sandbox: Sandbox,
     context_dir: str,
@@ -922,13 +932,14 @@ def _run_plan_remote_builder(
 
         emit({"type": "status", "message": "Running rootfs builder..."})
         result = sandbox.run(
-            builder.get("command", "tl-rootfs-build"),
+            _resolve_rootfs_builder_command(builder.get("command")),
             args=[
                 "--spec",
                 _REMOTE_BUILD_SPEC_PATH,
                 "--metadata-out",
                 _REMOTE_BUILD_METADATA_PATH,
             ],
+            env=_ROOTFS_BUILDER_ENV,
             timeout=3600,
             working_dir=_REMOTE_BUILD_SCRATCH_DIR,
         )

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -444,13 +444,25 @@ class TestOfflineRootfsBuilder(unittest.TestCase):
             "/tmp/tl-rootfs-build/parent-rootfs.img",
         )
         sandbox.run.assert_called_once()
-        self.assertEqual(sandbox.run.call_args.args[0], "tl-rootfs-build")
+        self.assertEqual(
+            sandbox.run.call_args.args[0], "/usr/local/bin/tl-rootfs-build"
+        )
         self.assertEqual(
             sandbox.run.call_args.kwargs["working_dir"],
             "/tmp/tl-rootfs-build",
         )
+        self.assertEqual(
+            sandbox.run.call_args.kwargs["env"],
+            {"PATH": "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+        )
         complete.assert_called_once()
         sandbox.terminate.assert_called_once_with()
+
+    def test_remote_builder_respects_absolute_command(self):
+        self.assertEqual(
+            sbm._resolve_rootfs_builder_command("/opt/bin/tl-rootfs-build"),
+            "/opt/bin/tl-rootfs-build",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -458,6 +458,57 @@ class TestOfflineRootfsBuilder(unittest.TestCase):
         complete.assert_called_once()
         sandbox.terminate.assert_called_once_with()
 
+    def test_remote_builder_rejects_unmaterialized_oci_base_import(self):
+        ctx = SimpleNamespace(
+            api_url="https://api.example.test",
+            api_key="key",
+            personal_access_token=None,
+            organization_id="org_1",
+            project_id="project_1",
+        )
+        prepared = {
+            "buildId": "build_1",
+            "snapshotId": "snap-base",
+            "snapshotUri": "s3://snapshots/base.tlsnap",
+            "rootfsNodeKind": "base",
+            "builder": {
+                "image": "tensorlake/rootfs-builder",
+                "command": "tl-rootfs-build",
+                "cpus": 2,
+                "memoryMb": 4096,
+                "diskMb": 32768,
+            },
+            "upload": {
+                "kind": "single_put",
+                "method": "PUT",
+                "url": "https://upload.example.test",
+            },
+        }
+        plan = sbm.DockerfileBuildPlan(
+            dockerfile_path="Dockerfile",
+            context_dir="/no/such/context",
+            registered_name="alpine-custom",
+            dockerfile_text="FROM alpine:3.20\n",
+            base_image="alpine:3.20",
+            instructions=[],
+        )
+
+        with patch.object(sbm, "SandboxClient") as sandbox_client_cls:
+            with self.assertRaises(sbm.SandboxImageBuildError) as err:
+                sbm._run_plan_remote_builder(
+                    plan,
+                    ctx,  # type: ignore[arg-type]
+                    BUILD_CPUS,
+                    BUILD_MEMORY_MB,
+                    False,
+                    sbm._noop_emit,
+                    None,
+                    prepared,
+                )
+
+        self.assertIn("customer-owned rootfs base", str(err.exception))
+        sandbox_client_cls.assert_not_called()
+
     def test_remote_builder_respects_absolute_command(self):
         self.assertEqual(
             sbm._resolve_rootfs_builder_command("/opt/bin/tl-rootfs-build"),

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 import unittest
 import warnings
@@ -85,6 +86,16 @@ def _make_build_patches(ctx, sandbox, snapshot):
 
 
 class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
+    def setUp(self):
+        self._legacy_env = patch.dict(
+            "os.environ",
+            {"TENSORLAKE_ENABLE_LEGACY_IMAGE_BUILD": "1"},
+        )
+        self._legacy_env.start()
+
+    def tearDown(self):
+        self._legacy_env.stop()
+
     def test_registers_snapshot_from_dockerfile(self):
         ctx = MagicMock()
         sandbox = MagicMock()
@@ -115,6 +126,11 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             )
             with (
                 build_ctx,
+                patch.object(
+                    sbm,
+                    "_prepare_offline_rootfs_build",
+                    side_effect=RuntimeError("offline disabled in legacy test"),
+                ),
                 execute as execute_mock,
                 register_image as register_mock,
                 sandbox_client_cls as sandbox_client_cls_mock,
@@ -183,6 +199,11 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             )
             with (
                 build_ctx,
+                patch.object(
+                    sbm,
+                    "_prepare_offline_rootfs_build",
+                    side_effect=RuntimeError("offline disabled in legacy test"),
+                ),
                 execute,
                 register_image as register_mock,
                 sandbox_client_cls as sandbox_client_cls_mock,
@@ -218,6 +239,16 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
 
 
 class TestBuildSandboxImageFromImage(unittest.TestCase):
+    def setUp(self):
+        self._legacy_env = patch.dict(
+            "os.environ",
+            {"TENSORLAKE_ENABLE_LEGACY_IMAGE_BUILD": "1"},
+        )
+        self._legacy_env.start()
+
+    def tearDown(self):
+        self._legacy_env.stop()
+
     def _run_build(self, image: Image, **kwargs):
         ctx = MagicMock()
         sandbox = MagicMock()
@@ -236,6 +267,11 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
         )
         with (
             build_ctx,
+            patch.object(
+                sbm,
+                "_prepare_offline_rootfs_build",
+                side_effect=RuntimeError("offline disabled in legacy test"),
+            ),
             execute,
             register_image as register_mock,
             sandbox_client_cls as sandbox_client_cls_mock,
@@ -307,6 +343,114 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
     def test_rejects_unknown_source_type(self):
         with self.assertRaises(TypeError):
             sbm.build_sandbox_image(12345)  # type: ignore[arg-type]
+
+
+class TestOfflineRootfsBuilder(unittest.TestCase):
+    def test_remote_builder_applies_dockerfile_before_snapshotting_diff(self):
+        ctx = SimpleNamespace(
+            api_url="https://api.example.test",
+            api_key="key",
+            personal_access_token=None,
+            organization_id="org_1",
+            project_id="project_1",
+        )
+        sandbox = MagicMock()
+        sandbox.sandbox_id = "sbx-builder"
+        sandbox.run.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        sandbox.read_file.return_value = SimpleNamespace(
+            value=json.dumps(
+                {
+                    "snapshot_id": "snap-child",
+                    "snapshot_uri": "s3://snapshots/child.tlsnap",
+                    "snapshot_format_version": "durable_archive_v1",
+                    "snapshot_size_bytes": 123,
+                    "rootfs_disk_bytes": 10 * 1024 * 1024 * 1024,
+                    "rootfs_node_kind": "diff",
+                    "parent_manifest_uri": "s3://snapshots/parent.tlsnap",
+                }
+            ).encode("utf-8")
+        )
+        prepared = {
+            "buildId": "build_1",
+            "snapshotId": "snap-child",
+            "snapshotUri": "s3://snapshots/child.tlsnap",
+            "rootfsNodeKind": "diff",
+            "builder": {
+                "image": "base-private",
+                "command": "tl-rootfs-build",
+                "cpus": 2,
+                "memoryMb": 4096,
+                "diskMb": 32768,
+            },
+            "upload": {
+                "kind": "single_put",
+                "method": "PUT",
+                "url": "https://upload.example.test",
+            },
+        }
+
+        plan = sbm.DockerfileBuildPlan(
+            dockerfile_path="Dockerfile",
+            context_dir="/no/such/context",
+            registered_name="child",
+            dockerfile_text="FROM base-private\nRUN touch /child\n",
+            base_image="base-private",
+            instructions=[
+                sbm.DockerfileInstruction("RUN", "touch /child", 2),
+            ],
+        )
+
+        with (
+            patch.object(sbm, "SandboxClient") as sandbox_client_cls,
+            patch.object(sbm, "_upload_build_context") as upload_context,
+            patch.object(sbm, "_copy_parent_rootfs_for_diff") as copy_parent,
+            patch.object(sbm, "_execute_dockerfile_plan") as execute_plan,
+            patch.object(
+                sbm,
+                "_complete_offline_rootfs_build",
+                return_value={"id": "template_1"},
+            ) as complete,
+        ):
+            sandbox_client_cls.return_value.create_and_connect.return_value = sandbox
+            result = sbm._run_plan_remote_builder(
+                plan,
+                ctx,  # type: ignore[arg-type]
+                BUILD_CPUS,
+                BUILD_MEMORY_MB,
+                False,
+                sbm._noop_emit,
+                None,
+                prepared,
+            )
+
+        self.assertEqual(result, {"id": "template_1"})
+        sandbox_client_cls.return_value.create_and_connect.assert_called_once_with(
+            image="base-private",
+            cpus=2,
+            memory_mb=4096,
+            disk_mb=32768,
+        )
+        upload_context.assert_called_once_with(
+            sandbox,
+            "/no/such/context",
+            emit=sbm._noop_emit,
+        )
+        copy_parent.assert_called_once_with(sandbox, emit=sbm._noop_emit)
+        execute_plan.assert_called_once_with(sandbox, plan, emit=sbm._noop_emit)
+        spec = json.loads(sandbox.write_file.call_args.args[1].decode("utf-8"))
+        self.assertEqual(spec["rootfsPath"], "/dev/vda")
+        self.assertEqual(
+            spec["parentRootfsPath"],
+            "/tmp/tl-rootfs-build/parent-rootfs.img",
+        )
+        sandbox.run.assert_called_once()
+        self.assertEqual(sandbox.run.call_args.args[0], "tl-rootfs-build")
+        self.assertEqual(
+            sandbox.run.call_args.kwargs["working_dir"],
+            "/tmp/tl-rootfs-build",
+        )
+        complete.assert_called_once()
+        sandbox.terminate.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -12,6 +12,13 @@ import { SandboxClient } from "./client.js";
 import { Image, dockerfileContent } from "./image.js";
 
 const BUILD_SANDBOX_PIP_ENV = { PIP_BREAK_SYSTEM_PACKAGES: "1" } as const;
+const REMOTE_BUILD_SCRATCH_DIR = "/tmp/tl-rootfs-build";
+const REMOTE_BUILD_SPEC_PATH = "/tmp/tl-rootfs-build/build-spec.json";
+const REMOTE_BUILD_METADATA_PATH = "/tmp/tl-rootfs-build/metadata.json";
+const REMOTE_BUILD_CONTEXT_DIR = "/tmp/tl-rootfs-build/context";
+const REMOTE_ROOTFS_PATH = "/dev/vda";
+const REMOTE_PARENT_ROOTFS_PATH = "/tmp/tl-rootfs-build/parent-rootfs.img";
+const LEGACY_IMAGE_BUILD_ENV = "TENSORLAKE_ENABLE_LEGACY_IMAGE_BUILD";
 const IGNORED_DOCKERFILE_INSTRUCTIONS = new Set([
   "CMD",
   "ENTRYPOINT",
@@ -93,6 +100,7 @@ interface BuildSandbox {
   getStderr(pid: number): Promise<OutputResponse>;
   getProcess(pid: number): Promise<ProcessInfo>;
   writeFile(path: string, content: Uint8Array): Promise<void>;
+  readFile(path: string): Promise<Uint8Array>;
   terminate(): Promise<void>;
 }
 
@@ -129,7 +137,40 @@ interface CreateSandboxImageDeps {
     isPublic: boolean,
     snapshotFormatVersion?: string,
   ) => Promise<Record<string, unknown>>;
+  prepareRootfsBuild?: (
+    context: BuildContext,
+    plan: DockerfileBuildPlan,
+    isPublic: boolean,
+  ) => Promise<PreparedRootfsBuild>;
+  completeRootfsBuild?: (
+    context: BuildContext,
+    buildId: string,
+    metadata: Record<string, unknown>,
+  ) => Promise<Record<string, unknown>>;
   sleep?: (ms: number) => Promise<void>;
+}
+
+interface PreparedRootfsBuild {
+  buildId: string;
+  snapshotId: string;
+  snapshotUri: string;
+  rootfsNodeKind: "base" | "diff";
+  builder: {
+    image: string;
+    command?: string;
+    buildSpecVersion: string;
+    cpus?: number;
+    memoryMb?: number;
+    diskMb?: number;
+  };
+  upload: {
+    kind: "single_put";
+    method: "PUT";
+    url: string;
+    headers?: Record<string, string>;
+    expiresAt?: string;
+  };
+  parent?: Record<string, unknown>;
 }
 
 export function defaultRegisteredName(dockerfilePath: string): string {
@@ -396,7 +437,10 @@ function parseCopyLikeValues(
   };
 }
 
-function parseEnvPairs(value: string, lineNumber: number): Array<[string, string]> {
+function parseEnvPairs(
+  value: string,
+  lineNumber: number,
+): Array<[string, string]> {
   const tokens = shellSplit(value);
   if (tokens.length === 0) {
     throw new Error(`line ${lineNumber}: ENV must include a key and value`);
@@ -419,7 +463,10 @@ function parseEnvPairs(value: string, lineNumber: number): Array<[string, string
   return [[tokens[0], tokens.slice(1).join(" ")]];
 }
 
-function resolveContainerPath(containerPath: string, workingDir: string): string {
+function resolveContainerPath(
+  containerPath: string,
+  workingDir: string,
+): string {
   if (!containerPath) {
     return workingDir;
   }
@@ -501,12 +548,16 @@ export async function loadDockerfilePlan(
 
 export function loadImagePlan(
   image: Image,
-  options: Pick<CreateSandboxImageOptions, "registeredName" | "contextDir"> = {},
+  options: Pick<
+    CreateSandboxImageOptions,
+    "registeredName" | "contextDir"
+  > = {},
 ): DockerfileBuildPlan {
   const contextDir = path.resolve(options.contextDir ?? process.cwd());
   const dockerfileText = dockerfileContent(image);
   const logicalLines = logicalDockerfileLines(dockerfileText);
-  const instructions = image.baseImage == null ? logicalLines : logicalLines.slice(1);
+  const instructions =
+    image.baseImage == null ? logicalLines : logicalLines.slice(1);
 
   return {
     dockerfilePath: path.join(contextDir, "Dockerfile"),
@@ -545,6 +596,12 @@ function stderrEmit(event: Record<string, unknown>) {
 function debugEnabled(): boolean {
   return ["1", "true", "yes", "on"].includes(
     (process.env.TENSORLAKE_DEBUG ?? "").toLowerCase(),
+  );
+}
+
+function legacyImageBuildEnabled(): boolean {
+  return ["1", "true", "yes", "on"].includes(
+    (process.env[LEGACY_IMAGE_BUILD_ENV] ?? "").toLowerCase(),
   );
 }
 
@@ -641,7 +698,11 @@ async function runStreaming(
   }
 
   const exitCode =
-    info.exitCode != null ? info.exitCode : info.signal != null ? -info.signal : 0;
+    info.exitCode != null
+      ? info.exitCode
+      : info.signal != null
+        ? -info.signal
+        : 0;
   if (exitCode !== 0) {
     throw new Error(
       `Command '${command} ${args.join(" ")}' failed with exit code ${exitCode}`,
@@ -662,7 +723,10 @@ function emitOutputLines(
 
 function isPathWithinContext(contextDir: string, localPath: string): boolean {
   const relative = path.relative(contextDir, localPath);
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
 }
 
 function resolveContextSourcePath(contextDir: string, source: string): string {
@@ -702,11 +766,10 @@ async function copyLocalPathToSandbox(
       await runChecked(sandbox, "mkdir", ["-p", destinationPath]);
       await copyLocalPathToSandbox(sandbox, sourcePath, destinationPath);
     } else if (entry.isFile()) {
-      await runChecked(
-        sandbox,
-        "mkdir",
-        ["-p", path.posix.dirname(destinationPath)],
-      );
+      await runChecked(sandbox, "mkdir", [
+        "-p",
+        path.posix.dirname(destinationPath),
+      ]);
       await sandbox.writeFile(destinationPath, await readFile(sourcePath));
     }
   }
@@ -782,9 +845,13 @@ async function addUrlToSandbox(
 ) {
   let destinationPath = resolveContainerPath(destination, workingDir);
   const parsedUrl = new URL(url);
-  const fileName = path.posix.basename(parsedUrl.pathname.replace(/\/$/, "")) || "downloaded";
+  const fileName =
+    path.posix.basename(parsedUrl.pathname.replace(/\/$/, "")) || "downloaded";
   if (destinationPath.endsWith("/")) {
-    destinationPath = path.posix.join(destinationPath.replace(/\/$/, ""), fileName);
+    destinationPath = path.posix.join(
+      destinationPath.replace(/\/$/, ""),
+      fileName,
+    );
   }
 
   const parentDir = path.posix.dirname(destinationPath) || "/";
@@ -836,7 +903,9 @@ async function executeDockerfilePlan(
     if (keyword === "WORKDIR") {
       const tokens = shellSplit(value);
       if (tokens.length !== 1) {
-        throw new Error(`line ${lineNumber}: WORKDIR must include exactly one path`);
+        throw new Error(
+          `line ${lineNumber}: WORKDIR must include exactly one path`,
+        );
       }
       workingDir = resolveContainerPath(tokens[0], workingDir);
       emit({ type: "status", message: `WORKDIR ${workingDir}` });
@@ -877,10 +946,7 @@ async function executeDockerfilePlan(
         lineNumber,
         keyword,
       );
-      if (
-        sources.length === 1 &&
-        /^https?:\/\//.test(sources[0])
-      ) {
+      if (sources.length === 1 && /^https?:\/\//.test(sources[0])) {
         await addUrlToSandbox(
           sandbox,
           emit,
@@ -982,18 +1048,161 @@ async function registerImage(
   return text ? (JSON.parse(text) as Record<string, unknown>) : {};
 }
 
+function platformAuthHeaders(context: BuildContext): Record<string, string> {
+  const bearerToken = context.apiKey ?? context.personalAccessToken;
+  if (!bearerToken) {
+    throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT.");
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${bearerToken}`,
+    "Content-Type": "application/json",
+  };
+  if (context.personalAccessToken && !context.apiKey) {
+    if (context.organizationId) {
+      headers["X-Forwarded-Organization-Id"] = context.organizationId;
+    }
+    if (context.projectId) {
+      headers["X-Forwarded-Project-Id"] = context.projectId;
+    }
+  }
+  return headers;
+}
+
+async function prepareRootfsBuild(
+  context: BuildContext,
+  plan: DockerfileBuildPlan,
+  isPublic: boolean,
+): Promise<PreparedRootfsBuild> {
+  if (!context.organizationId || !context.projectId) {
+    throw new Error(
+      "Organization ID and Project ID are required. Run 'tl login' and 'tl init'.",
+    );
+  }
+
+  const baseUrl = context.apiUrl.replace(/\/+$/, "");
+  const url =
+    `${baseUrl}/platform/v1/organizations/` +
+    `${encodeURIComponent(context.organizationId)}/projects/` +
+    `${encodeURIComponent(context.projectId)}/sandbox-template-builds`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: platformAuthHeaders(context),
+    body: JSON.stringify({
+      name: plan.registeredName,
+      dockerfile: plan.dockerfileText,
+      ...(plan.baseImage ? { baseImage: plan.baseImage } : {}),
+      public: isPublic,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${response.status} ${response.statusText}: ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as PreparedRootfsBuild;
+}
+
+async function completeRootfsBuild(
+  context: BuildContext,
+  buildId: string,
+  metadata: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  if (!context.organizationId || !context.projectId) {
+    throw new Error(
+      "Organization ID and Project ID are required. Run 'tl login' and 'tl init'.",
+    );
+  }
+
+  const baseUrl = context.apiUrl.replace(/\/+$/, "");
+  const url =
+    `${baseUrl}/platform/v1/organizations/` +
+    `${encodeURIComponent(context.organizationId)}/projects/` +
+    `${encodeURIComponent(context.projectId)}/sandbox-template-builds/` +
+    `${encodeURIComponent(buildId)}/complete`;
+
+  const body: Record<string, unknown> = {
+    snapshotId: metadata.snapshot_id,
+    snapshotUri: metadata.snapshot_uri,
+    snapshotFormatVersion: metadata.snapshot_format_version,
+    snapshotSizeBytes: metadata.snapshot_size_bytes,
+    rootfsDiskBytes: metadata.rootfs_disk_bytes,
+    rootfsNodeKind: metadata.rootfs_node_kind,
+  };
+  if (metadata.parent_manifest_uri != null) {
+    body.parentManifestUri = metadata.parent_manifest_uri;
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: platformAuthHeaders(context),
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${response.status} ${response.statusText}: ${await response.text()}`,
+    );
+  }
+  const text = await response.text();
+  return text ? (JSON.parse(text) as Record<string, unknown>) : {};
+}
+
+async function uploadBuildContext(
+  sandbox: BuildSandbox,
+  localDir: string,
+  remoteDir: string,
+) {
+  await sandbox.run("mkdir", { args: ["-p", remoteDir] });
+  async function visit(dir: string, relBase = "") {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const localPath = path.join(dir, entry.name);
+      const relPath = relBase
+        ? path.posix.join(relBase, entry.name)
+        : entry.name;
+      const remotePath = path.posix.join(remoteDir, relPath);
+      if (entry.isDirectory()) {
+        await sandbox.run("mkdir", { args: ["-p", remotePath] });
+        await visit(localPath, relPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      await sandbox.run("mkdir", {
+        args: ["-p", path.posix.dirname(remotePath)],
+      });
+      await sandbox.writeFile(remotePath, await readFile(localPath));
+    }
+  }
+  await visit(localDir);
+}
+
+async function copyParentRootfsForDiff(
+  sandbox: BuildSandbox,
+  emit: (event: Record<string, unknown>) => void,
+) {
+  emit({ type: "status", message: "Capturing parent rootfs for diff" });
+  await runChecked(sandbox, "sh", [
+    "-c",
+    `mkdir -p ${shellQuote(REMOTE_BUILD_SCRATCH_DIR)} && dd if=${shellQuote(REMOTE_ROOTFS_PATH)} of=${shellQuote(REMOTE_PARENT_ROOTFS_PATH)} bs=16M conv=sparse status=none && sync`,
+  ]);
+}
+
 export async function createSandboxImage(
   source: SandboxImageSource,
   options: CreateSandboxImageOptions = {},
   deps: CreateSandboxImageDeps = {},
 ) {
   const emit = deps.emit ?? (options.verbose ? stderrEmit : noopEmit);
-  const sleep = deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const sleep =
+    deps.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
   const context = buildContextFromEnv();
   const clientFactory = deps.createClient ?? createDefaultClient;
-  const register =
-    deps.registerImage ??
-    ((...args) => registerImage(...args));
+  const register = deps.registerImage ?? ((...args) => registerImage(...args));
+  const prepare =
+    deps.prepareRootfsBuild ??
+    (deps.registerImage == null ? prepareRootfsBuild : undefined);
+  const complete = deps.completeRootfsBuild ?? completeRootfsBuild;
 
   const sourceLabel =
     typeof source === "string" ? source : `Image(${source.name})`;
@@ -1014,6 +1223,130 @@ export async function createSandboxImage(
   let sandbox: BuildSandbox | undefined;
 
   try {
+    if (prepare) {
+      try {
+        const prepared = await prepare(
+          context,
+          plan,
+          options.isPublic ?? false,
+        );
+        emit({
+          type: "status",
+          message: `Starting rootfs builder sandbox from ${prepared.builder.image}...`,
+        });
+        const builderDiskMb = prepared.builder.diskMb ?? options.diskMb;
+        sandbox = await client.createAndConnect({
+          image: prepared.builder.image,
+          cpus: prepared.builder.cpus ?? options.cpus ?? 2.0,
+          memoryMb: prepared.builder.memoryMb ?? options.memoryMb ?? 4096,
+          ...(builderDiskMb != null ? { diskMb: builderDiskMb } : {}),
+        });
+
+        await uploadBuildContext(
+          sandbox,
+          plan.contextDir,
+          REMOTE_BUILD_CONTEXT_DIR,
+        );
+        if (prepared.rootfsNodeKind === "diff") {
+          await copyParentRootfsForDiff(sandbox, emit);
+        }
+        await executeDockerfilePlan(sandbox, plan, emit, sleep);
+        await sandbox.writeFile(
+          REMOTE_BUILD_SPEC_PATH,
+          new TextEncoder().encode(
+            JSON.stringify({
+              ...prepared,
+              name: plan.registeredName,
+              dockerfile: plan.dockerfileText,
+              baseImage: plan.baseImage,
+              contextDir: REMOTE_BUILD_CONTEXT_DIR,
+              rootfsPath: REMOTE_ROOTFS_PATH,
+              ...(prepared.rootfsNodeKind === "diff"
+                ? { parentRootfsPath: REMOTE_PARENT_ROOTFS_PATH }
+                : {}),
+              isPublic: options.isPublic ?? false,
+            }),
+          ),
+        );
+
+        const result = await sandbox.run(
+          prepared.builder.command ?? "tl-rootfs-build",
+          {
+            args: [
+              "--spec",
+              REMOTE_BUILD_SPEC_PATH,
+              "--metadata-out",
+              REMOTE_BUILD_METADATA_PATH,
+            ],
+            timeout: 3600,
+            workingDir: REMOTE_BUILD_SCRATCH_DIR,
+          },
+        );
+        if (result.stdout) {
+          emit({ type: "build_log", stream: "stdout", message: result.stdout });
+        }
+        if (result.stderr) {
+          emit({ type: "build_log", stream: "stderr", message: result.stderr });
+        }
+        if (result.exitCode !== 0) {
+          throw new Error(
+            `Rootfs builder exited with code ${result.exitCode}: ${result.stderr}`,
+          );
+        }
+
+        const metadata = JSON.parse(
+          new TextDecoder().decode(
+            await sandbox.readFile(REMOTE_BUILD_METADATA_PATH),
+          ),
+        ) as Record<string, unknown>;
+        emit({
+          type: "snapshot_created",
+          snapshot_id: metadata.snapshot_id,
+        });
+        const registered = await complete(context, prepared.buildId, metadata);
+        emit({
+          type: "image_registered",
+          name: plan.registeredName,
+          image_id:
+            (typeof registered.id === "string" && registered.id) ||
+            (typeof registered.templateId === "string" &&
+              registered.templateId) ||
+            "",
+        });
+        emit({ type: "done" });
+        return registered;
+      } catch (error) {
+        if (!legacyImageBuildEnabled()) {
+          if (sandbox) {
+            try {
+              await sandbox.terminate();
+            } catch {
+              // Ignore cleanup failures while preserving the builder error.
+            }
+            sandbox = undefined;
+          }
+          throw new Error(
+            "Offline rootfs builder flow failed and legacy runtime snapshot image registration is disabled: " +
+              String(error instanceof Error ? error.message : error),
+          );
+        }
+        emit({
+          type: "warning",
+          message:
+            `Offline rootfs builder failed; falling back to legacy filesystem snapshot flow because ${LEGACY_IMAGE_BUILD_ENV}=1: ` +
+            String(error instanceof Error ? error.message : error),
+        });
+        if (sandbox) {
+          try {
+            await sandbox.terminate();
+          } catch {
+            // Ignore cleanup failures and continue with the legacy path.
+          }
+          sandbox = undefined;
+        }
+      }
+    }
+
     sandbox = await client.createAndConnect({
       ...(plan.baseImage == null ? {} : { image: plan.baseImage }),
       cpus: options.cpus ?? 2.0,
@@ -1104,7 +1437,9 @@ export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {
 
   const dockerfilePath = parsed.positionals[0];
   if (!dockerfilePath) {
-    throw new Error("Usage: tensorlake-create-sandbox-image <dockerfile_path> [--name NAME] [--cpus N] [--memory MB] [--disk_mb MB] [--public]");
+    throw new Error(
+      "Usage: tensorlake-create-sandbox-image <dockerfile_path> [--name NAME] [--cpus N] [--memory MB] [--disk_mb MB] [--public]",
+    );
   }
 
   const cpus =

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -18,6 +18,11 @@ const REMOTE_BUILD_METADATA_PATH = "/tmp/tl-rootfs-build/metadata.json";
 const REMOTE_BUILD_CONTEXT_DIR = "/tmp/tl-rootfs-build/context";
 const REMOTE_ROOTFS_PATH = "/dev/vda";
 const REMOTE_PARENT_ROOTFS_PATH = "/tmp/tl-rootfs-build/parent-rootfs.img";
+const ROOTFS_BUILDER_COMMAND_DIR = "/usr/local/bin";
+const ROOTFS_BUILDER_DEFAULT_COMMAND = "tl-rootfs-build";
+const ROOTFS_BUILDER_ENV = {
+  PATH: "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+} as const;
 const LEGACY_IMAGE_BUILD_ENV = "TENSORLAKE_ENABLE_LEGACY_IMAGE_BUILD";
 const IGNORED_DOCKERFILE_INSTRUCTIONS = new Set([
   "CMD",
@@ -603,6 +608,16 @@ function legacyImageBuildEnabled(): boolean {
   return ["1", "true", "yes", "on"].includes(
     (process.env[LEGACY_IMAGE_BUILD_ENV] ?? "").toLowerCase(),
   );
+}
+
+function resolveRootfsBuilderCommand(command?: string): string {
+  const resolved =
+    command == null || command.length === 0
+      ? ROOTFS_BUILDER_DEFAULT_COMMAND
+      : command;
+  return resolved.includes("/")
+    ? resolved
+    : `${ROOTFS_BUILDER_COMMAND_DIR}/${resolved}`;
 }
 
 function buildContextFromEnv(): BuildContext {
@@ -1270,7 +1285,7 @@ export async function createSandboxImage(
         );
 
         const result = await sandbox.run(
-          prepared.builder.command ?? "tl-rootfs-build",
+          resolveRootfsBuilderCommand(prepared.builder.command),
           {
             args: [
               "--spec",
@@ -1278,6 +1293,7 @@ export async function createSandboxImage(
               "--metadata-out",
               REMOTE_BUILD_METADATA_PATH,
             ],
+            env: ROOTFS_BUILDER_ENV,
             timeout: 3600,
             workingDir: REMOTE_BUILD_SCRATCH_DIR,
           },

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -1203,6 +1203,17 @@ async function copyParentRootfsForDiff(
   ]);
 }
 
+function requiresOciBaseImport(
+  prepared: PreparedRootfsBuild,
+  plan: DockerfileBuildPlan,
+): boolean {
+  return (
+    prepared.rootfsNodeKind === "base" &&
+    plan.baseImage != null &&
+    prepared.builder.image !== plan.baseImage
+  );
+}
+
 export async function createSandboxImage(
   source: SandboxImageSource,
   options: CreateSandboxImageOptions = {},
@@ -1245,6 +1256,11 @@ export async function createSandboxImage(
           plan,
           options.isPublic ?? false,
         );
+        if (requiresOciBaseImport(prepared, plan)) {
+          throw new Error(
+            `Platform API prepared this Dockerfile as a customer-owned rootfs base for OCI image ${JSON.stringify(plan.baseImage)}, but this SDK cannot yet materialize OCI filesystems inside the offline rootfs builder. Use a registered Tensorlake rootfs base for now, or wait for the Docker export rootfs materializer.`,
+          );
+        }
         emit({
           type: "status",
           message: `Starting rootfs builder sandbox from ${prepared.builder.image}...`,

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -700,4 +700,58 @@ describe("sandbox image helpers", () => {
     );
     expect(sandbox.terminate).toHaveBeenCalled();
   });
+
+  it("offline rootfs builder rejects unmaterialized OCI base imports", async () => {
+    vi.stubEnv("TENSORLAKE_API_URL", "https://api.tensorlake.ai");
+    vi.stubEnv("TENSORLAKE_API_KEY", "tl_key_test");
+    vi.stubEnv("INDEXIFY_NAMESPACE", "default");
+    vi.stubEnv("TENSORLAKE_ORGANIZATION_ID", "org_123");
+    vi.stubEnv("TENSORLAKE_PROJECT_ID", "proj_123");
+
+    const tempDir = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-oci-base`),
+      { recursive: true },
+    );
+    const dockerfilePath = path.join(tempDir, "Dockerfile");
+    await writeFile(dockerfilePath, "FROM alpine:3.20\n", "utf8");
+
+    const client = {
+      createAndConnect: vi.fn(),
+      snapshotAndWait: vi.fn(),
+      close: vi.fn(() => {}),
+    };
+
+    await expect(
+      createSandboxImage(
+        dockerfilePath,
+        {},
+        {
+          emit: () => {},
+          createClient: () => client as never,
+          prepareRootfsBuild: async () => ({
+            buildId: "build_1",
+            snapshotId: "snap-base",
+            snapshotUri: "s3://snapshots/base.tlsnap",
+            rootfsNodeKind: "base",
+            builder: {
+              image: "tensorlake/rootfs-builder",
+              command: "tl-rootfs-build",
+              buildSpecVersion: "rootfs-build-spec-v1",
+              cpus: 2,
+              memoryMb: 4096,
+              diskMb: 32768,
+            },
+            upload: {
+              kind: "single_put",
+              method: "PUT",
+              url: "https://upload.example.test",
+            },
+          }),
+          sleep: async () => {},
+        },
+      ),
+    ).rejects.toThrow("customer-owned rootfs base");
+
+    expect(client.createAndConnect).not.toHaveBeenCalled();
+  });
 });

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -668,7 +668,7 @@ describe("sandbox image helpers", () => {
       }),
     );
     expect(sandbox.run).toHaveBeenCalledWith(
-      "tl-rootfs-build",
+      "/usr/local/bin/tl-rootfs-build",
       expect.objectContaining({
         args: [
           "--spec",
@@ -676,6 +676,7 @@ describe("sandbox image helpers", () => {
           "--metadata-out",
           "/tmp/tl-rootfs-build/metadata.json",
         ],
+        env: { PATH: "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" },
         timeout: 3600,
         workingDir: "/tmp/tl-rootfs-build",
       }),

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -553,4 +553,150 @@ describe("sandbox image helpers", () => {
     expect(registerImage).not.toHaveBeenCalled();
     expect(sandbox.terminate).toHaveBeenCalled();
   });
+
+  it("offline rootfs builder applies Dockerfile before snapshotting a diff", async () => {
+    vi.stubEnv("TENSORLAKE_API_URL", "https://api.tensorlake.ai");
+    vi.stubEnv("TENSORLAKE_API_KEY", "tl_key_test");
+    vi.stubEnv("INDEXIFY_NAMESPACE", "default");
+    vi.stubEnv("TENSORLAKE_ORGANIZATION_ID", "org_123");
+    vi.stubEnv("TENSORLAKE_PROJECT_ID", "proj_123");
+
+    const tempDir = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-offline`),
+      { recursive: true },
+    );
+    const dockerfilePath = path.join(tempDir, "Dockerfile");
+    await writeFile(
+      dockerfilePath,
+      "FROM base-private\nRUN touch /child\n",
+      "utf8",
+    );
+
+    const writes: Array<{ path: string; content: Uint8Array }> = [];
+    const sandbox = {
+      sandboxId: "sbx-builder",
+      run: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
+      startProcess: vi.fn(async () => ({ pid: 1 })),
+      getStdout: vi.fn(async () => ({ pid: 1, lines: [], lineCount: 0 })),
+      getStderr: vi.fn(async () => ({ pid: 1, lines: [], lineCount: 0 })),
+      getProcess: vi.fn(async () => ({
+        pid: 1,
+        status: "exited",
+        stdinWritable: false,
+        command: "sh",
+        args: [],
+        startedAt: new Date(),
+        exitCode: 0,
+      })),
+      writeFile: vi.fn(async (filePath: string, content: Uint8Array) => {
+        writes.push({ path: filePath, content });
+      }),
+      readFile: vi.fn(async () =>
+        new TextEncoder().encode(
+          JSON.stringify({
+            snapshot_id: "snap-child",
+            snapshot_uri: "s3://snapshots/child.tlsnap",
+            snapshot_format_version: "durable_archive_v1",
+            rootfs_node_kind: "diff",
+            snapshot_size_bytes: 123,
+            rootfs_disk_bytes: 10 * 1024 * 1024 * 1024,
+            parent_manifest_uri: "s3://snapshots/parent.tlsnap",
+          }),
+        ),
+      ),
+      terminate: vi.fn(async () => {}),
+    };
+
+    const client = {
+      createAndConnect: vi.fn(async () => sandbox),
+      snapshotAndWait: vi.fn(),
+      close: vi.fn(() => {}),
+    };
+    const completeRootfsBuild = vi.fn(async () => ({ id: "tpl-1" }));
+
+    await createSandboxImage(
+      dockerfilePath,
+      {},
+      {
+        emit: () => {},
+        createClient: () => client as never,
+        prepareRootfsBuild: async () => ({
+          buildId: "build_1",
+          snapshotId: "snap-child",
+          snapshotUri: "s3://snapshots/child.tlsnap",
+          rootfsNodeKind: "diff",
+          builder: {
+            image: "base-private",
+            command: "tl-rootfs-build",
+            buildSpecVersion: "rootfs-build-spec-v1",
+            cpus: 2,
+            memoryMb: 4096,
+            diskMb: 32768,
+          },
+          upload: {
+            kind: "single_put",
+            method: "PUT",
+            url: "https://upload.example.test",
+          },
+        }),
+        completeRootfsBuild,
+        sleep: async () => {},
+      },
+    );
+
+    expect(client.createAndConnect).toHaveBeenCalledWith({
+      image: "base-private",
+      cpus: 2,
+      memoryMb: 4096,
+      diskMb: 32768,
+    });
+    expect(sandbox.run).toHaveBeenCalledWith("sh", {
+      args: [
+        "-c",
+        expect.stringContaining(
+          "dd if='/dev/vda' of='/tmp/tl-rootfs-build/parent-rootfs.img'",
+        ),
+      ],
+      env: undefined,
+      workingDir: undefined,
+    });
+    expect(sandbox.startProcess).toHaveBeenCalledWith(
+      "sh",
+      expect.objectContaining({
+        args: ["-c", "touch /child"],
+        workingDir: "/",
+      }),
+    );
+    expect(sandbox.run).toHaveBeenCalledWith(
+      "tl-rootfs-build",
+      expect.objectContaining({
+        args: [
+          "--spec",
+          "/tmp/tl-rootfs-build/build-spec.json",
+          "--metadata-out",
+          "/tmp/tl-rootfs-build/metadata.json",
+        ],
+        timeout: 3600,
+        workingDir: "/tmp/tl-rootfs-build",
+      }),
+    );
+    const specWrite = writes.find(
+      (write) => write.path === "/tmp/tl-rootfs-build/build-spec.json",
+    );
+    expect(specWrite).toBeDefined();
+    const spec = JSON.parse(new TextDecoder().decode(specWrite!.content));
+    expect(spec.rootfsPath).toBe("/dev/vda");
+    expect(spec.parentRootfsPath).toBe(
+      "/tmp/tl-rootfs-build/parent-rootfs.img",
+    );
+    expect(completeRootfsBuild).toHaveBeenCalledWith(
+      expect.anything(),
+      "build_1",
+      expect.objectContaining({
+        snapshot_id: "snap-child",
+        rootfs_node_kind: "diff",
+      }),
+    );
+    expect(sandbox.terminate).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- route sandbox image builds through Platform API's offline rootfs build prepare/complete flow
- start registered-parent diff builds from the Platform API-selected parent image, apply Dockerfile steps there, then run the offline rootfs builder wrapper
- resolve rootfs builder commands to /usr/local/bin when the API returns a bare command, and set PATH so wrapper subprocesses can find indexify-rootfs-snapshot
- wire Python SDK, TypeScript SDK, and Rust CLI build specs through rootfsPath/parentRootfsPath
- fail closed when Platform API prepares an unregistered OCI base as a customer-owned rootfs base until the Docker-export rootfs materializer lands, so the clients do not snapshot tensorlake/rootfs-builder as the user image
- add unit coverage for builder command path resolution, offline rootfs builder flow, and the unmaterialized OCI-base guard

## Supporting PRs
- tensorlakeai/platform-api#502 prepares unregistered OCI bases as customer-owned rootfs base builds and keeps registered parents as diffs
- tensorlakeai/provisioner#767 injects tl-rootfs-build and indexify-rootfs-snapshot into all managed rootfs images so parent images can run the diff builder
- tensorlakeai/compute-engine-internal#880 lets indexify-rootfs-snapshot size /dev/vda as a block device instead of rejecting it as an empty rootfs

## Validation
- cargo fmt --check
- cargo test -p tensorlake-cli requires_oci_base_import_when_base_builder_differs_from_from_image
- poetry run black src/tensorlake/image/sandbox_builder.py tests/image/test_sandbox_builder.py
- PYTHONPATH=src poetry run python -m unittest tests.image.test_sandbox_builder.TestOfflineRootfsBuilder
- npm exec --yes --package=node@24 -- bash -lc 'cd typescript && node --version && npm test -- tests/sandbox-image.test.ts'
- git diff --check