### PR TITLE
RFC, do not merge feat(sandbox-image): support USER in Dockerfile and Image DSL

### DIFF
--- a/src/tensorlake/image/_dockerfile.py
+++ b/src/tensorlake/image/_dockerfile.py
@@ -23,15 +23,20 @@ def render_op_line(op: _ImageBuildOperation) -> str:
     return f"{op.type.name}{options_str} {' '.join(op.args)}"
 
 
-def image_to_dockerfile(image: Image) -> str:
+def image_to_dockerfile(image: Image, *, include_user: bool = True) -> str:
     """Render a plain Dockerfile string from an :class:`Image`.
 
     Mirrors the TypeScript ``dockerfileContent`` exactly.
+
+    When ``include_user`` is False, ``USER`` ops are skipped. Applications
+    image builds use this to keep the trailing SDK install step as root.
     """
     lines: list[str] = []
     if image._base_image:
         lines.append(f"FROM {image._base_image}")
     for op in image._build_operations:
+        if not include_user and op.type == _ImageBuildOperationType.USER:
+            continue
         lines.append(render_op_line(op))
     return "\n".join(lines)
 

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -15,6 +15,7 @@ class _ImageBuildOperationType(Enum):
     ENV = 3
     RUN = 4
     WORKDIR = 5
+    USER = 6
 
 
 @dataclass
@@ -93,6 +94,16 @@ class Image:
             _ImageBuildOperation(
                 type=_ImageBuildOperationType.WORKDIR,
                 args=[directory],
+                options={},
+            )
+        )
+
+    def user(self, name: str | int, group: str | int | None = None) -> "Image":
+        rendered = f"{name}:{group}" if group is not None else f"{name}"
+        return self._add_operation(
+            _ImageBuildOperation(
+                type=_ImageBuildOperationType.USER,
+                args=[rendered],
                 options={},
             )
         )

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -46,7 +46,6 @@ _UNSUPPORTED_DOCKERFILE_INSTRUCTIONS = {
     "ARG",
     "ONBUILD",
     "SHELL",
-    "USER",
 }
 
 _DEFAULT_IMAGE_NAME = "default"

--- a/src/tensorlake/image/utils.py
+++ b/src/tensorlake/image/utils.py
@@ -1,8 +1,9 @@
 import importlib
+import warnings
 from typing import List
 
 from ._dockerfile import image_has_workdir, render_op_line
-from .image import Image
+from .image import Image, _ImageBuildOperationType
 
 _SDK_VERSION: str = importlib.metadata.version("tensorlake")
 
@@ -29,8 +30,22 @@ def dockerfile_content(img: Image, extra_env_vars: List[tuple] | None = None) ->
         for key, value in extra_env_vars:
             dockerfile_lines.append(f"ENV {key}={value}")
 
+    user_op_seen = False
     for op in img._build_operations:
+        # The trailing `pip install tensorlake` must run as root, so USER ops
+        # are dropped from Applications images. .user() works for sandbox
+        # images but has no effect here.
+        if op.type == _ImageBuildOperationType.USER:
+            user_op_seen = True
+            continue
         dockerfile_lines.append(render_op_line(op))
+    if user_op_seen:
+        warnings.warn(
+            "Image.user() has no effect on Applications images; the trailing "
+            "`pip install tensorlake` step runs as root. Use it for sandbox "
+            "images instead.",
+            stacklevel=2,
+        )
 
     # Run tensorlake install after all user commands. There's implicit dependency
     # of tensorlake install success on user commands right now.

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -72,6 +72,28 @@ class TestDockerfileParsing(unittest.TestCase):
             ):
                 sbm._load_dockerfile_plan(str(dockerfile_path), None)
 
+    def test_load_dockerfile_plan_accepts_user(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dockerfile_path = Path(tmpdir) / "Dockerfile"
+            dockerfile_path.write_text(
+                "FROM python:3.12-slim\nRUN useradd -m appuser\nUSER appuser\n",
+                encoding="utf-8",
+            )
+
+            plan = sbm._load_dockerfile_plan(str(dockerfile_path), None)
+
+        self.assertEqual(
+            plan.instructions,
+            [
+                sbm.DockerfileInstruction(
+                    keyword="RUN", value="useradd -m appuser", line_number=2
+                ),
+                sbm.DockerfileInstruction(
+                    keyword="USER", value="appuser", line_number=3
+                ),
+            ],
+        )
+
 
 def _make_ctx(**overrides):
     defaults = dict(
@@ -301,6 +323,77 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
     def test_rejects_unknown_source_type(self):
         with self.assertRaises(TypeError):
             sbm.build_sandbox_image(12345)  # type: ignore[arg-type]
+
+    def test_user_op_renders_into_sandbox_dockerfile(self):
+        image = (
+            Image(name="user-image", base_image="python:3.12-slim")
+            .run("useradd -m appuser")
+            .user("appuser")
+        )
+
+        _, _, _, captured = self._run_build(image)
+
+        expected_dockerfile = "\n".join(
+            [
+                "FROM python:3.12-slim",
+                "RUN useradd -m appuser",
+                "USER appuser",
+            ]
+        )
+        self.assertEqual(captured["dockerfile_text"], expected_dockerfile + "\n")
+
+    def test_user_op_with_group_renders_name_colon_group(self):
+        image = Image(name="ug", base_image="python:3.12-slim").user(
+            "appuser", "appgroup"
+        )
+        _, _, _, captured = self._run_build(image)
+        self.assertIn("USER appuser:appgroup", captured["dockerfile_text"])
+
+    def test_user_op_with_numeric_uid_gid(self):
+        image = Image(name="numeric", base_image="python:3.12-slim").user(1000, 1000)
+        _, _, _, captured = self._run_build(image)
+        self.assertIn("USER 1000:1000", captured["dockerfile_text"])
+
+
+class TestApplicationsDockerfileRendering(unittest.TestCase):
+    """USER ops on the shared Image class must NOT appear in Applications
+    Dockerfiles — the trailing `pip install tensorlake` step runs as root.
+    """
+
+    def test_user_op_stripped_from_applications_dockerfile(self):
+        from tensorlake.image.utils import dockerfile_content
+
+        image = (
+            Image(name="app", base_image="python:3.12-slim")
+            .run("useradd -m appuser")
+            .user("appuser")
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            rendered = dockerfile_content(image)
+
+        self.assertNotIn("USER appuser", rendered)
+        self.assertIn("RUN useradd -m appuser", rendered)
+        self.assertIn("RUN pip install tensorlake==", rendered)
+        self.assertTrue(
+            any("Image.user()" in str(w.message) for w in caught),
+            "Expected a warning that Image.user() has no effect on Applications",
+        )
+
+    def test_no_warning_when_user_not_used(self):
+        from tensorlake.image.utils import dockerfile_content
+
+        image = Image(name="app", base_image="python:3.12-slim").run("echo hi")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            dockerfile_content(image)
+
+        self.assertFalse(
+            any("Image.user()" in str(w.message) for w in caught),
+            "Did not expect a USER-related warning when .user() was not called",
+        )
 
 
 class TestRegisterImage(unittest.TestCase):

--- a/typescript/src/image.ts
+++ b/typescript/src/image.ts
@@ -12,6 +12,7 @@ export const ImageBuildOperationType = {
   ENV: "ENV",
   RUN: "RUN",
   WORKDIR: "WORKDIR",
+  USER: "USER",
 } as const;
 
 export type ImageBuildOperationType =
@@ -134,6 +135,16 @@ export class Image {
     });
   }
 
+  user(name: string | number, group?: string | number | null): this {
+    const rendered =
+      group == null ? `${name}` : `${name}:${group}`;
+    return this._addOperation({
+      type: ImageBuildOperationType.USER,
+      args: [rendered],
+      options: {},
+    });
+  }
+
   /**
    * Build this image as a sandbox template and register it.
    *
@@ -177,8 +188,26 @@ function renderBuildOp(op: ImageBuildOperation): string {
   return `${op.type}${options} ${op.args.join(" ")}`;
 }
 
-export function dockerfileContent(image: Image): string {
+export interface DockerfileContentOptions {
+  /**
+   * When false, USER ops are dropped from the rendered Dockerfile. Used by
+   * Applications image rendering, where the trailing `pip install tensorlake`
+   * must run as root.
+   */
+  includeUser?: boolean;
+}
+
+export function dockerfileContent(
+  image: Image,
+  options: DockerfileContentOptions = {},
+): string {
+  const includeUser = options.includeUser ?? true;
   const lines = image.baseImage == null ? [] : [`FROM ${image.baseImage}`];
-  lines.push(...image.buildOperations.map((op) => renderBuildOp(op)));
+  for (const op of image.buildOperations) {
+    if (!includeUser && op.type === ImageBuildOperationType.USER) {
+      continue;
+    }
+    lines.push(renderBuildOp(op));
+  }
   return lines.join("\n");
 }

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -24,7 +24,6 @@ const UNSUPPORTED_DOCKERFILE_INSTRUCTIONS = new Set([
   "ARG",
   "ONBUILD",
   "SHELL",
-  "USER",
 ]);
 
 export interface DockerfileInstruction {

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -53,6 +53,63 @@ describe("sandbox image helpers", () => {
     ]);
   });
 
+  it("loadDockerfilePlan accepts USER instructions", async () => {
+    const tempDir = await mkdir(path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-user`), {
+      recursive: true,
+    });
+    const dockerfilePath = path.join(tempDir, "Dockerfile");
+    await writeFile(
+      dockerfilePath,
+      "FROM python:3.12-slim\nRUN useradd -m appuser\nUSER appuser\n",
+      "utf8",
+    );
+
+    const plan = await loadDockerfilePlan(dockerfilePath);
+    expect(plan.instructions).toEqual([
+      { keyword: "RUN", value: "useradd -m appuser", lineNumber: 2 },
+      { keyword: "USER", value: "appuser", lineNumber: 3 },
+    ]);
+  });
+
+  it("Image.user() renders USER lines into the Dockerfile", () => {
+    const single = new Image({ name: "u", baseImage: "python:3.12-slim" })
+      .run("useradd -m appuser")
+      .user("appuser");
+    expect(dockerfileContent(single)).toBe(
+      ["FROM python:3.12-slim", "RUN useradd -m appuser", "USER appuser"].join("\n"),
+    );
+
+    const withGroup = new Image({ name: "ug", baseImage: "python:3.12-slim" }).user(
+      "appuser",
+      "appgroup",
+    );
+    expect(dockerfileContent(withGroup)).toBe(
+      ["FROM python:3.12-slim", "USER appuser:appgroup"].join("\n"),
+    );
+
+    const numeric = new Image({ name: "n", baseImage: "python:3.12-slim" }).user(
+      1000,
+      1000,
+    );
+    expect(dockerfileContent(numeric)).toBe(
+      ["FROM python:3.12-slim", "USER 1000:1000"].join("\n"),
+    );
+  });
+
+  it("dockerfileContent strips USER ops when includeUser is false", () => {
+    const image = new Image({ name: "strip", baseImage: "python:3.12-slim" })
+      .run("useradd -m appuser")
+      .user("appuser")
+      .run("echo done");
+    expect(dockerfileContent(image, { includeUser: false })).toBe(
+      [
+        "FROM python:3.12-slim",
+        "RUN useradd -m appuser",
+        "RUN echo done",
+      ].join("\n"),
+    );
+  });
+
   it("loadDockerfilePlan rejects multistage Dockerfiles", async () => {
     const tempDir = await mkdir(path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-multi`), {
       recursive: true,


### PR DESCRIPTION
## Summary

- Stop rejecting `USER` in the Python and TypeScript sandbox-image Dockerfile parsers; `docker build` already handles USER semantics natively for the rootfs builder.
- Add `Image.user(name, group=None)` to the shared Python/TypeScript `Image` DSL (accepts names or numeric uid/gid; renders as Docker's `USER <user>[:<group>]`).
- Suppress `USER` rendering on the Applications-side Dockerfile (`tensorlake.image.utils.dockerfile_content`) so the trailing root-only `pip install tensorlake` step still works. Emits a one-time warning when an Image used by Applications has `.user()` set. TypeScript has no Applications render path, so only the sandbox flow is touched there.

## Safety / coordination

All changes here are additive and require no dataplane coordination:

- The Rust client parser (`crates/cloud-sdk/src/sandbox_images.rs:1139-1149`) already accepts USER (only validates FROM), so the dataplane request shape is unchanged.
- `docker build` natively handles USER, so build infrastructure needs no changes.
- The `include_user=False` filter on the Applications render path means existing `@function` Dockerfiles are byte-identical.

## Follow-ups (documented here, not in this PR)

The runtime default ProcessUser will use **safety-preserving semantics**: `tl-user` stays the default for sandboxes booted from images whose Dockerfile contains no `USER` directive. Only an explicit `USER` (or `Image.user(...)`) overrides the default.

| Dockerfile | Runtime default ProcessUser |
|---|---|
| no `USER` | `tl-user` (unchanged) |
| `USER appuser` | `appuser` |
| `USER root` (explicit) | `root` (opt-in) |
| `USER 1000:1000` | `1000:1000` |

### Builder: write `/etc/tensorlake/sandbox.json`

After `docker build`, the rootfs-builder (`tl-rootfs-build`, source in a sibling repo) should write the runtime default ProcessUser to `/etc/tensorlake/sandbox.json` **only when the Dockerfile contained an explicit `USER` directive**:

```json
{\"default_process_user\": {\"name\": \"appuser\", \"group\": \"appgroup\"}}
```

Images without `USER` either omit the file or leave the field absent — the daemon falls back to `tl-user` in either case. Concretely, the builder needs to distinguish \"Dockerfile had a USER line\" from \"Config.User defaulted to empty/root because nothing was set\", and only write the field in the first case.

This is a no-op until something reads it. Old daemons booting new images ignore the file; current SDKs still pass explicit \`user=\"tl-user\"\`, so it isn't consulted. Independently safe to release whenever the rootfs-builder change is ready.

### PR B: flip SDK default to image-derived (with tl-user fallback)

Once the daemon knows how to (a) read \`/etc/tensorlake/sandbox.json\` to resolve a default user, (b) fall back to \`tl-user\` when the file/field is absent, and (c) accept a \"use default\" sentinel on the wire:

- \`src/tensorlake/sandbox/sandbox.py:753, 835\` and \`async_sandbox.py:372, 429\`: \`user: ProcessUser = \"tl-user\"\` → \`user: ProcessUser | None = None\`
- TypeScript mirrors in \`typescript/src/sandbox.ts\`
- \`_normalize_process_user\` (\`sandbox.py:713\`): emit the new sentinel when \`user is None\`

**Hard ordering constraint:** that SDK change must ship only after the daemon update is rolled out, or \`start_process\` calls without an explicit \`user=\` will hit older daemons that mis-handle the sentinel. Gate on a daemon-version check if available; otherwise enforce by release order.

## Test plan

- [x] \`poetry run python -m unittest tests.image.test_sandbox_builder\` — all new USER tests pass (one pre-existing macOS \`/private/var\` symlink flake in \`test_image_build_does_not_write_generated_dockerfile_into_context\` is unrelated).
- [x] \`pnpm vitest run tests/sandbox-image.test.ts\` — 20/20 tests pass, including the 3 new USER cases.
- [ ] End-to-end: build a sandbox image with \`Image(...).run('useradd -m appuser').user('appuser').run('id')\` against staging and verify the second \`RUN\` records \`uid=appuser\` in build logs.
- [ ] End-to-end: deploy an \`@function\` with \`image=Image().user('appuser')\` and confirm the resulting Applications Dockerfile contains no \`USER\` line (the warning fires) and the SDK install step still completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)