### PR TITLE
Use registered application image names in function manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.24"
+version = "0.5.25"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.24"
+version = "0.5.25"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.24"
+version = "0.5.25"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/applications/remote/manifests/function.py
+++ b/src/tensorlake/applications/remote/manifests/function.py
@@ -23,7 +23,6 @@ from tensorlake.applications.user_data_serializer import (
     create_type_adapter,
     generate_json_schema,
 )
-from tensorlake.image import Image
 
 from .docstring import (
     DocstringStyle,
@@ -39,10 +38,6 @@ from .function_manifests import (
     RetryPolicyManifest,
 )
 from .function_resources import resources_for_function
-
-_DEFAULT_FUNCTION_IMAGE_NAME = "default"
-_DEFAULT_FUNCTION_IMAGE_TAG = "latest"
-_DEFAULT_RUNTIME_IMAGE_NAME = "tensorlake/ubuntu-minimal"
 
 
 class FunctionManifest(pydantic.BaseModel):
@@ -65,7 +60,7 @@ class FunctionManifest(pydantic.BaseModel):
     warm_containers: int | None = None
     min_containers: int | None = None
     max_containers: int | None = None
-    image: str | None = None
+    image: str
 
 
 @dataclass
@@ -311,16 +306,5 @@ def create_function_manifest(
         warm_containers=function._function_config.warm_containers,
         min_containers=function._function_config.min_containers,
         max_containers=function._function_config.max_containers,
-        image=_runtime_image_name(function._function_config.image),
+        image=function._function_config.image.name,
     )
-
-
-def _runtime_image_name(image: Image) -> str:
-    is_default_image = (
-        image.name == _DEFAULT_FUNCTION_IMAGE_NAME
-        and image.tag == _DEFAULT_FUNCTION_IMAGE_TAG
-        and not image._build_operations
-    )
-    if is_default_image:
-        return _DEFAULT_RUNTIME_IMAGE_NAME
-    return image.name

--- a/tests/applications/test_application_manifest.py
+++ b/tests/applications/test_application_manifest.py
@@ -259,7 +259,7 @@ def function_with_custom_image(x: int) -> str:
 
 
 class TestFunctionManifestImages(unittest.TestCase):
-    def test_default_function_image_uses_registered_runtime_image(self):
+    def test_default_function_image_uses_registered_build_image(self):
         app_manifest: ApplicationManifest = create_application_manifest(
             application_function=default_application_function,
             all_functions=get_functions(),
@@ -267,7 +267,7 @@ class TestFunctionManifestImages(unittest.TestCase):
 
         self.assertEqual(
             app_manifest.functions["function_with_default_image"].image,
-            "tensorlake/ubuntu-minimal",
+            "default",
         )
 
     def test_custom_function_image_is_preserved(self):
@@ -280,6 +280,18 @@ class TestFunctionManifestImages(unittest.TestCase):
             app_manifest.functions["function_with_custom_image"].image,
             "custom-runtime-image",
         )
+
+    def test_serialized_manifest_includes_function_image_names(self):
+        app_manifest: ApplicationManifest = create_application_manifest(
+            application_function=default_application_function,
+            all_functions=get_functions(),
+        )
+
+        manifest_json = app_manifest.model_dump_json()
+
+        self.assertIn('"function_with_default_image"', manifest_json)
+        self.assertIn('"image":"default"', manifest_json)
+        self.assertIn('"image":"custom-runtime-image"', manifest_json)
 
 
 # This test is commented out because right now we don't provide max_concurrency feature in SDK interface.

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.24",
+      "version": "0.5.25",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.24",
+  "version": "0.5.25",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- serialize function manifests with the registered application image name instead of rewriting the default Image() to the public base image
- make the manifest image field required again so deploys do not silently omit the runtime image identity
- bump Python SDK, Rust package metadata, and TypeScript package metadata to 0.5.25
- update only the npm package-lock root package version metadata to keep the TypeScript package version coherent

## Why
For application images built from a registered Tensorlake rootfs base such as tensorlake/ubuntu-minimal, platform-api records the runnable sandbox template under the application image name (for example default or indexify-integration-test). The base image is only the parent rootfs identity. Rewriting default functions to tensorlake/ubuntu-minimal makes dataplane boot the base rootfs, which does not contain the application runtime image contents.

## Validation
- PYTHONPATH=src:tests/applications poetry run python -m unittest tests.applications.test_application_manifest tests.cli.test_deploy
- PYTHONPATH=src:tests/applications poetry run python -m unittest tests.applications.test_application_json_schemas
- poetry run black --check src/tensorlake/applications/remote/manifests/function.py tests/applications/test_application_manifest.py
- npm pkg get version && node -e "const l=require('./package-lock.json'); if(l.version!==require('./package.json').version || l.packages[''].version!==require('./package.json').version) process.exit(1); console.log('lock metadata matches package version')"  # in typescript/
- npm run typecheck  # in typescript/
- git diff --check
- Dev end-to-end deploy using local SDK manifest fix with runtime image install pinned to published tensorlake==0.5.24: registered default and indexify-integration-test as RootfsDiff templates, deployed indexify_simple_stress_test, and request TlMm0T8yq5t07wQOXxSLS completed successfully
