### PR TITLE
Add PyO3 build config dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,6 +2882,7 @@ dependencies = [
  "futures",
  "pyo3",
  "pyo3-async-runtimes",
+ "pyo3-build-config",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ gethostname = "0.5"
 # Python bindings
 pyo3 = { version = "0.28.2", features = ["abi3-py310", "extension-module"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
+pyo3-build-config = "0.28.2"
 
 [profile.release]
 codegen-units = 1

--- a/crates/rust-cloud-sdk-py/Cargo.toml
+++ b/crates/rust-cloud-sdk-py/Cargo.toml
@@ -18,3 +18,6 @@ serde_json = { workspace = true }
 reqwest = { workspace = true }
 pyo3 = { workspace = true }
 pyo3-async-runtimes = { workspace = true }
+
+[build-dependencies]
+pyo3-build-config = { workspace = true }


### PR DESCRIPTION
## Summary
- add pyo3-build-config to workspace dependencies
- declare it as a build-dependency for the Rust Python extension crate

## Test
- cargo build