### PR TITLE
[codex] Add PTY token visibility to the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.18"
+version = "0.5.19"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/cache.rs
+++ b/crates/cli/src/cache.rs
@@ -35,4 +35,9 @@ impl KvCache {
         let _ = tokio::fs::create_dir_all(&self.ns_dir).await;
         let _ = tokio::fs::write(path, value.as_bytes()).await;
     }
+
+    pub async fn delete(&self, key: &str) {
+        let path = self.key_path(key);
+        let _ = tokio::fs::remove_file(path).await;
+    }
 }

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -8,6 +8,7 @@ pub mod ls;
 pub mod name;
 pub mod native_ssh;
 pub mod port;
+pub mod pty;
 pub mod resume;
 pub mod run;
 pub mod snapshot;

--- a/crates/cli/src/commands/sbx/pty.rs
+++ b/crates/cli/src/commands/sbx/pty.rs
@@ -1,0 +1,459 @@
+use comfy_table::Cell;
+use serde_json::Value;
+
+use crate::auth::context::CliContext;
+use crate::cache::KvCache;
+use crate::commands::sbx::{sandbox_proxy_base, with_sandbox_headers};
+use crate::config::files::normalize_api_url;
+use crate::error::{CliError, Result};
+use crate::output::table::new_table;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PtySessionSummary {
+    session_id: String,
+    command: Option<String>,
+    status: Option<String>,
+    clients: Option<String>,
+    created: Option<String>,
+    token: Option<String>,
+}
+
+const PTY_TOKEN_CACHE_NAMESPACE: &str = "pty_tokens";
+
+pub async fn list(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    show_token: bool,
+    output_json: bool,
+) -> Result<()> {
+    let client = ctx.client()?;
+    let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
+    let resp = with_sandbox_headers(
+        client.get(format!("{proxy_base}/api/v1/pty")),
+        sandbox_id,
+        host_override,
+    )
+    .send()
+    .await
+    .map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to list PTY sessions (HTTP {}): {}",
+            status,
+            body
+        )));
+    }
+
+    let response: Value = resp.json().await.map_err(CliError::Http)?;
+    let mut sessions = parse_session_listing(&response)?;
+
+    hydrate_session_tokens(ctx, sandbox_id, &mut sessions).await;
+
+    if sessions.is_empty() {
+        if output_json {
+            println!("[]");
+            return Ok(());
+        }
+        println!("No PTY sessions for sandbox {}.", sandbox_id);
+        return Ok(());
+    }
+
+    if output_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&sessions_to_json_value(&sessions))?
+        );
+        return Ok(());
+    }
+
+    let mut table = new_table(&[
+        "Session ID",
+        "Command",
+        "Status",
+        "Clients",
+        "Created",
+        "Token",
+    ]);
+    for session in sessions {
+        table.add_row(vec![
+            Cell::new(session.session_id),
+            Cell::new(display_value(session.command.as_deref())),
+            Cell::new(display_value(session.status.as_deref())),
+            Cell::new(display_value(session.clients.as_deref())),
+            Cell::new(display_value(session.created.as_deref())),
+            Cell::new(display_token(session.token.as_deref(), show_token)),
+        ]);
+    }
+
+    println!("{table}");
+    Ok(())
+}
+
+pub async fn attach(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    session_id: &str,
+    token: &str,
+) -> Result<()> {
+    cache_pty_token(ctx, sandbox_id, session_id, token).await;
+    super::ssh::attach_to_session(ctx, sandbox_id, session_id, token, "pty attach").await
+}
+
+pub async fn remove(ctx: &CliContext, sandbox_id: &str, session_ids: &[String]) -> Result<()> {
+    let client = ctx.client()?;
+    let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
+
+    for session_id in session_ids {
+        let resp = with_sandbox_headers(
+            client.delete(format!("{proxy_base}/api/v1/pty/{session_id}")),
+            sandbox_id,
+            host_override.clone(),
+        )
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(CliError::Other(anyhow::anyhow!(
+                "failed to remove PTY session {} (HTTP {}): {}",
+                session_id,
+                status,
+                body
+            )));
+        }
+
+        delete_cached_pty_token(ctx, sandbox_id, session_id).await;
+    }
+
+    if session_ids.len() == 1 {
+        println!(
+            "Removed PTY session {} from sandbox {}.",
+            session_ids[0], sandbox_id
+        );
+    } else {
+        println!(
+            "Removed {} PTY sessions from sandbox {}.",
+            session_ids.len(),
+            sandbox_id
+        );
+    }
+
+    Ok(())
+}
+
+fn parse_session_listing(value: &Value) -> Result<Vec<PtySessionSummary>> {
+    let entries = match value {
+        Value::Array(items) => items.iter().collect::<Vec<_>>(),
+        Value::Object(map) => {
+            if let Some(items) = ["sessions", "items", "pty_sessions", "ptySessions"]
+                .into_iter()
+                .find_map(|key| map.get(key))
+            {
+                let Value::Array(items) = items else {
+                    return Err(CliError::Other(anyhow::anyhow!(
+                        "unexpected PTY session listing shape: expected an array"
+                    )));
+                };
+                items.iter().collect::<Vec<_>>()
+            } else if map.contains_key("session_id") || map.contains_key("sessionId") {
+                vec![value]
+            } else {
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "unexpected PTY session listing response shape"
+                )));
+            }
+        }
+        _ => {
+            return Err(CliError::Other(anyhow::anyhow!(
+                "unexpected PTY session listing response type"
+            )));
+        }
+    };
+
+    entries.into_iter().map(parse_session_summary).collect()
+}
+
+fn parse_session_summary(value: &Value) -> Result<PtySessionSummary> {
+    let Value::Object(map) = value else {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "unexpected PTY session entry shape"
+        )));
+    };
+
+    let session_id = string_field(map, &["session_id", "sessionId"]).ok_or_else(|| {
+        CliError::Other(anyhow::anyhow!("PTY session entry is missing session_id"))
+    })?;
+
+    Ok(PtySessionSummary {
+        session_id,
+        command: command_field(map),
+        status: string_field(map, &["status", "state"]),
+        clients: string_field(
+            map,
+            &["client_count", "clientCount", "clients", "attached_clients"],
+        ),
+        created: string_field(map, &["created_at", "createdAt", "started_at", "startedAt"]),
+        token: string_field(
+            map,
+            &[
+                "token",
+                "pty_token",
+                "ptyToken",
+                "attach_token",
+                "attachToken",
+            ],
+        ),
+    })
+}
+
+fn command_field(map: &serde_json::Map<String, Value>) -> Option<String> {
+    let command = string_field(map, &["command", "cmd"]);
+    let args = array_field(map, &["args", "argv"]);
+
+    match (command, args) {
+        (Some(command), Some(args)) if !args.is_empty() => Some(format!("{command} {args}")),
+        (Some(command), _) => Some(command),
+        (None, Some(args)) if !args.is_empty() => Some(args),
+        _ => None,
+    }
+}
+
+fn array_field(map: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        let Some(value) = map.get(*key) else {
+            continue;
+        };
+        let Value::Array(items) = value else {
+            continue;
+        };
+        let values: Vec<String> = items.iter().filter_map(value_to_string).collect();
+        if !values.is_empty() {
+            return Some(values.join(" "));
+        }
+    }
+    None
+}
+
+fn string_field(map: &serde_json::Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| map.get(*key))
+        .and_then(value_to_string)
+}
+
+fn value_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(text) => {
+            let trimmed = text.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        }
+        Value::Bool(boolean) => Some(boolean.to_string()),
+        Value::Number(number) => Some(number.to_string()),
+        _ => Some(value.to_string()),
+    }
+}
+
+fn display_value(value: Option<&str>) -> &str {
+    value.unwrap_or("-")
+}
+
+fn display_token(token: Option<&str>, show_token: bool) -> String {
+    match token {
+        Some(token) if show_token => token.to_string(),
+        Some(token) => mask_token(token),
+        None => "-".to_string(),
+    }
+}
+
+fn mask_token(token: &str) -> String {
+    match token.len() {
+        0 => String::new(),
+        1..=4 => "****".to_string(),
+        5..=8 => format!("{}...{}", &token[..2], &token[token.len() - 2..]),
+        _ => format!("{}...{}", &token[..4], &token[token.len() - 4..]),
+    }
+}
+
+fn sessions_to_json_value(sessions: &[PtySessionSummary]) -> Value {
+    Value::Array(
+        sessions
+            .iter()
+            .map(|session| {
+                serde_json::json!({
+                    "session_id": session.session_id.clone(),
+                    "command": session.command.clone(),
+                    "status": session.status.clone(),
+                    "clients": session.clients.clone(),
+                    "created": session.created.clone(),
+                    "token": session.token.clone(),
+                })
+            })
+            .collect(),
+    )
+}
+
+async fn hydrate_session_tokens(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    sessions: &mut [PtySessionSummary],
+) {
+    for session in sessions.iter_mut() {
+        if let Some(token) = session.token.as_deref() {
+            cache_pty_token(ctx, sandbox_id, &session.session_id, token).await;
+            continue;
+        }
+
+        session.token = load_cached_pty_token(ctx, sandbox_id, &session.session_id).await;
+    }
+}
+
+pub(crate) async fn cache_pty_token(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    session_id: &str,
+    token: &str,
+) {
+    let cache = KvCache::new(PTY_TOKEN_CACHE_NAMESPACE);
+    cache
+        .set(&pty_token_cache_key(ctx, sandbox_id, session_id), token)
+        .await;
+}
+
+async fn load_cached_pty_token(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    session_id: &str,
+) -> Option<String> {
+    let cache = KvCache::new(PTY_TOKEN_CACHE_NAMESPACE);
+    cache
+        .get(&pty_token_cache_key(ctx, sandbox_id, session_id))
+        .await
+}
+
+async fn delete_cached_pty_token(ctx: &CliContext, sandbox_id: &str, session_id: &str) {
+    let cache = KvCache::new(PTY_TOKEN_CACHE_NAMESPACE);
+    cache
+        .delete(&pty_token_cache_key(ctx, sandbox_id, session_id))
+        .await;
+}
+
+fn pty_token_cache_key(ctx: &CliContext, sandbox_id: &str, session_id: &str) -> String {
+    format!(
+        "{}|{}|{}|{}|{}",
+        normalize_api_url(&ctx.api_url),
+        ctx.effective_organization_id().unwrap_or_default(),
+        ctx.effective_project_id().unwrap_or_default(),
+        sandbox_id,
+        session_id
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        PtySessionSummary, display_token, mask_token, parse_session_listing, sessions_to_json_value,
+    };
+
+    #[test]
+    fn parse_session_listing_supports_wrapped_sessions_array() {
+        let sessions = parse_session_listing(&serde_json::json!({
+            "sessions": [
+                {
+                    "session_id": "sess-1",
+                    "command": "/bin/bash",
+                    "args": ["-l"],
+                    "status": "running",
+                    "client_count": 2,
+                    "created_at": "2026-05-25T00:00:00Z",
+                    "token": "tok-12345678"
+                }
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(
+            sessions,
+            vec![PtySessionSummary {
+                session_id: "sess-1".to_string(),
+                command: Some("/bin/bash -l".to_string()),
+                status: Some("running".to_string()),
+                clients: Some("2".to_string()),
+                created: Some("2026-05-25T00:00:00Z".to_string()),
+                token: Some("tok-12345678".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_session_listing_supports_direct_array() {
+        let sessions = parse_session_listing(&serde_json::json!([
+            {
+                "sessionId": "sess-2",
+                "argv": ["/bin/sh", "-c", "echo hi"],
+                "state": "exited"
+            }
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            sessions,
+            vec![PtySessionSummary {
+                session_id: "sess-2".to_string(),
+                command: Some("/bin/sh -c echo hi".to_string()),
+                status: Some("exited".to_string()),
+                clients: None,
+                created: None,
+                token: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_session_listing_rejects_unknown_shape() {
+        let error = parse_session_listing(&serde_json::json!({"unexpected": []})).unwrap_err();
+        assert!(error.to_string().contains("unexpected PTY session listing"));
+    }
+
+    #[test]
+    fn mask_token_masks_middle_of_long_tokens() {
+        assert_eq!(mask_token("tok-12345678"), "tok-...5678");
+        assert_eq!(mask_token("token12"), "to...12");
+        assert_eq!(mask_token("abcd"), "****");
+    }
+
+    #[test]
+    fn display_token_hides_or_reveals_tokens() {
+        assert_eq!(display_token(Some("tok-12345678"), false), "tok-...5678");
+        assert_eq!(display_token(Some("tok-12345678"), true), "tok-12345678");
+        assert_eq!(display_token(None, false), "-");
+    }
+
+    #[test]
+    fn sessions_to_json_value_preserves_full_token() {
+        let value = sessions_to_json_value(&[PtySessionSummary {
+            session_id: "sess-1".to_string(),
+            command: Some("/bin/bash".to_string()),
+            status: Some("running".to_string()),
+            clients: Some("1".to_string()),
+            created: Some("2026-05-25T00:00:00Z".to_string()),
+            token: Some("tok-12345678".to_string()),
+        }]);
+
+        assert_eq!(
+            value,
+            serde_json::json!([{
+                "session_id": "sess-1",
+                "command": "/bin/bash",
+                "status": "running",
+                "clients": "1",
+                "created": "2026-05-25T00:00:00Z",
+                "token": "tok-12345678"
+            }])
+        );
+    }
+}

--- a/crates/cli/src/commands/sbx/ssh.rs
+++ b/crates/cli/src/commands/sbx/ssh.rs
@@ -2,8 +2,10 @@ use std::io::Read;
 use std::time::Duration;
 
 use crate::auth::context::CliContext;
+use crate::commands::sbx::pty::cache_pty_token;
 use crate::commands::sbx::{parse_env_vars, sandbox_proxy_base, with_sandbox_headers};
 use crate::error::{CliError, Result};
+use reqwest::header::{AUTHORIZATION, HOST, HeaderMap, HeaderName, HeaderValue};
 use tokio::sync::mpsc;
 
 const OP_DATA: u8 = 0x00;
@@ -26,54 +28,10 @@ pub async fn run(
     workdir: Option<&str>,
     env: &[String],
 ) -> Result<()> {
-    if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
-        return Err(CliError::usage("ssh requires an interactive terminal"));
-    }
+    ensure_interactive_terminal("ssh")?;
 
     let env_dict = parse_env_vars(env)?;
     let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
-
-    // Build headers for the WebSocket upgrade (tungstenite bypasses reqwest).
-    // ctx.client() handles auth + traceparent for the HTTP POST below.
-    let mut ws_headers = reqwest::header::HeaderMap::new();
-    if let Ok(token) = ctx.bearer_token() {
-        ws_headers.insert(
-            reqwest::header::AUTHORIZATION,
-            format!("Bearer {}", token).parse().map_err(|e| {
-                CliError::Other(anyhow::anyhow!("invalid bearer token header: {}", e))
-            })?,
-        );
-    }
-    if let Some(org_id) = ctx.effective_organization_id() {
-        ws_headers.insert(
-            "X-Forwarded-Organization-Id",
-            org_id.parse().map_err(|e| {
-                CliError::Other(anyhow::anyhow!("invalid organization id header: {}", e))
-            })?,
-        );
-    }
-    if let Some(proj_id) = ctx.effective_project_id() {
-        ws_headers.insert(
-            "X-Forwarded-Project-Id",
-            proj_id.parse().map_err(|e| {
-                CliError::Other(anyhow::anyhow!("invalid project id header: {}", e))
-            })?,
-        );
-    }
-    if let Some(ref host) = host_override {
-        ws_headers.insert(
-            reqwest::header::HOST,
-            host.parse()
-                .map_err(|e| CliError::Other(anyhow::anyhow!("invalid host header: {}", e)))?,
-        );
-    } else {
-        ws_headers.insert(
-            reqwest::header::HeaderName::from_static("x-tensorlake-sandbox-id"),
-            sandbox_id.parse().map_err(|e| {
-                CliError::Other(anyhow::anyhow!("invalid sandbox id header: {}", e))
-            })?,
-        );
-    }
     let client = ctx.client()?;
 
     // Get terminal size
@@ -144,13 +102,111 @@ pub async fn run(
         .and_then(|v| v.as_str())
         .ok_or_else(|| CliError::Other(anyhow::anyhow!("missing token in PTY response")))?;
 
+    cache_pty_token(ctx, sandbox_id, session_id, token).await;
+
+    attach_to_session_unchecked(
+        ctx,
+        sandbox_id,
+        session_id,
+        token,
+        "ssh",
+        Some((proxy_base, host_override)),
+    )
+    .await
+}
+
+pub(crate) async fn attach_to_session(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    session_id: &str,
+    token: &str,
+    command_name: &str,
+) -> Result<()> {
+    ensure_interactive_terminal(command_name)?;
+    attach_to_session_unchecked(ctx, sandbox_id, session_id, token, command_name, None).await
+}
+
+fn ensure_interactive_terminal(command_name: &str) -> Result<()> {
+    if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        return Err(CliError::usage(format!(
+            "{command_name} requires an interactive terminal"
+        )));
+    }
+
+    Ok(())
+}
+
+fn build_ws_headers(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    host_override: Option<&str>,
+) -> Result<HeaderMap> {
+    let mut ws_headers = HeaderMap::new();
+
+    if let Ok(token) = ctx.bearer_token() {
+        ws_headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", token)).map_err(|e| {
+                CliError::Other(anyhow::anyhow!("invalid bearer token header: {}", e))
+            })?,
+        );
+    }
+    if let Some(org_id) = ctx.effective_organization_id() {
+        ws_headers.insert(
+            HeaderName::from_static("x-forwarded-organization-id"),
+            HeaderValue::from_str(&org_id).map_err(|e| {
+                CliError::Other(anyhow::anyhow!("invalid organization id header: {}", e))
+            })?,
+        );
+    }
+    if let Some(proj_id) = ctx.effective_project_id() {
+        ws_headers.insert(
+            HeaderName::from_static("x-forwarded-project-id"),
+            HeaderValue::from_str(&proj_id).map_err(|e| {
+                CliError::Other(anyhow::anyhow!("invalid project id header: {}", e))
+            })?,
+        );
+    }
+    if let Some(host) = host_override {
+        ws_headers.insert(
+            HOST,
+            HeaderValue::from_str(host)
+                .map_err(|e| CliError::Other(anyhow::anyhow!("invalid host header: {}", e)))?,
+        );
+    } else {
+        ws_headers.insert(
+            HeaderName::from_static("x-tensorlake-sandbox-id"),
+            HeaderValue::from_str(sandbox_id).map_err(|e| {
+                CliError::Other(anyhow::anyhow!("invalid sandbox id header: {}", e))
+            })?,
+        );
+    }
+
+    Ok(ws_headers)
+}
+
+fn build_ws_url(proxy_base: &str, session_id: &str, token: &str) -> String {
     // Include the PTY token in both the header and query string for now. The
     // daemon accepts either form, and the query parameter keeps production
     // proxies that don't forward the custom header from breaking SSH.
     let ws_base = proxy_base
         .replace("https://", "wss://")
         .replace("http://", "ws://");
-    let ws_url = format!("{}/api/v1/pty/{}/ws?token={}", ws_base, session_id, token);
+    format!("{}/api/v1/pty/{}/ws?token={}", ws_base, session_id, token)
+}
+
+async fn attach_to_session_unchecked(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    session_id: &str,
+    token: &str,
+    _command_name: &str,
+    proxy_details: Option<(String, Option<String>)>,
+) -> Result<()> {
+    let (proxy_base, host_override) =
+        proxy_details.unwrap_or_else(|| sandbox_proxy_base(ctx, sandbox_id));
+    let ws_headers = build_ws_headers(ctx, sandbox_id, host_override.as_deref())?;
+    let ws_url = build_ws_url(&proxy_base, session_id, token);
 
     // Connect WebSocket
     use tokio_tungstenite::tungstenite;
@@ -467,7 +523,7 @@ async fn wait_for_reader_shutdown(
 mod tests {
     use super::{
         OP_DATA, OP_EXIT, PTY_CLOSE_WAIT_TIMEOUT, PtyBinaryFrame, build_pty_create_payload,
-        parse_legacy_exit_code, parse_pty_binary_frame, wait_for_reader_shutdown,
+        build_ws_url, parse_legacy_exit_code, parse_pty_binary_frame, wait_for_reader_shutdown,
     };
     use std::future::pending;
     use std::time::Duration;
@@ -539,6 +595,18 @@ mod tests {
         assert_eq!(payload["env"]["FOO"], "bar");
         assert_eq!(payload["env"]["TERM"], "screen-256color");
         assert_eq!(payload["env"]["COLORTERM"], "24bit");
+    }
+
+    #[test]
+    fn build_ws_url_uses_websocket_scheme_and_token_query() {
+        assert_eq!(
+            build_ws_url("https://sandbox.tensorlake.ai", "sess-1", "tok-1"),
+            "wss://sandbox.tensorlake.ai/api/v1/pty/sess-1/ws?token=tok-1"
+        );
+        assert_eq!(
+            build_ws_url("http://localhost:9443", "sess-1", "tok-1"),
+            "ws://localhost:9443/api/v1/pty/sess-1/ws?token=tok-1"
+        );
     }
 
     #[tokio::test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -238,7 +238,11 @@ struct SshArgs {
     shell: String,
 
     /// Shell argument (repeatable)
-    #[arg(long = "shell-arg", allow_hyphen_values = true, requires = "sandbox_id")]
+    #[arg(
+        long = "shell-arg",
+        allow_hyphen_values = true,
+        requires = "sandbox_id"
+    )]
     shell_args: Vec<String>,
 
     /// Working directory
@@ -575,6 +579,10 @@ enum SbxCommands {
     /// Interactive shell in a sandbox, or manage native SSH keys
     Ssh(SshArgs),
 
+    /// Manage PTY sessions for a sandbox
+    #[command(subcommand)]
+    Pty(PtyCommands),
+
     /// Tunnel a local TCP port into a sandbox over WebSocket
     Tunnel {
         /// Sandbox ID
@@ -736,6 +744,48 @@ enum PortCommands {
     },
 }
 
+#[derive(Subcommand)]
+enum PtyCommands {
+    /// List PTY sessions for a sandbox
+    #[command(name = "ls")]
+    Ls {
+        /// Sandbox ID or name
+        sandbox_id: String,
+
+        /// Show the full PTY token instead of a masked token
+        #[arg(long)]
+        show_token: bool,
+
+        /// Emit JSON suitable for scripting. Includes the full token.
+        #[arg(long = "json")]
+        output_json: bool,
+    },
+
+    /// Attach to an existing PTY session
+    Attach {
+        /// Sandbox ID or name
+        sandbox_id: String,
+
+        /// PTY session ID
+        session_id: String,
+
+        /// PTY token returned when the session was created
+        #[arg(long)]
+        token: String,
+    },
+
+    /// Remove one or more PTY sessions
+    #[command(name = "rm")]
+    Rm {
+        /// Sandbox ID or name
+        sandbox_id: String,
+
+        /// PTY session IDs
+        #[arg(required = true)]
+        session_ids: Vec<String>,
+    },
+}
+
 fn parse_user_port(value: &str) -> std::result::Result<u16, String> {
     let port = parse_tcp_port(value)?;
 
@@ -893,7 +943,9 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
             }
         }
         Commands::Sbx(subcmd) => match subcmd {
-            SbxCommands::Ssh(ssh_args) if matches!(ssh_args.command, Some(SshCommands::Keys(_))) => {
+            SbxCommands::Ssh(ssh_args)
+                if matches!(ssh_args.command, Some(SshCommands::Keys(_))) =>
+            {
                 ensure_auth(ctx).await?;
                 match ssh_args.command {
                     Some(SshCommands::Keys(keys_cmd)) => run_ssh_keys_command(ctx, keys_cmd).await,
@@ -1094,6 +1146,27 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         )
                         .await
                     }
+                    SbxCommands::Pty(pty_cmd) => match pty_cmd {
+                        PtyCommands::Ls {
+                            sandbox_id,
+                            show_token,
+                            output_json,
+                        } => {
+                            commands::sbx::pty::list(ctx, &sandbox_id, show_token, output_json)
+                                .await
+                        }
+                        PtyCommands::Attach {
+                            sandbox_id,
+                            session_id,
+                            token,
+                        } => {
+                            commands::sbx::pty::attach(ctx, &sandbox_id, &session_id, &token).await
+                        }
+                        PtyCommands::Rm {
+                            sandbox_id,
+                            session_ids,
+                        } => commands::sbx::pty::remove(ctx, &sandbox_id, &session_ids).await,
+                    },
                     SbxCommands::Image(image_cmd) => match image_cmd {
                         ImageCommands::Register {
                             image_name,
@@ -1569,6 +1642,89 @@ mod tests {
                 ..
             })) => {}
             _ => panic!("expected sbx ssh keys ls command"),
+        }
+    }
+
+    #[test]
+    fn sbx_pty_ls_parses() {
+        let cli = Cli::try_parse_from(["tl", "sbx", "pty", "ls", "sbx-123"]).unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Pty(PtyCommands::Ls {
+                sandbox_id,
+                show_token,
+                output_json,
+            })) => {
+                assert_eq!(sandbox_id, "sbx-123");
+                assert!(!show_token);
+                assert!(!output_json);
+            }
+            _ => panic!("expected sbx pty ls command"),
+        }
+    }
+
+    #[test]
+    fn sbx_pty_ls_with_token_flags_parses() {
+        let cli = Cli::try_parse_from([
+            "tl",
+            "sbx",
+            "pty",
+            "ls",
+            "sbx-123",
+            "--show-token",
+            "--json",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Pty(PtyCommands::Ls {
+                sandbox_id,
+                show_token,
+                output_json,
+            })) => {
+                assert_eq!(sandbox_id, "sbx-123");
+                assert!(show_token);
+                assert!(output_json);
+            }
+            _ => panic!("expected sbx pty ls command"),
+        }
+    }
+
+    #[test]
+    fn sbx_pty_attach_parses() {
+        let cli = Cli::try_parse_from([
+            "tl", "sbx", "pty", "attach", "sbx-123", "sess-1", "--token", "tok-1",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Pty(PtyCommands::Attach {
+                sandbox_id,
+                session_id,
+                token,
+            })) => {
+                assert_eq!(sandbox_id, "sbx-123");
+                assert_eq!(session_id, "sess-1");
+                assert_eq!(token, "tok-1");
+            }
+            _ => panic!("expected sbx pty attach command"),
+        }
+    }
+
+    #[test]
+    fn sbx_pty_rm_parses_multiple_session_ids() {
+        let cli =
+            Cli::try_parse_from(["tl", "sbx", "pty", "rm", "sbx-123", "sess-1", "sess-2"]).unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Pty(PtyCommands::Rm {
+                sandbox_id,
+                session_ids,
+            })) => {
+                assert_eq!(sandbox_id, "sbx-123");
+                assert_eq!(session_ids, vec!["sess-1", "sess-2"]);
+            }
+            _ => panic!("expected sbx pty rm command"),
         }
     }
 

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.18"
+version = "0.5.19"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.18"
+version = "0.5.19"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.18",
+      "version": "0.5.19",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- add `tl sbx pty` CLI commands for listing, attaching, and removing PTY sessions
- show masked PTY tokens by default in `tl sbx pty ls`, with `--show-token` and `--json` for full token output
- cache PTY tokens learned from `tl sbx ssh` and `tl sbx pty attach` so listings can surface tokens even when the dataplane list response omits them
- bump the published package versions across Rust, Python, and TypeScript metadata from `0.5.18` to `0.5.19`

## Testing
- `cargo test -p tensorlake-cli`
