### PR TITLE
[codex] Bump SDK and CLI version to 0.5.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "base64",
  "bollard",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "base64",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cloud-sdk", "crates/cli", "crates/rust-cloud-sdk-py"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.16"
+version = "0.5.17"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.16"
+version = "0.5.17"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.16"
+version = "0.5.17"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.16",
+      "version": "0.5.17",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.16",
+  "version": "0.5.17",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the workspace, Python package, Rust Python bindings, and TypeScript package versions from `0.5.16` to `0.5.17`
- update the Rust and npm lockfiles to keep the version metadata in sync

## Validation

- metadata-only change; no tests run
