### PR TITLE
Default function ephemeral disk to 10GB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.22"
+version = "0.5.24"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.22"
+version = "0.5.24"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.22"
+version = "0.5.24"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.22"
+version = "0.5.24"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.23"
+version = "0.5.24"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.23"
+version = "0.5.24"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.23"
+version = "0.5.24"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/applications/interface/decorators.py
+++ b/src/tensorlake/applications/interface/decorators.py
@@ -172,7 +172,7 @@ _DEFAULT_CPU: float = 1.0
 # So we need a large enough minimal memory limit to ensure stability while running customer
 # functions that consume memory too.
 _DEFAULT_MEMORY_GB: float = 1.0
-_DEFAULT_EPHEMERAL_DISK_GB: float = 2.0  # 2 GB
+_DEFAULT_EPHEMERAL_DISK_GB: float = 10.0  # 10 GB
 _DEFAULT_GPU = None  # No GPU by default
 _DEFAULT_MAX_CONCURRENCY = 1  # No concurrent threads running the function by default
 

--- a/tests/applications/test_application_manifest.py
+++ b/tests/applications/test_application_manifest.py
@@ -189,7 +189,7 @@ class TestFunctionManifestResources(unittest.TestCase):
         self.assertIsNotNone(resource_metadata)
         self.assertEqual(resource_metadata.cpus, 1.0)
         self.assertEqual(resource_metadata.memory_mb, 1024)
-        self.assertEqual(resource_metadata.ephemeral_disk_mb, 2 * 1024)
+        self.assertEqual(resource_metadata.ephemeral_disk_mb, 10 * 1024)
         self.assertEqual(resource_metadata.gpus, [])
 
     def test_custom_function_resources(self):
@@ -221,7 +221,7 @@ class TestFunctionManifestResources(unittest.TestCase):
         self.assertIsNotNone(resource_metadata)
         self.assertEqual(resource_metadata.cpus, 1.0)
         self.assertEqual(resource_metadata.memory_mb, 1024)
-        self.assertEqual(resource_metadata.ephemeral_disk_mb, 2 * 1024)
+        self.assertEqual(resource_metadata.ephemeral_disk_mb, 10 * 1024)
         self.assertEqual(len(resource_metadata.gpus), 1)
         self.assertEqual(resource_metadata.gpus[0].count, 4)
         self.assertEqual(resource_metadata.gpus[0].model, "A100-40GB")
@@ -238,7 +238,7 @@ class TestFunctionManifestResources(unittest.TestCase):
         self.assertIsNotNone(resource_metadata)
         self.assertEqual(resource_metadata.cpus, 1.0)
         self.assertEqual(resource_metadata.memory_mb, 1024)
-        self.assertEqual(resource_metadata.ephemeral_disk_mb, 2 * 1024)
+        self.assertEqual(resource_metadata.ephemeral_disk_mb, 10 * 1024)
         self.assertEqual(len(resource_metadata.gpus), 3)
         self.assertEqual(resource_metadata.gpus[0].count, 4)
         self.assertEqual(resource_metadata.gpus[0].model, "A100-40GB")

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.21",
+  "version": "0.5.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.21",
+      "version": "0.5.24",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.21",
+  "version": "0.5.24",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- raise the Python application function default ephemeral disk from 2GB to 10GB
- update application manifest tests to assert the new 10GB default
- bump Tensorlake SDK/CLI package versions to 0.5.24, including Python, Rust workspace/bindings, TypeScript package, Cargo.lock, and package-lock metadata

## Validation
- PYTHONPATH=/tmp/tensorlake-sdk-default-disk-pr/src:/tmp/tensorlake-sdk-default-disk-pr/tests/applications /home/diptanuc/Projects/indexify-deployment/.venv-local-sdk/bin/python -m unittest test_application_manifest.py
- cargo check --locked -p tensorlake-cli
- node -e "const p=require('./typescript/package.json'); const l=require('./typescript/package-lock.json'); if(p.version !== '0.5.24' || l.version !== '0.5.24' || l.packages[''].version !== '0.5.24') process.exit(1); console.log(p.version, l.version, l.packages[''].version)"
- git diff --check
- Dev end-to-end proof used a local SDK venv with this default and completed request uQciMp8k4N6OhOAq-X5ti successfully through the Firecracker dataplane