### PR TITLE
[codex] Add native SSH helpers for sandboxes

### DIFF
--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -158,7 +158,6 @@ fn print_post_create_tip(ctx: &CliContext, sandbox_id: &str, display_id: &str, i
     eprintln!();
     eprintln!("Get started:");
     eprintln!("  tl sbx ssh {display_id}");
-    eprintln!("  ssh {sandbox_id}@sandbox.tensorlake.ai  # native SSH with a registered key");
     eprintln!("  tl sbx exec {display_id} -- bash -c \"echo Hello, World!\"");
     if is_ephemeral {
         eprintln!("  tl sbx name {display_id} <name>  # make persistent (enables suspend/resume)");

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -128,7 +128,7 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
     let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdout());
     let display_id = name.unwrap_or(&sandbox_id);
     if is_tty {
-        eprintln!("Sandbox {} is ready.", display_id);
+        eprint!("{}", format_ready_message(name, &sandbox_id));
     }
     if !is_tty {
         println!("{}", sandbox_id);
@@ -137,6 +137,13 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         print_post_create_tip(ctx, &sandbox_id, display_id, name.is_none());
     }
     Ok(())
+}
+
+fn format_ready_message(name: Option<&str>, sandbox_id: &str) -> String {
+    match name.filter(|name| !name.is_empty()) {
+        Some(name) => format!("Sandbox {name} is ready.\nID: {sandbox_id}\n"),
+        None => format!("Sandbox {sandbox_id} is ready.\n"),
+    }
 }
 
 fn print_post_create_tip(ctx: &CliContext, sandbox_id: &str, display_id: &str, is_ephemeral: bool) {
@@ -151,6 +158,7 @@ fn print_post_create_tip(ctx: &CliContext, sandbox_id: &str, display_id: &str, i
     eprintln!();
     eprintln!("Get started:");
     eprintln!("  tl sbx ssh {display_id}");
+    eprintln!("  ssh {sandbox_id}@sandbox.tensorlake.ai  # native SSH with a registered key");
     eprintln!("  tl sbx exec {display_id} -- bash -c \"echo Hello, World!\"");
     if is_ephemeral {
         eprintln!("  tl sbx name {display_id} <name>  # make persistent (enables suspend/resume)");
@@ -257,7 +265,7 @@ fn build_create_request_body(
 
 #[cfg(test)]
 mod tests {
-    use super::build_create_request_body;
+    use super::{build_create_request_body, format_ready_message};
 
     #[test]
     fn create_body_uses_defaults_without_snapshot() {
@@ -322,5 +330,19 @@ mod tests {
         assert_eq!(body["image"], "tensorlake/ubuntu-minimal");
         assert_eq!(body["resources"]["disk_mb"], 25 * 1024);
         assert!(body.get("snapshot_id").is_none());
+    }
+
+    #[test]
+    fn ready_message_includes_labeled_id_for_named_sandbox() {
+        let output = format_ready_message(Some("stable-name"), "sbx-123");
+
+        assert_eq!(output, "Sandbox stable-name is ready.\nID: sbx-123\n");
+    }
+
+    #[test]
+    fn ready_message_falls_back_to_id_for_unnamed_sandbox() {
+        let output = format_ready_message(None, "sbx-123");
+
+        assert_eq!(output, "Sandbox sbx-123 is ready.\n");
     }
 }

--- a/crates/cli/src/commands/sbx/describe.rs
+++ b/crates/cli/src/commands/sbx/describe.rs
@@ -1,6 +1,6 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
-    DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME, format_created_at, sandbox_endpoint,
+    DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME, format_created_at, native_ssh, sandbox_endpoint,
 };
 use crate::error::{CliError, Result};
 
@@ -30,6 +30,7 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str) -> Result<()> {
         .await
         .map_err(CliError::Http)?;
     print_sandbox_details(&item);
+    print_ssh_config_details(&item)?;
     Ok(())
 }
 
@@ -62,6 +63,7 @@ async fn run_archived(ctx: &CliContext, sandbox_id: &str) -> Result<()> {
         .await
         .map_err(CliError::Http)?;
     print_archived_sandbox_details(&item);
+    print_ssh_config_details(&item)?;
     Ok(())
 }
 
@@ -243,4 +245,20 @@ fn print_sandbox_details(item: &serde_json::Value) {
         let outcome = item.get("outcome").and_then(|v| v.as_str()).unwrap_or("");
         println!("Outcome:         {}", outcome);
     }
+}
+
+fn print_ssh_config_details(item: &serde_json::Value) -> Result<()> {
+    let id = item
+        .get("sandbox_id")
+        .or_else(|| item.get("id"))
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("-");
+    let name = item.get("name").and_then(|v| v.as_str());
+    let sandbox = native_ssh::ResolvedSandbox::new(id, name);
+    let config = native_ssh::format_ssh_config(&sandbox, None, None)?;
+
+    println!("SSH Config:");
+    print!("{config}");
+    Ok(())
 }

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -6,6 +6,7 @@ pub mod exec;
 pub mod image;
 pub mod ls;
 pub mod name;
+pub mod native_ssh;
 pub mod port;
 pub mod resume;
 pub mod run;

--- a/crates/cli/src/commands/sbx/native_ssh.rs
+++ b/crates/cli/src/commands/sbx/native_ssh.rs
@@ -1,67 +1,27 @@
-use crate::auth::context::CliContext;
-use crate::commands::sbx::sandbox_endpoint;
 use crate::error::{CliError, Result};
 
 const SSH_HOSTNAME: &str = "sandbox.tensorlake.ai";
 const DEFAULT_IDENTITY_FILE: &str = "~/.ssh/id_ed25519_tensorlake";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ResolvedSandbox {
+pub struct ResolvedSandbox {
     sandbox_id: String,
     name: Option<String>,
 }
 
-pub async fn print_config(
-    ctx: &CliContext,
-    sandbox_identifier: &str,
-    host_alias: Option<&str>,
-    identity_file: Option<&str>,
-) -> Result<()> {
-    let sandbox = resolve_sandbox(ctx, sandbox_identifier).await?;
-    let config = format_ssh_config(&sandbox, host_alias, identity_file)?;
-    print!("{config}");
-    Ok(())
-}
-
-async fn resolve_sandbox(ctx: &CliContext, sandbox_identifier: &str) -> Result<ResolvedSandbox> {
-    let client = ctx.client()?;
-    let url = sandbox_endpoint(ctx, &format!("sandboxes/{sandbox_identifier}"));
-
-    let resp = client.get(&url).send().await.map_err(CliError::Http)?;
-
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        return Err(CliError::Other(anyhow::anyhow!(
-            "failed to fetch sandbox '{}' (HTTP {}): {}",
-            sandbox_identifier,
-            status,
-            body
-        )));
+impl ResolvedSandbox {
+    pub fn new(sandbox_id: impl Into<String>, name: Option<&str>) -> Self {
+        Self {
+            sandbox_id: sandbox_id.into(),
+            name: name
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string),
+        }
     }
-
-    let item = resp
-        .json::<serde_json::Value>()
-        .await
-        .map_err(CliError::Http)?;
-    let sandbox_id = item
-        .get("sandbox_id")
-        .or_else(|| item.get("id"))
-        .and_then(|value| value.as_str())
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| CliError::Other(anyhow::anyhow!("sandbox response missing sandbox id")))?
-        .to_string();
-    let name = item
-        .get("name")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string);
-
-    Ok(ResolvedSandbox { sandbox_id, name })
 }
 
-fn format_ssh_config(
+pub fn format_ssh_config(
     sandbox: &ResolvedSandbox,
     host_alias: Option<&str>,
     identity_file: Option<&str>,
@@ -87,7 +47,7 @@ fn format_ssh_config(
         }
         None => {
             lines.push(
-                "    # Set this to the private key whose public key you registered with `tl ssh-keys add`"
+                "    # Set this to the private key whose public key you registered with `tl sbx ssh keys add`"
                     .to_string(),
             );
             lines.push(format!("    IdentityFile {DEFAULT_IDENTITY_FILE}"));
@@ -130,10 +90,7 @@ mod tests {
     #[test]
     fn format_ssh_config_uses_named_alias_and_placeholder_identity_file() {
         let config = format_ssh_config(
-            &ResolvedSandbox {
-                sandbox_id: "sbx-123".to_string(),
-                name: Some("my-sandbox".to_string()),
-            },
+            &ResolvedSandbox::new("sbx-123", Some("my-sandbox")),
             None,
             None,
         )
@@ -145,7 +102,7 @@ mod tests {
                 "Host tl-my-sandbox\n",
                 "    HostName sandbox.tensorlake.ai\n",
                 "    User sbx-123\n",
-                "    # Set this to the private key whose public key you registered with `tl ssh-keys add`\n",
+                "    # Set this to the private key whose public key you registered with `tl sbx ssh keys add`\n",
                 "    IdentityFile ~/.ssh/id_ed25519_tensorlake\n",
                 "    IdentitiesOnly yes\n",
                 "    ServerAliveInterval 30\n",

--- a/crates/cli/src/commands/sbx/native_ssh.rs
+++ b/crates/cli/src/commands/sbx/native_ssh.rs
@@ -1,0 +1,156 @@
+use crate::auth::context::CliContext;
+use crate::commands::sbx::sandbox_endpoint;
+use crate::error::{CliError, Result};
+
+const SSH_HOSTNAME: &str = "sandbox.tensorlake.ai";
+const DEFAULT_IDENTITY_FILE: &str = "~/.ssh/id_ed25519_tensorlake";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedSandbox {
+    sandbox_id: String,
+    name: Option<String>,
+}
+
+pub async fn print_config(
+    ctx: &CliContext,
+    sandbox_identifier: &str,
+    host_alias: Option<&str>,
+    identity_file: Option<&str>,
+) -> Result<()> {
+    let sandbox = resolve_sandbox(ctx, sandbox_identifier).await?;
+    let config = format_ssh_config(&sandbox, host_alias, identity_file)?;
+    print!("{config}");
+    Ok(())
+}
+
+async fn resolve_sandbox(ctx: &CliContext, sandbox_identifier: &str) -> Result<ResolvedSandbox> {
+    let client = ctx.client()?;
+    let url = sandbox_endpoint(ctx, &format!("sandboxes/{sandbox_identifier}"));
+
+    let resp = client.get(&url).send().await.map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to fetch sandbox '{}' (HTTP {}): {}",
+            sandbox_identifier,
+            status,
+            body
+        )));
+    }
+
+    let item = resp
+        .json::<serde_json::Value>()
+        .await
+        .map_err(CliError::Http)?;
+    let sandbox_id = item
+        .get("sandbox_id")
+        .or_else(|| item.get("id"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| CliError::Other(anyhow::anyhow!("sandbox response missing sandbox id")))?
+        .to_string();
+    let name = item
+        .get("name")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    Ok(ResolvedSandbox { sandbox_id, name })
+}
+
+fn format_ssh_config(
+    sandbox: &ResolvedSandbox,
+    host_alias: Option<&str>,
+    identity_file: Option<&str>,
+) -> Result<String> {
+    let host_alias = match host_alias {
+        Some(alias) => {
+            validate_single_token("host", alias)?;
+            alias.trim().to_string()
+        }
+        None => default_host_alias(sandbox),
+    };
+
+    let mut lines = vec![
+        format!("Host {host_alias}"),
+        format!("    HostName {SSH_HOSTNAME}"),
+        format!("    User {}", sandbox.sandbox_id),
+    ];
+
+    match identity_file {
+        Some(path) => {
+            validate_single_token("identity file", path)?;
+            lines.push(format!("    IdentityFile {}", path.trim()));
+        }
+        None => {
+            lines.push(
+                "    # Set this to the private key whose public key you registered with `tl ssh-keys add`"
+                    .to_string(),
+            );
+            lines.push(format!("    IdentityFile {DEFAULT_IDENTITY_FILE}"));
+        }
+    }
+
+    lines.extend([
+        "    IdentitiesOnly yes".to_string(),
+        "    ServerAliveInterval 30".to_string(),
+        "    ServerAliveCountMax 3".to_string(),
+    ]);
+
+    Ok(format!("{}\n", lines.join("\n")))
+}
+
+fn default_host_alias(sandbox: &ResolvedSandbox) -> String {
+    match sandbox.name.as_deref() {
+        Some(name) => format!("tl-{name}"),
+        None => format!("tl-{}", sandbox.sandbox_id),
+    }
+}
+
+fn validate_single_token(label: &str, value: &str) -> Result<()> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(CliError::usage(format!("{label} must not be empty")));
+    }
+    if trimmed.chars().any(char::is_whitespace) {
+        return Err(CliError::usage(format!(
+            "{label} must not contain whitespace"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ResolvedSandbox, format_ssh_config};
+
+    #[test]
+    fn format_ssh_config_uses_named_alias_and_placeholder_identity_file() {
+        let config = format_ssh_config(
+            &ResolvedSandbox {
+                sandbox_id: "sbx-123".to_string(),
+                name: Some("my-sandbox".to_string()),
+            },
+            None,
+            None,
+        )
+        .expect("config");
+
+        assert_eq!(
+            config,
+            concat!(
+                "Host tl-my-sandbox\n",
+                "    HostName sandbox.tensorlake.ai\n",
+                "    User sbx-123\n",
+                "    # Set this to the private key whose public key you registered with `tl ssh-keys add`\n",
+                "    IdentityFile ~/.ssh/id_ed25519_tensorlake\n",
+                "    IdentitiesOnly yes\n",
+                "    ServerAliveInterval 30\n",
+                "    ServerAliveCountMax 3\n"
+            )
+        );
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -225,25 +225,36 @@ enum SshKeysCommands {
     },
 }
 
+#[derive(Parser)]
+struct SshArgs {
+    #[command(subcommand)]
+    command: Option<SshCommands>,
+
+    /// Sandbox ID or name
+    sandbox_id: Option<String>,
+
+    /// Shell to use
+    #[arg(short, long, default_value = "/bin/bash", requires = "sandbox_id")]
+    shell: String,
+
+    /// Shell argument (repeatable)
+    #[arg(long = "shell-arg", allow_hyphen_values = true, requires = "sandbox_id")]
+    shell_args: Vec<String>,
+
+    /// Working directory
+    #[arg(short, long, requires = "sandbox_id")]
+    workdir: Option<String>,
+
+    /// Environment variable (KEY=VALUE)
+    #[arg(short, long, requires = "sandbox_id")]
+    env: Vec<String>,
+}
+
 #[derive(Subcommand)]
-enum NativeSshCommands {
-    /// Manage SSH public keys for native SSH access
+enum SshCommands {
+    /// Manage native SSH public keys
     #[command(subcommand)]
     Keys(SshKeysCommands),
-
-    /// Print an OpenSSH config block for a sandbox
-    PrintConfig {
-        /// Sandbox ID or name
-        sandbox_id: String,
-
-        /// Host alias to emit in the config block
-        #[arg(long = "host")]
-        host_alias: Option<String>,
-
-        /// Local private key path to include in IdentityFile
-        #[arg(long)]
-        identity_file: Option<String>,
-    },
 }
 
 #[derive(Subcommand)]
@@ -561,27 +572,8 @@ enum SbxCommands {
         new_name: String,
     },
 
-    /// Interactive shell in a sandbox
-    Ssh {
-        /// Sandbox ID or name
-        sandbox_id: String,
-
-        /// Shell to use
-        #[arg(short, long, default_value = "/bin/bash")]
-        shell: String,
-
-        /// Shell argument (repeatable)
-        #[arg(long = "shell-arg", allow_hyphen_values = true)]
-        shell_args: Vec<String>,
-
-        /// Working directory
-        #[arg(short, long)]
-        workdir: Option<String>,
-
-        /// Environment variable (KEY=VALUE)
-        #[arg(short, long)]
-        env: Vec<String>,
-    },
+    /// Interactive shell in a sandbox, or manage native SSH keys
+    Ssh(SshArgs),
 
     /// Tunnel a local TCP port into a sandbox over WebSocket
     Tunnel {
@@ -596,10 +588,6 @@ enum SbxCommands {
         #[arg(short, long, value_parser = parse_tcp_port)]
         listen_port: Option<u16>,
     },
-
-    /// Connect with ssh, scp, VS Code Remote-SSH, and any other tool that speaks SSH
-    #[command(subcommand, name = "native-ssh")]
-    NativeSsh(NativeSshCommands),
 
     /// Manage sandbox images
     #[command(subcommand)]
@@ -905,9 +893,12 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
             }
         }
         Commands::Sbx(subcmd) => match subcmd {
-            SbxCommands::NativeSsh(NativeSshCommands::Keys(keys_cmd)) => {
+            SbxCommands::Ssh(ssh_args) if matches!(ssh_args.command, Some(SshCommands::Keys(_))) => {
                 ensure_auth(ctx).await?;
-                run_ssh_keys_command(ctx, keys_cmd).await
+                match ssh_args.command {
+                    Some(SshCommands::Keys(keys_cmd)) => run_ssh_keys_command(ctx, keys_cmd).await,
+                    None => unreachable!(),
+                }
             }
             other => {
                 ensure_auth_and_project(ctx).await?;
@@ -1087,20 +1078,19 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         )
                         .await
                     }
-                    SbxCommands::Ssh {
-                        sandbox_id,
-                        shell,
-                        shell_args,
-                        workdir,
-                        env,
-                    } => {
+                    SbxCommands::Ssh(ssh_args) => {
+                        let sandbox_id = ssh_args.sandbox_id.ok_or_else(|| {
+                            CliError::usage(
+                                "ssh requires a sandbox ID or name, or the 'keys' subcommand",
+                            )
+                        })?;
                         commands::sbx::ssh::run(
                             ctx,
                             &sandbox_id,
-                            &shell,
-                            &shell_args,
-                            workdir.as_deref(),
-                            &env,
+                            &ssh_args.shell,
+                            &ssh_args.shell_args,
+                            ssh_args.workdir.as_deref(),
+                            &ssh_args.env,
                         )
                         .await
                     }
@@ -1167,20 +1157,6 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     } => {
                         commands::sbx::tunnel::run(ctx, &sandbox_id, remote_port, listen_port).await
                     }
-                    SbxCommands::NativeSsh(NativeSshCommands::PrintConfig {
-                        sandbox_id,
-                        host_alias,
-                        identity_file,
-                    }) => {
-                        commands::sbx::native_ssh::print_config(
-                            ctx,
-                            &sandbox_id,
-                            host_alias.as_deref(),
-                            identity_file.as_deref(),
-                        )
-                        .await
-                    }
-                    SbxCommands::NativeSsh(NativeSshCommands::Keys(_)) => unreachable!(),
                 }
             }
         },
@@ -1563,14 +1539,16 @@ mod tests {
         .unwrap();
 
         match cli.command {
-            Commands::Sbx(SbxCommands::Ssh {
+            Commands::Sbx(SbxCommands::Ssh(SshArgs {
+                command,
                 sandbox_id,
                 shell,
                 shell_args,
                 workdir,
                 env,
-            }) => {
-                assert_eq!(sandbox_id, "sbx-123");
+            })) => {
+                assert!(command.is_none());
+                assert_eq!(sandbox_id.as_deref(), Some("sbx-123"));
                 assert_eq!(shell, "/bin/zsh");
                 assert_eq!(shell_args, vec!["-l", "-c"]);
                 assert_eq!(workdir, Some("/tmp/work".to_string()));
@@ -1581,34 +1559,16 @@ mod tests {
     }
 
     #[test]
-    fn sbx_native_ssh_print_config_parses_optional_flags() {
-        let cli = Cli::try_parse_from([
-            "tl",
-            "sbx",
-            "native-ssh",
-            "print-config",
-            "my-sandbox",
-            "--host",
-            "tl-my-sandbox",
-            "--identity-file",
-            "~/.ssh/id_ed25519_tensorlake",
-        ])
-        .unwrap();
+    fn sbx_ssh_keys_ls_parses() {
+        let cli = Cli::try_parse_from(["tl", "sbx", "ssh", "keys", "ls"]).unwrap();
 
         match cli.command {
-            Commands::Sbx(SbxCommands::NativeSsh(NativeSshCommands::PrintConfig {
-                sandbox_id,
-                host_alias,
-                identity_file,
-            })) => {
-                assert_eq!(sandbox_id, "my-sandbox");
-                assert_eq!(host_alias.as_deref(), Some("tl-my-sandbox"));
-                assert_eq!(
-                    identity_file.as_deref(),
-                    Some("~/.ssh/id_ed25519_tensorlake")
-                );
-            }
-            _ => panic!("expected sbx native-ssh print-config command"),
+            Commands::Sbx(SbxCommands::Ssh(SshArgs {
+                command: Some(SshCommands::Keys(SshKeysCommands::Ls)),
+                sandbox_id: None,
+                ..
+            })) => {}
+            _ => panic!("expected sbx ssh keys ls command"),
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -174,7 +174,7 @@ enum Commands {
     Secrets(SecretsCommands),
 
     /// Manage SSH public keys for sandbox SSH access
-    #[command(subcommand, name = "ssh-keys", alias = "ssh-key")]
+    #[command(subcommand, name = "ssh-keys", alias = "ssh-key", hide = true)]
     SshKeys(SshKeysCommands),
 
     /// List applications
@@ -222,6 +222,27 @@ enum SshKeysCommands {
         /// Key ids (`ssh_key_…`) or unique names to remove
         #[arg(required = true)]
         keys: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum NativeSshCommands {
+    /// Manage SSH public keys for native SSH access
+    #[command(subcommand)]
+    Keys(SshKeysCommands),
+
+    /// Print an OpenSSH config block for a sandbox
+    PrintConfig {
+        /// Sandbox ID or name
+        sandbox_id: String,
+
+        /// Host alias to emit in the config block
+        #[arg(long = "host")]
+        host_alias: Option<String>,
+
+        /// Local private key path to include in IdentityFile
+        #[arg(long)]
+        identity_file: Option<String>,
     },
 }
 
@@ -576,6 +597,10 @@ enum SbxCommands {
         listen_port: Option<u16>,
     },
 
+    /// Connect with ssh, scp, VS Code Remote-SSH, and any other tool that speaks SSH
+    #[command(subcommand, name = "native-ssh")]
+    NativeSsh(NativeSshCommands),
+
     /// Manage sandbox images
     #[command(subcommand)]
     Image(ImageCommands),
@@ -871,13 +896,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
             // SSH keys live on the user, not on a project — only auth (PAT or
             // logged-in session) is required, no org/project context.
             ensure_auth(ctx).await?;
-            match subcmd {
-                SshKeysCommands::Ls => commands::ssh_keys::list(ctx).await,
-                SshKeysCommands::Add { name, public_key } => {
-                    commands::ssh_keys::add(ctx, &name, &public_key).await
-                }
-                SshKeysCommands::Rm { keys } => commands::ssh_keys::remove(ctx, &keys).await,
-            }
+            run_ssh_keys_command(ctx, subcmd).await
         }
         Commands::Applications(app_args) => {
             ensure_auth_and_project(ctx).await?;
@@ -885,225 +904,45 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                 Some(ApplicationsCommands::Ls) | None => commands::applications::ls(ctx).await,
             }
         }
-        Commands::Sbx(subcmd) => {
-            ensure_auth_and_project(ctx).await?;
-            match subcmd {
-                SbxCommands::Ls {
-                    all,
-                    running,
-                    suspended,
-                    quiet,
-                    archived,
-                } => commands::sbx::ls::run(ctx, running, suspended, all, quiet, archived).await,
-                SbxCommands::Describe { sandbox_id } => {
-                    commands::sbx::describe::run(ctx, &sandbox_id).await
-                }
-                SbxCommands::Terminate { sandbox_ids } => {
-                    commands::sbx::terminate::run(ctx, &sandbox_ids).await
-                }
-                SbxCommands::Create {
-                    name,
-                    cpus,
-                    memory,
-                    disk_mb,
-                    disk_gb,
-                    timeout,
-                    entrypoint,
-                    snapshot,
-                    image,
-                    no_wait,
-                    ports,
-                    allow_unauthenticated_access,
-                    no_internet,
-                    network_allow,
-                    network_deny,
-                } => {
-                    let disk_mb = if let Some(value) = disk_mb {
-                        Some(value)
-                    } else {
-                        disk_gb
-                            .map(|value| {
-                                value.checked_mul(1024).ok_or_else(|| {
-                                    CliError::usage("--disk is too large to convert to MiB")
-                                })
-                            })
-                            .transpose()?
-                    };
-                    commands::sbx::create::run(
-                        ctx,
-                        commands::sbx::create::CreateArgs {
-                            name: name.as_deref(),
-                            cpus,
-                            memory,
-                            disk_mb,
-                            timeout,
-                            entrypoint: &entrypoint,
-                            snapshot_id: snapshot.as_deref(),
-                            image_name: image.as_deref(),
-                            wait: !no_wait,
-                            ports: &ports,
-                            allow_unauthenticated_access,
-                            no_internet,
-                            network_allow: &network_allow,
-                            network_deny: &network_deny,
-                        },
-                    )
-                    .await
-                }
-                SbxCommands::Name {
-                    sandbox_id,
-                    new_name,
-                } => commands::sbx::name::run(ctx, &sandbox_id, &new_name).await,
-                SbxCommands::Suspend {
-                    sandbox_id,
-                    no_wait,
-                } => commands::sbx::suspend::run(ctx, &sandbox_id, !no_wait).await,
-                SbxCommands::Resume {
-                    sandbox_id,
-                    no_wait,
-                } => commands::sbx::resume::run(ctx, &sandbox_id, !no_wait).await,
-                SbxCommands::Exec {
-                    sandbox_id,
-                    command,
-                    args,
-                    timeout,
-                    workdir,
-                    env,
-                    user,
-                } => {
-                    commands::sbx::exec::run(
-                        ctx,
-                        &sandbox_id,
-                        &command,
-                        &args,
-                        timeout,
-                        workdir.as_deref(),
-                        &env,
-                        Some(user.as_str()),
-                    )
-                    .await
-                }
-                SbxCommands::Cp { src, dest } => commands::sbx::cp::run(ctx, &src, &dest).await,
-                SbxCommands::Checkpoint(snapshot_args) => match snapshot_args.command {
-                    Some(SnapshotCommands::Ls) => commands::sbx::snapshot_ls::run(ctx).await,
-                    Some(SnapshotCommands::Rm { snapshot_ids }) => {
-                        commands::sbx::snapshot_rm::run(ctx, &snapshot_ids).await
+        Commands::Sbx(subcmd) => match subcmd {
+            SbxCommands::NativeSsh(NativeSshCommands::Keys(keys_cmd)) => {
+                ensure_auth(ctx).await?;
+                run_ssh_keys_command(ctx, keys_cmd).await
+            }
+            other => {
+                ensure_auth_and_project(ctx).await?;
+                match other {
+                    SbxCommands::Ls {
+                        all,
+                        running,
+                        suspended,
+                        quiet,
+                        archived,
+                    } => {
+                        commands::sbx::ls::run(ctx, running, suspended, all, quiet, archived).await
                     }
-                    None => {
-                        let sandbox_id = snapshot_args.sandbox_id.ok_or_else(|| {
-                            CliError::usage(
-                                "checkpoint requires a sandbox ID or the 'ls' subcommand",
-                            )
-                        })?;
-                        commands::sbx::snapshot::run(
-                            ctx,
-                            &sandbox_id,
-                            snapshot_args.timeout,
-                            snapshot_args
-                                .checkpoint_type
-                                .map(SnapshotTypeArg::as_wire_value),
-                        )
-                        .await
+                    SbxCommands::Describe { sandbox_id } => {
+                        commands::sbx::describe::run(ctx, &sandbox_id).await
                     }
-                },
-                SbxCommands::Clone {
-                    sandbox_id,
-                    timeout,
-                    times,
-                } => commands::sbx::clone::run(ctx, &sandbox_id, timeout, times.get()).await,
-                SbxCommands::Port(port_cmd) => match port_cmd {
-                    PortCommands::Ls { sandbox_id } => {
-                        commands::sbx::port::list(ctx, &sandbox_id).await
+                    SbxCommands::Terminate { sandbox_ids } => {
+                        commands::sbx::terminate::run(ctx, &sandbox_ids).await
                     }
-                    PortCommands::Expose { sandbox_id, ports } => {
-                        commands::sbx::port::expose(ctx, &sandbox_id, &ports).await
-                    }
-                    PortCommands::Rm { sandbox_id, ports } => {
-                        commands::sbx::port::remove(ctx, &sandbox_id, &ports).await
-                    }
-                },
-                SbxCommands::Run {
-                    command,
-                    args,
-                    image,
-                    cpus,
-                    memory,
-                    disk_mb,
-                    timeout,
-                    workdir,
-                    env,
-                    user,
-                    keep,
-                    ports,
-                    allow_unauthenticated_access,
-                    no_internet,
-                    network_allow,
-                    network_deny,
-                } => {
-                    commands::sbx::run::run(
-                        ctx,
-                        &command,
-                        &args,
-                        image.as_deref(),
+                    SbxCommands::Create {
+                        name,
                         cpus,
                         memory,
                         disk_mb,
+                        disk_gb,
                         timeout,
-                        workdir.as_deref(),
-                        &env,
-                        Some(user.as_str()),
-                        keep,
-                        &ports,
+                        entrypoint,
+                        snapshot,
+                        image,
+                        no_wait,
+                        ports,
                         allow_unauthenticated_access,
                         no_internet,
-                        &network_allow,
-                        &network_deny,
-                    )
-                    .await
-                }
-                SbxCommands::Ssh {
-                    sandbox_id,
-                    shell,
-                    shell_args,
-                    workdir,
-                    env,
-                } => {
-                    commands::sbx::ssh::run(
-                        ctx,
-                        &sandbox_id,
-                        &shell,
-                        &shell_args,
-                        workdir.as_deref(),
-                        &env,
-                    )
-                    .await
-                }
-                SbxCommands::Image(image_cmd) => match image_cmd {
-                    ImageCommands::Register {
-                        image_name,
-                        snapshot_id,
-                        dockerfile_path,
-                        public,
-                    } => {
-                        commands::sbx::image::register::run(
-                            ctx,
-                            &image_name,
-                            &snapshot_id,
-                            &dockerfile_path,
-                            public,
-                        )
-                        .await
-                    }
-                    ImageCommands::Create {
-                        dockerfile_path,
-                        registered_name,
-                        disk_mb,
-                        builder_disk_mb,
-                        disk_gb,
-                        cpus,
-                        memory,
-                        public,
-                        json,
+                        network_allow,
+                        network_deny,
                     } => {
                         let disk_mb = if let Some(value) = disk_mb {
                             Some(value)
@@ -1116,31 +955,245 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 })
                                 .transpose()?
                         };
-                        commands::sbx::image::create::run(
+                        commands::sbx::create::run(
                             ctx,
-                            &dockerfile_path,
-                            registered_name.as_deref(),
+                            commands::sbx::create::CreateArgs {
+                                name: name.as_deref(),
+                                cpus,
+                                memory,
+                                disk_mb,
+                                timeout,
+                                entrypoint: &entrypoint,
+                                snapshot_id: snapshot.as_deref(),
+                                image_name: image.as_deref(),
+                                wait: !no_wait,
+                                ports: &ports,
+                                allow_unauthenticated_access,
+                                no_internet,
+                                network_allow: &network_allow,
+                                network_deny: &network_deny,
+                            },
+                        )
+                        .await
+                    }
+                    SbxCommands::Name {
+                        sandbox_id,
+                        new_name,
+                    } => commands::sbx::name::run(ctx, &sandbox_id, &new_name).await,
+                    SbxCommands::Suspend {
+                        sandbox_id,
+                        no_wait,
+                    } => commands::sbx::suspend::run(ctx, &sandbox_id, !no_wait).await,
+                    SbxCommands::Resume {
+                        sandbox_id,
+                        no_wait,
+                    } => commands::sbx::resume::run(ctx, &sandbox_id, !no_wait).await,
+                    SbxCommands::Exec {
+                        sandbox_id,
+                        command,
+                        args,
+                        timeout,
+                        workdir,
+                        env,
+                        user,
+                    } => {
+                        commands::sbx::exec::run(
+                            ctx,
+                            &sandbox_id,
+                            &command,
+                            &args,
+                            timeout,
+                            workdir.as_deref(),
+                            &env,
+                            Some(user.as_str()),
+                        )
+                        .await
+                    }
+                    SbxCommands::Cp { src, dest } => commands::sbx::cp::run(ctx, &src, &dest).await,
+                    SbxCommands::Checkpoint(snapshot_args) => match snapshot_args.command {
+                        Some(SnapshotCommands::Ls) => commands::sbx::snapshot_ls::run(ctx).await,
+                        Some(SnapshotCommands::Rm { snapshot_ids }) => {
+                            commands::sbx::snapshot_rm::run(ctx, &snapshot_ids).await
+                        }
+                        None => {
+                            let sandbox_id = snapshot_args.sandbox_id.ok_or_else(|| {
+                                CliError::usage(
+                                    "checkpoint requires a sandbox ID or the 'ls' subcommand",
+                                )
+                            })?;
+                            commands::sbx::snapshot::run(
+                                ctx,
+                                &sandbox_id,
+                                snapshot_args.timeout,
+                                snapshot_args
+                                    .checkpoint_type
+                                    .map(SnapshotTypeArg::as_wire_value),
+                            )
+                            .await
+                        }
+                    },
+                    SbxCommands::Clone {
+                        sandbox_id,
+                        timeout,
+                        times,
+                    } => commands::sbx::clone::run(ctx, &sandbox_id, timeout, times.get()).await,
+                    SbxCommands::Port(port_cmd) => match port_cmd {
+                        PortCommands::Ls { sandbox_id } => {
+                            commands::sbx::port::list(ctx, &sandbox_id).await
+                        }
+                        PortCommands::Expose { sandbox_id, ports } => {
+                            commands::sbx::port::expose(ctx, &sandbox_id, &ports).await
+                        }
+                        PortCommands::Rm { sandbox_id, ports } => {
+                            commands::sbx::port::remove(ctx, &sandbox_id, &ports).await
+                        }
+                    },
+                    SbxCommands::Run {
+                        command,
+                        args,
+                        image,
+                        cpus,
+                        memory,
+                        disk_mb,
+                        timeout,
+                        workdir,
+                        env,
+                        user,
+                        keep,
+                        ports,
+                        allow_unauthenticated_access,
+                        no_internet,
+                        network_allow,
+                        network_deny,
+                    } => {
+                        commands::sbx::run::run(
+                            ctx,
+                            &command,
+                            &args,
+                            image.as_deref(),
+                            cpus,
+                            memory,
+                            disk_mb,
+                            timeout,
+                            workdir.as_deref(),
+                            &env,
+                            Some(user.as_str()),
+                            keep,
+                            &ports,
+                            allow_unauthenticated_access,
+                            no_internet,
+                            &network_allow,
+                            &network_deny,
+                        )
+                        .await
+                    }
+                    SbxCommands::Ssh {
+                        sandbox_id,
+                        shell,
+                        shell_args,
+                        workdir,
+                        env,
+                    } => {
+                        commands::sbx::ssh::run(
+                            ctx,
+                            &sandbox_id,
+                            &shell,
+                            &shell_args,
+                            workdir.as_deref(),
+                            &env,
+                        )
+                        .await
+                    }
+                    SbxCommands::Image(image_cmd) => match image_cmd {
+                        ImageCommands::Register {
+                            image_name,
+                            snapshot_id,
+                            dockerfile_path,
+                            public,
+                        } => {
+                            commands::sbx::image::register::run(
+                                ctx,
+                                &image_name,
+                                &snapshot_id,
+                                &dockerfile_path,
+                                public,
+                            )
+                            .await
+                        }
+                        ImageCommands::Create {
+                            dockerfile_path,
+                            registered_name,
                             disk_mb,
                             builder_disk_mb,
+                            disk_gb,
                             cpus,
                             memory,
                             public,
                             json,
+                        } => {
+                            let disk_mb = if let Some(value) = disk_mb {
+                                Some(value)
+                            } else {
+                                disk_gb
+                                    .map(|value| {
+                                        value.checked_mul(1024).ok_or_else(|| {
+                                            CliError::usage("--disk is too large to convert to MiB")
+                                        })
+                                    })
+                                    .transpose()?
+                            };
+                            commands::sbx::image::create::run(
+                                ctx,
+                                &dockerfile_path,
+                                registered_name.as_deref(),
+                                disk_mb,
+                                builder_disk_mb,
+                                cpus,
+                                memory,
+                                public,
+                                json,
+                            )
+                            .await
+                        }
+                        ImageCommands::Ls => commands::sbx::image::ls::run(ctx).await,
+                        ImageCommands::Describe { name_or_id } => {
+                            commands::sbx::image::describe::run(ctx, &name_or_id).await
+                        }
+                    },
+                    SbxCommands::Tunnel {
+                        sandbox_id,
+                        remote_port,
+                        listen_port,
+                    } => {
+                        commands::sbx::tunnel::run(ctx, &sandbox_id, remote_port, listen_port).await
+                    }
+                    SbxCommands::NativeSsh(NativeSshCommands::PrintConfig {
+                        sandbox_id,
+                        host_alias,
+                        identity_file,
+                    }) => {
+                        commands::sbx::native_ssh::print_config(
+                            ctx,
+                            &sandbox_id,
+                            host_alias.as_deref(),
+                            identity_file.as_deref(),
                         )
                         .await
                     }
-                    ImageCommands::Ls => commands::sbx::image::ls::run(ctx).await,
-                    ImageCommands::Describe { name_or_id } => {
-                        commands::sbx::image::describe::run(ctx, &name_or_id).await
-                    }
-                },
-                SbxCommands::Tunnel {
-                    sandbox_id,
-                    remote_port,
-                    listen_port,
-                } => commands::sbx::tunnel::run(ctx, &sandbox_id, remote_port, listen_port).await,
+                    SbxCommands::NativeSsh(NativeSshCommands::Keys(_)) => unreachable!(),
+                }
             }
+        },
+    }
+}
+
+async fn run_ssh_keys_command(ctx: &CliContext, subcmd: SshKeysCommands) -> error::Result<()> {
+    match subcmd {
+        SshKeysCommands::Ls => commands::ssh_keys::list(ctx).await,
+        SshKeysCommands::Add { name, public_key } => {
+            commands::ssh_keys::add(ctx, &name, &public_key).await
         }
+        SshKeysCommands::Rm { keys } => commands::ssh_keys::remove(ctx, &keys).await,
     }
 }
 
@@ -1524,6 +1577,38 @@ mod tests {
                 assert_eq!(env, vec!["FOO=bar", "TERM=screen-256color"]);
             }
             _ => panic!("expected sbx ssh command"),
+        }
+    }
+
+    #[test]
+    fn sbx_native_ssh_print_config_parses_optional_flags() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "native-ssh",
+            "print-config",
+            "my-sandbox",
+            "--host",
+            "tl-my-sandbox",
+            "--identity-file",
+            "~/.ssh/id_ed25519_tensorlake",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::NativeSsh(NativeSshCommands::PrintConfig {
+                sandbox_id,
+                host_alias,
+                identity_file,
+            })) => {
+                assert_eq!(sandbox_id, "my-sandbox");
+                assert_eq!(host_alias.as_deref(), Some("tl-my-sandbox"));
+                assert_eq!(
+                    identity_file.as_deref(),
+                    Some("~/.ssh/id_ed25519_tensorlake")
+                );
+            }
+            _ => panic!("expected sbx native-ssh print-config command"),
         }
     }
 


### PR DESCRIPTION
## Summary

- add `tl sbx ssh` with `keys` and add ssh config in describe
- keep top-level `ssh-keys` working but hide it from help while the new sandbox-native entry point rolls out
- show a labeled sandbox ID plus a native SSH one-liner in sandbox creation output

## Why

Native SSH setup was split across top-level key management and sandbox commands. This change makes native SSH discoverable from `tl sbx` without changing the existing PTY-based `tl sbx ssh` flow.

## Validation

- `cargo test -p tensorlake-cli`
- `TENSORLAKE_BIN=target/debug/tl bash scripts/e2e_sandbox_name_status_update_cli.sh`
