### PR TITLE
Use offline rootfs builder for sandbox image creation

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -55,9 +55,11 @@ jobs:
             cloud_sdk_interpreter: python3
           - os: macos-14
             target: aarch64
+            rust_target: aarch64-apple-darwin
             cloud_sdk_interpreter: python3.10
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            rust_target: x86_64-pc-windows-msvc
             cloud_sdk_interpreter: python
     steps:
       - uses: actions/checkout@v4
@@ -66,6 +68,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+
+      - name: Install Rust toolchain
+        if: runner.os != 'Linux'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.rust_target }}
 
       - name: Cache Rust build artifacts (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/publish_test_pypi.yaml
+++ b/.github/workflows/publish_test_pypi.yaml
@@ -68,9 +68,11 @@ jobs:
             cloud_sdk_interpreter: python3
           - os: macos-14
             target: aarch64
+            rust_target: aarch64-apple-darwin
             cloud_sdk_interpreter: python3.10
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            rust_target: x86_64-pc-windows-msvc
             cloud_sdk_interpreter: python
     steps:
       - uses: actions/checkout@v4
@@ -82,6 +84,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+
+      - name: Install Rust toolchain
+        if: runner.os != 'Linux'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.rust_target }}
 
       - name: Cache Rust build artifacts (macOS)
         if: runner.os == 'macOS'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2869,6 +2869,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
  "toml",
  "url",
  "urlencoding",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = { workspace = true }
 reqwest = { workspace = true }
 rustls = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 eventsource-stream = { workspace = true }

--- a/crates/cli/src/auth/context.rs
+++ b/crates/cli/src/auth/context.rs
@@ -179,13 +179,11 @@ impl CliContext {
                 .map(|s| s.to_string()),
         };
 
-        // For API keys, set org/project from introspection
-        if self.organization_id.is_none() {
-            self.organization_id = result.organization_id.clone();
-        }
-        if self.project_id.is_none() {
-            self.project_id = result.project_id.clone();
-        }
+        // API keys are scoped to exactly one project. Treat the server-returned
+        // scope as authoritative so stale local config cannot route API-key
+        // requests to an unrelated org/project and trigger confusing 403s.
+        self.organization_id = result.organization_id.clone();
+        self.project_id = result.project_id.clone();
 
         self.introspect_cache = Some(result);
         Ok(())

--- a/crates/cli/src/commands/sbx/cp.rs
+++ b/crates/cli/src/commands/sbx/cp.rs
@@ -1,5 +1,10 @@
 use std::path::Path;
 
+use futures::StreamExt;
+use reqwest::header::CONTENT_LENGTH;
+use tokio::io::AsyncWriteExt;
+use tokio_util::io::ReaderStream;
+
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{parse_sandbox_path, sandbox_proxy_base, with_sandbox_headers};
 use crate::error::{CliError, Result};
@@ -47,7 +52,6 @@ pub async fn run(ctx: &CliContext, src: &str, dest: &str) -> Result<()> {
             )));
         }
 
-        let data = resp.bytes().await.map_err(CliError::Http)?;
         let mut final_dest = dest_path.to_string();
         if Path::new(dest_path).is_dir() {
             let filename = Path::new(src_path)
@@ -56,8 +60,17 @@ pub async fn run(ctx: &CliContext, src: &str, dest: &str) -> Result<()> {
                 .unwrap_or("file");
             final_dest = Path::new(dest_path).join(filename).display().to_string();
         }
-        std::fs::write(&final_dest, &data)?;
-        println!("{} -> {} ({} bytes)", src, final_dest, data.len());
+
+        let mut file = tokio::fs::File::create(&final_dest).await?;
+        let mut downloaded = 0u64;
+        let mut stream = resp.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(CliError::Http)?;
+            file.write_all(&chunk).await?;
+            downloaded += chunk.len() as u64;
+        }
+        file.flush().await?;
+        println!("{} -> {} ({} bytes)", src, final_dest, downloaded);
     } else if let Some(sandbox_id) = dest_sbx {
         // Upload: local -> sandbox
         if !Path::new(src_path).is_file() {
@@ -67,7 +80,9 @@ pub async fn run(ctx: &CliContext, src: &str, dest: &str) -> Result<()> {
             )));
         }
 
-        let data = std::fs::read(src_path)?;
+        let file = tokio::fs::File::open(src_path).await?;
+        let size = file.metadata().await?.len();
+        let stream = ReaderStream::new(file);
         let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
         let client = ctx.client()?;
 
@@ -78,7 +93,8 @@ pub async fn run(ctx: &CliContext, src: &str, dest: &str) -> Result<()> {
                     proxy_base,
                     urlencoding::encode(dest_path)
                 ))
-                .body(data.clone()),
+                .header(CONTENT_LENGTH, size)
+                .body(reqwest::Body::wrap_stream(stream)),
             sandbox_id,
             host_override,
         )
@@ -95,7 +111,7 @@ pub async fn run(ctx: &CliContext, src: &str, dest: &str) -> Result<()> {
                 body
             )));
         }
-        println!("{} -> {} ({} bytes)", src_path, dest, data.len());
+        println!("{} -> {} ({} bytes)", src_path, dest, size);
     }
 
     Ok(())

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -6,11 +6,13 @@ use std::{
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use docker_credentials_config::DockerConfig;
+use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use shlex::split as shlex_split;
 use tensorlake::{
     Client,
+    error::SdkError,
     sandboxes::{
         SandboxProxyClient, SandboxesClient,
         models::{CreateSandboxRequest, CreateSandboxResources, ProcessInfo},
@@ -27,6 +29,8 @@ const DEFAULT_ROOTFS_DISK_MB: u64 = 10 * 1024;
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(300);
 const PROCESS_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const PROCESS_EXIT_POLL_ATTEMPTS: usize = 10;
+const PROXY_READY_TIMEOUT: Duration = Duration::from_secs(120);
+const PROXY_READY_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const REMOTE_BUILD_DIR: &str = "/var/lib/tensorlake/rootfs-builder/build";
 const REMOTE_CONTEXT_DIR: &str = "/var/lib/tensorlake/rootfs-builder/build/context";
 const REMOTE_SPEC_PATH: &str = "/var/lib/tensorlake/rootfs-builder/build/spec.json";
@@ -148,6 +152,7 @@ pub async fn run(
         eprintln!("⚙️  Rootfs builder sandbox {sandbox_id} is running");
 
         let proxy = sandbox_proxy_client(ctx, &client, &sandbox_id, routing_hint)?;
+        wait_for_proxy_ready(&proxy).await?;
         upload_build_inputs(&proxy, &plan, &prepared_spec, disk_mb).await?;
 
         eprintln!("⚙️  Running offline rootfs builder...");
@@ -265,6 +270,39 @@ fn sandbox_proxy_client(
             .with_sandbox_id(sandbox_id_header)
             .with_routing_hint(routing_hint),
     )
+}
+
+async fn wait_for_proxy_ready(proxy: &SandboxProxyClient) -> Result<()> {
+    let deadline = tokio::time::Instant::now() + PROXY_READY_TIMEOUT;
+    loop {
+        match run_streaming_process(proxy, "/bin/true", Vec::new(), None, None).await {
+            Ok(()) => return Ok(()),
+            Err(error) if is_transient_proxy_error(&error) => {
+                if tokio::time::Instant::now() > deadline {
+                    return Err(error);
+                }
+                tokio::time::sleep(PROXY_READY_POLL_INTERVAL).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn is_transient_proxy_error(error: &CliError) -> bool {
+    match error {
+        CliError::Sdk(SdkError::ServerError { status, message }) => {
+            matches!(
+                *status,
+                StatusCode::BAD_GATEWAY
+                    | StatusCode::SERVICE_UNAVAILABLE
+                    | StatusCode::GATEWAY_TIMEOUT
+            ) || (*status == StatusCode::BAD_REQUEST && message.contains("not running"))
+                || message.contains("PROXY_ERROR")
+                || message.contains("Failed to proxy request")
+        }
+        CliError::Http(error) => error.is_timeout() || error.is_connect(),
+        _ => false,
+    }
 }
 
 async fn upload_build_inputs(

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -31,6 +31,9 @@ const REMOTE_BUILD_DIR: &str = "/var/lib/tensorlake/rootfs-builder/build";
 const REMOTE_CONTEXT_DIR: &str = "/var/lib/tensorlake/rootfs-builder/build/context";
 const REMOTE_SPEC_PATH: &str = "/var/lib/tensorlake/rootfs-builder/build/spec.json";
 const REMOTE_METADATA_PATH: &str = "/var/lib/tensorlake/rootfs-builder/build/metadata.json";
+const ROOTFS_BUILDER_BIN_DIR: &str = "/usr/local/bin";
+const ROOTFS_BUILDER_PATH: &str = "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const ROOTFS_BUILDER_COMMAND: &str = "tl-rootfs-build";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DockerfileBuildPlan {
@@ -386,14 +389,32 @@ async fn run_rootfs_builder(proxy: &SandboxProxyClient, command: &str) -> Result
         REMOTE_METADATA_PATH.to_string(),
     ]);
 
+    let executable = rootfs_builder_executable(executable);
     run_streaming_process(
         proxy,
-        executable,
+        &executable,
         args,
-        None,
+        Some(rootfs_builder_env()),
         Some(REMOTE_BUILD_DIR.to_string()),
     )
     .await
+}
+
+fn rootfs_builder_executable(executable: &str) -> String {
+    if executable == ROOTFS_BUILDER_COMMAND {
+        format!("{ROOTFS_BUILDER_BIN_DIR}/{ROOTFS_BUILDER_COMMAND}")
+    } else {
+        executable.to_string()
+    }
+}
+
+fn rootfs_builder_env() -> Map<String, Value> {
+    let mut env = Map::new();
+    env.insert(
+        "PATH".to_string(),
+        Value::String(ROOTFS_BUILDER_PATH.to_string()),
+    );
+    env
 }
 
 async fn read_build_metadata(proxy: &SandboxProxyClient) -> Result<Value> {
@@ -857,7 +878,7 @@ mod tests {
         CompleteSandboxTemplateBuildRequest, PreparedRootfsBuilder, PreparedRootfsParent,
         PreparedSandboxTemplateBuild, build_rootfs_spec, complete_request_from_metadata,
         default_registered_name, load_dockerfile_plan, logical_dockerfile_lines, normalize_posix,
-        rootfs_disk_bytes,
+        rootfs_builder_env, rootfs_builder_executable, rootfs_disk_bytes,
     };
     use serde_json::{Value, json};
     use std::io::Write;
@@ -956,6 +977,24 @@ mod tests {
         );
         assert_eq!(spec["rootfsDiskBytes"], 2048_u64 * 1024 * 1024);
         assert_eq!(spec["dockerConfigJson"], "{}");
+    }
+
+    #[test]
+    fn rootfs_builder_command_uses_installed_path_and_tool_path() {
+        assert_eq!(
+            rootfs_builder_executable("tl-rootfs-build"),
+            "/usr/local/bin/tl-rootfs-build"
+        );
+        assert_eq!(
+            rootfs_builder_executable("/custom/tl-rootfs-build"),
+            "/custom/tl-rootfs-build"
+        );
+
+        let env = rootfs_builder_env();
+        assert_eq!(
+            env.get("PATH").and_then(Value::as_str),
+            Some("/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+        );
     }
 
     #[test]

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -47,7 +47,7 @@ struct DockerfileBuildPlan {
     base_image: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PreparedSandboxTemplateBuild {
     build_id: String,
@@ -58,7 +58,7 @@ struct PreparedSandboxTemplateBuild {
     parent: Option<PreparedRootfsParent>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PreparedRootfsBuilder {
     image: String,
@@ -68,10 +68,12 @@ struct PreparedRootfsBuilder {
     disk_mb: u64,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PreparedRootfsParent {
     parent_manifest_uri: String,
+    #[serde(default)]
+    rootfs_disk_bytes: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -112,9 +114,8 @@ pub async fn run(
 
     let client = super::sandbox_lifecycle_client(ctx)?;
     let sandboxes = SandboxesClient::new(client.clone(), ctx.namespace.clone(), is_localhost(ctx));
-    let builder_disk_mb = disk_mb
-        .map(|requested| requested.max(prepared.builder.disk_mb))
-        .unwrap_or(prepared.builder.disk_mb);
+    let rootfs_disk_bytes = rootfs_disk_bytes(disk_mb, &prepared)?;
+    let builder_disk_mb = rootfs_disk_bytes_to_mb(rootfs_disk_bytes)?.max(prepared.builder.disk_mb);
     let resources = CreateSandboxResources {
         cpus: cpus.unwrap_or(prepared.builder.cpus),
         memory_mb: memory_mb.unwrap_or(prepared.builder.memory_mb),
@@ -153,7 +154,7 @@ pub async fn run(
 
         let proxy = sandbox_proxy_client(ctx, &client, &sandbox_id, routing_hint)?;
         wait_for_proxy_ready(&proxy).await?;
-        upload_build_inputs(&proxy, &plan, &prepared_spec, disk_mb).await?;
+        upload_build_inputs(&proxy, &plan, &prepared, &prepared_spec, disk_mb).await?;
 
         eprintln!("⚙️  Running offline rootfs builder...");
         run_rootfs_builder(&proxy, &prepared.builder.command).await?;
@@ -308,6 +309,7 @@ fn is_transient_proxy_error(error: &CliError) -> bool {
 async fn upload_build_inputs(
     proxy: &SandboxProxyClient,
     plan: &DockerfileBuildPlan,
+    prepared: &PreparedSandboxTemplateBuild,
     prepared_spec: &Value,
     disk_mb: Option<u64>,
 ) -> Result<()> {
@@ -315,7 +317,7 @@ async fn upload_build_inputs(
     copy_local_path(proxy, &plan.context_dir, REMOTE_CONTEXT_DIR).await?;
 
     let docker_config_json = resolved_docker_config_json().await?;
-    let spec = build_rootfs_spec(prepared_spec, plan, disk_mb, docker_config_json)?;
+    let spec = build_rootfs_spec(prepared_spec, prepared, plan, disk_mb, docker_config_json)?;
     ensure_remote_parent_dir(proxy, REMOTE_SPEC_PATH).await?;
     proxy
         .write_file(
@@ -328,6 +330,7 @@ async fn upload_build_inputs(
 
 fn build_rootfs_spec(
     prepared_spec: &Value,
+    prepared: &PreparedSandboxTemplateBuild,
     plan: &DockerfileBuildPlan,
     disk_mb: Option<u64>,
     docker_config_json: Option<String>,
@@ -353,7 +356,7 @@ fn build_rootfs_spec(
     );
     object.insert(
         "rootfsDiskBytes".to_string(),
-        Value::Number(rootfs_disk_bytes(disk_mb)?.into()),
+        Value::Number(rootfs_disk_bytes(disk_mb, prepared)?.into()),
     );
     if let Some(docker_config_json) = docker_config_json {
         object.insert(
@@ -365,11 +368,29 @@ fn build_rootfs_spec(
     Ok(spec)
 }
 
-fn rootfs_disk_bytes(disk_mb: Option<u64>) -> Result<u64> {
-    disk_mb
-        .unwrap_or(DEFAULT_ROOTFS_DISK_MB)
-        .checked_mul(1024 * 1024)
-        .ok_or_else(|| CliError::usage("--disk_mb is too large to convert to bytes"))
+fn rootfs_disk_bytes(disk_mb: Option<u64>, prepared: &PreparedSandboxTemplateBuild) -> Result<u64> {
+    if let Some(disk_mb) = disk_mb {
+        return disk_mb
+            .checked_mul(1024 * 1024)
+            .ok_or_else(|| CliError::usage("--disk_mb is too large to convert to bytes"));
+    }
+
+    if let Some(parent) = &prepared.parent {
+        return parent.rootfs_disk_bytes.ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "platform API did not return parent rootfsDiskBytes for diff build; pass --disk_mb explicitly or update Platform API"
+            ))
+        });
+    }
+
+    Ok(DEFAULT_ROOTFS_DISK_MB * 1024 * 1024)
+}
+
+fn rootfs_disk_bytes_to_mb(rootfs_disk_bytes: u64) -> Result<u64> {
+    rootfs_disk_bytes
+        .checked_add((1024 * 1024) - 1)
+        .ok_or_else(|| CliError::usage("rootfsDiskBytes is too large to convert to megabytes"))
+        .map(|bytes| bytes / (1024 * 1024))
 }
 
 async fn resolved_docker_config_json() -> Result<Option<String>> {
@@ -916,7 +937,7 @@ mod tests {
         CompleteSandboxTemplateBuildRequest, PreparedRootfsBuilder, PreparedRootfsParent,
         PreparedSandboxTemplateBuild, build_rootfs_spec, complete_request_from_metadata,
         default_registered_name, load_dockerfile_plan, logical_dockerfile_lines, normalize_posix,
-        rootfs_builder_env, rootfs_builder_executable, rootfs_disk_bytes,
+        rootfs_builder_env, rootfs_builder_executable, rootfs_disk_bytes, rootfs_disk_bytes_to_mb,
     };
     use serde_json::{Value, json};
     use std::io::Write;
@@ -969,13 +990,46 @@ mod tests {
 
     #[test]
     fn rootfs_disk_bytes_uses_default_and_validates_overflow() {
-        assert_eq!(rootfs_disk_bytes(None).unwrap(), 10 * 1024 * 1024 * 1024);
-        assert!(rootfs_disk_bytes(Some(u64::MAX)).is_err());
+        let mut base = prepared_build("base");
+        base.parent = None;
+        let diff = prepared_build("diff");
+
+        assert_eq!(
+            rootfs_disk_bytes(None, &base).unwrap(),
+            10 * 1024 * 1024 * 1024
+        );
+        assert_eq!(
+            rootfs_disk_bytes(None, &diff).unwrap(),
+            20 * 1024 * 1024 * 1024
+        );
+        assert_eq!(
+            rootfs_disk_bytes(Some(2048), &diff).unwrap(),
+            2048 * 1024 * 1024
+        );
+        assert!(rootfs_disk_bytes(Some(u64::MAX), &base).is_err());
+    }
+
+    #[test]
+    fn rootfs_disk_bytes_requires_parent_size_for_diff_default() {
+        let mut prepared = prepared_build("diff");
+        prepared.parent.as_mut().unwrap().rootfs_disk_bytes = None;
+
+        let error = rootfs_disk_bytes(None, &prepared).unwrap_err();
+        assert!(
+            error.to_string().contains("parent rootfsDiskBytes"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn rootfs_disk_bytes_to_mb_rounds_up() {
+        assert_eq!(rootfs_disk_bytes_to_mb(1024 * 1024).unwrap(), 1);
+        assert_eq!(rootfs_disk_bytes_to_mb((1024 * 1024) + 1).unwrap(), 2);
     }
 
     #[test]
     fn build_rootfs_spec_adds_cli_builder_inputs() {
-        let prepared = json!({
+        let prepared_spec = json!({
             "buildId": "build-1",
             "snapshotId": "snapshot-1",
             "snapshotUri": "s3://bucket/snapshot.tlsnap",
@@ -1000,6 +1054,8 @@ mod tests {
                 "guestBootContract": "supervisor-init-wrapper-v1"
             }
         });
+        let prepared: PreparedSandboxTemplateBuild =
+            serde_json::from_value(prepared_spec.clone()).unwrap();
         let plan = super::DockerfileBuildPlan {
             context_dir: "/tmp/context".into(),
             registered_name: "child".to_string(),
@@ -1007,7 +1063,14 @@ mod tests {
             base_image: "alpine".to_string(),
         };
 
-        let spec = build_rootfs_spec(&prepared, &plan, Some(2048), Some("{}".to_string())).unwrap();
+        let spec = build_rootfs_spec(
+            &prepared_spec,
+            &prepared,
+            &plan,
+            Some(2048),
+            Some("{}".to_string()),
+        )
+        .unwrap();
         assert_eq!(spec["dockerfile"], "FROM alpine\nRUN echo hi\n");
         assert_eq!(
             spec["contextDir"],
@@ -1015,6 +1078,21 @@ mod tests {
         );
         assert_eq!(spec["rootfsDiskBytes"], 2048_u64 * 1024 * 1024);
         assert_eq!(spec["dockerConfigJson"], "{}");
+    }
+
+    #[test]
+    fn build_rootfs_spec_defaults_diff_to_parent_rootfs_size() {
+        let prepared = prepared_build("diff");
+        let prepared_spec = serde_json::to_value(&prepared).unwrap();
+        let plan = super::DockerfileBuildPlan {
+            context_dir: "/tmp/context".into(),
+            registered_name: "child".to_string(),
+            dockerfile_text: "FROM parent\nRUN echo hi\n".to_string(),
+            base_image: "parent".to_string(),
+        };
+
+        let spec = build_rootfs_spec(&prepared_spec, &prepared, &plan, None, None).unwrap();
+        assert_eq!(spec["rootfsDiskBytes"], 20_u64 * 1024 * 1024 * 1024);
     }
 
     #[test]
@@ -1096,6 +1174,7 @@ mod tests {
             },
             parent: Some(PreparedRootfsParent {
                 parent_manifest_uri: "s3://bucket/parent.tlsnap".to_string(),
+                rootfs_disk_bytes: Some(20 * 1024 * 1024 * 1024),
             }),
         }
     }

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -1,19 +1,19 @@
 use std::{
-    ffi::OsString,
+    collections::HashMap,
     path::{Path, PathBuf},
     time::Duration,
 };
 
-use serde_json::{Map, Value};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use docker_credentials_config::DockerConfig;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
 use shlex::split as shlex_split;
 use tensorlake::{
     Client,
-    sandbox_templates::models::CreateSandboxTemplateRequest,
     sandboxes::{
         SandboxProxyClient, SandboxesClient,
-        models::{
-            CreateSandboxRequest, CreateSandboxResources, ProcessInfo, SnapshotInfo, SnapshotType,
-        },
+        models::{CreateSandboxRequest, CreateSandboxResources, ProcessInfo},
     },
 };
 
@@ -23,21 +23,14 @@ use crate::{
     error::{CliError, Result},
 };
 
-const BUILD_SANDBOX_PIP_ENV: &[(&str, &str)] = &[("PIP_BREAK_SYSTEM_PACKAGES", "1")];
-const DEFAULT_CPUS: f64 = 2.0;
-const DEFAULT_MEMORY_MB: i64 = 4096;
-const SNAPSHOT_POLL_INTERVAL: Duration = Duration::from_secs(1);
-const SNAPSHOT_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+const DEFAULT_ROOTFS_DISK_MB: u64 = 10 * 1024;
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(300);
 const PROCESS_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const PROCESS_EXIT_POLL_ATTEMPTS: usize = 10;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct DockerfileInstruction {
-    keyword: String,
-    value: String,
-    line_number: usize,
-}
+const REMOTE_BUILD_DIR: &str = "/var/lib/tensorlake/rootfs-builder/build";
+const REMOTE_CONTEXT_DIR: &str = "/var/lib/tensorlake/rootfs-builder/build/context";
+const REMOTE_SPEC_PATH: &str = "/var/lib/tensorlake/rootfs-builder/build/spec.json";
+const REMOTE_METADATA_PATH: &str = "/var/lib/tensorlake/rootfs-builder/build/metadata.json";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DockerfileBuildPlan {
@@ -45,17 +38,46 @@ struct DockerfileBuildPlan {
     registered_name: String,
     dockerfile_text: String,
     base_image: String,
-    instructions: Vec<DockerfileInstruction>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SnapshotRegistrationMetadata {
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PreparedSandboxTemplateBuild {
+    build_id: String,
     snapshot_id: String,
-    sandbox_id: String,
     snapshot_uri: String,
-    snapshot_format_version: Option<String>,
+    rootfs_node_kind: String,
+    builder: PreparedRootfsBuilder,
+    parent: Option<PreparedRootfsParent>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PreparedRootfsBuilder {
+    image: String,
+    command: String,
+    cpus: f64,
+    memory_mb: i64,
+    disk_mb: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PreparedRootfsParent {
+    parent_manifest_uri: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CompleteSandboxTemplateBuildRequest {
+    snapshot_id: String,
+    snapshot_uri: String,
+    snapshot_format_version: String,
     snapshot_size_bytes: u64,
     rootfs_disk_bytes: u64,
+    rootfs_node_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_manifest_uri: Option<String>,
 }
 
 pub async fn run(
@@ -71,20 +93,34 @@ pub async fn run(
     let plan = load_dockerfile_plan(dockerfile_path, registered_name)?;
     eprintln!("⚙️  Selected image name: {}", plan.registered_name);
 
+    eprintln!("⚙️  Preparing rootfs build...");
+    let (prepared, prepared_spec) = prepare_rootfs_build(ctx, &plan, is_public).await?;
+    eprintln!(
+        "⚙️  Build mode: Rootfs{}",
+        match prepared.rootfs_node_kind.as_str() {
+            "diff" => "Diff",
+            _ => "Base",
+        }
+    );
+
     let client = super::sandbox_lifecycle_client(ctx)?;
     let sandboxes = SandboxesClient::new(client.clone(), ctx.namespace.clone(), is_localhost(ctx));
-    let templates = super::sandbox_templates_client(ctx)?;
-
+    let builder_disk_mb = disk_mb
+        .map(|requested| requested.max(prepared.builder.disk_mb))
+        .unwrap_or(prepared.builder.disk_mb);
     let resources = CreateSandboxResources {
-        cpus: cpus.unwrap_or(DEFAULT_CPUS),
-        memory_mb: memory_mb.unwrap_or(DEFAULT_MEMORY_MB),
-        disk_mb,
+        cpus: cpus.unwrap_or(prepared.builder.cpus),
+        memory_mb: memory_mb.unwrap_or(prepared.builder.memory_mb),
+        disk_mb: Some(builder_disk_mb),
     };
 
-    eprintln!("⚙️  Creating build sandbox...");
+    eprintln!(
+        "⚙️  Creating rootfs builder sandbox from {}...",
+        prepared.builder.image
+    );
     let created = sandboxes
         .create(&CreateSandboxRequest {
-            image: Some(plan.base_image.clone()),
+            image: Some(prepared.builder.image.clone()),
             resources,
             secret_names: None,
             timeout_secs: None,
@@ -101,36 +137,25 @@ pub async fn run(
         wait_for_sandbox_status(
             ctx,
             &sandbox_id,
-            &format!("Waiting for build sandbox {sandbox_id}"),
+            &format!("Waiting for rootfs builder sandbox {sandbox_id}"),
             "running",
             DEFAULT_SANDBOX_WAIT_TIMEOUT,
         )
         .await?;
-        eprintln!("⚙️  Build sandbox {sandbox_id} is running");
+        eprintln!("⚙️  Rootfs builder sandbox {sandbox_id} is running");
 
         let proxy = sandbox_proxy_client(ctx, &client, &sandbox_id, routing_hint)?;
-        execute_dockerfile_plan(&proxy, &plan).await?;
+        upload_build_inputs(&proxy, &plan, &prepared_spec, disk_mb).await?;
 
-        eprintln!("⚙️  Creating snapshot...");
-        let snapshot = create_snapshot_and_wait(&sandboxes, &sandbox_id).await?;
-        eprintln!("📸 Snapshot created: {}", snapshot.snapshot_id);
+        eprintln!("⚙️  Running offline rootfs builder...");
+        run_rootfs_builder(&proxy, &prepared.builder.command).await?;
 
-        eprintln!("⚙️  Registering image '{}'...", plan.registered_name);
-        let registered = templates
-            .create(&CreateSandboxTemplateRequest {
-                name: plan.registered_name.clone(),
-                dockerfile: plan.dockerfile_text.clone(),
-                snapshot_id: snapshot.snapshot_id.clone(),
-                snapshot_sandbox_id: snapshot.sandbox_id.clone(),
-                snapshot_uri: snapshot.snapshot_uri.clone(),
-                snapshot_format_version: snapshot.snapshot_format_version.clone(),
-                snapshot_size_bytes: snapshot.snapshot_size_bytes,
-                rootfs_disk_bytes: snapshot.rootfs_disk_bytes,
-                public: is_public,
-            })
-            .await?;
+        let metadata = read_build_metadata(&proxy).await?;
+        let complete_request = complete_request_from_metadata(&prepared, &metadata)?;
 
-        let template_id = registered.id.as_deref().unwrap_or("-");
+        eprintln!("⚙️  Completing image registration...");
+        let registered = complete_rootfs_build(ctx, &prepared.build_id, &complete_request).await?;
+        let template_id = registered.get("id").and_then(Value::as_str).unwrap_or("-");
         eprintln!(
             "✅ Image '{}' registered ({})",
             plan.registered_name, template_id
@@ -141,12 +166,87 @@ pub async fn run(
 
     if let Err(error) = sandboxes.delete(&sandbox_id).await {
         eprintln!(
-            "⚠️  Failed to terminate build sandbox {} during cleanup: {}",
+            "⚠️  Failed to terminate rootfs builder sandbox {} during cleanup: {}",
             sandbox_id, error
         );
     }
 
     result
+}
+
+async fn prepare_rootfs_build(
+    ctx: &CliContext,
+    plan: &DockerfileBuildPlan,
+    is_public: bool,
+) -> Result<(PreparedSandboxTemplateBuild, Value)> {
+    let client = ctx.client()?;
+    let url = sandbox_template_builds_url(ctx)?;
+    let response = client
+        .post(url)
+        .json(&json!({
+            "name": plan.registered_name,
+            "dockerfile": plan.dockerfile_text,
+            "baseImage": plan.base_image,
+            "public": is_public,
+        }))
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to prepare sandbox image build (HTTP {}): {}",
+            status,
+            body
+        )));
+    }
+
+    let raw: Value = response.json().await.map_err(CliError::Http)?;
+    let prepared = serde_json::from_value(raw.clone()).map_err(CliError::Json)?;
+    Ok((prepared, raw))
+}
+
+async fn complete_rootfs_build(
+    ctx: &CliContext,
+    build_id: &str,
+    request: &CompleteSandboxTemplateBuildRequest,
+) -> Result<Value> {
+    let client = ctx.client()?;
+    let url = format!(
+        "{}/{}/complete",
+        sandbox_template_builds_url(ctx)?,
+        build_id
+    );
+    let response = client
+        .post(url)
+        .json(request)
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to complete sandbox image build (HTTP {}): {}",
+            status,
+            body
+        )));
+    }
+
+    response.json().await.map_err(CliError::Http)
+}
+
+fn sandbox_template_builds_url(ctx: &CliContext) -> Result<String> {
+    let (org_id, project_id) = super::org_and_project(ctx)?;
+    Ok(format!(
+        "{}/platform/v1/organizations/{}/projects/{}/sandbox-template-builds",
+        ctx.api_url.trim_end_matches('/'),
+        org_id,
+        project_id
+    ))
 }
 
 fn sandbox_proxy_client(
@@ -164,221 +264,220 @@ fn sandbox_proxy_client(
     )
 }
 
-async fn create_snapshot_and_wait(
-    sandboxes: &SandboxesClient,
-    sandbox_id: &str,
-) -> Result<SnapshotRegistrationMetadata> {
-    let snapshot = sandboxes
-        .snapshot(sandbox_id, Some(SnapshotType::Filesystem))
-        .await?;
-    let snapshot_id = snapshot.snapshot_id.clone();
+async fn upload_build_inputs(
+    proxy: &SandboxProxyClient,
+    plan: &DockerfileBuildPlan,
+    prepared_spec: &Value,
+    disk_mb: Option<u64>,
+) -> Result<()> {
+    eprintln!("⚙️  Uploading build context...");
+    copy_local_path(proxy, &plan.context_dir, REMOTE_CONTEXT_DIR).await?;
 
-    wait_for_snapshot(&snapshot_id, SNAPSHOT_WAIT_TIMEOUT, || {
-        let snapshot_id = snapshot_id.clone();
-        async move {
-            sandboxes
-                .get_snapshot(&snapshot_id)
-                .await
-                .map(|snapshot| snapshot.into_inner())
-                .map_err(Into::into)
+    let docker_config_json = resolved_docker_config_json().await?;
+    let spec = build_rootfs_spec(prepared_spec, plan, disk_mb, docker_config_json)?;
+    ensure_remote_parent_dir(proxy, REMOTE_SPEC_PATH).await?;
+    proxy
+        .write_file(
+            REMOTE_SPEC_PATH,
+            serde_json::to_vec_pretty(&spec).map_err(CliError::Json)?,
+        )
+        .await?;
+    Ok(())
+}
+
+fn build_rootfs_spec(
+    prepared_spec: &Value,
+    plan: &DockerfileBuildPlan,
+    disk_mb: Option<u64>,
+    docker_config_json: Option<String>,
+) -> Result<Value> {
+    let mut spec = prepared_spec.clone();
+    let object = spec.as_object_mut().ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!(
+            "platform API returned a non-object rootfs build spec"
+        ))
+    })?;
+
+    object.insert(
+        "dockerfile".to_string(),
+        Value::String(plan.dockerfile_text.clone()),
+    );
+    object.insert(
+        "contextDir".to_string(),
+        Value::String(REMOTE_CONTEXT_DIR.to_string()),
+    );
+    object.insert(
+        "baseImage".to_string(),
+        Value::String(plan.base_image.clone()),
+    );
+    object.insert(
+        "rootfsDiskBytes".to_string(),
+        Value::Number(rootfs_disk_bytes(disk_mb)?.into()),
+    );
+    if let Some(docker_config_json) = docker_config_json {
+        object.insert(
+            "dockerConfigJson".to_string(),
+            Value::String(docker_config_json),
+        );
+    }
+
+    Ok(spec)
+}
+
+fn rootfs_disk_bytes(disk_mb: Option<u64>) -> Result<u64> {
+    disk_mb
+        .unwrap_or(DEFAULT_ROOTFS_DISK_MB)
+        .checked_mul(1024 * 1024)
+        .ok_or_else(|| CliError::usage("--disk_mb is too large to convert to bytes"))
+}
+
+async fn resolved_docker_config_json() -> Result<Option<String>> {
+    let docker_config = DockerConfig::load().await.map_err(|error| {
+        CliError::Other(anyhow::anyhow!("Failed to load Docker config: {error}"))
+    })?;
+    let credentials = docker_config.all_credentials();
+    if credentials.is_empty() {
+        return Ok(None);
+    }
+
+    docker_config_json_from_credentials(credentials)
+        .map(Some)
+        .map_err(CliError::Json)
+}
+
+fn docker_config_json_from_credentials(
+    credentials: HashMap<String, bollard::auth::DockerCredentials>,
+) -> serde_json::Result<String> {
+    let mut auths = Map::new();
+    for (registry, creds) in credentials {
+        let mut entry = Map::new();
+        if let Some(identity_token) = creds.identitytoken {
+            entry.insert("identitytoken".to_string(), Value::String(identity_token));
         }
-    })
+        if let (Some(username), Some(password)) = (creds.username, creds.password) {
+            let encoded = STANDARD.encode(format!("{username}:{password}"));
+            entry.insert("auth".to_string(), Value::String(encoded));
+        }
+        if !entry.is_empty() {
+            auths.insert(registry, Value::Object(entry));
+        }
+    }
+
+    serde_json::to_string(&json!({ "auths": auths }))
+}
+
+async fn run_rootfs_builder(proxy: &SandboxProxyClient, command: &str) -> Result<()> {
+    let parts = shlex_split(command).ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!(
+            "invalid rootfs builder command returned by platform API: {}",
+            command
+        ))
+    })?;
+    let Some((executable, command_args)) = parts.split_first() else {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "empty rootfs builder command returned by platform API"
+        )));
+    };
+    let mut args = command_args.to_vec();
+    args.extend([
+        "--spec".to_string(),
+        REMOTE_SPEC_PATH.to_string(),
+        "--metadata-out".to_string(),
+        REMOTE_METADATA_PATH.to_string(),
+    ]);
+
+    run_streaming_process(
+        proxy,
+        executable,
+        args,
+        None,
+        Some(REMOTE_BUILD_DIR.to_string()),
+    )
     .await
 }
 
-async fn wait_for_snapshot<F, Fut>(
-    snapshot_id: &str,
-    timeout: Duration,
-    mut fetch_snapshot: F,
-) -> Result<SnapshotRegistrationMetadata>
-where
-    F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = Result<SnapshotInfo>>,
-{
-    let deadline = tokio::time::Instant::now() + timeout;
-
-    loop {
-        if tokio::time::Instant::now() >= deadline {
-            return Err(CliError::Other(anyhow::anyhow!(
-                "snapshot {} did not complete within {}s",
-                snapshot_id,
-                timeout.as_secs()
-            )));
-        }
-
-        let info = fetch_snapshot().await?;
-        match info.status.as_str() {
-            "completed" => return parse_completed_snapshot(&info),
-            "failed" => {
-                let error = info.error.as_deref().unwrap_or("unknown error");
-                return Err(CliError::Other(anyhow::anyhow!(
-                    "snapshot {} failed: {}",
-                    snapshot_id,
-                    error
-                )));
-            }
-            _ => {
-                tokio::time::sleep(SNAPSHOT_POLL_INTERVAL).await;
-            }
-        }
-    }
+async fn read_build_metadata(proxy: &SandboxProxyClient) -> Result<Value> {
+    let content = proxy.read_file(REMOTE_METADATA_PATH).await?.into_inner();
+    serde_json::from_slice(&content).map_err(CliError::Json)
 }
 
-fn parse_completed_snapshot(info: &SnapshotInfo) -> Result<SnapshotRegistrationMetadata> {
-    let snapshot_uri = info.snapshot_uri.clone().ok_or_else(|| {
-        CliError::Other(anyhow::anyhow!(
-            "snapshot {} completed without snapshot_uri",
-            info.snapshot_id
-        ))
-    })?;
-    let snapshot_size_bytes = info
-        .size_bytes
-        .ok_or_else(|| {
-            CliError::Other(anyhow::anyhow!(
-                "snapshot {} completed without size_bytes",
-                info.snapshot_id
-            ))
-        })?
-        .try_into()
-        .map_err(|_| {
-            CliError::Other(anyhow::anyhow!(
-                "snapshot {} reported a negative size_bytes",
-                info.snapshot_id
-            ))
-        })?;
-    let rootfs_disk_bytes = info.rootfs_disk_bytes.ok_or_else(|| {
-        CliError::Other(anyhow::anyhow!(
-            "snapshot {} completed without rootfs_disk_bytes",
-            info.snapshot_id
-        ))
-    })?;
+fn complete_request_from_metadata(
+    prepared: &PreparedSandboxTemplateBuild,
+    metadata: &Value,
+) -> Result<CompleteSandboxTemplateBuildRequest> {
+    let rootfs_node_kind = metadata_string(metadata, "rootfs_node_kind", "rootfsNodeKind")
+        .unwrap_or_else(|| prepared.rootfs_node_kind.clone());
+    let parent_manifest_uri = metadata_string(metadata, "parent_manifest_uri", "parentManifestUri")
+        .or_else(|| {
+            (rootfs_node_kind == "diff")
+                .then(|| {
+                    prepared
+                        .parent
+                        .as_ref()
+                        .map(|parent| parent.parent_manifest_uri.clone())
+                })
+                .flatten()
+        });
 
-    Ok(SnapshotRegistrationMetadata {
-        snapshot_id: info.snapshot_id.clone(),
-        sandbox_id: info.sandbox_id.clone(),
-        snapshot_uri,
-        snapshot_format_version: info.snapshot_format_version.clone(),
-        snapshot_size_bytes,
-        rootfs_disk_bytes,
+    if rootfs_node_kind == "diff" && parent_manifest_uri.is_none() {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "rootfs diff build completed without parent_manifest_uri"
+        )));
+    }
+
+    Ok(CompleteSandboxTemplateBuildRequest {
+        snapshot_id: metadata_string(metadata, "snapshot_id", "snapshotId")
+            .unwrap_or_else(|| prepared.snapshot_id.clone()),
+        snapshot_uri: metadata_string(metadata, "snapshot_uri", "snapshotUri")
+            .unwrap_or_else(|| prepared.snapshot_uri.clone()),
+        snapshot_format_version: required_metadata_string(
+            metadata,
+            "snapshot_format_version",
+            "snapshotFormatVersion",
+        )?,
+        snapshot_size_bytes: required_metadata_u64(
+            metadata,
+            "snapshot_size_bytes",
+            "snapshotSizeBytes",
+        )?,
+        rootfs_disk_bytes: required_metadata_u64(metadata, "rootfs_disk_bytes", "rootfsDiskBytes")?,
+        rootfs_node_kind,
+        parent_manifest_uri,
     })
 }
 
-async fn execute_dockerfile_plan(
-    proxy: &SandboxProxyClient,
-    plan: &DockerfileBuildPlan,
-) -> Result<()> {
-    let mut process_env = BUILD_SANDBOX_PIP_ENV
-        .iter()
-        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-        .collect::<Vec<(String, String)>>();
-    let mut working_dir = "/".to_string();
+fn required_metadata_string(metadata: &Value, snake_key: &str, camel_key: &str) -> Result<String> {
+    metadata_string(metadata, snake_key, camel_key).ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!(
+            "rootfs builder metadata is missing {}",
+            snake_key
+        ))
+    })
+}
 
-    for instruction in &plan.instructions {
-        match instruction.keyword.as_str() {
-            "RUN" => {
-                eprintln!("⚙️  RUN {}", instruction.value);
-                run_streaming_process(
-                    proxy,
-                    "sh",
-                    vec!["-c".to_string(), instruction.value.clone()],
-                    Some(build_env_map(&process_env)),
-                    Some(working_dir.clone()),
-                )
-                .await?;
-            }
-            "WORKDIR" => {
-                let tokens = shlex_split(&instruction.value).ok_or_else(|| {
-                    CliError::Other(anyhow::anyhow!(
-                        "line {}: invalid WORKDIR syntax",
-                        instruction.line_number
-                    ))
-                })?;
-                if tokens.len() != 1 {
-                    return Err(CliError::Other(anyhow::anyhow!(
-                        "line {}: WORKDIR must include exactly one path",
-                        instruction.line_number
-                    )));
-                }
-                working_dir = resolve_container_path(&tokens[0], &working_dir);
-                eprintln!("⚙️  WORKDIR {}", working_dir);
-                run_streaming_process(
-                    proxy,
-                    "mkdir",
-                    vec!["-p".to_string(), working_dir.clone()],
-                    Some(build_env_map(&process_env)),
-                    None,
-                )
-                .await?;
-            }
-            "ENV" => {
-                for (key, value) in parse_env_pairs(&instruction.value, instruction.line_number)? {
-                    eprintln!("⚙️  ENV {}={}", key, value);
-                    process_env.push((key.clone(), value.clone()));
-                    persist_env_var(proxy, &process_env, &key, &value).await?;
-                }
-            }
-            "COPY" => {
-                let (_, sources, destination) = parse_copy_like_values(
-                    &instruction.value,
-                    instruction.line_number,
-                    &instruction.keyword,
-                )?;
-                copy_from_context(
-                    proxy,
-                    &plan.context_dir,
-                    &sources,
-                    &destination,
-                    &working_dir,
-                    &instruction.keyword,
-                    &process_env,
-                )
-                .await?;
-            }
-            "ADD" => {
-                let (_, sources, destination) = parse_copy_like_values(
-                    &instruction.value,
-                    instruction.line_number,
-                    &instruction.keyword,
-                )?;
-                if sources.len() == 1 && is_http_source(&sources[0]) {
-                    add_url_to_sandbox(
-                        proxy,
-                        &sources[0],
-                        &destination,
-                        &working_dir,
-                        &process_env,
-                    )
-                    .await?;
-                } else {
-                    copy_from_context(
-                        proxy,
-                        &plan.context_dir,
-                        &sources,
-                        &destination,
-                        &working_dir,
-                        &instruction.keyword,
-                        &process_env,
-                    )
-                    .await?;
-                }
-            }
-            "CMD" | "ENTRYPOINT" | "EXPOSE" | "HEALTHCHECK" | "LABEL" | "STOPSIGNAL" | "VOLUME" => {
-                eprintln!(
-                    "⚠️  Skipping Dockerfile instruction '{}' during snapshot materialization. It is still preserved in the registered Dockerfile.",
-                    instruction.keyword
-                );
-            }
-            other => {
-                return Err(CliError::Other(anyhow::anyhow!(
-                    "line {}: Dockerfile instruction '{}' is not supported for sandbox image creation",
-                    instruction.line_number,
-                    other
-                )));
-            }
-        }
-    }
+fn metadata_string(metadata: &Value, snake_key: &str, camel_key: &str) -> Option<String> {
+    metadata
+        .get(snake_key)
+        .or_else(|| metadata.get(camel_key))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
 
-    Ok(())
+fn required_metadata_u64(metadata: &Value, snake_key: &str, camel_key: &str) -> Result<u64> {
+    metadata
+        .get(snake_key)
+        .or_else(|| metadata.get(camel_key))
+        .and_then(|value| match value {
+            Value::Number(number) => number.as_u64(),
+            Value::String(value) => value.parse::<u64>().ok(),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "rootfs builder metadata is missing numeric {}",
+                snake_key
+            ))
+        })
 }
 
 async fn run_streaming_process(
@@ -455,124 +554,13 @@ async fn run_streaming_process(
     Ok(())
 }
 
-async fn persist_env_var(
-    proxy: &SandboxProxyClient,
-    process_env: &[(String, String)],
-    key: &str,
-    value: &str,
-) -> Result<()> {
-    let escaped_value = value.replace('\\', "\\\\").replace('"', "\\\"");
-    let export_line = format!("export {key}=\"{escaped_value}\"");
-    run_streaming_process(
-        proxy,
-        "sh",
-        vec![
-            "-c".to_string(),
-            format!(
-                "printf '%s\\n' {} >> /etc/environment",
-                shell_quote(&export_line)
-            ),
-        ],
-        Some(build_env_map(process_env)),
-        None,
-    )
-    .await
-}
-
-async fn copy_from_context(
-    proxy: &SandboxProxyClient,
-    context_dir: &Path,
-    sources: &[String],
-    destination: &str,
-    working_dir: &str,
-    keyword: &str,
-    process_env: &[(String, String)],
-) -> Result<()> {
-    let destination_path = resolve_container_path(destination, working_dir);
-    if sources.len() > 1 && !destination_path.ends_with('/') {
-        return Err(CliError::Other(anyhow::anyhow!(
-            "{} with multiple sources requires a directory destination ending in '/'",
-            keyword
-        )));
-    }
-
-    for source in sources {
-        let local_source = resolve_context_source_path(context_dir, source)?;
-        let remote_destination = if sources.len() > 1 {
-            join_posix(
-                destination_path.trim_end_matches('/'),
-                file_name_string(Path::new(source))?.as_str(),
-            )
-        } else if local_source.is_file() && destination_path.ends_with('/') {
-            join_posix(
-                destination_path.trim_end_matches('/'),
-                file_name_string(Path::new(source))?.as_str(),
-            )
-        } else {
-            destination_path.clone()
-        };
-
-        eprintln!("⚙️  {} {} -> {}", keyword, source, remote_destination);
-        copy_local_path(proxy, &local_source, &remote_destination, process_env).await?;
-    }
-
-    Ok(())
-}
-
-async fn add_url_to_sandbox(
-    proxy: &SandboxProxyClient,
-    url: &str,
-    destination: &str,
-    working_dir: &str,
-    process_env: &[(String, String)],
-) -> Result<()> {
-    let mut destination_path = resolve_container_path(destination, working_dir);
-    let parsed = url::Url::parse(url).map_err(|error| {
-        CliError::Other(anyhow::anyhow!("invalid ADD URL '{}': {}", url, error))
-    })?;
-    let file_name = parsed
-        .path_segments()
-        .and_then(|segments| segments.filter(|segment| !segment.is_empty()).next_back())
-        .unwrap_or("downloaded");
-    if destination_path.ends_with('/') {
-        destination_path = join_posix(destination_path.trim_end_matches('/'), file_name);
-    }
-    let parent_dir = parent_posix(&destination_path);
-
-    eprintln!("⚙️  ADD {} -> {}", url, destination_path);
-    run_streaming_process(
-        proxy,
-        "mkdir",
-        vec!["-p".to_string(), parent_dir.clone()],
-        Some(build_env_map(process_env)),
-        None,
-    )
-    .await?;
-    run_streaming_process(
-        proxy,
-        "sh",
-        vec![
-            "-c".to_string(),
-            format!(
-                "curl -fsSL --location {} -o {}",
-                shell_quote(url),
-                shell_quote(&destination_path)
-            ),
-        ],
-        Some(build_env_map(process_env)),
-        Some(working_dir.to_string()),
-    )
-    .await
-}
-
 async fn copy_local_path(
     proxy: &SandboxProxyClient,
     local_path: &Path,
     remote_path: &str,
-    process_env: &[(String, String)],
 ) -> Result<()> {
     if local_path.is_file() {
-        ensure_remote_parent_dir(proxy, remote_path, process_env).await?;
+        ensure_remote_parent_dir(proxy, remote_path).await?;
         let content = tokio::fs::read(local_path).await.map_err(CliError::Io)?;
         proxy.write_file(remote_path, content).await?;
         return Ok(());
@@ -581,7 +569,7 @@ async fn copy_local_path(
     if local_path.is_dir() {
         for (full_path, relative_path) in collect_dir_files(local_path, local_path)? {
             let remote_destination = join_posix(remote_path, &relative_path);
-            ensure_remote_parent_dir(proxy, &remote_destination, process_env).await?;
+            ensure_remote_parent_dir(proxy, &remote_destination).await?;
             let content = tokio::fs::read(&full_path).await.map_err(CliError::Io)?;
             proxy.write_file(&remote_destination, content).await?;
         }
@@ -594,54 +582,16 @@ async fn copy_local_path(
     )))
 }
 
-async fn ensure_remote_parent_dir(
-    proxy: &SandboxProxyClient,
-    remote_path: &str,
-    process_env: &[(String, String)],
-) -> Result<()> {
+async fn ensure_remote_parent_dir(proxy: &SandboxProxyClient, remote_path: &str) -> Result<()> {
     let parent_dir = parent_posix(remote_path);
     run_streaming_process(
         proxy,
         "mkdir",
         vec!["-p".to_string(), parent_dir],
-        Some(build_env_map(process_env)),
+        None,
         None,
     )
     .await
-}
-
-fn resolve_context_source_path(context_dir: &Path, source: &str) -> Result<PathBuf> {
-    let resolved_context_dir = std::fs::canonicalize(context_dir).map_err(CliError::Io)?;
-    let candidate = if Path::new(source).is_absolute() {
-        PathBuf::from(source)
-    } else {
-        resolved_context_dir.join(source)
-    };
-    let resolved_source = std::fs::canonicalize(&candidate).map_err(|error| {
-        if error.kind() == std::io::ErrorKind::NotFound {
-            CliError::Other(anyhow::anyhow!(
-                "Local path not found: {}",
-                candidate.display()
-            ))
-        } else {
-            CliError::Io(error)
-        }
-    })?;
-
-    if !resolved_source.starts_with(&resolved_context_dir) {
-        return Err(CliError::Other(anyhow::anyhow!(
-            "Local path escapes the build context: {}",
-            source
-        )));
-    }
-
-    Ok(resolved_source)
-}
-
-fn build_env_map(env: &[(String, String)]) -> Map<String, Value> {
-    env.iter()
-        .map(|(key, value)| (key.clone(), Value::String(value.clone())))
-        .collect()
 }
 
 fn is_localhost(ctx: &CliContext) -> bool {
@@ -670,7 +620,6 @@ fn load_dockerfile_plan(
 
     let dockerfile_text = std::fs::read_to_string(&absolute_path).map_err(CliError::Io)?;
     let mut base_image: Option<String> = None;
-    let mut instructions = Vec::new();
 
     for (line_number, line) in logical_dockerfile_lines(&dockerfile_text) {
         let (keyword, value) = split_instruction(&line, line_number)?;
@@ -682,22 +631,7 @@ fn load_dockerfile_plan(
                 )));
             }
             base_image = Some(parse_from_value(&value, line_number)?);
-            continue;
         }
-
-        if matches!(keyword.as_str(), "ARG" | "ONBUILD" | "SHELL" | "USER") {
-            return Err(CliError::Other(anyhow::anyhow!(
-                "line {}: Dockerfile instruction '{}' is not supported for sandbox image creation",
-                line_number,
-                keyword
-            )));
-        }
-
-        instructions.push(DockerfileInstruction {
-            keyword,
-            value,
-            line_number,
-        });
     }
 
     let base_image = base_image.ok_or_else(|| {
@@ -716,7 +650,6 @@ fn load_dockerfile_plan(
             .unwrap_or_else(|| default_registered_name(&absolute_path)),
         dockerfile_text,
         base_image,
-        instructions,
     })
 }
 
@@ -862,136 +795,6 @@ fn strip_leading_flags(value: &str) -> Result<(Vec<(String, String)>, String)> {
     Ok((flags, remaining))
 }
 
-fn parse_copy_like_values(
-    value: &str,
-    line_number: usize,
-    keyword: &str,
-) -> Result<(Vec<(String, String)>, Vec<String>, String)> {
-    let (flags, payload) = strip_leading_flags(value)?;
-    if flags.iter().any(|(key, _)| key == "from") {
-        return Err(CliError::Other(anyhow::anyhow!(
-            "line {}: {} --from is not supported for sandbox image creation",
-            line_number,
-            keyword
-        )));
-    }
-    let payload = payload.trim();
-    if payload.is_empty() {
-        return Err(CliError::Other(anyhow::anyhow!(
-            "line {}: {} must include source and destination",
-            line_number,
-            keyword
-        )));
-    }
-
-    let parts = if payload.starts_with('[') {
-        let items: Vec<String> = serde_json::from_str(payload).map_err(|error| {
-            CliError::Other(anyhow::anyhow!(
-                "line {}: invalid JSON array syntax for {}: {}",
-                line_number,
-                keyword,
-                error
-            ))
-        })?;
-        if items.len() < 2 {
-            return Err(CliError::Other(anyhow::anyhow!(
-                "line {}: {} JSON array form requires at least two string values",
-                line_number,
-                keyword
-            )));
-        }
-        items
-    } else {
-        let parts = shlex_split(payload).ok_or_else(|| {
-            CliError::Other(anyhow::anyhow!(
-                "line {}: invalid {} syntax",
-                line_number,
-                keyword
-            ))
-        })?;
-        if parts.len() < 2 {
-            return Err(CliError::Other(anyhow::anyhow!(
-                "line {}: {} must include at least one source and one destination",
-                line_number,
-                keyword
-            )));
-        }
-        parts
-    };
-
-    let (destination, sources) = parts.split_last().unwrap();
-    Ok((flags, sources.to_vec(), destination.clone()))
-}
-
-fn parse_env_pairs(value: &str, line_number: usize) -> Result<Vec<(String, String)>> {
-    let tokens = shlex_split(value).ok_or_else(|| {
-        CliError::Other(anyhow::anyhow!(
-            "line {}: invalid ENV syntax '{}'",
-            line_number,
-            value
-        ))
-    })?;
-    if tokens.is_empty() {
-        return Err(CliError::Other(anyhow::anyhow!(
-            "line {}: ENV must include a key and value",
-            line_number
-        )));
-    }
-
-    if tokens.iter().all(|token| token.contains('=')) {
-        return tokens
-            .into_iter()
-            .map(|token| {
-                let (key, env_value) = token.split_once('=').ok_or_else(|| {
-                    CliError::Other(anyhow::anyhow!(
-                        "line {}: invalid ENV token '{}'",
-                        line_number,
-                        token
-                    ))
-                })?;
-                if key.is_empty() {
-                    return Err(CliError::Other(anyhow::anyhow!(
-                        "line {}: invalid ENV token '{}'",
-                        line_number,
-                        token
-                    )));
-                }
-                Ok((key.to_string(), env_value.to_string()))
-            })
-            .collect();
-    }
-
-    if tokens.len() < 2 {
-        return Err(CliError::Other(anyhow::anyhow!(
-            "line {}: ENV must include a key and value",
-            line_number
-        )));
-    }
-
-    Ok(vec![(tokens[0].clone(), tokens[1..].join(" "))])
-}
-
-fn resolve_container_path(path: &str, working_dir: &str) -> String {
-    if path.is_empty() {
-        return working_dir.to_string();
-    }
-    let preserve_trailing_slash = path.ends_with('/');
-    let raw = if path.starts_with('/') {
-        path.to_string()
-    } else if working_dir == "/" {
-        format!("/{}", path)
-    } else {
-        format!("{}/{}", working_dir.trim_end_matches('/'), path)
-    };
-
-    let normalized = normalize_posix(&raw);
-    if preserve_trailing_slash && normalized != "/" {
-        format!("{}/", normalized.trim_end_matches('/'))
-    } else {
-        normalized
-    }
-}
-
 fn normalize_posix(path: &str) -> String {
     let mut parts = Vec::new();
     for segment in path.split('/') {
@@ -1026,16 +829,6 @@ fn join_posix(base: &str, child: &str) -> String {
     normalize_posix(&format!("{}/{}", base.trim_end_matches('/'), child))
 }
 
-fn shell_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
-}
-
-fn is_http_source(source: &str) -> bool {
-    url::Url::parse(source)
-        .map(|url| matches!(url.scheme(), "http" | "https"))
-        .unwrap_or(false)
-}
-
 fn collect_dir_files(root: &Path, current: &Path) -> Result<Vec<(PathBuf, String)>> {
     let mut files = Vec::new();
     for entry in std::fs::read_dir(current).map_err(CliError::Io)? {
@@ -1058,27 +851,16 @@ fn collect_dir_files(root: &Path, current: &Path) -> Result<Vec<(PathBuf, String
     Ok(files)
 }
 
-fn file_name_string(path: &Path) -> Result<String> {
-    path.file_name()
-        .map(OsString::from)
-        .and_then(|value| value.into_string().ok())
-        .ok_or_else(|| {
-            CliError::Other(anyhow::anyhow!(
-                "path '{}' has no file name",
-                path.display()
-            ))
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
+        CompleteSandboxTemplateBuildRequest, PreparedRootfsBuilder, PreparedRootfsParent,
+        PreparedSandboxTemplateBuild, build_rootfs_spec, complete_request_from_metadata,
         default_registered_name, load_dockerfile_plan, logical_dockerfile_lines, normalize_posix,
-        parse_copy_like_values, parse_env_pairs, resolve_container_path,
-        resolve_context_source_path, wait_for_snapshot,
+        rootfs_disk_bytes,
     };
-    use std::{cell::Cell, io::Write, time::Duration};
-    use tensorlake::sandboxes::models::SnapshotInfo;
+    use serde_json::{Value, json};
+    use std::io::Write;
 
     #[test]
     fn default_registered_name_uses_parent_for_dockerfile() {
@@ -1099,53 +881,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_copy_like_values_supports_json_array_form() {
-        let (_, sources, destination) =
-            parse_copy_like_values(r#"["a.txt", "b.txt", "/dst/"]"#, 1, "COPY").unwrap();
-        assert_eq!(sources, vec!["a.txt".to_string(), "b.txt".to_string()]);
-        assert_eq!(destination, "/dst/");
-    }
-
-    #[test]
-    fn parse_env_pairs_supports_equals_form() {
-        let pairs = parse_env_pairs("A=1 B=two", 1).unwrap();
-        assert_eq!(
-            pairs,
-            vec![
-                ("A".to_string(), "1".to_string()),
-                ("B".to_string(), "two".to_string())
-            ]
-        );
-    }
-
-    #[test]
-    fn resolve_container_path_normalizes_relative_paths() {
-        assert_eq!(
-            resolve_container_path("app", "/workspace"),
-            "/workspace/app"
-        );
-        assert_eq!(
-            resolve_container_path("../bin", "/workspace/app"),
-            "/workspace/bin"
-        );
-        assert_eq!(normalize_posix("/a//b/../c"), "/a/c");
-    }
-
-    #[test]
-    fn resolve_container_path_preserves_trailing_slash_for_directories() {
-        assert_eq!(resolve_container_path("/dst/", "/"), "/dst/");
-        assert_eq!(
-            resolve_container_path("dst/", "/workspace"),
-            "/workspace/dst/"
-        );
-    }
-
-    #[test]
     fn load_dockerfile_plan_reads_base_image_and_name() {
         let temp_dir = tempfile::tempdir().unwrap();
         let dockerfile_path = temp_dir.path().join("Dockerfile");
         let mut file = std::fs::File::create(&dockerfile_path).unwrap();
-        writeln!(file, "FROM python:3.12-slim\nRUN echo hi").unwrap();
+        writeln!(file, "FROM python:3.12-slim\nUSER app\nRUN echo hi").unwrap();
 
         let plan = load_dockerfile_plan(dockerfile_path.to_str().unwrap(), None).unwrap();
         assert_eq!(plan.base_image, "python:3.12-slim");
@@ -1153,52 +893,136 @@ mod tests {
             plan.registered_name,
             temp_dir.path().file_name().unwrap().to_string_lossy()
         );
-        assert_eq!(plan.instructions.len(), 1);
     }
 
     #[test]
-    fn resolve_context_source_path_rejects_escaping_the_build_context() {
+    fn load_dockerfile_plan_rejects_multistage_builds() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let context_dir = temp_dir.path().join("context");
-        std::fs::create_dir_all(&context_dir).unwrap();
-        let outside_file = temp_dir.path().join("secret.txt");
-        std::fs::write(&outside_file, b"secret").unwrap();
+        let dockerfile_path = temp_dir.path().join("Dockerfile");
+        std::fs::write(&dockerfile_path, "FROM alpine AS build\nFROM scratch\n").unwrap();
 
-        let error = resolve_context_source_path(&context_dir, "../secret.txt").unwrap_err();
+        let error = load_dockerfile_plan(dockerfile_path.to_str().unwrap(), None).unwrap_err();
         assert!(
-            error
-                .to_string()
-                .contains("Local path escapes the build context"),
+            error.to_string().contains("multi-stage Dockerfiles"),
             "{error}"
         );
     }
 
-    #[tokio::test]
-    async fn wait_for_snapshot_times_out() {
-        let polls = Cell::new(0usize);
-        let error = wait_for_snapshot("snap-1", Duration::from_secs(0), || {
-            polls.set(polls.get() + 1);
-            async {
-                Ok(SnapshotInfo {
-                    snapshot_id: "snap-1".to_string(),
-                    namespace: "ns".to_string(),
-                    sandbox_id: "sbx-1".to_string(),
-                    base_image: None,
-                    status: "pending".to_string(),
-                    error: None,
-                    snapshot_uri: None,
-                    snapshot_format_version: None,
-                    size_bytes: None,
-                    rootfs_disk_bytes: None,
-                    snapshot_type: None,
-                    created_at: None,
-                })
-            }
-        })
-        .await
-        .unwrap_err();
-
-        assert!(error.to_string().contains("did not complete within 0s"));
-        assert_eq!(polls.get(), 0);
+    #[test]
+    fn rootfs_disk_bytes_uses_default_and_validates_overflow() {
+        assert_eq!(rootfs_disk_bytes(None).unwrap(), 10 * 1024 * 1024 * 1024);
+        assert!(rootfs_disk_bytes(Some(u64::MAX)).is_err());
     }
+
+    #[test]
+    fn build_rootfs_spec_adds_cli_builder_inputs() {
+        let prepared = json!({
+            "buildId": "build-1",
+            "snapshotId": "snapshot-1",
+            "snapshotUri": "s3://bucket/snapshot.tlsnap",
+            "rootfsNodeKind": "base",
+            "builder": {
+                "image": "tensorlake/rootfs-builder",
+                "command": "tl-rootfs-build",
+                "cpus": 2,
+                "memoryMb": 4096,
+                "diskMb": 30720
+            },
+            "upload": {
+                "kind": "single_put",
+                "method": "PUT",
+                "url": "https://example/upload",
+                "headers": {},
+                "expiresAt": "2026-05-12T00:00:00Z"
+            },
+            "runtimeContract": {
+                "guestRuntimeLayout": "embedded",
+                "guestRuntimeDriveFormat": "none",
+                "guestBootContract": "supervisor-init-wrapper-v1"
+            }
+        });
+        let plan = super::DockerfileBuildPlan {
+            context_dir: "/tmp/context".into(),
+            registered_name: "child".to_string(),
+            dockerfile_text: "FROM alpine\nRUN echo hi\n".to_string(),
+            base_image: "alpine".to_string(),
+        };
+
+        let spec = build_rootfs_spec(&prepared, &plan, Some(2048), Some("{}".to_string())).unwrap();
+        assert_eq!(spec["dockerfile"], "FROM alpine\nRUN echo hi\n");
+        assert_eq!(
+            spec["contextDir"],
+            "/var/lib/tensorlake/rootfs-builder/build/context"
+        );
+        assert_eq!(spec["rootfsDiskBytes"], 2048_u64 * 1024 * 1024);
+        assert_eq!(spec["dockerConfigJson"], "{}");
+    }
+
+    #[test]
+    fn complete_request_maps_snapshotter_metadata_to_platform_api_shape() {
+        let prepared = prepared_build("diff");
+        let metadata = json!({
+            "snapshot_id": "snapshot-1",
+            "snapshot_uri": "s3://bucket/child.tlsnap",
+            "snapshot_format_version": "durable_archive_v1",
+            "snapshot_size_bytes": 1234,
+            "rootfs_disk_bytes": 10 * 1024 * 1024 * 1024_u64,
+            "rootfs_node_kind": "diff",
+            "parent_manifest_uri": "s3://bucket/parent.tlsnap"
+        });
+
+        let request = complete_request_from_metadata(&prepared, &metadata).unwrap();
+        let body = serde_json::to_value(&request).unwrap();
+        assert_eq!(body["snapshotId"], "snapshot-1");
+        assert_eq!(body["snapshotUri"], "s3://bucket/child.tlsnap");
+        assert_eq!(body["snapshotFormatVersion"], "durable_archive_v1");
+        assert_eq!(body["snapshotSizeBytes"], 1234);
+        assert_eq!(body["rootfsNodeKind"], "diff");
+        assert_eq!(body["parentManifestUri"], "s3://bucket/parent.tlsnap");
+    }
+
+    #[test]
+    fn complete_request_uses_prepared_parent_for_diff_when_metadata_omits_it() {
+        let prepared = prepared_build("diff");
+        let metadata = json!({
+            "snapshot_format_version": "durable_archive_v1",
+            "snapshot_size_bytes": "1234",
+            "rootfs_disk_bytes": 10 * 1024 * 1024 * 1024_u64
+        });
+
+        let request = complete_request_from_metadata(&prepared, &metadata).unwrap();
+        assert_eq!(request.snapshot_id, "snapshot-prepared");
+        assert_eq!(request.snapshot_uri, "s3://bucket/prepared.tlsnap");
+        assert_eq!(
+            request.parent_manifest_uri.as_deref(),
+            Some("s3://bucket/parent.tlsnap")
+        );
+    }
+
+    #[test]
+    fn normalize_posix_collapses_dot_segments() {
+        assert_eq!(normalize_posix("/a//b/../c"), "/a/c");
+    }
+
+    fn prepared_build(rootfs_node_kind: &str) -> PreparedSandboxTemplateBuild {
+        PreparedSandboxTemplateBuild {
+            build_id: "build-1".to_string(),
+            snapshot_id: "snapshot-prepared".to_string(),
+            snapshot_uri: "s3://bucket/prepared.tlsnap".to_string(),
+            rootfs_node_kind: rootfs_node_kind.to_string(),
+            builder: PreparedRootfsBuilder {
+                image: "tensorlake/rootfs-builder".to_string(),
+                command: "tl-rootfs-build".to_string(),
+                cpus: 2.0,
+                memory_mb: 4096,
+                disk_mb: 30720,
+            },
+            parent: Some(PreparedRootfsParent {
+                parent_manifest_uri: "s3://bucket/parent.tlsnap".to_string(),
+            }),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn assert_serialize(_: &CompleteSandboxTemplateBuildRequest, _: &Value) {}
 }

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -641,8 +641,7 @@ async fn copy_local_path(
 ) -> Result<()> {
     if local_path.is_file() {
         ensure_remote_parent_dir(proxy, remote_path).await?;
-        let content = tokio::fs::read(local_path).await.map_err(CliError::Io)?;
-        proxy.write_file(remote_path, content).await?;
+        proxy.upload_file(remote_path, local_path).await?;
         return Ok(());
     }
 
@@ -650,8 +649,7 @@ async fn copy_local_path(
         for (full_path, relative_path) in collect_dir_files(local_path, local_path)? {
             let remote_destination = join_posix(remote_path, &relative_path);
             ensure_remote_parent_dir(proxy, &remote_destination).await?;
-            let content = tokio::fs::read(&full_path).await.map_err(CliError::Io)?;
-            proxy.write_file(&remote_destination, content).await?;
+            proxy.upload_file(&remote_destination, &full_path).await?;
         }
         return Ok(());
     }

--- a/crates/cli/src/commands/sbx/snapshot.rs
+++ b/crates/cli/src/commands/sbx/snapshot.rs
@@ -5,7 +5,30 @@ use crate::error::{CliError, Result};
 pub struct SnapshotDetails {
     pub snapshot_id: String,
     #[allow(dead_code)]
-    pub snapshot_uri: String,
+    pub snapshot_uri: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SnapshotWaitTarget {
+    LocalReady,
+    #[allow(dead_code)]
+    Completed,
+}
+
+impl SnapshotWaitTarget {
+    fn label(self) -> &'static str {
+        match self {
+            Self::LocalReady => "local_ready",
+            Self::Completed => "completed",
+        }
+    }
+
+    fn satisfies(self, status: &str) -> bool {
+        match self {
+            Self::LocalReady => matches!(status, "local_ready" | "completed"),
+            Self::Completed => status == "completed",
+        }
+    }
 }
 
 pub(crate) async fn fetch_snapshot_info(
@@ -42,6 +65,23 @@ pub async fn create_snapshot_with_details(
     sandbox_id: &str,
     timeout: f64,
     snapshot_type: Option<&str>,
+) -> Result<SnapshotDetails> {
+    create_snapshot_with_details_until(
+        ctx,
+        sandbox_id,
+        timeout,
+        snapshot_type,
+        SnapshotWaitTarget::LocalReady,
+    )
+    .await
+}
+
+async fn create_snapshot_with_details_until(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    timeout: f64,
+    snapshot_type: Option<&str>,
+    wait_target: SnapshotWaitTarget,
 ) -> Result<SnapshotDetails> {
     let client = ctx.client()?;
 
@@ -82,14 +122,16 @@ pub async fn create_snapshot_with_details(
 
     eprintln!("Snapshot {} initiated ({})", snapshot_id, status);
 
-    let spinner = crate::commands::sbx::new_spinner("Waiting for snapshot to complete...");
+    let wait_message = format!("Waiting for snapshot to reach {}...", wait_target.label());
+    let spinner = crate::commands::sbx::new_spinner(&wait_message);
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs_f64(timeout);
 
     loop {
         if tokio::time::Instant::now() > deadline {
-            spinner.finish_with_message("Waiting for snapshot to complete... timed out");
+            spinner.finish_with_message(format!("{} timed out", wait_message));
             return Err(CliError::Other(anyhow::anyhow!(
-                "Snapshot did not complete within {}s",
+                "Snapshot did not reach {} within {}s",
+                wait_target.label(),
                 timeout
             )));
         }
@@ -106,20 +148,25 @@ pub async fn create_snapshot_with_details(
 
         let current_status = info.get("status").and_then(|v| v.as_str()).unwrap_or("");
 
-        if current_status == "completed" {
+        if wait_target.satisfies(current_status) {
             let size_bytes = info.get("size_bytes").and_then(|v| v.as_i64()).unwrap_or(0);
             let size_mb = size_bytes as f64 / (1024.0 * 1024.0);
             let snapshot_uri = info
                 .get("snapshot_uri")
                 .and_then(|v| v.as_str())
-                .ok_or_else(|| {
-                    CliError::Other(anyhow::anyhow!(
-                        "snapshot {} completed without snapshot_uri",
-                        snapshot_id
-                    ))
-                })?
-                .to_string();
-            spinner.finish_with_message(format!("Snapshot completed ({:.1} MB)", size_mb));
+                .map(ToString::to_string);
+            if wait_target == SnapshotWaitTarget::Completed && snapshot_uri.is_none() {
+                spinner.finish_with_message("Snapshot completed without snapshot_uri");
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "snapshot {} completed without snapshot_uri",
+                    snapshot_id
+                )));
+            }
+            if current_status == "completed" {
+                spinner.finish_with_message(format!("Snapshot completed ({:.1} MB)", size_mb));
+            } else {
+                spinner.finish_with_message("Snapshot locally ready");
+            }
             return Ok(SnapshotDetails {
                 snapshot_id,
                 snapshot_uri,
@@ -164,4 +211,22 @@ pub async fn run(
     let snapshot_id = create_snapshot(ctx, sandbox_id, timeout, snapshot_type).await?;
     println!("{}", snapshot_id);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SnapshotWaitTarget;
+
+    #[test]
+    fn local_ready_wait_target_accepts_local_ready_and_completed() {
+        assert!(SnapshotWaitTarget::LocalReady.satisfies("local_ready"));
+        assert!(SnapshotWaitTarget::LocalReady.satisfies("completed"));
+        assert!(!SnapshotWaitTarget::LocalReady.satisfies("in_progress"));
+    }
+
+    #[test]
+    fn completed_wait_target_only_accepts_completed() {
+        assert!(SnapshotWaitTarget::Completed.satisfies("completed"));
+        assert!(!SnapshotWaitTarget::Completed.satisfies("local_ready"));
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -593,11 +593,11 @@ enum ImageCommands {
         #[arg(short = 'n', long)]
         registered_name: Option<String>,
 
-        /// Root disk size in MB for the temporary build sandbox (default: 10240 for new sandboxes)
+        /// Root disk size in MB for the generated sandbox image (default: 10240)
         #[arg(long = "disk_mb")]
         disk_mb: Option<u64>,
 
-        /// Deprecated: root disk size in GB for the temporary build sandbox
+        /// Deprecated: root disk size in GB for the generated sandbox image
         #[arg(long = "disk", hide = true, conflicts_with = "disk_mb")]
         disk_gb: Option<u64>,
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -437,7 +437,7 @@ enum SbxCommands {
         /// Source sandbox ID or name
         sandbox_id: String,
 
-        /// Max seconds to wait for snapshot completion
+        /// Max seconds to wait for the snapshot to become locally ready
         #[arg(short, long, default_value = "300")]
         timeout: f64,
 

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -4,8 +4,11 @@ pub mod models;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::Method;
-use reqwest::header::ACCEPT;
+use reqwest::header::{ACCEPT, CONTENT_LENGTH};
 use serde_json::Value;
+use std::path::Path;
+use tokio::fs::File;
+use tokio_util::io::ReaderStream;
 
 use crate::{
     client::{Client, Traced},
@@ -466,6 +469,23 @@ impl SandboxProxyClient {
             .request(Method::PUT, "/api/v1/files")
             .query(&[("path", path)])
             .body(content)
+            .build()?;
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
+    }
+
+    pub async fn upload_file(
+        &self,
+        path: &str,
+        local_path: impl AsRef<Path>,
+    ) -> Result<Traced<()>, SdkError> {
+        let file = File::open(local_path.as_ref()).await?;
+        let size = file.metadata().await?.len();
+        let stream = ReaderStream::new(file);
+        let req = self
+            .request(Method::PUT, "/api/v1/files")
+            .query(&[("path", path)])
+            .header(CONTENT_LENGTH, size)
+            .body(reqwest::Body::wrap_stream(stream))
             .build()?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -1353,6 +1353,17 @@ impl CloudSandboxProxyClient {
         })
     }
 
+    fn upload_file(&self, path: String, local_path: String) -> PyResult<String> {
+        self.run_with_retry(5, move |client| {
+            let path = path.clone();
+            let local_path = local_path.clone();
+            async move {
+                let traced = client.upload_file(&path, local_path).await?;
+                Ok(traced.trace_id)
+            }
+        })
+    }
+
     fn delete_file(&self, path: String) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let path = path.clone();
@@ -1678,6 +1689,25 @@ impl CloudSandboxProxyClient {
                 let path = path.clone();
                 let content = content.clone();
                 async move { c.write_file(&path, content).await.map(|t| t.trace_id) }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
+            Ok(trace_id)
+        })
+    }
+
+    fn upload_file_async<'py>(
+        &self,
+        py: Python<'py>,
+        path: String,
+        local_path: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.client.clone();
+        future_into_py(py, async move {
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let path = path.clone();
+                let local_path = local_path.clone();
+                async move { c.upload_file(&path, local_path).await.map(|t| t.trace_id) }
             })
             .await
             .map_err(into_sandbox_py_error)?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.9"
+version = "0.5.10"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -25,7 +25,7 @@ import httpx
 from tensorlake._tracing import USER_AGENT, inject_traceparent
 from tensorlake.cli._common import Context
 from tensorlake.sandbox import Sandbox, SandboxClient
-from tensorlake.sandbox.models import ProcessStatus, SnapshotType
+from tensorlake.sandbox.models import ProcessStatus, SnapshotType, SnapshotWaitCondition
 
 from ._dockerfile import image_to_dockerfile, render_op_line
 from .image import Image
@@ -789,6 +789,7 @@ def _run_plan(
         snapshot = sandbox_client.snapshot_and_wait(
             sandbox.sandbox_id,
             snapshot_type=SnapshotType.FILESYSTEM,
+            wait_until=SnapshotWaitCondition.COMPLETED,
         )
         emit(
             {

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -467,16 +467,14 @@ def _run_streaming(
 def _copy_to_sandbox(sandbox: Sandbox, local_path: str, remote_path: str):
     """Copy a local file or directory into the sandbox."""
     if os.path.isfile(local_path):
-        with open(local_path, "rb") as f:
-            sandbox.write_file(remote_path, f.read())
+        sandbox.upload_file(local_path, remote_path)
     elif os.path.isdir(local_path):
         for root, _dirs, files in os.walk(local_path):
             for filename in files:
                 full = os.path.join(root, filename)
                 rel = os.path.relpath(full, local_path)
                 dest = posixpath.join(remote_path, rel)
-                with open(full, "rb") as f:
-                    sandbox.write_file(dest, f.read())
+                sandbox.upload_file(full, dest)
     else:
         raise FileNotFoundError(f"Local path not found: {local_path}")
 

--- a/src/tensorlake/sandbox/__init__.py
+++ b/src/tensorlake/sandbox/__init__.py
@@ -39,6 +39,7 @@ from .models import (
     SnapshotInfo,
     SnapshotStatus,
     SnapshotType,
+    SnapshotWaitCondition,
     StdinMode,
 )
 from .pty import Pty
@@ -66,6 +67,7 @@ __all__ = [
     # Snapshot models
     "SnapshotStatus",
     "SnapshotType",
+    "SnapshotWaitCondition",
     "SnapshotInfo",
     "CheckpointType",
     "CreateSnapshotResponse",

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -55,7 +55,9 @@ from .models import (
     SnapshotInfo,
     SnapshotStatus,
     SnapshotType,
+    SnapshotWaitCondition,
     UpdateSandboxRequest,
+    snapshot_satisfies_wait_condition,
 )
 
 
@@ -440,12 +442,18 @@ class AsyncSandboxClient:
         timeout: float = 300,
         poll_interval: float = 1.0,
         snapshot_type: SnapshotType | None = None,
+        wait_until: SnapshotWaitCondition | str = SnapshotWaitCondition.LOCAL_READY,
     ) -> Traced[SnapshotInfo]:
+        try:
+            wait_condition = SnapshotWaitCondition(wait_until)
+        except ValueError as e:
+            raise SandboxError("wait_until must be 'local_ready' or 'completed'") from e
+
         traced_create = await self.snapshot(sandbox_id, snapshot_type=snapshot_type)
         deadline = asyncio.get_running_loop().time() + timeout
         while asyncio.get_running_loop().time() < deadline:
             traced_info = await self.get_snapshot(traced_create.snapshot_id)
-            if traced_info.status == SnapshotStatus.COMPLETED:
+            if snapshot_satisfies_wait_condition(traced_info.status, wait_condition):
                 return traced_info
             if traced_info.status == SnapshotStatus.FAILED:
                 raise SandboxError(
@@ -453,7 +461,7 @@ class AsyncSandboxClient:
                 )
             await asyncio.sleep(poll_interval)
         raise SandboxError(
-            f"Snapshot {traced_create.snapshot_id} did not complete within {timeout}s"
+            f"Snapshot {traced_create.snapshot_id} did not reach {wait_condition.value} within {timeout}s"
         )
 
     # --- Pools ---

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -8,6 +8,7 @@ asyncio event loop instead of blocking a worker thread.
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -558,6 +559,17 @@ class AsyncSandbox:
         try:
             trace_id = await self._rust_client.write_file_async(
                 path=path, content=content
+            )
+            return Traced(trace_id, None)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    async def upload_file(
+        self, local_path: str | os.PathLike[str], path: str
+    ) -> Traced[None]:
+        try:
+            trace_id = await self._rust_client.upload_file_async(
+                path=path, local_path=os.fspath(local_path)
             )
             return Traced(trace_id, None)
         except Exception as e:

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -32,6 +32,7 @@ from .models import (
     SendSignalResponse,
     SnapshotInfo,
     SnapshotType,
+    SnapshotWaitCondition,
     StdinMode,
 )
 from .sandbox import (
@@ -249,6 +250,7 @@ class AsyncSandbox:
         timeout: float = 300,
         poll_interval: float = 1.0,
         checkpoint_type: CheckpointType | None = None,
+        wait_until: SnapshotWaitCondition | str = SnapshotWaitCondition.LOCAL_READY,
     ) -> SnapshotInfo | None:
         self._require_lifecycle_client("checkpoint")
         snapshot_type = (
@@ -264,6 +266,7 @@ class AsyncSandbox:
             timeout=timeout,
             poll_interval=poll_interval,
             snapshot_type=snapshot_type,
+            wait_until=wait_until,
         )
         return traced.value
 

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -38,7 +38,9 @@ from .models import (
     SnapshotInfo,
     SnapshotStatus,
     SnapshotType,
+    SnapshotWaitCondition,
     UpdateSandboxRequest,
+    snapshot_satisfies_wait_condition,
 )
 
 try:
@@ -696,7 +698,7 @@ class SandboxClient:
         """Create a snapshot of a running sandbox's filesystem.
 
         This is an asynchronous operation. Poll with :meth:`get_snapshot`
-        until the status is ``completed`` or ``failed``.
+        until the status is ``local_ready``, ``completed``, or ``failed``.
 
         Args:
             sandbox_id: ID of the running sandbox to snapshot.
@@ -789,27 +791,38 @@ class SandboxClient:
         timeout: float = 300,
         poll_interval: float = 1.0,
         snapshot_type: SnapshotType | None = None,
+        wait_until: SnapshotWaitCondition | str = SnapshotWaitCondition.LOCAL_READY,
     ) -> Traced[SnapshotInfo]:
-        """Create a snapshot and wait for it to complete.
+        """Create a snapshot and wait until it is resumable.
 
         Args:
             sandbox_id: ID of the running sandbox to snapshot
-            timeout: Max seconds to wait for completion (default 300)
+            timeout: Max seconds to wait (default 300)
             poll_interval: Seconds between status polls (default 1)
             snapshot_type: Optional snapshot type. See :meth:`snapshot` for
                 details.
+            wait_until: Snapshot readiness condition. Defaults to
+                :attr:`SnapshotWaitCondition.LOCAL_READY`, which is enough to
+                resume from the snapshot. Use
+                :attr:`SnapshotWaitCondition.COMPLETED` when durable
+                ``snapshot_uri`` metadata is required.
 
         Returns:
-            Traced[SnapshotInfo] with completed snapshot details and trace_id
+            Traced[SnapshotInfo] with snapshot details and trace_id
 
         Raises:
             SandboxError: If snapshot fails or times out
         """
+        try:
+            wait_condition = SnapshotWaitCondition(wait_until)
+        except ValueError as e:
+            raise SandboxError("wait_until must be 'local_ready' or 'completed'") from e
+
         traced_create = self.snapshot(sandbox_id, snapshot_type=snapshot_type)
         deadline = time.time() + timeout
         while time.time() < deadline:
             traced_info = self.get_snapshot(traced_create.snapshot_id)
-            if traced_info.status == SnapshotStatus.COMPLETED:
+            if snapshot_satisfies_wait_condition(traced_info.status, wait_condition):
                 return traced_info
             if traced_info.status == SnapshotStatus.FAILED:
                 raise SandboxError(
@@ -817,7 +830,7 @@ class SandboxClient:
                 )
             time.sleep(poll_interval)
         raise SandboxError(
-            f"Snapshot {traced_create.snapshot_id} did not complete within {timeout}s"
+            f"Snapshot {traced_create.snapshot_id} did not reach {wait_condition.value} within {timeout}s"
         )
 
     # --- Pool operations ---

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -45,8 +45,37 @@ class SnapshotStatus(str, Enum):
     """Status of a snapshot."""
 
     IN_PROGRESS = "in_progress"
+    LOCAL_READY = "local_ready"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+class SnapshotWaitCondition(str, Enum):
+    """Snapshot readiness condition to wait for."""
+
+    LOCAL_READY = "local_ready"
+    COMPLETED = "completed"
+
+
+def snapshot_satisfies_wait_condition(
+    status: SnapshotStatus | str,
+    wait_until: SnapshotWaitCondition | str,
+) -> bool:
+    """Return whether a snapshot status satisfies the requested wait condition."""
+
+    status_value = status.value if isinstance(status, SnapshotStatus) else str(status)
+    wait_value = (
+        wait_until.value
+        if isinstance(wait_until, SnapshotWaitCondition)
+        else SnapshotWaitCondition(wait_until).value
+    )
+
+    if wait_value == SnapshotWaitCondition.LOCAL_READY.value:
+        return status_value in (
+            SnapshotStatus.LOCAL_READY.value,
+            SnapshotStatus.COMPLETED.value,
+        )
+    return status_value == SnapshotStatus.COMPLETED.value
 
 
 class SnapshotType(str, Enum):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -34,6 +34,7 @@ from .models import (
     SendSignalResponse,
     SnapshotInfo,
     SnapshotType,
+    SnapshotWaitCondition,
     StdinMode,
 )
 
@@ -500,21 +501,23 @@ class Sandbox:
         timeout: float = 300,
         poll_interval: float = 1.0,
         checkpoint_type: CheckpointType | None = None,
+        wait_until: SnapshotWaitCondition | str = SnapshotWaitCondition.LOCAL_READY,
     ) -> SnapshotInfo | None:
-        """Create a snapshot of this sandbox's filesystem.
+        """Create a checkpoint of this sandbox.
 
-        By default blocks until the snapshot artifact is committed and
-        returns the completed ``SnapshotInfo``. Pass ``wait=False`` to
+        By default blocks until the snapshot is locally ready and resumable.
+        Pass ``wait=False`` to
         fire-and-return (returns ``None``).
 
         Args:
-            wait: If True (default), poll until the snapshot is committed.
+            wait: If True (default), poll until the requested wait condition.
             timeout: Max seconds to wait when wait=True (default 300).
             poll_interval: Seconds between polls when wait=True (default 1.0).
             checkpoint_type: Optional checkpoint type.
+            wait_until: Snapshot readiness condition. Defaults to local-ready.
 
         Returns:
-            Completed SnapshotInfo when wait=True; None when wait=False.
+            SnapshotInfo when wait=True; None when wait=False.
 
         Raises:
             SandboxError: If the snapshot fails or times out.
@@ -533,6 +536,7 @@ class Sandbox:
             timeout=timeout,
             poll_interval=poll_interval,
             snapshot_type=snapshot_type,
+            wait_until=wait_until,
         ).value
 
     def list_snapshots(self) -> TracedIterator[SnapshotInfo]:

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -969,6 +970,23 @@ class Sandbox:
         """
         try:
             trace_id = self._rust_client.write_file(path=path, content=content)
+            return Traced(trace_id, None)
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+    def upload_file(
+        self, local_path: str | os.PathLike[str], path: str
+    ) -> Traced[None]:
+        """Stream a local file into the sandbox.
+
+        Args:
+            local_path: Local file path to upload
+            path: Absolute destination path inside the sandbox
+        """
+        try:
+            trace_id = self._rust_client.upload_file(
+                path=path, local_path=os.fspath(local_path)
+            )
             return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from tensorlake.image import Image
 from tensorlake.image import sandbox_builder as sbm
-from tensorlake.sandbox.models import SnapshotType
+from tensorlake.sandbox.models import SnapshotType, SnapshotWaitCondition
 
 BUILD_CPUS = 2.0
 BUILD_MEMORY_MB = 4096
@@ -155,6 +155,7 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
         sandbox_client.snapshot_and_wait.assert_called_once_with(
             "sbx-1",
             snapshot_type=SnapshotType.FILESYSTEM,
+            wait_until=SnapshotWaitCondition.COMPLETED,
         )
 
     def test_public_flag_and_registered_name(self):
@@ -284,6 +285,7 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
         sandbox_client.snapshot_and_wait.assert_called_once_with(
             "sbx-1",
             snapshot_type=SnapshotType.FILESYSTEM,
+            wait_until=SnapshotWaitCondition.COMPLETED,
         )
 
     def test_registered_name_overrides_image_name(self):

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -5,7 +5,9 @@ from unittest.mock import patch
 from tensorlake.sandbox import (
     PoolInUseError,
     SandboxNotFoundError,
+    SnapshotStatus,
     SnapshotType,
+    SnapshotWaitCondition,
 )
 from tensorlake.sandbox.client import SandboxClient
 from tensorlake.sandbox.exceptions import SandboxError
@@ -406,6 +408,52 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(snapshot_type, "filesystem")
         self.assertEqual(info.snapshot_id, "snap-1")
         self.assertEqual(info.snapshot_type, SnapshotType.FILESYSTEM)
+
+    def test_snapshot_and_wait_returns_on_local_ready_by_default(self):
+        class _LocalReadyRustClient(_FakeRustClient):
+            def get_snapshot_json(self, snapshot_id):
+                return (
+                    "trace-get",
+                    '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
+                    '"base_image":"python:3.12","status":"local_ready"}',
+                )
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _LocalReadyRustClient()
+
+        info = client.snapshot_and_wait("sbx-1")
+
+        self.assertEqual(info.status, SnapshotStatus.LOCAL_READY)
+        self.assertIsNone(info.snapshot_uri)
+
+    def test_snapshot_and_wait_can_wait_for_completed(self):
+        class _SnapshotSequenceRustClient(_FakeRustClient):
+            def __init__(self):
+                super().__init__()
+                self.get_calls = 0
+
+            def get_snapshot_json(self, snapshot_id):
+                self.get_calls += 1
+                status = "local_ready" if self.get_calls == 1 else "completed"
+                return (
+                    "trace-get",
+                    '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
+                    f'"base_image":"python:3.12","status":"{status}",'
+                    '"snapshot_uri":"s3://snap-1.tar.zst"}',
+                )
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _SnapshotSequenceRustClient()
+        client._rust_client = fake
+
+        info = client.snapshot_and_wait(
+            "sbx-1",
+            poll_interval=0,
+            wait_until=SnapshotWaitCondition.COMPLETED,
+        )
+
+        self.assertEqual(info.status, SnapshotStatus.COMPLETED)
+        self.assertEqual(fake.get_calls, 2)
 
     def test_snapshot_omits_snapshot_type_when_none(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -5,7 +5,9 @@ from unittest.mock import patch
 from tensorlake.sandbox import (
     PoolInUseError,
     SandboxNotFoundError,
+    SnapshotStatus,
     SnapshotType,
+    SnapshotWaitCondition,
 )
 from tensorlake.sandbox.async_client import AsyncSandboxClient
 from tensorlake.sandbox.exceptions import SandboxError
@@ -485,6 +487,50 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(snapshot_type, "filesystem")
         self.assertEqual(info.snapshot_id, "snap-1")
         self.assertEqual(info.snapshot_type, SnapshotType.FILESYSTEM)
+
+    async def test_snapshot_and_wait_returns_on_local_ready_by_default(self):
+        class _LocalReadyRustClient(_FakeAsyncRustClient):
+            async def get_snapshot_json_async(self, *, snapshot_id):
+                return (
+                    "trace-get",
+                    '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
+                    '"base_image":"python:3.12","status":"local_ready"}',
+                )
+
+        client = _make_client(_LocalReadyRustClient())
+
+        info = await client.snapshot_and_wait("sbx-1")
+
+        self.assertEqual(info.status, SnapshotStatus.LOCAL_READY)
+        self.assertIsNone(info.snapshot_uri)
+
+    async def test_snapshot_and_wait_can_wait_for_completed(self):
+        class _SnapshotSequenceRustClient(_FakeAsyncRustClient):
+            def __init__(self):
+                super().__init__()
+                self.get_calls = 0
+
+            async def get_snapshot_json_async(self, *, snapshot_id):
+                self.get_calls += 1
+                status = "local_ready" if self.get_calls == 1 else "completed"
+                return (
+                    "trace-get",
+                    '{"id":"snap-1","namespace":"default","sandbox_id":"sbx-1",'
+                    f'"base_image":"python:3.12","status":"{status}",'
+                    '"snapshot_uri":"s3://snap-1.tar.zst"}',
+                )
+
+        fake = _SnapshotSequenceRustClient()
+        client = _make_client(fake)
+
+        info = await client.snapshot_and_wait(
+            "sbx-1",
+            poll_interval=0,
+            wait_until=SnapshotWaitCondition.COMPLETED,
+        )
+
+        self.assertEqual(info.status, SnapshotStatus.COMPLETED)
+        self.assertEqual(fake.get_calls, 2)
 
     async def test_snapshot_omits_snapshot_type_when_none(self):
         fake = _FakeAsyncRustClient()

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -27,7 +27,7 @@ _SANDBOX_IMAGE = os.environ.get(
 )
 _SANDBOX_CPUS = 1.0
 _SANDBOX_MEMORY_MB = 1024
-_SANDBOX_DISK_MB = 1024
+_SANDBOX_DISK_MB = 10240
 
 
 # ---------------------------------------------------------------------------

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -19,6 +19,7 @@ import {
   type SnapshotInfo,
   type SnapshotOptions,
   SnapshotStatus,
+  type SnapshotWaitCondition,
   type SuspendResumeOptions,
   type UpdatePoolOptions,
   type UpdateSandboxOptions,
@@ -324,7 +325,8 @@ export class SandboxClient {
    *
    * This call **returns immediately** with a `snapshotId` and `in_progress`
    * status — the snapshot is created asynchronously. Poll `getSnapshot()` until
-   * `completed` or `failed`, or use `snapshotAndWait()` to block automatically.
+   * `local_ready`, `completed`, or `failed`, or use `snapshotAndWait()` to
+   * block automatically.
    *
    * @param options.snapshotType - `"filesystem"` for cold-boot snapshots (e.g. image builds).
    *   Omit to use the server default (`filesystem`).
@@ -376,9 +378,11 @@ export class SandboxClient {
   }
 
   /**
-   * Create a snapshot and block until it is committed.
+   * Create a snapshot and block until it is locally ready.
    *
-   * Combines `snapshot()` with polling `getSnapshot()` until `completed`.
+   * Combines `snapshot()` with polling `getSnapshot()` until `local_ready`
+   * or `completed`. Pass `{ waitUntil: "completed" }` when durable
+   * `snapshotUri` metadata is required.
    * Prefer `sandbox.checkpoint()` on a `Sandbox` handle for the same behavior
    * without managing the client separately.
    *
@@ -394,6 +398,7 @@ export class SandboxClient {
   ): Promise<Traced<SnapshotInfo>> {
     const timeout = options?.timeout ?? 300;
     const pollInterval = options?.pollInterval ?? 1;
+    const waitUntil = options?.waitUntil ?? "local_ready";
 
     const result = await this.snapshot(sandboxId, {
       snapshotType: options?.snapshotType,
@@ -402,7 +407,7 @@ export class SandboxClient {
 
     while (Date.now() < deadline) {
       const info = await this.getSnapshot(result.snapshotId);
-      if (info.status === SnapshotStatus.COMPLETED) return info;
+      if (snapshotStatusSatisfiesWaitCondition(info.status, waitUntil)) return info;
       if (info.status === SnapshotStatus.FAILED) {
         throw new SandboxError(
           `Snapshot ${result.snapshotId} failed: ${info.error}`,
@@ -412,7 +417,7 @@ export class SandboxClient {
     }
 
     throw new SandboxError(
-      `Snapshot ${result.snapshotId} did not complete within ${timeout}s`,
+      `Snapshot ${result.snapshotId} did not reach ${waitUntil} within ${timeout}s`,
     );
   }
 
@@ -598,6 +603,16 @@ export class SandboxClient {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function snapshotStatusSatisfiesWaitCondition(
+  status: SnapshotStatus | string,
+  waitUntil: SnapshotWaitCondition,
+): boolean {
+  if (waitUntil === "local_ready") {
+    return status === SnapshotStatus.LOCAL_READY || status === SnapshotStatus.COMPLETED;
+  }
+  return status === SnapshotStatus.COMPLETED;
 }
 
 function formatStartupFailureMessage(

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -50,7 +50,12 @@ export {
   ContainerState,
 } from "./models.js";
 
-export type { CheckpointType, SnapshotType, SnapshotOptions } from "./models.js";
+export type {
+  CheckpointType,
+  SnapshotType,
+  SnapshotOptions,
+  SnapshotWaitCondition,
+} from "./models.js";
 
 export type {
   BinaryPayload,

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -11,6 +11,7 @@ export enum SandboxStatus {
 
 export enum SnapshotStatus {
   IN_PROGRESS = "in_progress",
+  LOCAL_READY = "local_ready",
   COMPLETED = "completed",
   FAILED = "failed",
 }
@@ -36,6 +37,8 @@ export type SnapshotType = "memory" | "filesystem";
  *   this checkpoint cold-boot from the snapshot tarball.
  */
 export type CheckpointType = "memory" | "filesystem";
+
+export type SnapshotWaitCondition = "local_ready" | "completed";
 
 export enum ProcessStatus {
   RUNNING = "running",
@@ -174,6 +177,8 @@ export interface SnapshotOptions {
 export interface SnapshotAndWaitOptions extends SnapshotOptions {
   timeout?: number;
   pollInterval?: number;
+  /** Defaults to `"local_ready"`, which is enough to resume from a snapshot. */
+  waitUntil?: SnapshotWaitCondition;
 }
 
 // --- Pools ---
@@ -367,6 +372,8 @@ export interface SuspendResumeOptions {
 
 export interface CheckpointOptions extends SuspendResumeOptions {
   checkpointType?: CheckpointType;
+  /** Defaults to `"local_ready"`, which is enough to resume from a checkpoint. */
+  waitUntil?: SnapshotWaitCondition;
 }
 
 export interface ConnectOptions {

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -6,6 +6,7 @@ import {
   type ProcessInfo,
   type SnapshotInfo,
   type SnapshotType,
+  type SnapshotWaitCondition,
 } from "./models.js";
 import { type OutputResponse, ProcessStatus } from "./models.js";
 import { SandboxClient } from "./client.js";
@@ -109,6 +110,7 @@ interface BuildClient {
       timeout?: number;
       pollInterval?: number;
       snapshotType?: SnapshotType;
+      waitUntil?: SnapshotWaitCondition;
     },
   ): Promise<SnapshotInfo>;
   close(): void;
@@ -1040,6 +1042,7 @@ export async function createSandboxImage(
     emit({ type: "status", message: "Creating snapshot..." });
     const snapshot = await client.snapshotAndWait(sandbox.sandboxId, {
       snapshotType: "filesystem",
+      waitUntil: "completed",
     });
     emit({
       type: "snapshot_created",

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -29,7 +29,6 @@ import {
   type SnapshotInfo,
   type StartProcessOptions,
   SandboxStatus,
-  SnapshotStatus,
   StdinMode,
   type SuspendResumeOptions,
   type UpdateSandboxOptions,
@@ -508,11 +507,10 @@ export class Sandbox {
   }
 
   /**
-   * Create a snapshot of this sandbox's filesystem and wait for it to
-   * be committed.
+   * Create a checkpoint of this sandbox and wait for it to be locally ready.
    *
-   * By default blocks until the snapshot artifact is ready and returns
-   * the completed `SnapshotInfo`. Pass `{ wait: false }` to fire-and-return
+   * By default blocks until the checkpoint is resumable and returns
+   * `SnapshotInfo`. Pass `{ wait: false }` to fire-and-return
    * (returns `undefined`).
    */
   async checkpoint(options?: CheckpointOptions): Promise<Traced<SnapshotInfo> | undefined> {
@@ -525,6 +523,7 @@ export class Sandbox {
       timeout: options?.timeout,
       pollInterval: options?.pollInterval,
       snapshotType: options?.checkpointType,
+      waitUntil: options?.waitUntil,
     });
   }
 

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -664,6 +664,66 @@ describe("SandboxClient", () => {
       client.close();
     });
 
+    it("snapshotAndWait returns on local_ready by default", async () => {
+      mockFetch((_url, init) => {
+        if (init?.method === "POST") {
+          return new Response(
+            JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            id: "snap-1",
+            namespace: "default",
+            sandbox_id: "sbx-1",
+            base_image: "python:3.12",
+            status: "local_ready",
+          }),
+          { status: 200 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost();
+      const info = await client.snapshotAndWait("sbx-1");
+      expect(info.status).toBe(SnapshotStatus.LOCAL_READY);
+      expect(info.snapshotUri).toBeUndefined();
+      client.close();
+    });
+
+    it("snapshotAndWait can wait for completed snapshots", async () => {
+      let getCalls = 0;
+      mockFetch((_url, init) => {
+        if (init?.method === "POST") {
+          return new Response(
+            JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
+            { status: 200 },
+          );
+        }
+        getCalls += 1;
+        return new Response(
+          JSON.stringify({
+            id: "snap-1",
+            namespace: "default",
+            sandbox_id: "sbx-1",
+            base_image: "python:3.12",
+            status: getCalls === 1 ? "local_ready" : "completed",
+            snapshot_uri: "s3://snap-1.tar.zst",
+          }),
+          { status: 200 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost();
+      const info = await client.snapshotAndWait("sbx-1", {
+        pollInterval: 0,
+        waitUntil: "completed",
+      });
+      expect(info.status).toBe(SnapshotStatus.COMPLETED);
+      expect(getCalls).toBe(2);
+      client.close();
+    });
+
     it("listSnapshots returns traceId on the array", async () => {
       mockFetch(() =>
         new Response(

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -25,7 +25,7 @@ import { Sandbox } from "../src/sandbox.js";
 const SANDBOX_IMAGE = "tensorlake/ubuntu-minimal";
 const SANDBOX_CPUS = 1.0;
 const SANDBOX_MEMORY_MB = 1024;
-const SANDBOX_DISK_MB = 1024;
+const SANDBOX_DISK_MB = 10240;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -216,7 +216,10 @@ describe("sandbox image helpers", () => {
     // snapshot so restored sandboxes cold-boot (see PR #583).
     expect(client.snapshotAndWait).toHaveBeenCalledWith(
       "sbx-1",
-      expect.objectContaining({ snapshotType: "filesystem" }),
+      expect.objectContaining({
+        snapshotType: "filesystem",
+        waitUntil: "completed",
+      }),
     );
     expect(registerImage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -310,7 +313,10 @@ describe("sandbox image helpers", () => {
     });
     expect(client.snapshotAndWait).toHaveBeenCalledWith(
       "sbx-1",
-      expect.objectContaining({ snapshotType: "filesystem" }),
+      expect.objectContaining({
+        snapshotType: "filesystem",
+        waitUntil: "completed",
+      }),
     );
     expect(writeFileMock).toHaveBeenCalledWith(
       "/workspace/hello.txt",
@@ -469,7 +475,10 @@ describe("sandbox image helpers", () => {
     });
     expect(client.snapshotAndWait).toHaveBeenCalledWith(
       "sbx-1",
-      expect.objectContaining({ snapshotType: "filesystem" }),
+      expect.objectContaining({
+        snapshotType: "filesystem",
+        waitUntil: "completed",
+      }),
     );
     expect(registerImage).toHaveBeenCalledWith(
       expect.anything(),


### PR DESCRIPTION
## Summary
- route `tl sbx image create` through the offline rootfs builder path
- preserve parent rootfs disk size for diff builds
- set the rootfs builder PATH when invoking the builder wrapper
- stream sandbox file uploads from the Rust CLI/SDK and Python SDK instead of buffering entire files in memory

## Verification
- `cargo check -p tensorlake -p tensorlake-cli -p tensorlake-rust-cloud-sdk-py`
- `poetry run black --check src/tensorlake/sandbox/sandbox.py src/tensorlake/sandbox/async_sandbox.py src/tensorlake/image/sandbox_builder.py`
- manual dev smoke with runtime metadata injected: registered `codex-runtime-metadata-fix-20260513011752`, booted it successfully, and verified `/root/build-marker` contained `fixed-runtime-metadata`

## Notes
- Large build contexts still need the matching Compute Engine container-daemon streaming PR deployed; otherwise the deployed daemon returns HTTP 413 before the streamed client path can help.
