### PR TITLE
[codex] Use npm trusted publishing

### DIFF
--- a/.github/workflows/publish_npm.yaml
+++ b/.github/workflows/publish_npm.yaml
@@ -111,12 +111,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-          cache: "npm"
-          cache-dependency-path: typescript/package-lock.json
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -152,6 +151,4 @@ jobs:
         run: npm pack --dry-run --ignore-scripts
 
       - name: Publish to npm
-        run: npm publish --provenance --access public --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --ignore-scripts


### PR DESCRIPTION
## Summary
- update the npm publish job to authenticate through GitHub Actions OIDC trusted publishing
- remove the long-lived npm token from the publish step
- rely on npm trusted publishing for automatic provenance generation
- run the publish job on Node 24 and npm 11.5.1+ for OIDC support

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish_npm.yaml"); puts "yaml ok"'`\n\n## Notes\n- `actionlint` is not installed locally, so workflow linting was not run.