### PR TITLE
Default function runtime image to ubuntu minimal

### DIFF
--- a/src/tensorlake/applications/remote/manifests/function.py
+++ b/src/tensorlake/applications/remote/manifests/function.py
@@ -23,6 +23,7 @@ from tensorlake.applications.user_data_serializer import (
     create_type_adapter,
     generate_json_schema,
 )
+from tensorlake.image import Image
 
 from .docstring import (
     DocstringStyle,
@@ -38,6 +39,10 @@ from .function_manifests import (
     RetryPolicyManifest,
 )
 from .function_resources import resources_for_function
+
+_DEFAULT_FUNCTION_IMAGE_NAME = "default"
+_DEFAULT_FUNCTION_IMAGE_TAG = "latest"
+_DEFAULT_RUNTIME_IMAGE_NAME = "tensorlake/ubuntu-minimal"
 
 
 class FunctionManifest(pydantic.BaseModel):
@@ -306,5 +311,16 @@ def create_function_manifest(
         warm_containers=function._function_config.warm_containers,
         min_containers=function._function_config.min_containers,
         max_containers=function._function_config.max_containers,
-        image=function._function_config.image.name,
+        image=_runtime_image_name(function._function_config.image),
     )
+
+
+def _runtime_image_name(image: Image) -> str:
+    is_default_image = (
+        image.name == _DEFAULT_FUNCTION_IMAGE_NAME
+        and image.tag == _DEFAULT_FUNCTION_IMAGE_TAG
+        and not image._build_operations
+    )
+    if is_default_image:
+        return _DEFAULT_RUNTIME_IMAGE_NAME
+    return image.name

--- a/tests/applications/test_application_manifest.py
+++ b/tests/applications/test_application_manifest.py
@@ -2,7 +2,7 @@ import unittest
 
 import validate_all_applications
 
-from tensorlake.applications import Retries, application, cls, function
+from tensorlake.applications import Image, Retries, application, cls, function
 from tensorlake.applications.registry import get_functions
 from tensorlake.applications.remote.manifests.application import (
     ApplicationManifest,
@@ -246,6 +246,40 @@ class TestFunctionManifestResources(unittest.TestCase):
         self.assertEqual(resource_metadata.gpus[1].model, "H100")
         self.assertEqual(resource_metadata.gpus[2].count, 1)
         self.assertEqual(resource_metadata.gpus[2].model, "A100-80GB")
+
+
+@function()
+def function_with_default_image(x: int) -> str:
+    return "success"
+
+
+@function(image=Image(name="custom-runtime-image"))
+def function_with_custom_image(x: int) -> str:
+    return "success"
+
+
+class TestFunctionManifestImages(unittest.TestCase):
+    def test_default_function_image_uses_registered_runtime_image(self):
+        app_manifest: ApplicationManifest = create_application_manifest(
+            application_function=default_application_function,
+            all_functions=get_functions(),
+        )
+
+        self.assertEqual(
+            app_manifest.functions["function_with_default_image"].image,
+            "tensorlake/ubuntu-minimal",
+        )
+
+    def test_custom_function_image_is_preserved(self):
+        app_manifest: ApplicationManifest = create_application_manifest(
+            application_function=default_application_function,
+            all_functions=get_functions(),
+        )
+
+        self.assertEqual(
+            app_manifest.functions["function_with_custom_image"].image,
+            "custom-runtime-image",
+        )
 
 
 # This test is commented out because right now we don't provide max_concurrency feature in SDK interface.


### PR DESCRIPTION
## Summary
- serialize the SDK default function image as `tensorlake/ubuntu-minimal` instead of `default`
- preserve explicitly named custom function images
- add manifest coverage for default/custom image serialization

## Tests
- `PYTHONPATH=tests/applications poetry run python -m unittest tests.applications.test_application_manifest`
- `poetry run python -m unittest tests.cli.test_deploy`
- `git diff --check origin/main...HEAD`