### PR TITLE
feat(sandbox-image): register custom images with just TENSORLAKE_API_KEY

### DIFF
--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -701,9 +701,7 @@ def _register_image(
     # headers for that path.
     bearer_token = ctx.api_key or ctx.personal_access_token
     if not bearer_token:
-        raise RuntimeError(
-            "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
-        )
+        raise RuntimeError("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.")
 
     headers = {
         "Authorization": f"Bearer {bearer_token}",

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -718,9 +718,11 @@ def _register_image(
         proj_id = ctx.project_id
         if not org_id or not proj_id:
             raise RuntimeError(
-                "Organization ID and Project ID are required when authenticating "
-                "with a Personal Access Token. Set TENSORLAKE_API_KEY to skip "
-                "this requirement, or run 'tl login' and 'tl init'."
+                "Personal Access Token authentication requires "
+                "TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID to be set "
+                "(e.g. via 'tl login && tl init'). To skip this requirement, "
+                "authenticate with TENSORLAKE_API_KEY instead — API keys are "
+                "bound to a single project at creation."
             )
         url = f"{ctx.api_url}/platform/v1/organizations/{org_id}/projects/{proj_id}/sandbox-templates"
         headers["X-Forwarded-Organization-Id"] = org_id

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -695,21 +695,34 @@ def _register_image(
     snapshot_format_version: str | None = None,
 ) -> dict:
     """POST to Platform API through the ingress to register the image."""
-    org_id = ctx.organization_id
-    proj_id = ctx.project_id
-    if not org_id or not proj_id:
+    # API key auth: the platform-api resolves the org/project from the key
+    # itself, so we hit the scope-less route and skip the env var requirement.
+    # PAT auth isn't project-scoped — keep the explicit IDs and forwarded
+    # headers for that path.
+    bearer_token = ctx.api_key or ctx.personal_access_token
+    if not bearer_token:
         raise RuntimeError(
-            "Organization ID and Project ID are required. Run 'tl login' and 'tl init'."
+            "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
         )
 
-    url = f"{ctx.api_url}/platform/v1/organizations/{org_id}/projects/{proj_id}/sandbox-templates"
-    bearer_token = ctx.api_key or ctx.personal_access_token
     headers = {
         "Authorization": f"Bearer {bearer_token}",
         "Content-Type": "application/json",
         "User-Agent": USER_AGENT,
     }
-    if ctx.personal_access_token and not ctx.api_key:
+
+    if ctx.api_key:
+        url = f"{ctx.api_url}/platform/v1/sandbox-templates"
+    else:
+        org_id = ctx.organization_id
+        proj_id = ctx.project_id
+        if not org_id or not proj_id:
+            raise RuntimeError(
+                "Organization ID and Project ID are required when authenticating "
+                "with a Personal Access Token. Set TENSORLAKE_API_KEY to skip "
+                "this requirement, or run 'tl login' and 'tl init'."
+            )
+        url = f"{ctx.api_url}/platform/v1/organizations/{org_id}/projects/{proj_id}/sandbox-templates"
         headers["X-Forwarded-Organization-Id"] = org_id
         headers["X-Forwarded-Project-Id"] = proj_id
 

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -309,5 +309,135 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
             sbm.build_sandbox_image(12345)  # type: ignore[arg-type]
 
 
+class TestRegisterImage(unittest.TestCase):
+    """Coverage for _register_image's branching on api_key vs PAT auth."""
+
+    def _make_ctx(self, **overrides):
+        defaults = dict(
+            api_url="https://api.tensorlake.test",
+            api_key=None,
+            personal_access_token=None,
+            organization_id=None,
+            project_id=None,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def _mock_response(self):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"id": "tpl-1"}
+        return resp
+
+    def test_api_key_uses_scope_less_route_without_forwarded_headers(self):
+        ctx = self._make_ctx(api_key="tl_apiKey_abc")
+        with patch.object(sbm, "httpx") as httpx_mock:
+            httpx_mock.post.return_value = self._mock_response()
+            sbm._register_image(
+                ctx,
+                "img",
+                "FROM python",
+                "snap-1",
+                "sbx-1",
+                "s3://x",
+                100,
+                200,
+            )
+
+        call_kwargs = httpx_mock.post.call_args
+        url = call_kwargs.args[0]
+        headers = call_kwargs.kwargs["headers"]
+        self.assertEqual(
+            url, "https://api.tensorlake.test/platform/v1/sandbox-templates"
+        )
+        self.assertEqual(headers["Authorization"], "Bearer tl_apiKey_abc")
+        self.assertNotIn("X-Forwarded-Organization-Id", headers)
+        self.assertNotIn("X-Forwarded-Project-Id", headers)
+
+    def test_api_key_ignores_env_var_org_project(self):
+        # Even if the user has org/project env vars set, the API-key path
+        # ignores them — platform-api resolves scope from the bearer token.
+        ctx = self._make_ctx(
+            api_key="tl_apiKey_abc",
+            organization_id="org_env",
+            project_id="proj_env",
+        )
+        with patch.object(sbm, "httpx") as httpx_mock:
+            httpx_mock.post.return_value = self._mock_response()
+            sbm._register_image(
+                ctx,
+                "img",
+                "FROM python",
+                "snap-1",
+                "sbx-1",
+                "s3://x",
+                100,
+                200,
+            )
+
+        url = httpx_mock.post.call_args.args[0]
+        self.assertNotIn("/organizations/", url)
+        self.assertNotIn("/projects/", url)
+
+    def test_pat_keeps_scoped_url_and_forwarded_headers(self):
+        ctx = self._make_ctx(
+            personal_access_token="tl_pat_xyz",
+            organization_id="org_1",
+            project_id="proj_1",
+        )
+        with patch.object(sbm, "httpx") as httpx_mock:
+            httpx_mock.post.return_value = self._mock_response()
+            sbm._register_image(
+                ctx,
+                "img",
+                "FROM python",
+                "snap-1",
+                "sbx-1",
+                "s3://x",
+                100,
+                200,
+            )
+
+        url = httpx_mock.post.call_args.args[0]
+        headers = httpx_mock.post.call_args.kwargs["headers"]
+        self.assertEqual(
+            url,
+            "https://api.tensorlake.test/platform/v1/organizations/org_1/projects/proj_1/sandbox-templates",
+        )
+        self.assertEqual(headers["Authorization"], "Bearer tl_pat_xyz")
+        self.assertEqual(headers["X-Forwarded-Organization-Id"], "org_1")
+        self.assertEqual(headers["X-Forwarded-Project-Id"], "proj_1")
+
+    def test_pat_without_scope_raises(self):
+        ctx = self._make_ctx(personal_access_token="tl_pat_xyz")
+        with self.assertRaisesRegex(
+            RuntimeError, "Personal Access Token"
+        ):
+            sbm._register_image(
+                ctx,
+                "img",
+                "FROM python",
+                "snap-1",
+                "sbx-1",
+                "s3://x",
+                100,
+                200,
+            )
+
+    def test_no_credentials_raises(self):
+        ctx = self._make_ctx()
+        with self.assertRaisesRegex(RuntimeError, "Missing TENSORLAKE_API_KEY"):
+            sbm._register_image(
+                ctx,
+                "img",
+                "FROM python",
+                "snap-1",
+                "sbx-1",
+                "s3://x",
+                100,
+                200,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -410,9 +410,7 @@ class TestRegisterImage(unittest.TestCase):
 
     def test_pat_without_scope_raises(self):
         ctx = self._make_ctx(personal_access_token="tl_pat_xyz")
-        with self.assertRaisesRegex(
-            RuntimeError, "Personal Access Token"
-        ):
+        with self.assertRaisesRegex(RuntimeError, "Personal Access Token"):
             sbm._register_image(
                 ctx,
                 "img",

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -951,9 +951,11 @@ export async function registerImage(
   } else {
     if (!context.organizationId || !context.projectId) {
       throw new Error(
-        "Organization ID and Project ID are required when authenticating with " +
-          "a Personal Access Token. Set TENSORLAKE_API_KEY to skip this " +
-          "requirement, or run 'tl login' and 'tl init'.",
+        "Personal Access Token authentication requires " +
+          "TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID to be set " +
+          "(e.g. via 'tl login && tl init'). To skip this requirement, " +
+          "authenticate with TENSORLAKE_API_KEY instead — API keys are " +
+          "bound to a single project at creation.",
       );
     }
     url =

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -60,7 +60,7 @@ export interface CreateSandboxImageOptions {
 
 export type SandboxImageSource = string | Image;
 
-interface BuildContext {
+export interface BuildContext {
   apiUrl: string;
   apiKey?: string;
   personalAccessToken?: string;
@@ -918,7 +918,7 @@ async function executeDockerfilePlan(
   }
 }
 
-async function registerImage(
+export async function registerImage(
   context: BuildContext,
   name: string,
   dockerfile: string,
@@ -930,28 +930,36 @@ async function registerImage(
   isPublic: boolean,
   snapshotFormatVersion?: string,
 ): Promise<Record<string, unknown>> {
-  if (!context.organizationId || !context.projectId) {
-    throw new Error(
-      "Organization ID and Project ID are required. Run 'tl login' and 'tl init'.",
-    );
-  }
-
   const bearerToken = context.apiKey ?? context.personalAccessToken;
   if (!bearerToken) {
     throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT.");
   }
 
   const baseUrl = context.apiUrl.replace(/\/+$/, "");
-  const url =
-    `${baseUrl}/platform/v1/organizations/` +
-    `${encodeURIComponent(context.organizationId)}/projects/` +
-    `${encodeURIComponent(context.projectId)}/sandbox-templates`;
 
+  // API key auth: platform-api resolves org/project from the key itself, so
+  // we hit the scope-less route and skip the env var requirement.
+  // PAT auth isn't project-scoped — keep the explicit IDs and X-Forwarded
+  // headers for that path.
   const headers: Record<string, string> = {
     Authorization: `Bearer ${bearerToken}`,
     "Content-Type": "application/json",
   };
-  if (context.personalAccessToken && !context.apiKey) {
+  let url: string;
+  if (context.apiKey) {
+    url = `${baseUrl}/platform/v1/sandbox-templates`;
+  } else {
+    if (!context.organizationId || !context.projectId) {
+      throw new Error(
+        "Organization ID and Project ID are required when authenticating with " +
+          "a Personal Access Token. Set TENSORLAKE_API_KEY to skip this " +
+          "requirement, or run 'tl login' and 'tl init'.",
+      );
+    }
+    url =
+      `${baseUrl}/platform/v1/organizations/` +
+      `${encodeURIComponent(context.organizationId)}/projects/` +
+      `${encodeURIComponent(context.projectId)}/sandbox-templates`;
     headers["X-Forwarded-Organization-Id"] = context.organizationId;
     headers["X-Forwarded-Project-Id"] = context.projectId;
   }

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -7,6 +7,8 @@ import {
   loadImagePlan,
   loadDockerfilePlan,
   logicalDockerfileLines,
+  registerImage,
+  type BuildContext,
 } from "../src/sandbox-image.js";
 import { Image, dockerfileContent } from "../src/image.js";
 
@@ -552,5 +554,144 @@ describe("sandbox image helpers", () => {
     expect(sandbox.writeFile).not.toHaveBeenCalled();
     expect(registerImage).not.toHaveBeenCalled();
     expect(sandbox.terminate).toHaveBeenCalled();
+  });
+});
+
+describe("registerImage url selection", () => {
+  const baseContext: BuildContext = {
+    apiUrl: "https://api.tensorlake.test",
+    apiKey: undefined,
+    personalAccessToken: undefined,
+    namespace: "default",
+    organizationId: undefined,
+    projectId: undefined,
+    debug: false,
+  };
+
+  function stubFetch() {
+    const fetchMock = vi.fn(async () =>
+      Promise.resolve(
+        new Response(JSON.stringify({ id: "tpl-1" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("uses the scope-less URL when authenticating with an API key", async () => {
+    const fetchMock = stubFetch();
+    await registerImage(
+      { ...baseContext, apiKey: "tl_apiKey_abc" },
+      "img",
+      "FROM python",
+      "snap-1",
+      "sbx-1",
+      "s3://x",
+      100,
+      200,
+      false,
+    );
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.tensorlake.test/platform/v1/sandbox-templates");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tl_apiKey_abc");
+    expect(headers["X-Forwarded-Organization-Id"]).toBeUndefined();
+    expect(headers["X-Forwarded-Project-Id"]).toBeUndefined();
+  });
+
+  it("ignores env org/project values when an API key is present", async () => {
+    const fetchMock = stubFetch();
+    await registerImage(
+      {
+        ...baseContext,
+        apiKey: "tl_apiKey_abc",
+        organizationId: "org_env",
+        projectId: "proj_env",
+      },
+      "img",
+      "FROM python",
+      "snap-1",
+      "sbx-1",
+      "s3://x",
+      100,
+      200,
+      false,
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).not.toContain("/organizations/");
+    expect(url).not.toContain("/projects/");
+  });
+
+  it("keeps the scoped URL and X-Forwarded headers for PAT auth", async () => {
+    const fetchMock = stubFetch();
+    await registerImage(
+      {
+        ...baseContext,
+        personalAccessToken: "tl_pat_xyz",
+        organizationId: "org_1",
+        projectId: "proj_1",
+      },
+      "img",
+      "FROM python",
+      "snap-1",
+      "sbx-1",
+      "s3://x",
+      100,
+      200,
+      false,
+    );
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://api.tensorlake.test/platform/v1/organizations/org_1/projects/proj_1/sandbox-templates",
+    );
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Forwarded-Organization-Id"]).toBe("org_1");
+    expect(headers["X-Forwarded-Project-Id"]).toBe("proj_1");
+    expect(headers.Authorization).toBe("Bearer tl_pat_xyz");
+  });
+
+  it("throws when authenticating with PAT but no org/project", async () => {
+    stubFetch();
+    await expect(
+      registerImage(
+        { ...baseContext, personalAccessToken: "tl_pat_xyz" },
+        "img",
+        "FROM python",
+        "snap-1",
+        "sbx-1",
+        "s3://x",
+        100,
+        200,
+        false,
+      ),
+    ).rejects.toThrow(/Personal Access Token/);
+  });
+
+  it("throws when no credentials are configured at all", async () => {
+    stubFetch();
+    await expect(
+      registerImage(
+        { ...baseContext },
+        "img",
+        "FROM python",
+        "snap-1",
+        "sbx-1",
+        "s3://x",
+        100,
+        200,
+        false,
+      ),
+    ).rejects.toThrow(/Missing TENSORLAKE_API_KEY/);
   });
 });


### PR DESCRIPTION
## Summary

- Both SDKs (Python and TypeScript) now register custom sandbox images via the new scope-less route `POST /platform/v1/sandbox-templates` when a `TENSORLAKE_API_KEY` is configured. The server resolves the org and project from the key itself.
- Callers no longer need to set `TENSORLAKE_ORGANIZATION_ID` and `TENSORLAKE_PROJECT_ID` env vars on the API-key path.
- PAT auth (`TENSORLAKE_PAT`) keeps its current behavior — PATs aren't project-scoped, so they continue to require explicit IDs and `X-Forwarded-*` headers.

## Motivation

Customer complaint: the TS SDK demands `TENSORLAKE_ORGANIZATION_ID` and `TENSORLAKE_PROJECT_ID` env vars to register custom images, even though an API key uniquely identifies its (org, project) on the backend. The Python SDK has the same gap. The platform-api change in tensorlakeai/platform-api#501 exposes a scope-less endpoint that uses the API key's binding directly — no introspect round-trip needed, the server already has the answer at auth time.

## Server-side dependency

This PR depends on [tensorlakeai/platform-api#501](https://github.com/tensorlakeai/platform-api/pull/501). Land that first; this client change is backwards-compatible because PAT auth still hits the old route, and API keys hit the new route only after #501 ships.

## Test plan

- [x] `poetry run python tests/image/test_sandbox_builder.py` — all 15 tests pass, including 5 new ones covering API-key vs PAT branching
- [x] `pnpm vitest run tests/sandbox-image.test.ts` — all 17 tests pass, including 5 new ones
- [x] `tsc --noEmit` clean
- [ ] End-to-end manual: build a Dockerfile via `tl sandbox image build` against staging with only `TENSORLAKE_API_KEY` set (blocked until #501 deploys to staging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)