### PR TITLE
Use ubuntu minimal as default image base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.21"
+version = "0.5.22"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.21"
+version = "0.5.22"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.21"
+version = "0.5.22"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.21"
+version = "0.5.22"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.21"
+version = "0.5.22"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/python_ast/image_extractor.rs
+++ b/crates/cli/src/python_ast/image_extractor.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rustpython_parser::{Parse, ast};
 
 /// Default base image when `base_image` is not specified in `Image(...)`.
-pub const DEFAULT_BASE_IMAGE: &str = "python:3.12-slim-bookworm";
+pub const DEFAULT_BASE_IMAGE: &str = "tensorlake/ubuntu-minimal";
 const DEFAULT_IMAGE_NAME: &str = "default";
 const DEFAULT_IMAGE_TAG: &str = "latest";
 

--- a/crates/cloud-sdk/src/images/models.rs
+++ b/crates/cloud-sdk/src/images/models.rs
@@ -399,16 +399,17 @@ impl Image {
             lines.push(render_build_operation(op));
         }
 
-        if sdk_version.starts_with("~=")
+        let install_command = if sdk_version.starts_with("~=")
             || sdk_version.starts_with(">=")
             || sdk_version.starts_with("<=")
             || sdk_version.starts_with("!=")
             || sdk_version.starts_with("==")
         {
-            lines.push(format!("RUN pip install tensorlake{}", sdk_version));
+            format!("RUN python3 -m pip install --break-system-packages tensorlake{sdk_version}")
         } else {
-            lines.push(format!("RUN pip install tensorlake=={}", sdk_version));
-        }
+            format!("RUN python3 -m pip install --break-system-packages tensorlake=={sdk_version}")
+        };
+        lines.push(install_command);
 
         lines.join("\n")
     }
@@ -662,6 +663,26 @@ mod tests {
         assert_eq!(
             rendered,
             "COPY --chmod=755 --chown=1000:1000 --from=builder src/ /app/"
+        );
+    }
+
+    #[test]
+    fn test_dockerfile_installs_sdk_with_python3_module_pip() {
+        let image = Image::builder()
+            .name("test")
+            .base_image("tensorlake/ubuntu-minimal")
+            .build()
+            .unwrap();
+
+        assert!(
+            image
+                .dockerfile_content("1.2.3", None)
+                .contains("RUN python3 -m pip install --break-system-packages tensorlake==1.2.3")
+        );
+        assert!(
+            image
+                .dockerfile_content(">=1.2.3", None)
+                .contains("RUN python3 -m pip install --break-system-packages tensorlake>=1.2.3")
         );
     }
 

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -1508,7 +1508,12 @@ mod tests {
 
     #[test]
     fn load_dockerfile_plan_rejects_unsupported_instructions() {
-        for instruction in ["ARG FOO=1", "ONBUILD RUN echo", "SHELL [\"/bin/bash\"]", "USER app"] {
+        for instruction in [
+            "ARG FOO=1",
+            "ONBUILD RUN echo",
+            "SHELL [\"/bin/bash\"]",
+            "USER app",
+        ] {
             let temp_dir = tempfile::tempdir().unwrap();
             let dockerfile_path = temp_dir.path().join("Dockerfile");
             std::fs::write(

--- a/crates/rust-cloud-sdk-node/src/lib.rs
+++ b/crates/rust-cloud-sdk-node/src/lib.rs
@@ -17,7 +17,8 @@ use napi::{
 };
 use napi_derive::napi;
 use tensorlake::sandbox_images::{
-    SandboxImageBuildEvent, SandboxImageBuildOptions, build_sandbox_image as rust_build_sandbox_image,
+    SandboxImageBuildEvent, SandboxImageBuildOptions,
+    build_sandbox_image as rust_build_sandbox_image,
 };
 
 #[napi(object)]

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.21"
+version = "0.5.22"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.21"
+version = "0.5.22"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/cli/deploy.py
+++ b/src/tensorlake/cli/deploy.py
@@ -22,11 +22,11 @@ from tensorlake.applications.validation import (
     has_error_message,
     validate_loaded_applications,
 )
+from tensorlake.cli._common import Context
 from tensorlake.image.sandbox_builder import (
     SandboxImageBuildError,
     build_sandbox_application_image,
 )
-from tensorlake.cli._common import Context
 
 
 def _emit(obj):

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -1,12 +1,10 @@
-import sys
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List
 
 from tensorlake.vendor.nanoid.nanoid import generate as nanoid_generate
 
-_LOCAL_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
-_DEFAULT_BASE_IMAGE_NAME = f"python:{_LOCAL_PYTHON_VERSION}-slim-bookworm"
+_DEFAULT_BASE_IMAGE_NAME = "tensorlake/ubuntu-minimal"
 
 
 class _ImageBuildOperationType(Enum):

--- a/src/tensorlake/image/utils.py
+++ b/src/tensorlake/image/utils.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.metadata
 from typing import List
 
 from ._dockerfile import image_has_workdir, render_op_line
@@ -13,8 +13,8 @@ def dockerfile_content(img: Image, extra_env_vars: List[tuple] | None = None) ->
     Wraps the plain image rendering with the extras the Applications image
     builder expects: a default ``WORKDIR /app`` (skipped when the image
     declares its own WORKDIR), ``PIP_BREAK_SYSTEM_PACKAGES=1`` for PEP 668
-    Linux distros, and a trailing ``pip install tensorlake`` so the SDK is
-    available at runtime.
+    Linux distros, and a trailing ``python3 -m pip install`` so the SDK is
+    available at runtime on the default Ubuntu base image.
     """
     dockerfile_lines: List[str] = [f"FROM {img._base_image}"]
     if not image_has_workdir(img):
@@ -34,6 +34,8 @@ def dockerfile_content(img: Image, extra_env_vars: List[tuple] | None = None) ->
 
     # Run tensorlake install after all user commands. There's implicit dependency
     # of tensorlake install success on user commands right now.
-    dockerfile_lines.append(f"RUN pip install tensorlake=={_SDK_VERSION}")
+    dockerfile_lines.append(
+        f"RUN python3 -m pip install --break-system-packages tensorlake=={_SDK_VERSION}"
+    )
 
     return "\n".join(dockerfile_lines)

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, patch
 
 from tensorlake.image import Image
 from tensorlake.image import sandbox_builder as sbm
+from tensorlake.image.utils import dockerfile_content
 
 BUILD_CPUS = 2.0
 BUILD_MEMORY_MB = 4096
@@ -242,6 +243,19 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
     def test_rejects_unknown_source_type(self):
         with self.assertRaises(TypeError):
             sbm.build_sandbox_image(12345)  # type: ignore[arg-type]
+
+
+class TestApplicationDockerfileContent(unittest.TestCase):
+    def test_default_image_uses_ubuntu_minimal_base(self):
+        dockerfile = dockerfile_content(Image(name="default-base"))
+        self.assertTrue(dockerfile.startswith("FROM tensorlake/ubuntu-minimal\n"))
+
+    def test_sdk_install_uses_python3_module_pip(self):
+        dockerfile = dockerfile_content(Image(name="install-command"))
+        self.assertIn(
+            "RUN python3 -m pip install --break-system-packages tensorlake==",
+            dockerfile,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- change the default Tensorlake Image base to tensorlake/ubuntu-minimal
- align the deploy CLI image extractor default with the Python SDK default
- install the SDK with python3 -m pip --break-system-packages for Ubuntu-based images
- bump package versions to 0.5.22

## Tests
- uv run --python 3.13 --with pytest pytest tests/image/test_sandbox_builder.py
- cargo test -p tensorlake images::models::tests::test_dockerfile_installs_sdk_with_python3_module_pip
- cargo test -p tensorlake-cli python_ast::image_extractor::tests