### PR TITLE
sandbox image build: keep builder sandbox alive during long Dockerfile RUN steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "base64",
  "bollard",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "anyhow",
  "base64",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.11"
+version = "0.5.12"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -28,6 +28,19 @@ type Result<T> = std::result::Result<T, SandboxImageBuildError>;
 const DEFAULT_ROOTFS_DISK_MB: u64 = 10 * 1024;
 const DEFAULT_SANDBOX_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
 const SANDBOX_WAIT_POLL_INTERVAL: Duration = Duration::from_secs(1);
+/// Lifetime budget requested for the temporary rootfs-builder sandbox. The
+/// builder is short-lived (Dockerfile-defined RUN steps), but it has to outlive
+/// long single steps like `dd if=/dev/urandom ...` or large `apt install` runs
+/// that produce no client traffic. Setting an explicit value here makes the
+/// CLI's behavior independent of whatever default the Platform API hands back
+/// today. Paired with the keepalive loop below, which renews this budget while
+/// the build is in flight.
+const BUILDER_SANDBOX_TIMEOUT_SECS: i64 = 300;
+/// Cadence at which the SDK pings the builder sandbox while the offline
+/// rootfs builder is running, to keep it from being suspended due to
+/// inactivity / lifetime expiry mid-build. Must be shorter than
+/// `BUILDER_SANDBOX_TIMEOUT_SECS`.
+const BUILDER_SANDBOX_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(120);
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(300);
 const PROCESS_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(200);
 const PROCESS_EXIT_POLL_ATTEMPTS: usize = 10;
@@ -223,7 +236,7 @@ where
             image: Some(prepared.builder.image.clone()),
             resources,
             secret_names: None,
-            timeout_secs: None,
+            timeout_secs: Some(BUILDER_SANDBOX_TIMEOUT_SECS),
             entrypoint: None,
             network: None,
             snapshot_id: None,
@@ -260,7 +273,16 @@ where
         emit(SandboxImageBuildEvent::Status(
             "Running offline rootfs builder...".to_string(),
         ));
-        run_rootfs_builder(&proxy, &prepared.builder.command, &mut emit).await?;
+        // The rootfs builder runs entirely inside the sandbox and can stay
+        // silent for minutes at a time (e.g. a single large `RUN dd ...` step
+        // in the user's Dockerfile produces no client traffic). Keep the
+        // sandbox visibly alive while that step is in flight so the Platform
+        // doesn't suspend it out from under us. Aborted as soon as the
+        // builder returns, regardless of outcome.
+        let keepalive_task = spawn_builder_keepalive(proxy.clone());
+        let builder_result = run_rootfs_builder(&proxy, &prepared.builder.command, &mut emit).await;
+        keepalive_task.abort();
+        builder_result?;
 
         let metadata = read_build_metadata(&proxy).await?;
         let complete_request = complete_request_from_metadata(&prepared, &metadata)?;
@@ -702,6 +724,29 @@ fn docker_config_json_from_credentials(
     }
 
     serde_json::to_string(&json!({ "auths": auths }))
+}
+
+/// Spawn a background task that pings the builder sandbox at a fixed cadence
+/// to keep it from being suspended due to inactivity / lifetime expiry. The
+/// caller MUST `.abort()` the returned handle when the build phase finishes
+/// (success or failure) — otherwise the task would outlive the build and keep
+/// poking a sandbox we're about to delete.
+fn spawn_builder_keepalive(proxy: SandboxProxyClient) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(BUILDER_SANDBOX_KEEPALIVE_INTERVAL);
+        // The first tick fires immediately; skip it — we don't need a ping
+        // right after the build kicks off, since the upload that just ran
+        // already counts as activity.
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            // Best-effort: a transient error here is uninteresting. If the
+            // sandbox is genuinely gone, run_rootfs_builder's streaming
+            // process call will surface the real error.
+            let _ = proxy.health().await;
+        }
+    })
 }
 
 async fn run_rootfs_builder(

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.11"
+version = "0.5.12"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.11"
+version = "0.5.12"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Summary
-------
- Set `timeout_secs = 300` (5 min) on the temporary rootfs-builder sandbox created by `tl sbx image create` / `build_sandbox_image` instead of passing `None` (which fell through to whatever default the Platform API / plan quotas decided to apply).
- Spawn a background keepalive task while `run_rootfs_builder` is in flight that pings the builder sandbox's `/api/v1/health` endpoint via `SandboxProxyClient::health()` every 120s, so a single long-running Dockerfile RUN step (e.g. `dd if=/dev/urandom of=... count=11000`, large `apt install`, big `pip install`) does not look idle to the Platform.
- Bump workspace / package versions 0.5.11 -> 0.5.12 across Rust workspace, Cargo.lock, root pyproject.toml, the PyO3 bridge pyproject.toml, and the TypeScript package.json / package-lock.json, so this change can be released.

Background / why
----------------
The "Test Sandbox in dev" workflow in `tensorlakeai/indexify-deployment` has been failing for ~10 consecutive runs on the `stress-test-large-disk` step (e.g. run 25890767228, job 76255917380):

  Error: Server error: 400 Bad Request -
  {"error":"Sandbox 'o2bd6899hshs52dqd11st' is not running
   (status: suspending).","code":"SANDBOX_NOT_RUNNING"}

That test invokes `tl sbx image create Dockerfile.large-disk-builder --disk 20`, whose Dockerfile body is essentially a single

    RUN dd if=/dev/urandom of=/opt/image-bigfile.bin bs=1M count=11000
        && sha256sum /opt/image-bigfile.bin | ...

i.e. one ~11 GiB urandom write followed by a sha256sum. While that RUN step runs, the builder sandbox produces no client traffic — the SDK is just blocked waiting for the streamed process to exit. The Platform transitions the sandbox to `Suspending { reason: Timeout }` mid-build, and the next call from the SDK (used for log streaming / process polling) returns the 400 above.

The CLI side of the build is implemented in
`crates/cloud-sdk/src/sandbox_images.rs::build_sandbox_image`. Before this change it was creating the builder with `timeout_secs: None`, so the lifetime budget came entirely from the server's `default_sandbox_timeout_secs` (and any per-plan
`sandbox_default_timeout_secs` cap). That is not under SDK control and varies by environment, which is exactly why the dev runs were dying inside a single RUN step.

What the fix does
-----------------
1. Explicit 5-minute initial budget. `timeout_secs: Some(300)` means every environment gets the same starting budget, independent of Platform-side defaults. This is enough headroom for most Dockerfile builds we expect to run via `tl sbx image create`.

2. Background keepalive via `SandboxProxyClient::health()` every 120s. The keepalive runs inside a dedicated `tokio::spawn` task that is `abort()`ed the moment `run_rootfs_builder` returns (success or failure), so it cannot outlive the build phase and never pokes a sandbox we are about to delete. The keepalive uses the proxy path (i.e. talks to the dataplane / container daemon) rather than the Platform API directly, so it constitutes real inbound traffic to the sandbox — the same kind of activity the builder normally produces when it streams logs.

   `health()` errors during keepalive are intentionally swallowed: if the sandbox is genuinely gone, the streaming process call inside `run_rootfs_builder` will surface the real error with full context; we don't want to clobber that with a flaky keepalive warning.

3. The first `interval.tick()` is consumed before the loop body so we don't emit a redundant ping immediately after the build context upload (which is already activity).

Files touched
-------------
- `crates/cloud-sdk/src/sandbox_images.rs`
  - New constants `BUILDER_SANDBOX_TIMEOUT_SECS` (300s) and `BUILDER_SANDBOX_KEEPALIVE_INTERVAL` (120s).
  - Pass `timeout_secs: Some(BUILDER_SANDBOX_TIMEOUT_SECS)` on the builder `CreateSandboxRequest`.
  - New `spawn_builder_keepalive(SandboxProxyClient)` helper that returns the `JoinHandle` so the caller can `abort()` it.
  - Wrap the `run_rootfs_builder` call with the keepalive lifecycle.
- Version bumps to 0.5.12 in `Cargo.toml`, `Cargo.lock`, `pyproject.toml`, `crates/rust-cloud-sdk-py/pyproject.toml`, `typescript/package.json`, `typescript/package-lock.json`.

Validation
----------
- `RUSTFLAGS="-D warnings" cargo build --workspace --bins --tests --locked` (clean).
- `cargo fmt -p tensorlake -p tensorlake-cli -p tensorlake-rust-cloud-sdk-py --check` (clean).
- `cargo test -p tensorlake --lib --locked` (48 passed).
- End-to-end validation is the failing `Test Sandbox in dev` workflow in indexify-deployment; we expect it to pass once a 0.5.12 release is cut and the `tl` binary on the runner picks it up.