### PR TITLE
Bump release version to 0.5.10

### DIFF
--- a/.github/workflows/publish_npm.yaml
+++ b/.github/workflows/publish_npm.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: typescript/package-lock.json
 
@@ -110,7 +110,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
           cache-dependency-path: typescript/package-lock.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -2834,7 +2834,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "base64",
@@ -2877,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.9"
+version = "0.5.10"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.9"
+version = "0.5.10"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- bump npm, Rust workspace/Cargo.lock, and PyO3 package metadata to 0.5.10
- switch the npm release workflow's remaining Node 20 setup steps to Node 22 to match package engines and avoid undici runtime warnings

## Why
Two release jobs were rerun from main while package metadata still pointed at 0.5.9:
- npm publish job https://github.com/tensorlakeai/tensorlake/actions/runs/25827280902/job/75884632133 tried to publish tensorlake@0.5.9, which npm already has
- CLI release job https://github.com/tensorlakeai/tensorlake/actions/runs/25827275471/job/75884499128 tried to create cli-v0.5.9, which already exists

This PR bumps release metadata to 0.5.10. npm reports tensorlake@0.5.10 is not published, and cli-v0.5.10 is not present as a GitHub release or remote tag.

## Validation
- npm view tensorlake@0.5.10 version confirmed 0.5.10 is not currently published
- gh release view cli-v0.5.10 --repo tensorlakeai/tensorlake returned release not found
- git ls-remote --tags origin cli-v0.5.10 returned no tag
- npm pkg get version
- npm pack --dry-run --ignore-scripts
- cargo metadata --locked --no-deps --format-version 1
- cargo check -p tensorlake-cli --locked
- npx -y -p node@22 -c 'node --version && npm test'
- npx -y -p node@22 -c 'node --version && npm run build:sdk && npm pack --dry-run --ignore-scripts'
- git diff --check

Note: running npm test with this machine's default Node 18 fails because undici@8 expects Node 22 globals; the Node 22 run passes.
