### PR TITLE
[codex] page through sandbox list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.19"
+version = "0.5.20"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/ls.rs
+++ b/crates/cli/src/commands/sbx/ls.rs
@@ -1,11 +1,10 @@
-use comfy_table::Cell;
-
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
-    DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME, created_at_sort_key, format_created_at, sandbox_endpoint,
+    DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME, format_created_at, sandbox_endpoint,
 };
 use crate::error::{CliError, Result};
-use crate::output::table::new_table;
+
+const MAX_SANDBOX_LIST_PAGES: usize = 10_000;
 
 pub async fn run(
     ctx: &CliContext,
@@ -22,134 +21,42 @@ pub async fn run(
     let client = ctx.client()?;
     let url = sandbox_endpoint(ctx, "sandboxes");
 
-    let resp = client.get(&url).send().await.map_err(CliError::Http)?;
+    let mut count = 0usize;
+    let mut terminated_hidden = 0usize;
+    let mut printed_header = false;
 
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        return Err(CliError::Other(anyhow::anyhow!(
-            "failed to list sandboxes (HTTP {}): {}",
-            status,
-            body
-        )));
-    }
-
-    let body: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
-    let mut sandboxes = body
-        .get("sandboxes")
-        .or_else(|| body.get("items"))
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
-
-    let terminated_hidden = if include_terminated {
-        0
-    } else {
-        sandboxes
-            .iter()
-            .filter(|sandbox| is_terminated_sandbox(sandbox))
-            .count()
-    };
-
-    if !include_terminated {
-        sandboxes.retain(is_non_terminated_sandbox);
-    }
-
-    if running_only {
-        sandboxes.retain(is_running_sandbox);
-    }
-
-    if suspended_only {
-        sandboxes.retain(is_suspended_sandbox);
-    }
-
-    sandboxes.sort_by(|a, b| {
-        let a_created_at = created_at_sort_key(a.get("created_at"));
-        let b_created_at = created_at_sort_key(b.get("created_at"));
-        b_created_at.cmp(&a_created_at)
-    });
-
-    if quiet {
-        for s in &sandboxes {
-            let id = s
-                .get("sandbox_id")
-                .or_else(|| s.get("id"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("-");
-            println!("{}", id);
+    list_sandboxes_by_page(ctx, &client, &url, "sandboxes", |sandbox| {
+        if !include_terminated && is_terminated_sandbox(sandbox) {
+            terminated_hidden += 1;
+            return;
         }
-        return Ok(());
-    }
 
-    if sandboxes.is_empty() {
+        if running_only && !is_running_sandbox(sandbox) {
+            return;
+        }
+
+        if suspended_only && !is_suspended_sandbox(sandbox) {
+            return;
+        }
+
+        count += 1;
+        print_live_sandbox(sandbox, quiet, &mut printed_header);
+    })
+    .await?;
+
+    if count == 0 && !quiet {
         println!("No sandboxes found.");
         return Ok(());
     }
 
-    let mut table = new_table(&[
-        "ID",
-        "Name",
-        "Status",
-        "Image",
-        "CPUs",
-        "Memory",
-        "Disk",
-        "Created At",
-    ]);
-
-    for s in &sandboxes {
-        let id = s
-            .get("sandbox_id")
-            .or_else(|| s.get("id"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
-        let name = s.get("name").and_then(|v| v.as_str()).unwrap_or("");
-        let status = s.get("status").and_then(|v| v.as_str()).unwrap_or("-");
-        let image = s
-            .get("image")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or(DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME);
-
-        let resources = s.get("resources");
-        let cpus = resources
-            .and_then(|r| r.get("cpus"))
-            .and_then(|v| v.as_f64())
-            .map(|v| format!("{}", v))
-            .unwrap_or_else(|| "-".to_string());
-        let memory = resources
-            .and_then(|r| r.get("memory_mb"))
-            .and_then(|v| v.as_i64())
-            .map(|v| format!("{} MB", v))
-            .unwrap_or_else(|| "-".to_string());
-        let disk = resources
-            .and_then(|r| r.get("disk_mb"))
-            .and_then(|v| v.as_i64())
-            .map(|v| format!("{} MB", v))
-            .unwrap_or_else(|| "-".to_string());
-
-        let created_at = format_created_at(s.get("created_at"));
-
-        table.add_row(vec![
-            Cell::new(id),
-            Cell::new(name),
-            Cell::new(status),
-            Cell::new(image),
-            Cell::new(&cpus),
-            Cell::new(&memory),
-            Cell::new(&disk),
-            Cell::new(created_at),
-        ]);
+    if !quiet {
+        println!(
+            "{} sandbox{}, {} terminated hidden (use --all to show)",
+            count,
+            if count != 1 { "es" } else { "" },
+            terminated_hidden
+        );
     }
-
-    println!("{table}");
-    let count = sandboxes.len();
-    println!(
-        "{} sandbox{}, {} terminated hidden (use --all to show)",
-        count,
-        if count != 1 { "es" } else { "" },
-        terminated_hidden
-    );
 
     Ok(())
 }
@@ -158,110 +65,288 @@ async fn run_archived(ctx: &CliContext, quiet: bool) -> Result<()> {
     let client = ctx.client()?;
     let url = sandbox_endpoint(ctx, "archived-sandboxes");
 
-    let resp = client.get(&url).send().await.map_err(CliError::Http)?;
+    let mut count = 0usize;
+    let mut printed_header = false;
 
-    if !resp.status().is_success() {
-        let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        return Err(CliError::Other(anyhow::anyhow!(
-            "failed to list archived sandboxes (HTTP {}): {}",
-            status,
-            body
-        )));
-    }
+    list_sandboxes_by_page(ctx, &client, &url, "archived sandboxes", |sandbox| {
+        count += 1;
+        print_archived_sandbox(sandbox, quiet, &mut printed_header);
+    })
+    .await?;
 
-    let body: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
-    let mut sandboxes = body
-        .get("sandboxes")
-        .and_then(|v| v.as_array())
-        .cloned()
-        .unwrap_or_default();
-
-    sandboxes.sort_by(|a, b| {
-        let a_archived_at = created_at_sort_key(a.get("archived_at"));
-        let b_archived_at = created_at_sort_key(b.get("archived_at"));
-        b_archived_at.cmp(&a_archived_at)
-    });
-
-    if quiet {
-        for s in &sandboxes {
-            let id = s
-                .get("sandbox_id")
-                .or_else(|| s.get("id"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("-");
-            println!("{}", id);
-        }
-        return Ok(());
-    }
-
-    if sandboxes.is_empty() {
+    if count == 0 && !quiet {
         println!("No archived sandboxes found.");
         return Ok(());
     }
 
-    let mut table = new_table(&[
-        "ID",
-        "Name",
-        "Image",
-        "CPUs",
-        "Memory",
-        "Disk",
-        "Archived At",
-    ]);
-
-    for s in &sandboxes {
-        let id = s
-            .get("sandbox_id")
-            .or_else(|| s.get("id"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("-");
-        let name = s.get("name").and_then(|v| v.as_str()).unwrap_or("");
-        let image = s
-            .get("image")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or(DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME);
-
-        let resources = s.get("resources");
-        let cpus = resources
-            .and_then(|r| r.get("cpus"))
-            .and_then(|v| v.as_f64())
-            .map(|v| format!("{}", v))
-            .unwrap_or_else(|| "-".to_string());
-        let memory = resources
-            .and_then(|r| r.get("memory_mb"))
-            .and_then(|v| v.as_i64())
-            .map(|v| format!("{} MB", v))
-            .unwrap_or_else(|| "-".to_string());
-        let disk = resources
-            .and_then(|r| r.get("disk_mb").or_else(|| r.get("ephemeral_disk_mb")))
-            .and_then(|v| v.as_i64())
-            .map(|v| format!("{} MB", v))
-            .unwrap_or_else(|| "-".to_string());
-
-        let archived_at = format_created_at(s.get("archived_at"));
-
-        table.add_row(vec![
-            Cell::new(id),
-            Cell::new(name),
-            Cell::new(image),
-            Cell::new(&cpus),
-            Cell::new(&memory),
-            Cell::new(&disk),
-            Cell::new(archived_at),
-        ]);
+    if !quiet {
+        println!(
+            "{} archived sandbox{}",
+            count,
+            if count != 1 { "es" } else { "" },
+        );
     }
 
-    println!("{table}");
-    let count = sandboxes.len();
-    println!(
-        "{} archived sandbox{}",
-        count,
-        if count != 1 { "es" } else { "" },
-    );
-
     Ok(())
+}
+
+async fn list_sandboxes_by_page(
+    ctx: &CliContext,
+    client: &reqwest::Client,
+    initial_url: &str,
+    label: &str,
+    mut on_sandbox: impl FnMut(&serde_json::Value),
+) -> Result<()> {
+    let mut url = initial_url.to_string();
+
+    for _ in 0..MAX_SANDBOX_LIST_PAGES {
+        if ctx.debug {
+            eprintln!("DEBUG sbx ls: GET {}", url);
+        }
+
+        let resp = client.get(&url).send().await.map_err(CliError::Http)?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(CliError::Other(anyhow::anyhow!(
+                "failed to list {} (HTTP {}): {}",
+                label,
+                status,
+                body
+            )));
+        }
+
+        let body: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
+
+        if let Some(items) = body
+            .get("sandboxes")
+            .or_else(|| body.get("items"))
+            .and_then(|v| v.as_array())
+        {
+            for sandbox in items {
+                on_sandbox(sandbox);
+            }
+        }
+
+        let Some(next_url) = next_sandbox_list_url(&url, &body) else {
+            return Ok(());
+        };
+        url = next_url;
+    }
+
+    Err(CliError::Other(anyhow::anyhow!(
+        "failed to list {}: exceeded pagination limit of {} pages",
+        label,
+        MAX_SANDBOX_LIST_PAGES
+    )))
+}
+
+fn print_live_sandbox(sandbox: &serde_json::Value, quiet: bool, printed_header: &mut bool) {
+    let id = sandbox_id(sandbox);
+    if quiet {
+        println!("{}", id);
+        return;
+    }
+
+    if !*printed_header {
+        print_live_header();
+        *printed_header = true;
+    }
+
+    let resources = sandbox.get("resources");
+    println!(
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+        id,
+        sandbox.get("name").and_then(|v| v.as_str()).unwrap_or(""),
+        sandbox
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("-"),
+        sandbox_image(sandbox),
+        format_cpus(resources),
+        format_memory(resources),
+        format_disk(resources, false),
+        format_created_at(sandbox.get("created_at")),
+    );
+}
+
+fn print_archived_sandbox(sandbox: &serde_json::Value, quiet: bool, printed_header: &mut bool) {
+    let id = sandbox_id(sandbox);
+    if quiet {
+        println!("{}", id);
+        return;
+    }
+
+    if !*printed_header {
+        print_archived_header();
+        *printed_header = true;
+    }
+
+    let resources = sandbox.get("resources");
+    println!(
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+        id,
+        sandbox.get("name").and_then(|v| v.as_str()).unwrap_or(""),
+        sandbox_image(sandbox),
+        format_cpus(resources),
+        format_memory(resources),
+        format_disk(resources, true),
+        format_created_at(sandbox.get("archived_at")),
+    );
+}
+
+fn print_live_header() {
+    println!("ID\tName\tStatus\tImage\tCPUs\tMemory\tDisk\tCreated At");
+}
+
+fn print_archived_header() {
+    println!("ID\tName\tImage\tCPUs\tMemory\tDisk\tArchived At");
+}
+
+fn sandbox_id(sandbox: &serde_json::Value) -> &str {
+    sandbox
+        .get("sandbox_id")
+        .or_else(|| sandbox.get("id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("-")
+}
+
+fn sandbox_image(sandbox: &serde_json::Value) -> &str {
+    sandbox
+        .get("image")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME)
+}
+
+fn format_cpus(resources: Option<&serde_json::Value>) -> String {
+    resources
+        .and_then(|r| r.get("cpus"))
+        .and_then(|v| v.as_f64())
+        .map(|v| format!("{}", v))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn format_memory(resources: Option<&serde_json::Value>) -> String {
+    resources
+        .and_then(|r| r.get("memory_mb"))
+        .and_then(|v| v.as_i64())
+        .map(|v| format!("{} MB", v))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn format_disk(resources: Option<&serde_json::Value>, include_ephemeral_fallback: bool) -> String {
+    resources
+        .and_then(|r| {
+            if include_ephemeral_fallback {
+                r.get("disk_mb").or_else(|| r.get("ephemeral_disk_mb"))
+            } else {
+                r.get("disk_mb")
+            }
+        })
+        .and_then(|v| v.as_i64())
+        .map(|v| format!("{} MB", v))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn next_sandbox_list_url(current_url: &str, body: &serde_json::Value) -> Option<String> {
+    if let Some(next) = body
+        .get("pagination")
+        .and_then(|v| v.get("next"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return Some(resolve_next_url_or_token(current_url, "next", next));
+    }
+
+    if let Some(next) = body
+        .get("paginator")
+        .and_then(|v| v.get("next"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        return Some(resolve_next_url_or_token(current_url, "next", next));
+    }
+
+    for (container, field, query_name) in [
+        ("pagination", "next_token", "nextToken"),
+        ("pagination", "nextToken", "nextToken"),
+        ("pagination", "next_cursor", "cursor"),
+        ("pagination", "nextCursor", "cursor"),
+        ("paginator", "next_token", "nextToken"),
+        ("paginator", "nextToken", "nextToken"),
+        ("paginator", "next_cursor", "cursor"),
+        ("paginator", "nextCursor", "cursor"),
+    ] {
+        if let Some(token) = body
+            .get(container)
+            .and_then(|v| v.get(field))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            return Some(url_with_query_param(current_url, query_name, token));
+        }
+    }
+
+    for (field, query_name) in [
+        ("next_cursor", "cursor"),
+        ("nextCursor", "cursor"),
+        ("next_token", "nextToken"),
+        ("nextToken", "nextToken"),
+    ] {
+        if let Some(token) = body
+            .get(field)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            return Some(url_with_query_param(current_url, query_name, token));
+        }
+    }
+
+    None
+}
+
+fn resolve_next_url_or_token(current_url: &str, query_name: &str, next: &str) -> String {
+    if next.starts_with("http://") || next.starts_with("https://") {
+        return next.to_string();
+    }
+
+    if next.starts_with('/')
+        && let Ok(current) = url::Url::parse(current_url)
+        && let Ok(resolved) = current.join(next)
+    {
+        return resolved.to_string();
+    }
+
+    url_with_query_param(current_url, query_name, next)
+}
+
+fn url_with_query_param(current_url: &str, name: &str, value: &str) -> String {
+    let mut parsed =
+        url::Url::parse(current_url).expect("sandbox list URL should be absolute and valid");
+    let existing_pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .filter(|(key, _)| !is_pagination_query_param(key))
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+
+    parsed.set_query(None);
+    {
+        let mut query_pairs = parsed.query_pairs_mut();
+        for (key, value) in existing_pairs {
+            query_pairs.append_pair(&key, &value);
+        }
+        query_pairs.append_pair(name, value);
+    }
+    parsed.to_string()
+}
+
+fn is_pagination_query_param(key: &str) -> bool {
+    matches!(
+        key,
+        "next" | "cursor" | "nextToken" | "next_token" | "nextCursor" | "next_cursor"
+    )
 }
 
 fn is_running_sandbox(sandbox: &serde_json::Value) -> bool {
@@ -293,7 +378,9 @@ fn is_terminated_sandbox(sandbox: &serde_json::Value) -> bool {
 mod tests {
     use super::{
         is_non_terminated_sandbox, is_running_sandbox, is_suspended_sandbox, is_terminated_sandbox,
+        next_sandbox_list_url,
     };
+    use serde_json::json;
 
     #[test]
     fn running_filter_matches_only_running_status() {
@@ -337,5 +424,68 @@ mod tests {
         assert!(!is_terminated_sandbox(&running));
         assert!(is_terminated_sandbox(&terminated));
         assert!(!is_terminated_sandbox(&pending));
+    }
+
+    #[test]
+    fn pagination_next_link_resolves_against_current_host() {
+        let body = json!({
+            "sandboxes": [],
+            "pagination": {
+                "next": "/sandboxes?next=abc"
+            }
+        });
+
+        assert_eq!(
+            next_sandbox_list_url("https://sandbox.tensorlake.ai/sandboxes", &body),
+            Some("https://sandbox.tensorlake.ai/sandboxes?next=abc".to_string())
+        );
+    }
+
+    #[test]
+    fn pagination_next_token_is_added_as_next_query_param() {
+        let body = json!({
+            "sandboxes": [],
+            "pagination": {
+                "next": "abc"
+            }
+        });
+
+        assert_eq!(
+            next_sandbox_list_url("https://sandbox.tensorlake.ai/sandboxes", &body),
+            Some("https://sandbox.tensorlake.ai/sandboxes?next=abc".to_string())
+        );
+    }
+
+    #[test]
+    fn top_level_next_cursor_is_added_as_cursor_query_param() {
+        let body = json!({
+            "sandboxes": [],
+            "next_cursor": "abc"
+        });
+
+        assert_eq!(
+            next_sandbox_list_url(
+                "https://sandbox.tensorlake.ai/archived-sandboxes?limit=100",
+                &body
+            ),
+            Some(
+                "https://sandbox.tensorlake.ai/archived-sandboxes?limit=100&cursor=abc".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn pagination_query_param_replaces_previous_value() {
+        let body = json!({
+            "sandboxes": [],
+            "pagination": {
+                "next": "def"
+            }
+        });
+
+        assert_eq!(
+            next_sandbox_list_url("https://sandbox.tensorlake.ai/sandboxes?next=abc", &body),
+            Some("https://sandbox.tensorlake.ai/sandboxes?next=def".to_string())
+        );
     }
 }

--- a/crates/cli/src/commands/sbx/ls.rs
+++ b/crates/cli/src/commands/sbx/ls.rs
@@ -51,10 +51,8 @@ pub async fn run(
 
     if !quiet {
         println!(
-            "{} sandbox{}, {} terminated hidden (use --all to show)",
-            count,
-            if count != 1 { "es" } else { "" },
-            terminated_hidden
+            "{}",
+            sandbox_summary(count, terminated_hidden, running_only, suspended_only)
         );
     }
 
@@ -374,11 +372,36 @@ fn is_terminated_sandbox(sandbox: &serde_json::Value) -> bool {
         .is_some_and(|status| status.eq_ignore_ascii_case("terminated"))
 }
 
+fn sandbox_summary(
+    count: usize,
+    terminated_hidden: usize,
+    running_only: bool,
+    suspended_only: bool,
+) -> String {
+    let noun = if count == 1 { "sandbox" } else { "sandboxes" };
+    let scope = if running_only {
+        "running "
+    } else if suspended_only {
+        "suspended "
+    } else {
+        ""
+    };
+    let mut summary = format!("{count} {scope}{noun}");
+
+    if terminated_hidden > 0 && !running_only && !suspended_only {
+        summary.push_str(&format!(
+            ", {terminated_hidden} terminated hidden (use --all to show them all)"
+        ));
+    }
+
+    summary
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         is_non_terminated_sandbox, is_running_sandbox, is_suspended_sandbox, is_terminated_sandbox,
-        next_sandbox_list_url,
+        next_sandbox_list_url, sandbox_summary,
     };
     use serde_json::json;
 
@@ -424,6 +447,29 @@ mod tests {
         assert!(!is_terminated_sandbox(&running));
         assert!(is_terminated_sandbox(&terminated));
         assert!(!is_terminated_sandbox(&pending));
+    }
+
+    #[test]
+    fn summary_mentions_hidden_terminated_for_default_listing() {
+        assert_eq!(
+            sandbox_summary(2, 3, false, false),
+            "2 sandboxes, 3 terminated hidden (use --all to show them all)"
+        );
+    }
+
+    #[test]
+    fn summary_omits_hidden_terminated_when_none_are_hidden() {
+        assert_eq!(sandbox_summary(1, 0, false, false), "1 sandbox");
+    }
+
+    #[test]
+    fn summary_describes_running_filter_without_hidden_terminated_hint() {
+        assert_eq!(sandbox_summary(2, 3, true, false), "2 running sandboxes");
+    }
+
+    #[test]
+    fn summary_describes_suspended_filter_without_hidden_terminated_hint() {
+        assert_eq!(sandbox_summary(1, 3, false, true), "1 suspended sandbox");
     }
 
     #[test]

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.19"
+version = "0.5.20"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.19"
+version = "0.5.20"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.19",
+      "version": "0.5.20",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Page through `tl sbx ls` responses by following paginator tokens/links.
- Print sandbox rows as each response page is read instead of collecting all sandboxes in memory.
- Preserve status filtering, quiet mode, archived listing, and final counts while streaming output.

## Root Cause

`tl sbx ls --all` only read the first list response, so sandboxes after the first API page were never displayed.

## Validation

- `rustfmt --edition 2024 --check crates/cli/src/commands/sbx/ls.rs`
- `cargo test -p tensorlake-cli commands::sbx::ls::tests`
