### PR TITLE
[codex] fix TS sandbox image context uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.15"
+version = "0.5.16"
 dependencies = [
  "base64",
  "bollard",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.15"
+version = "0.5.16"
 dependencies = [
  "anyhow",
  "base64",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.15"
+version = "0.5.16"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.15"
+version = "0.5.16"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.15"
+version = "0.5.16"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.15"
+version = "0.5.16"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.15",
+      "version": "0.5.16",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.15",
+  "version": "0.5.16",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -869,13 +869,23 @@ async function runChecked(
   args: string[],
   env?: Record<string, string>,
   workingDir?: string,
+  user?: ProcessUser,
 ): Promise<CommandResult> {
-  const result = await sandbox.run(command, {
+  const options: {
+    args: string[];
+    env?: Record<string, string>;
+    workingDir?: string;
+    user?: ProcessUser;
+  } = {
     args,
     env,
     workingDir,
-    user: ROOTFS_BUILDER_PROCESS_USER,
-  });
+  };
+  if (user != null) {
+    options.user = user;
+  }
+
+  const result = await sandbox.run(command, options);
   if (result.exitCode !== 0) {
     throw new Error(
       `Command '${command} ${args.join(" ")}' failed with exit code ${result.exitCode}`,
@@ -955,6 +965,33 @@ function emitOutputLines(
   }
 }
 
+async function ensureRemoteBuildRoot(sandbox: BuildSandbox) {
+  await runChecked(
+    sandbox,
+    "mkdir",
+    ["-p", REMOTE_BUILD_DIR],
+    undefined,
+    undefined,
+    ROOTFS_BUILDER_PROCESS_USER,
+  );
+  await runChecked(
+    sandbox,
+    "chmod",
+    ["0777", REMOTE_BUILD_DIR],
+    undefined,
+    undefined,
+    ROOTFS_BUILDER_PROCESS_USER,
+  );
+}
+
+async function ensureRemoteDirectory(sandbox: BuildSandbox, remotePath: string) {
+  await runChecked(sandbox, "mkdir", ["-p", remotePath]);
+}
+
+async function ensureRemoteParentDir(sandbox: BuildSandbox, remotePath: string) {
+  await ensureRemoteDirectory(sandbox, path.posix.dirname(remotePath));
+}
+
 async function copyLocalPathToSandbox(
   sandbox: BuildSandbox,
   localPath: string,
@@ -966,7 +1003,7 @@ async function copyLocalPathToSandbox(
   }
 
   if (fileStats.isFile()) {
-    await runChecked(sandbox, "mkdir", ["-p", path.posix.dirname(remotePath)]);
+    await ensureRemoteParentDir(sandbox, remotePath);
     await sandbox.writeFile(remotePath, await readFile(localPath));
     return;
   }
@@ -980,14 +1017,10 @@ async function copyLocalPathToSandbox(
     const sourcePath = path.join(localPath, entry.name);
     const destinationPath = path.posix.join(remotePath, entry.name);
     if (entry.isDirectory()) {
-      await runChecked(sandbox, "mkdir", ["-p", destinationPath]);
+      await ensureRemoteDirectory(sandbox, destinationPath);
       await copyLocalPathToSandbox(sandbox, sourcePath, destinationPath);
     } else if (entry.isFile()) {
-      await runChecked(
-        sandbox,
-        "mkdir",
-        ["-p", path.posix.dirname(destinationPath)],
-      );
+      await ensureRemoteParentDir(sandbox, destinationPath);
       await sandbox.writeFile(destinationPath, await readFile(sourcePath));
     }
   }
@@ -1129,6 +1162,7 @@ export async function createSandboxImage(
       message: `Rootfs builder sandbox ${sandbox.sandboxId} is running`,
     });
     emit({ type: "status", message: "Uploading build context..." });
+    await ensureRemoteBuildRoot(sandbox);
     await copyLocalPathToSandbox(sandbox, plan.contextDir, REMOTE_CONTEXT_DIR);
     const spec = await buildRootfsSpec(
       preparedSpec,
@@ -1136,7 +1170,7 @@ export async function createSandboxImage(
       plan,
       options.diskMb,
     );
-    await runChecked(sandbox, "mkdir", ["-p", path.posix.dirname(REMOTE_SPEC_PATH)]);
+    await ensureRemoteParentDir(sandbox, REMOTE_SPEC_PATH);
     await sandbox.writeFile(
       REMOTE_SPEC_PATH,
       new TextEncoder().encode(JSON.stringify(spec, null, 2)),

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -266,6 +266,30 @@ describe("sandbox image helpers", () => {
       memoryMb: 4096,
       diskMb: 10 * 1024,
     });
+    expect(sandbox.run).toHaveBeenCalledWith(
+      "mkdir",
+      expect.objectContaining({
+        args: ["-p", "/var/lib/tensorlake/rootfs-builder/build"],
+        user: "root",
+      }),
+    );
+    expect(sandbox.run).toHaveBeenCalledWith(
+      "chmod",
+      expect.objectContaining({
+        args: ["0777", "/var/lib/tensorlake/rootfs-builder/build"],
+        user: "root",
+      }),
+    );
+    const contextMkdirCall = sandbox.run.mock.calls.find(
+      ([command, options]) =>
+        command === "mkdir" &&
+        options?.args?.[1] ===
+          "/var/lib/tensorlake/rootfs-builder/build/context",
+    );
+    expect(contextMkdirCall?.[1]).toMatchObject({
+      args: ["-p", "/var/lib/tensorlake/rootfs-builder/build/context"],
+    });
+    expect(contextMkdirCall?.[1]?.user).toBeUndefined();
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.tensorlake.ai/platform/v1/organizations/org_introspected/projects/proj_introspected/sandbox-template-builds",
       expect.objectContaining({ method: "POST" }),


### PR DESCRIPTION
## What changed

- Prepare the rootfs-builder build directory as root, then chmod it so file API uploads can write their temp files.
- Stop forcing root for per-file upload directory creation, matching the file API sandbox-user write path.
- Keep the offline rootfs builder process running as root.
- Bump SDK and CLI package versions from 0.5.15 to 0.5.16.

## Why

TS SDK `createSandboxImage` could fail while uploading build context files because `Sandbox.writeFile` creates a temporary file in the destination directory using the sandbox user. The previous upload prep created directories under `/var/lib/tensorlake/rootfs-builder/build/context` as root, so the temp-file creation surfaced as a 500 error from the sandbox file API.

## Validation

- `npm test -- --run tests/sandbox-image.test.ts`
- `npm run typecheck`
- `cargo metadata --locked --no-deps --format-version 1`