### PR TITLE
Build default application runtime images

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -227,9 +227,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
-    concurrency:
-      group: sandbox-integration-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -227,6 +227,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+    concurrency:
+      group: sandbox-integration-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -260,6 +260,5 @@ jobs:
         env:
           TENSORLAKE_API_URL: ${{ secrets.TENSORLAKE_API_URL }}
           TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
-          TENSORLAKE_SANDBOX_IMAGE: docker.io/library/alpine:latest
           TENSORLAKE_TEST_CLEANUP_ALL: ${{ (github.event_name != 'workflow_dispatch' || inputs.environment == 'dev') && '1' || '0' }}
           TENSORLAKE_TEST_CLEANUP_GRACE_SECS: "300"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -260,4 +260,6 @@ jobs:
         env:
           TENSORLAKE_API_URL: ${{ secrets.TENSORLAKE_API_URL }}
           TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
-          TENSORLAKE_SANDBOX_IMAGE: tensorlake/ubuntu-minimal
+          TENSORLAKE_SANDBOX_IMAGE: docker.io/library/alpine:latest
+          TENSORLAKE_TEST_CLEANUP_ALL: ${{ (github.event_name != 'workflow_dispatch' || inputs.environment == 'dev') && '1' || '0' }}
+          TENSORLAKE_TEST_CLEANUP_GRACE_SECS: "300"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -264,4 +264,4 @@ jobs:
           TENSORLAKE_API_URL: ${{ secrets.TENSORLAKE_API_URL }}
           TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
           TENSORLAKE_TEST_CLEANUP_ALL: ${{ (github.event_name != 'workflow_dispatch' || inputs.environment == 'dev') && '1' || '0' }}
-          TENSORLAKE_TEST_CLEANUP_GRACE_SECS: "300"
+          TENSORLAKE_TEST_CLEANUP_GRACE_SECS: "60"

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -93,4 +93,4 @@ jobs:
           TENSORLAKE_API_URL: ${{ secrets.TENSORLAKE_API_URL }}
           TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
           TENSORLAKE_TEST_CLEANUP_ALL: ${{ (github.event_name != 'workflow_dispatch' || inputs.environment == 'dev') && '1' || '0' }}
-          TENSORLAKE_TEST_CLEANUP_GRACE_SECS: "300"
+          TENSORLAKE_TEST_CLEANUP_GRACE_SECS: "60"

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 defaults:
   run:
@@ -73,9 +74,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
-    concurrency:
-      group: sandbox-integration-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 
@@ -86,6 +84,45 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Wait for Python sandbox integration
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          deadline=$((SECONDS + 1800))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            run_id=$(gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow tests.yaml \
+              --json databaseId,headSha \
+              --limit 20 \
+              --jq ".[] | select(.headSha == \"$HEAD_SHA\") | .databaseId" \
+              | head -n 1)
+
+            if [ -n "$run_id" ]; then
+              job=$(gh run view "$run_id" \
+                --repo "$GITHUB_REPOSITORY" \
+                --json jobs \
+                --jq '.jobs[] | select(.name == "Sandbox integration tests") | "\(.status)\t\(.conclusion // "")"')
+              status=$(printf '%s' "$job" | cut -f 1)
+              conclusion=$(printf '%s' "$job" | cut -f 2)
+
+              if [ "$status" = "completed" ] && [ "$conclusion" = "success" ]; then
+                exit 0
+              fi
+              if [ "$status" = "completed" ]; then
+                echo "Sandbox integration tests completed with conclusion: $conclusion"
+                exit 1
+              fi
+            fi
+
+            sleep 15
+          done
+
+          echo "Timed out waiting for Sandbox integration tests"
+          exit 1
 
       - name: Run integration tests
         run: npm run test:integration

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -81,20 +81,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          prefix-key: v1-rust-no-bin
-          cache-bin: false
-
       - name: Install dependencies
         run: npm ci
-
-      - name: Build native binding
-        run: npm run build:native
 
       - name: Run integration tests
         run: npm run test:integration

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -89,3 +89,6 @@ jobs:
         env:
           TENSORLAKE_API_URL: ${{ secrets.TENSORLAKE_API_URL }}
           TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
+          TENSORLAKE_SANDBOX_IMAGE: docker.io/library/alpine:latest
+          TENSORLAKE_TEST_CLEANUP_ALL: ${{ (github.event_name != 'workflow_dispatch' || inputs.environment == 'dev') && '1' || '0' }}
+          TENSORLAKE_TEST_CLEANUP_GRACE_SECS: "300"

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -73,6 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+    concurrency:
+      group: sandbox-integration-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -81,14 +81,25 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust-no-bin
+          cache-bin: false
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Build native binding
+        run: npm run build:native
 
       - name: Run integration tests
         run: npm run test:integration
         env:
           TENSORLAKE_API_URL: ${{ secrets.TENSORLAKE_API_URL }}
           TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
-          TENSORLAKE_SANDBOX_IMAGE: docker.io/library/alpine:latest
           TENSORLAKE_TEST_CLEANUP_ALL: ${{ (github.event_name != 'workflow_dispatch' || inputs.environment == 'dev') && '1' || '0' }}
           TENSORLAKE_TEST_CLEANUP_GRACE_SECS: "300"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.26"
+version = "0.5.27"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/cli/deploy.py
+++ b/src/tensorlake/cli/deploy.py
@@ -4,9 +4,10 @@ import json
 import os
 import sys
 import traceback
+from dataclasses import dataclass
 from pathlib import Path
 
-from tensorlake.applications import Function, SDKUsageError, TensorlakeError
+from tensorlake.applications import Function, Image, SDKUsageError, TensorlakeError
 from tensorlake.applications.applications import (
     filter_applications,
     functions_for_application,
@@ -27,6 +28,14 @@ from tensorlake.image.sandbox_builder import (
     SandboxImageBuildError,
     build_sandbox_application_image,
 )
+
+_DEFAULT_APPLICATION_IMAGE_NAME = "default"
+
+
+@dataclass(frozen=True)
+class _ApplicationImageBuild:
+    image: Image
+    registered_name: str
 
 
 def _emit(obj):
@@ -219,9 +228,10 @@ async def _prepare_images(
     context_dir: str,
     build_envs: list[tuple[str, str]] | None = None,
 ):
-    images = _application_images(functions)
-    for image in images:
-        image_name = image.name
+    image_builds = _application_images(functions)
+    for image_build in image_builds:
+        image = image_build.image
+        image_name = image_build.registered_name
         _emit({"type": "build_start", "image": image_name})
         try:
             await asyncio.to_thread(
@@ -247,28 +257,66 @@ async def _prepare_images(
     _emit({"type": "build_done"})
 
 
-def _application_images(functions: list[Function]):
-    images = []
+def default_application_image_name(
+    application_name: str, application_version: str
+) -> str:
+    return f"applications/{application_name}/versions/{application_version}/default"
+
+
+def _append_image_build(
+    image_builds: list[_ApplicationImageBuild],
+    seen_image_ids: set[str],
+    seen_registered_names: dict[str, str],
+    image: Image,
+    registered_name: str,
+) -> None:
+    previous_image_id = seen_registered_names.get(registered_name)
+    if previous_image_id is not None and previous_image_id != image._id:
+        raise SDKUsageError(
+            f"multiple different Image objects use the name '{registered_name}'. "
+            "Use unique Image(name=...) values so each function resolves "
+            "to the intended sandbox image."
+        )
+    seen_registered_names[registered_name] = image._id
+    if image._id in seen_image_ids:
+        return
+    seen_image_ids.add(image._id)
+    image_builds.append(
+        _ApplicationImageBuild(image=image, registered_name=registered_name)
+    )
+
+
+def _application_images(functions: list[Function]) -> list[_ApplicationImageBuild]:
+    image_builds: list[_ApplicationImageBuild] = []
     seen_image_ids: set[str] = set()
     seen_image_names: dict[str, str] = {}
     for application in filter_applications(functions):
+        default_image: Image | None = None
+        default_registered_name = default_application_image_name(
+            application._function_config.function_name,
+            application._application_config.version,
+        )
         for function in functions_for_application(application, functions):
             image = function._function_config.image
             if image is None:
-                continue
-            previous_image_id = seen_image_names.get(image.name)
-            if previous_image_id is not None and previous_image_id != image._id:
-                raise SDKUsageError(
-                    f"multiple different Image objects use the name '{image.name}'. "
-                    "Use unique Image(name=...) values so each function resolves "
-                    "to the intended sandbox image."
+                if default_image is None:
+                    default_image = Image(name=_DEFAULT_APPLICATION_IMAGE_NAME)
+                _append_image_build(
+                    image_builds,
+                    seen_image_ids,
+                    seen_image_names,
+                    default_image,
+                    default_registered_name,
                 )
-            seen_image_names[image.name] = image._id
-            if image._id in seen_image_ids:
                 continue
-            seen_image_ids.add(image._id)
-            images.append(image)
-    return images
+            _append_image_build(
+                image_builds,
+                seen_image_ids,
+                seen_image_names,
+                image,
+                image.name,
+            )
+    return image_builds
 
 
 def _deploy_applications(

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -288,7 +288,9 @@ class TestDeployEntrypoints(unittest.TestCase):
         self.assertEqual(missing_event["count"], 2)
         self.assertEqual(missing_event["names"], ["MISSING_ONE", "MISSING_TWO"])
 
-    def test_deploy_builds_each_explicit_application_image_as_sandbox_template(self):
+    def test_deploy_builds_default_and_explicit_application_images_as_sandbox_templates(
+        self,
+    ):
         auth = self._make_auth_context()
         with isolated_registry():
             parser_image = Image(name="parser-image")
@@ -361,15 +363,76 @@ class TestDeployEntrypoints(unittest.TestCase):
                     upgrade_running_requests=False,
                 )
 
-        self.assertEqual(
-            [call.kwargs["registered_name"] for call in build_image.call_args_list],
-            ["parser-image", "agent-image", "code-exec-image"],
+        finance_analyzer_default = deploy_module.default_application_image_name(
+            finance_analyzer._function_config.function_name,
+            finance_analyzer._application_config.version,
+        )
+        finance_query_default = deploy_module.default_application_image_name(
+            finance_query._function_config.function_name,
+            finance_query._application_config.version,
         )
         self.assertEqual(
-            [call.args[0] for call in build_image.call_args_list],
+            [call.kwargs["registered_name"] for call in build_image.call_args_list],
+            [
+                finance_analyzer_default,
+                "parser-image",
+                "agent-image",
+                "code-exec-image",
+                finance_query_default,
+            ],
+        )
+        self.assertEqual(
+            [
+                call.args[0]
+                for call in build_image.call_args_list
+                if call.kwargs["registered_name"]
+                in {"parser-image", "agent-image", "code-exec-image"}
+            ],
             [parser_image, agent_image, code_exec_image],
         )
         emit.assert_any_call({"type": "build_done"})
+
+    def test_deploy_builds_default_application_image_for_functions_without_explicit_image(
+        self,
+    ):
+        auth = self._make_auth_context()
+        with isolated_registry():
+
+            @function()
+            def helper(payload):
+                return payload
+
+            @application()
+            @function()
+            def default_image_app(payload):
+                return helper(payload)
+
+            functions = [helper, default_image_app]
+            with (
+                self._successful_deploy_patches(auth, functions),
+                patch.object(
+                    deploy_module,
+                    "build_sandbox_application_image",
+                    return_value={},
+                ) as build_image,
+                patch.object(deploy_module, "_deploy_applications"),
+                patch.object(deploy_module, "_emit") as emit,
+            ):
+                deploy_module.deploy(
+                    application_file_path="my_app.py",
+                    upgrade_running_requests=False,
+                )
+
+        registered_name = deploy_module.default_application_image_name(
+            default_image_app._function_config.function_name,
+            default_image_app._application_config.version,
+        )
+        build_image.assert_called_once()
+        self.assertEqual(build_image.call_args.args[0].name, "default")
+        self.assertEqual(
+            build_image.call_args.kwargs["registered_name"], registered_name
+        )
+        emit.assert_any_call({"type": "build_start", "image": registered_name})
 
     def test_deploy_builds_shared_explicit_image_once(self):
         auth = self._make_auth_context()
@@ -476,7 +539,11 @@ class TestDeployEntrypoints(unittest.TestCase):
     def test_prepare_images_emits_inner_build_error_message(self):
         image = Image(name="parser-image")
         application = SimpleNamespace(
-            _function_config=SimpleNamespace(image=image),
+            _function_config=SimpleNamespace(
+                function_name="app",
+                image=image,
+            ),
+            _application_config=SimpleNamespace(version="v1"),
         )
 
         with (

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -150,6 +150,7 @@ def _ensure_sandbox_image() -> None:
     build_sandbox_image(
         Image(name=image_name, base_image=_TEST_IMAGE_BASE),
         registered_name=image_name,
+        cpus=_SANDBOX_CPUS,
         disk_mb=_SANDBOX_DISK_MB,
         verbose=True,
     )

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -151,6 +151,7 @@ def _ensure_sandbox_image() -> None:
         Image(name=image_name, base_image=_TEST_IMAGE_BASE),
         registered_name=image_name,
         cpus=_SANDBOX_CPUS,
+        memory_mb=2048,
         disk_mb=_SANDBOX_DISK_MB,
         verbose=True,
     )

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -9,10 +9,13 @@ Usage:
 """
 
 import os
+import re
 import time
 import unittest
 from datetime import datetime, timedelta, timezone
 
+from tensorlake.image import Image
+from tensorlake.image.sandbox_builder import build_sandbox_image
 from tensorlake.sandbox import (
     PoolContainerInfo,
     PoolInUseError,
@@ -23,8 +26,9 @@ from tensorlake.sandbox import (
     SandboxStatus,
 )
 
-_SANDBOX_IMAGE = os.environ.get(
-    "TENSORLAKE_SANDBOX_IMAGE", "docker.io/library/alpine:latest"
+_SANDBOX_IMAGE = os.environ.get("TENSORLAKE_SANDBOX_IMAGE", "")
+_TEST_IMAGE_BASE = os.environ.get(
+    "TENSORLAKE_TEST_SANDBOX_IMAGE_BASE", "tensorlake/ubuntu-minimal"
 )
 _SANDBOX_CPUS = 1.0
 _SANDBOX_MEMORY_MB = 1024
@@ -112,9 +116,51 @@ def _is_older_than_cleanup_grace(created_at: datetime | None, cutoff: datetime) 
     return created_at is not None and created_at < cutoff
 
 
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9_.-]+", "-", value.lower()).strip("-")
+
+
+def _default_test_image_name() -> str:
+    run_id = os.environ.get("GITHUB_RUN_ID")
+    if run_id:
+        parts = [
+            "tl-sdk-integration",
+            run_id,
+            os.environ.get("GITHUB_JOB", "python"),
+            os.environ.get("GITHUB_RUN_ATTEMPT", "1"),
+        ]
+    else:
+        parts = ["tl-sdk-integration", "local", str(os.getpid())]
+    return _slug("-".join(parts))
+
+
+def _ensure_sandbox_image() -> None:
+    global _SANDBOX_IMAGE
+
+    if _SANDBOX_IMAGE:
+        return
+
+    image_name = os.environ.get(
+        "TENSORLAKE_TEST_SANDBOX_IMAGE_NAME", _default_test_image_name()
+    )
+    print(
+        f"Building sandbox integration image {image_name!r} "
+        f"from base {_TEST_IMAGE_BASE!r}..."
+    )
+    build_sandbox_image(
+        Image(name=image_name, base_image=_TEST_IMAGE_BASE),
+        registered_name=image_name,
+        disk_mb=_SANDBOX_DISK_MB,
+        verbose=True,
+    )
+    _SANDBOX_IMAGE = image_name
+    print(f"Using sandbox integration image {_SANDBOX_IMAGE!r}.")
+
+
 def _is_test_sandbox(info) -> bool:
     return (
-        info.image == _SANDBOX_IMAGE
+        bool(_SANDBOX_IMAGE)
+        and info.image == _SANDBOX_IMAGE
         and info.entrypoint == ["sleep", "300"]
         and info.resources.memory_mb == _SANDBOX_MEMORY_MB
     )
@@ -122,7 +168,8 @@ def _is_test_sandbox(info) -> bool:
 
 def _is_test_pool(info) -> bool:
     return (
-        info.image == _SANDBOX_IMAGE
+        bool(_SANDBOX_IMAGE)
+        and info.image == _SANDBOX_IMAGE
         and info.entrypoint == ["sleep", "300"]
         and info.resources.memory_mb == _SANDBOX_MEMORY_MB
     )
@@ -184,6 +231,7 @@ def setUpModule():
         _cleanup_stale_test_resources(client)
     finally:
         client.close()
+    _ensure_sandbox_image()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -32,6 +32,9 @@ _SANDBOX_DISK_MB = 10240
 _STALE_RESOURCE_GRACE_SECS = int(
     os.environ.get("TENSORLAKE_TEST_CLEANUP_GRACE_SECS", "60")
 )
+_CLEANUP_ALL_TEST_RESOURCES = os.environ.get(
+    "TENSORLAKE_TEST_CLEANUP_ALL", ""
+).lower() in {"1", "true", "yes"}
 
 
 # ---------------------------------------------------------------------------
@@ -102,6 +105,10 @@ def _claimed_containers(containers: list[PoolContainerInfo]) -> list[PoolContain
 
 
 def _is_stale(created_at: datetime | None, cutoff: datetime) -> bool:
+    return created_at is None or created_at < cutoff
+
+
+def _is_older_than_cleanup_grace(created_at: datetime | None, cutoff: datetime) -> bool:
     return created_at is not None and created_at < cutoff
 
 
@@ -128,10 +135,12 @@ def _cleanup_stale_test_resources(client: SandboxClient) -> None:
 
     try:
         for sandbox in client.list():
-            if (
-                sandbox.status != SandboxStatus.TERMINATED
-                and _is_test_sandbox(sandbox)
-                and _is_stale(sandbox.created_at, cutoff)
+            if sandbox.status != SandboxStatus.TERMINATED and (
+                (
+                    _CLEANUP_ALL_TEST_RESOURCES
+                    and _is_older_than_cleanup_grace(sandbox.created_at, cutoff)
+                )
+                or (_is_test_sandbox(sandbox) and _is_stale(sandbox.created_at, cutoff))
             ):
                 try:
                     client.delete(sandbox.sandbox_id)
@@ -142,7 +151,10 @@ def _cleanup_stale_test_resources(client: SandboxClient) -> None:
 
     try:
         for pool in client.list_pools():
-            if _is_test_pool(pool) and _is_stale(pool.created_at, cutoff):
+            if (
+                _CLEANUP_ALL_TEST_RESOURCES
+                and _is_older_than_cleanup_grace(pool.created_at, cutoff)
+            ) or (_is_test_pool(pool) and _is_stale(pool.created_at, cutoff)):
                 pool_ids.add(pool.pool_id)
     except Exception:
         pass
@@ -152,12 +164,17 @@ def _cleanup_stale_test_resources(client: SandboxClient) -> None:
 
     # Give sandbox deletes a short chance to release pool claims, then remove
     # stale pools that may still be holding warm containers against quota.
-    time.sleep(2)
-    for pool_id in pool_ids:
-        try:
-            client.delete_pool(pool_id)
-        except Exception:
-            pass
+    for _ in range(5):
+        if not pool_ids:
+            break
+        time.sleep(2)
+        remaining_pool_ids: set[str] = set()
+        for pool_id in pool_ids:
+            try:
+                client.delete_pool(pool_id)
+            except Exception:
+                remaining_pool_ids.add(pool_id)
+        pool_ids = remaining_pool_ids
 
 
 def setUpModule():

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -9,13 +9,10 @@ Usage:
 """
 
 import os
-import re
 import time
 import unittest
 from datetime import datetime, timedelta, timezone
 
-from tensorlake.image import Image
-from tensorlake.image.sandbox_builder import build_sandbox_image
 from tensorlake.sandbox import (
     PoolContainerInfo,
     PoolInUseError,
@@ -26,10 +23,7 @@ from tensorlake.sandbox import (
     SandboxStatus,
 )
 
-_SANDBOX_IMAGE = os.environ.get("TENSORLAKE_SANDBOX_IMAGE", "")
-_TEST_IMAGE_BASE = os.environ.get(
-    "TENSORLAKE_TEST_SANDBOX_IMAGE_BASE", "tensorlake/ubuntu-minimal"
-)
+_SANDBOX_IMAGE = os.environ.get("TENSORLAKE_SANDBOX_IMAGE", "tensorlake/ubuntu-minimal")
 _SANDBOX_CPUS = 1.0
 _SANDBOX_MEMORY_MB = 1024
 _SANDBOX_DISK_MB = 10240
@@ -116,49 +110,6 @@ def _is_older_than_cleanup_grace(created_at: datetime | None, cutoff: datetime) 
     return created_at is not None and created_at < cutoff
 
 
-def _slug(value: str) -> str:
-    return re.sub(r"[^a-z0-9_.-]+", "-", value.lower()).strip("-")
-
-
-def _default_test_image_name() -> str:
-    run_id = os.environ.get("GITHUB_RUN_ID")
-    if run_id:
-        parts = [
-            "tl-sdk-integration",
-            run_id,
-            os.environ.get("GITHUB_JOB", "python"),
-            os.environ.get("GITHUB_RUN_ATTEMPT", "1"),
-        ]
-    else:
-        parts = ["tl-sdk-integration", "local", str(os.getpid())]
-    return _slug("-".join(parts))
-
-
-def _ensure_sandbox_image() -> None:
-    global _SANDBOX_IMAGE
-
-    if _SANDBOX_IMAGE:
-        return
-
-    image_name = os.environ.get(
-        "TENSORLAKE_TEST_SANDBOX_IMAGE_NAME", _default_test_image_name()
-    )
-    print(
-        f"Building sandbox integration image {image_name!r} "
-        f"from base {_TEST_IMAGE_BASE!r}..."
-    )
-    build_sandbox_image(
-        Image(name=image_name, base_image=_TEST_IMAGE_BASE),
-        registered_name=image_name,
-        cpus=_SANDBOX_CPUS,
-        memory_mb=2048,
-        disk_mb=_SANDBOX_DISK_MB,
-        verbose=True,
-    )
-    _SANDBOX_IMAGE = image_name
-    print(f"Using sandbox integration image {_SANDBOX_IMAGE!r}.")
-
-
 def _is_test_sandbox(info) -> bool:
     return (
         bool(_SANDBOX_IMAGE)
@@ -233,7 +184,6 @@ def setUpModule():
         _cleanup_stale_test_resources(client)
     finally:
         client.close()
-    _ensure_sandbox_image()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -11,6 +11,7 @@ Usage:
 import os
 import time
 import unittest
+from datetime import datetime, timedelta, timezone
 
 from tensorlake.sandbox import (
     PoolContainerInfo,
@@ -28,6 +29,9 @@ _SANDBOX_IMAGE = os.environ.get(
 _SANDBOX_CPUS = 1.0
 _SANDBOX_MEMORY_MB = 1024
 _SANDBOX_DISK_MB = 10240
+_STALE_RESOURCE_GRACE_SECS = int(
+    os.environ.get("TENSORLAKE_TEST_CLEANUP_GRACE_SECS", "60")
+)
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +99,74 @@ def _warm_containers(containers: list[PoolContainerInfo]) -> list[PoolContainerI
 def _claimed_containers(containers: list[PoolContainerInfo]) -> list[PoolContainerInfo]:
     """Filter to claimed (sandbox-assigned) containers."""
     return [c for c in containers if c.sandbox_id is not None]
+
+
+def _is_stale(created_at: datetime | None, cutoff: datetime) -> bool:
+    return created_at is not None and created_at < cutoff
+
+
+def _is_test_sandbox(info) -> bool:
+    return (
+        info.image == _SANDBOX_IMAGE
+        and info.entrypoint == ["sleep", "300"]
+        and info.resources.memory_mb == _SANDBOX_MEMORY_MB
+    )
+
+
+def _is_test_pool(info) -> bool:
+    return (
+        info.image == _SANDBOX_IMAGE
+        and info.entrypoint == ["sleep", "300"]
+        and info.resources.memory_mb == _SANDBOX_MEMORY_MB
+    )
+
+
+def _cleanup_stale_test_resources(client: SandboxClient) -> None:
+    """Remove old integration-test resources left by interrupted CI runs."""
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=_STALE_RESOURCE_GRACE_SECS)
+    pool_ids: set[str] = set()
+
+    try:
+        for sandbox in client.list():
+            if (
+                sandbox.status != SandboxStatus.TERMINATED
+                and _is_test_sandbox(sandbox)
+                and _is_stale(sandbox.created_at, cutoff)
+            ):
+                try:
+                    client.delete(sandbox.sandbox_id)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+    try:
+        for pool in client.list_pools():
+            if _is_test_pool(pool) and _is_stale(pool.created_at, cutoff):
+                pool_ids.add(pool.pool_id)
+    except Exception:
+        pass
+
+    if not pool_ids:
+        return
+
+    # Give sandbox deletes a short chance to release pool claims, then remove
+    # stale pools that may still be holding warm containers against quota.
+    time.sleep(2)
+    for pool_id in pool_ids:
+        try:
+            client.delete_pool(pool_id)
+        except Exception:
+            pass
+
+
+def setUpModule():
+    api_url = os.environ.get("TENSORLAKE_API_URL", "http://localhost:8900")
+    client = SandboxClient(api_url=api_url)
+    try:
+        _cleanup_stale_test_resources(client)
+    finally:
+        client.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -44,7 +44,7 @@ def _poll_sandbox_status(
     client: SandboxClient,
     sandbox_id: str,
     target: SandboxStatus,
-    timeout: float = 60.0,
+    timeout: float = 120.0,
     interval: float = 1.0,
 ) -> SandboxStatus:
     """Poll until the sandbox reaches *target* status or times out."""
@@ -66,7 +66,7 @@ def _poll_pool_containers(
     client: SandboxClient,
     pool_id: str,
     min_count: int,
-    timeout: float = 60.0,
+    timeout: float = 120.0,
     interval: float = 1.0,
 ) -> list[PoolContainerInfo]:
     """Poll until the pool has at least *min_count* containers or times out."""

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -10,8 +10,6 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
-  createSandboxImage,
-  Image,
   PoolInUseError,
   PoolNotFoundError,
   SandboxClient,
@@ -24,10 +22,8 @@ import {
 } from "../src/index.js";
 import { Sandbox } from "../src/sandbox.js";
 
-let sandboxImage = process.env.TENSORLAKE_SANDBOX_IMAGE ?? "";
-const TEST_IMAGE_BASE =
-  process.env.TENSORLAKE_TEST_SANDBOX_IMAGE_BASE ??
-  "tensorlake/ubuntu-minimal";
+const sandboxImage =
+  process.env.TENSORLAKE_SANDBOX_IMAGE ?? "tensorlake/ubuntu-minimal";
 const SANDBOX_CPUS = 1.0;
 const SANDBOX_MEMORY_MB = 1024;
 const SANDBOX_DISK_MB = 10240;
@@ -120,54 +116,6 @@ function claimedContainers(
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function slug(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9_.-]+/g, "-")
-    .replace(/^-|-$/g, "");
-}
-
-function defaultTestImageName(): string {
-  const runId = process.env.GITHUB_RUN_ID;
-  const parts = runId
-    ? [
-        "tl-sdk-integration",
-        runId,
-        process.env.GITHUB_JOB ?? "typescript",
-        process.env.GITHUB_RUN_ATTEMPT ?? "1",
-      ]
-    : ["tl-sdk-integration", "local", String(process.pid)];
-  return slug(parts.join("-"));
-}
-
-async function ensureSandboxImage(): Promise<void> {
-  if (sandboxImage) return;
-
-  const imageName =
-    process.env.TENSORLAKE_TEST_SANDBOX_IMAGE_NAME ?? defaultTestImageName();
-  process.stderr.write(
-    `Building sandbox integration image '${imageName}' from base '${TEST_IMAGE_BASE}'...\n`,
-  );
-  await createSandboxImage(
-    new Image({ name: imageName, baseImage: TEST_IMAGE_BASE }),
-    {
-      registeredName: imageName,
-      cpus: SANDBOX_CPUS,
-      memoryMb: 2048,
-      diskMb: SANDBOX_DISK_MB,
-    },
-    {
-      emit: (event) => {
-        const type = typeof event.type === "string" ? event.type : "event";
-        const message = typeof event.message === "string" ? event.message : "";
-        if (message) process.stderr.write(`[${type}] ${message}\n`);
-      },
-    },
-  );
-  sandboxImage = imageName;
-  process.stderr.write(`Using sandbox integration image '${sandboxImage}'.\n`);
 }
 
 function isStale(createdAt: Date | undefined, cutoff: Date): boolean {
@@ -266,8 +214,7 @@ beforeAll(async () => {
   } finally {
     client.close();
   }
-  await ensureSandboxImage();
-}, 600_000);
+}, 120_000);
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -26,6 +26,8 @@ const SANDBOX_IMAGE = "tensorlake/ubuntu-minimal";
 const SANDBOX_CPUS = 1.0;
 const SANDBOX_MEMORY_MB = 1024;
 const SANDBOX_DISK_MB = 10240;
+const STALE_RESOURCE_GRACE_MS =
+  Number(process.env.TENSORLAKE_TEST_CLEANUP_GRACE_SECS ?? "60") * 1000;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -102,13 +104,88 @@ function warmContainers(containers: PoolContainerInfo[]): PoolContainerInfo[] {
   return containers.filter((c) => c.sandboxId == null);
 }
 
-function claimedContainers(containers: PoolContainerInfo[]): PoolContainerInfo[] {
+function claimedContainers(
+  containers: PoolContainerInfo[],
+): PoolContainerInfo[] {
   return containers.filter((c) => c.sandboxId != null);
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+function isStale(createdAt: Date | undefined, cutoff: Date): boolean {
+  return createdAt != null && createdAt.getTime() < cutoff.getTime();
+}
+
+function isTestSandbox(info: SandboxInfo): boolean {
+  return (
+    info.image === SANDBOX_IMAGE &&
+    info.entrypoint?.length === 2 &&
+    info.entrypoint[0] === "sleep" &&
+    info.entrypoint[1] === "300" &&
+    info.resources.memoryMb === SANDBOX_MEMORY_MB
+  );
+}
+
+function isTestPool(info: SandboxPoolInfo): boolean {
+  return (
+    info.image === SANDBOX_IMAGE &&
+    info.entrypoint?.length === 2 &&
+    info.entrypoint[0] === "sleep" &&
+    info.entrypoint[1] === "300" &&
+    info.resources.memoryMb === SANDBOX_MEMORY_MB
+  );
+}
+
+async function cleanupStaleTestResources(client: SandboxClient): Promise<void> {
+  const cutoff = new Date(Date.now() - STALE_RESOURCE_GRACE_MS);
+  const poolIds = new Set<string>();
+
+  try {
+    const sandboxes = await client.list();
+    await Promise.all(
+      sandboxes
+        .filter(
+          (sandbox) =>
+            sandbox.status !== SandboxStatus.TERMINATED &&
+            isTestSandbox(sandbox) &&
+            isStale(sandbox.createdAt, cutoff),
+        )
+        .map((sandbox) => client.delete(sandbox.sandboxId).catch(() => {})),
+    );
+  } catch {}
+
+  try {
+    const pools = await client.listPools();
+    for (const pool of pools) {
+      if (isTestPool(pool) && isStale(pool.createdAt, cutoff)) {
+        poolIds.add(pool.poolId);
+      }
+    }
+  } catch {}
+
+  if (poolIds.size === 0) return;
+
+  // Give sandbox deletes a short chance to release pool claims, then remove
+  // stale pools that may still be holding warm containers against quota.
+  await sleep(2000);
+  await Promise.all(
+    [...poolIds].map((poolId) => client.deletePool(poolId).catch(() => {})),
+  );
+}
+
+beforeAll(async () => {
+  const client = new SandboxClient({
+    apiUrl: process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai",
+    apiKey: process.env.TENSORLAKE_API_KEY,
+  });
+  try {
+    await cleanupStaleTestResources(client);
+  } finally {
+    client.close();
+  }
+}, 30_000);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -146,7 +223,11 @@ describe(
       });
       expect(resp.sandboxId).toBeTruthy();
       expect(
-        [SandboxStatus.PENDING, SandboxStatus.RUNNING, SandboxStatus.TERMINATED],
+        [
+          SandboxStatus.PENDING,
+          SandboxStatus.RUNNING,
+          SandboxStatus.TERMINATED,
+        ],
         `sandbox ${resp.sandboxId}`,
       ).toContain(resp.status);
       sandboxId = resp.sandboxId;
@@ -156,7 +237,11 @@ describe(
       const info = await client.get(sandboxId);
       expect(info.sandboxId, `sandbox ${sandboxId}`).toBe(sandboxId);
       expect(
-        [SandboxStatus.PENDING, SandboxStatus.RUNNING, SandboxStatus.TERMINATED],
+        [
+          SandboxStatus.PENDING,
+          SandboxStatus.RUNNING,
+          SandboxStatus.TERMINATED,
+        ],
         `sandbox ${sandboxId}`,
       ).toContain(info.status);
     });
@@ -164,15 +249,16 @@ describe(
     it("lists sandboxes", async () => {
       const list = await client.list();
       const ids = list.map((s) => s.sandboxId);
-      expect(ids, `sandbox ${sandboxId} not found in list`).toContain(sandboxId);
+      expect(ids, `sandbox ${sandboxId} not found in list`).toContain(
+        sandboxId,
+      );
     });
 
     it("transitions out of pending", async () => {
-      const status = await pollSandboxStatus(
-        client,
-        sandboxId,
-        [SandboxStatus.RUNNING, SandboxStatus.TERMINATED],
-      );
+      const status = await pollSandboxStatus(client, sandboxId, [
+        SandboxStatus.RUNNING,
+        SandboxStatus.TERMINATED,
+      ]);
       expect(
         [SandboxStatus.RUNNING, SandboxStatus.TERMINATED],
         `sandbox ${sandboxId}`,
@@ -195,9 +281,9 @@ describe(
     });
 
     it("throws SandboxNotFoundError for non-existent sandbox", async () => {
-      await expect(
-        client.delete("nonexistent-sandbox-id-000"),
-      ).rejects.toThrow(SandboxNotFoundError);
+      await expect(client.delete("nonexistent-sandbox-id-000")).rejects.toThrow(
+        SandboxNotFoundError,
+      );
     });
   },
   { timeout: 120_000 },
@@ -225,10 +311,14 @@ describe(
       });
       poolId = pool.poolId;
       await pollPoolContainers(client, poolId, 1);
-      sandbox = await createAndConnectWithStartupRetry(client, {
-        poolId,
-        startupTimeout: 120,
-      }, 5);
+      sandbox = await createAndConnectWithStartupRetry(
+        client,
+        {
+          poolId,
+          startupTimeout: 120,
+        },
+        5,
+      );
     });
 
     afterAll(async () => {
@@ -236,7 +326,12 @@ describe(
         try {
           const sandboxId = sandbox.sandboxId;
           await sandbox.terminate();
-          await pollSandboxStatus(client, sandboxId, SandboxStatus.TERMINATED, 30);
+          await pollSandboxStatus(
+            client,
+            sandboxId,
+            SandboxStatus.TERMINATED,
+            30,
+          );
         } catch {}
       }
       if (poolId) {
@@ -251,7 +346,9 @@ describe(
     it("runs a command and captures stdout", async () => {
       const result = await sandbox.run("echo", { args: ["hello world"] });
       expect(result.exitCode, `sandbox ${sandbox.sandboxId}: exitCode`).toBe(0);
-      expect(result.stdout, `sandbox ${sandbox.sandboxId}: stdout`).toContain("hello world");
+      expect(result.stdout, `sandbox ${sandbox.sandboxId}: stdout`).toContain(
+        "hello world",
+      );
     });
 
     it("captures stderr", async () => {
@@ -259,7 +356,9 @@ describe(
         args: ["-c", "echo error >&2"],
       });
       expect(result.exitCode, `sandbox ${sandbox.sandboxId}: exitCode`).toBe(0);
-      expect(result.stderr, `sandbox ${sandbox.sandboxId}: stderr`).toContain("error");
+      expect(result.stderr, `sandbox ${sandbox.sandboxId}: stderr`).toContain(
+        "error",
+      );
     });
 
     it("returns non-zero exit code", async () => {
@@ -273,13 +372,17 @@ describe(
         env: { MY_VAR: "test-value" },
       });
       expect(result.exitCode, `sandbox ${sandbox.sandboxId}: exitCode`).toBe(0);
-      expect(result.stdout, `sandbox ${sandbox.sandboxId}: stdout`).toContain("test-value");
+      expect(result.stdout, `sandbox ${sandbox.sandboxId}: stdout`).toContain(
+        "test-value",
+      );
     });
 
     it("runs command with working directory", async () => {
       const result = await sandbox.run("pwd", { workingDir: "/tmp" });
       expect(result.exitCode, `sandbox ${sandbox.sandboxId}: exitCode`).toBe(0);
-      expect(result.stdout, `sandbox ${sandbox.sandboxId}: stdout`).toContain("/tmp");
+      expect(result.stdout, `sandbox ${sandbox.sandboxId}: stdout`).toContain(
+        "/tmp",
+      );
     });
 
     it("writes and reads a file", async () => {
@@ -288,7 +391,9 @@ describe(
 
       const data = await sandbox.readFile("/tmp/test-ts-sdk.txt");
       const text = new TextDecoder().decode(data);
-      expect(text, `sandbox ${sandbox.sandboxId}`).toBe("hello from typescript sdk");
+      expect(text, `sandbox ${sandbox.sandboxId}`).toBe(
+        "hello from typescript sdk",
+      );
     });
 
     it("lists a directory", async () => {
@@ -300,9 +405,15 @@ describe(
 
       const listing = await sandbox.listDirectory("/tmp");
       expect(listing.path, `sandbox ${sandbox.sandboxId}: path`).toBe("/tmp");
-      expect(listing.entries.length, `sandbox ${sandbox.sandboxId}: entries`).toBeGreaterThan(0);
+      expect(
+        listing.entries.length,
+        `sandbox ${sandbox.sandboxId}: entries`,
+      ).toBeGreaterThan(0);
       const names = listing.entries.map((e) => e.name);
-      expect(names, `sandbox ${sandbox.sandboxId}: list-test.txt not found`).toContain("list-test.txt");
+      expect(
+        names,
+        `sandbox ${sandbox.sandboxId}: list-test.txt not found`,
+      ).toContain("list-test.txt");
     });
 
     it("deletes a file", async () => {
@@ -315,24 +426,35 @@ describe(
       // Verify the file is gone by listing the directory
       const listing = await sandbox.listDirectory("/tmp");
       const names = listing.entries.map((e) => e.name);
-      expect(names, `sandbox ${sandbox.sandboxId}: to-delete.txt still present`).not.toContain("to-delete.txt");
+      expect(
+        names,
+        `sandbox ${sandbox.sandboxId}: to-delete.txt still present`,
+      ).not.toContain("to-delete.txt");
     });
 
     it("starts and manages processes", async () => {
       const proc = await sandbox.startProcess("sleep", { args: ["10"] });
       expect(proc.pid, `sandbox ${sandbox.sandboxId}: pid`).toBeGreaterThan(0);
-      expect(proc.status, `sandbox ${sandbox.sandboxId}: status`).toBe("running");
+      expect(proc.status, `sandbox ${sandbox.sandboxId}: status`).toBe(
+        "running",
+      );
 
       const processes = await sandbox.listProcesses();
       const pids = processes.map((p) => p.pid);
-      expect(pids, `sandbox ${sandbox.sandboxId}: pid ${proc.pid} not in list`).toContain(proc.pid);
+      expect(
+        pids,
+        `sandbox ${sandbox.sandboxId}: pid ${proc.pid} not in list`,
+      ).toContain(proc.pid);
 
       await sandbox.killProcess(proc.pid);
 
       // Wait for process to exit
       await sleep(500);
       const info = await sandbox.getProcess(proc.pid);
-      expect(info.status, `sandbox ${sandbox.sandboxId}: process ${proc.pid} still running`).not.toBe("running");
+      expect(
+        info.status,
+        `sandbox ${sandbox.sandboxId}: process ${proc.pid} still running`,
+      ).not.toBe("running");
     });
 
     it("checks health", async () => {
@@ -342,8 +464,14 @@ describe(
 
     it("gets daemon info", async () => {
       const info = await sandbox.daemonInfo();
-      expect(info.version, `sandbox ${sandbox.sandboxId}: version`).toBeTruthy();
-      expect(info.uptimeSecs, `sandbox ${sandbox.sandboxId}: uptimeSecs`).toBeGreaterThanOrEqual(0);
+      expect(
+        info.version,
+        `sandbox ${sandbox.sandboxId}: version`,
+      ).toBeTruthy();
+      expect(
+        info.uptimeSecs,
+        `sandbox ${sandbox.sandboxId}: uptimeSecs`,
+      ).toBeGreaterThanOrEqual(0);
     });
   },
   { timeout: 180_000 },
@@ -474,7 +602,11 @@ describe(
     });
 
     it("sandbox from pool reaches running", async () => {
-      const status = await pollSandboxStatus(client, sandboxId, SandboxStatus.RUNNING);
+      const status = await pollSandboxStatus(
+        client,
+        sandboxId,
+        SandboxStatus.RUNNING,
+      );
       expect(status, `sandbox ${sandboxId}`).toBe(SandboxStatus.RUNNING);
     });
 
@@ -553,15 +685,24 @@ describe(
       const claimed = (detail.containers ?? []).filter(
         (c) => c.id === warmContainerId,
       );
-      expect(claimed, `sandbox ${sandboxId}: warm container not claimed`).toHaveLength(1);
+      expect(
+        claimed,
+        `sandbox ${sandboxId}: warm container not claimed`,
+      ).toHaveLength(1);
       expect(claimed[0].sandboxId, `sandbox ${sandboxId}`).toBe(sandboxId);
     });
 
     it("replacement warm container is created", async () => {
       const containers = await pollPoolContainers(client, poolId, 2);
       const warm = warmContainers(containers);
-      expect(warm.length, `sandbox ${sandboxId}: no replacement warm container`).toBeGreaterThanOrEqual(1);
-      expect(warm[0].id, `sandbox ${sandboxId}: replacement has same id`).not.toBe(warmContainerId);
+      expect(
+        warm.length,
+        `sandbox ${sandboxId}: no replacement warm container`,
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        warm[0].id,
+        `sandbox ${sandboxId}: replacement has same id`,
+      ).not.toBe(warmContainerId);
     });
 
     it("deleting sandbox removes claimed container", async () => {
@@ -649,7 +790,11 @@ describe(
     });
 
     it("sandbox reaches running", async () => {
-      const status = await pollSandboxStatus(client, sandboxId, SandboxStatus.RUNNING);
+      const status = await pollSandboxStatus(
+        client,
+        sandboxId,
+        SandboxStatus.RUNNING,
+      );
       expect(status, `sandbox ${sandboxId}`).toBe(SandboxStatus.RUNNING);
     });
 
@@ -683,7 +828,12 @@ describe(
       if (sandboxId) {
         try {
           await client.delete(sandboxId);
-          await pollSandboxStatus(client, sandboxId, SandboxStatus.TERMINATED, 30);
+          await pollSandboxStatus(
+            client,
+            sandboxId,
+            SandboxStatus.TERMINATED,
+            30,
+          );
         } catch {}
         sandboxId = undefined!;
       }

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -10,6 +10,8 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  createSandboxImage,
+  Image,
   PoolInUseError,
   PoolNotFoundError,
   SandboxClient,
@@ -22,8 +24,10 @@ import {
 } from "../src/index.js";
 import { Sandbox } from "../src/sandbox.js";
 
-const SANDBOX_IMAGE =
-  process.env.TENSORLAKE_SANDBOX_IMAGE ?? "docker.io/library/alpine:latest";
+let sandboxImage = process.env.TENSORLAKE_SANDBOX_IMAGE ?? "";
+const TEST_IMAGE_BASE =
+  process.env.TENSORLAKE_TEST_SANDBOX_IMAGE_BASE ??
+  "tensorlake/ubuntu-minimal";
 const SANDBOX_CPUS = 1.0;
 const SANDBOX_MEMORY_MB = 1024;
 const SANDBOX_DISK_MB = 10240;
@@ -118,6 +122,52 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function defaultTestImageName(): string {
+  const runId = process.env.GITHUB_RUN_ID;
+  const parts = runId
+    ? [
+        "tl-sdk-integration",
+        runId,
+        process.env.GITHUB_JOB ?? "typescript",
+        process.env.GITHUB_RUN_ATTEMPT ?? "1",
+      ]
+    : ["tl-sdk-integration", "local", String(process.pid)];
+  return slug(parts.join("-"));
+}
+
+async function ensureSandboxImage(): Promise<void> {
+  if (sandboxImage) return;
+
+  const imageName =
+    process.env.TENSORLAKE_TEST_SANDBOX_IMAGE_NAME ?? defaultTestImageName();
+  process.stderr.write(
+    `Building sandbox integration image '${imageName}' from base '${TEST_IMAGE_BASE}'...\n`,
+  );
+  await createSandboxImage(
+    new Image({ name: imageName, baseImage: TEST_IMAGE_BASE }),
+    {
+      registeredName: imageName,
+      diskMb: SANDBOX_DISK_MB,
+    },
+    {
+      emit: (event) => {
+        const type = typeof event.type === "string" ? event.type : "event";
+        const message = typeof event.message === "string" ? event.message : "";
+        if (message) process.stderr.write(`[${type}] ${message}\n`);
+      },
+    },
+  );
+  sandboxImage = imageName;
+  process.stderr.write(`Using sandbox integration image '${sandboxImage}'.\n`);
+}
+
 function isStale(createdAt: Date | undefined, cutoff: Date): boolean {
   return createdAt == null || createdAt.getTime() < cutoff.getTime();
 }
@@ -131,7 +181,8 @@ function isOlderThanCleanupGrace(
 
 function isTestSandbox(info: SandboxInfo): boolean {
   return (
-    info.image === SANDBOX_IMAGE &&
+    sandboxImage.length > 0 &&
+    info.image === sandboxImage &&
     info.entrypoint?.length === 2 &&
     info.entrypoint[0] === "sleep" &&
     info.entrypoint[1] === "300" &&
@@ -141,7 +192,8 @@ function isTestSandbox(info: SandboxInfo): boolean {
 
 function isTestPool(info: SandboxPoolInfo): boolean {
   return (
-    info.image === SANDBOX_IMAGE &&
+    sandboxImage.length > 0 &&
+    info.image === sandboxImage &&
     info.entrypoint?.length === 2 &&
     info.entrypoint[0] === "sleep" &&
     info.entrypoint[1] === "300" &&
@@ -212,7 +264,8 @@ beforeAll(async () => {
   } finally {
     client.close();
   }
-}, 30_000);
+  await ensureSandboxImage();
+}, 600_000);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -242,7 +295,7 @@ describe(
 
     it("creates a sandbox", async () => {
       const resp = await client.create({
-        image: SANDBOX_IMAGE,
+        image: sandboxImage,
         cpus: SANDBOX_CPUS,
         memoryMb: SANDBOX_MEMORY_MB,
         diskMb: SANDBOX_DISK_MB,
@@ -329,7 +382,7 @@ describe(
         apiKey: process.env.TENSORLAKE_API_KEY,
       });
       const pool = await client.createPool({
-        image: SANDBOX_IMAGE,
+        image: sandboxImage,
         cpus: SANDBOX_CPUS,
         memoryMb: SANDBOX_MEMORY_MB,
         ephemeralDiskMb: SANDBOX_DISK_MB,
@@ -528,7 +581,7 @@ describe(
 
     it("creates a pool", async () => {
       const resp = await client.createPool({
-        image: SANDBOX_IMAGE,
+        image: sandboxImage,
         cpus: SANDBOX_CPUS,
         memoryMb: SANDBOX_MEMORY_MB,
         ephemeralDiskMb: SANDBOX_DISK_MB,
@@ -541,7 +594,7 @@ describe(
     it("gets pool details", async () => {
       const info = await client.getPool(poolId);
       expect(info.poolId).toBe(poolId);
-      expect(info.image).toBe(SANDBOX_IMAGE);
+      expect(info.image).toBe(sandboxImage);
       expect(info.resources.memoryMb).toBe(SANDBOX_MEMORY_MB);
     });
 
@@ -553,7 +606,7 @@ describe(
 
     it("updates a pool", async () => {
       const updated = await client.updatePool(poolId, {
-        image: SANDBOX_IMAGE,
+        image: sandboxImage,
         cpus: SANDBOX_CPUS,
         memoryMb: 2048,
         ephemeralDiskMb: SANDBOX_DISK_MB,
@@ -608,7 +661,7 @@ describe(
 
     it("creates a pool with warm containers", async () => {
       const resp = await client.createPool({
-        image: SANDBOX_IMAGE,
+        image: sandboxImage,
         cpus: SANDBOX_CPUS,
         memoryMb: SANDBOX_MEMORY_MB,
         ephemeralDiskMb: SANDBOX_DISK_MB,
@@ -685,7 +738,7 @@ describe(
 
     it("creates pool with one warm container", async () => {
       const resp = await client.createPool({
-        image: SANDBOX_IMAGE,
+        image: sandboxImage,
         cpus: SANDBOX_CPUS,
         memoryMb: SANDBOX_MEMORY_MB,
         ephemeralDiskMb: SANDBOX_DISK_MB,
@@ -799,7 +852,7 @@ describe(
 
     it("creates pool with timeout", async () => {
       const resp = await client.createPool({
-        image: SANDBOX_IMAGE,
+        image: sandboxImage,
         cpus: SANDBOX_CPUS,
         memoryMb: SANDBOX_MEMORY_MB,
         ephemeralDiskMb: SANDBOX_DISK_MB,

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -155,6 +155,7 @@ async function ensureSandboxImage(): Promise<void> {
     {
       registeredName: imageName,
       cpus: SANDBOX_CPUS,
+      memoryMb: 2048,
       diskMb: SANDBOX_DISK_MB,
     },
     {

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -27,6 +27,12 @@ const sandboxImage =
 const SANDBOX_CPUS = 1.0;
 const SANDBOX_MEMORY_MB = 1024;
 const SANDBOX_DISK_MB = 10240;
+const SANDBOX_STATUS_TIMEOUT_SEC = 120;
+const SANDBOX_POOL_TIMEOUT_SEC = 120;
+const SANDBOX_LIFECYCLE_TIMEOUT_MS = 360_000;
+const SANDBOX_CREATE_TIMEOUT_MS = 180_000;
+const SANDBOX_SETUP_TIMEOUT_MS = 300_000;
+const SANDBOX_SUITE_TIMEOUT_MS = 420_000;
 const STALE_RESOURCE_GRACE_MS =
   Number(process.env.TENSORLAKE_TEST_CLEANUP_GRACE_SECS ?? "60") * 1000;
 const CLEANUP_ALL_TEST_RESOURCES = ["1", "true", "yes"].includes(
@@ -41,7 +47,7 @@ async function pollSandboxStatus(
   client: SandboxClient,
   sandboxId: string,
   target: SandboxStatus | SandboxStatus[],
-  timeoutSec = 60,
+  timeoutSec = SANDBOX_STATUS_TIMEOUT_SEC,
   intervalMs = 1000,
 ): Promise<SandboxStatus> {
   const targets = Array.isArray(target) ? target : [target];
@@ -88,7 +94,7 @@ async function pollPoolContainers(
   client: SandboxClient,
   poolId: string,
   minCount: number,
-  timeoutSec = 60,
+  timeoutSec = SANDBOX_POOL_TIMEOUT_SEC,
   intervalMs = 1000,
 ): Promise<PoolContainerInfo[]> {
   const deadline = Date.now() + timeoutSec * 1000;
@@ -116,6 +122,15 @@ function claimedContainers(
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createTestClient(): SandboxClient {
+  return new SandboxClient({
+    apiUrl: process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai",
+    apiKey: process.env.TENSORLAKE_API_KEY,
+    maxRetries: 0,
+    timeoutMs: SANDBOX_CREATE_TIMEOUT_MS,
+  });
 }
 
 function isStale(createdAt: Date | undefined, cutoff: Date): boolean {
@@ -205,16 +220,13 @@ async function cleanupStaleTestResources(client: SandboxClient): Promise<void> {
 }
 
 beforeAll(async () => {
-  const client = new SandboxClient({
-    apiUrl: process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai",
-    apiKey: process.env.TENSORLAKE_API_KEY,
-  });
+  const client = createTestClient();
   try {
     await cleanupStaleTestResources(client);
   } finally {
     client.close();
   }
-}, 120_000);
+}, SANDBOX_SETUP_TIMEOUT_MS);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -227,10 +239,7 @@ describe(
     let sandboxId: string;
 
     beforeAll(() => {
-      client = new SandboxClient({
-        apiUrl: process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai",
-        apiKey: process.env.TENSORLAKE_API_KEY,
-      });
+      client = createTestClient();
     });
 
     afterAll(async () => {
@@ -315,7 +324,7 @@ describe(
       );
     });
   },
-  { timeout: 120_000 },
+  { timeout: SANDBOX_LIFECYCLE_TIMEOUT_MS },
 );
 
 describe(
@@ -326,10 +335,7 @@ describe(
     let poolId: string;
 
     beforeAll(async () => {
-      client = new SandboxClient({
-        apiUrl: process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai",
-        apiKey: process.env.TENSORLAKE_API_KEY,
-      });
+      client = createTestClient();
       const pool = await client.createPool({
         image: sandboxImage,
         cpus: SANDBOX_CPUS,
@@ -348,7 +354,7 @@ describe(
         },
         5,
       );
-    });
+    }, SANDBOX_SETUP_TIMEOUT_MS);
 
     afterAll(async () => {
       if (sandbox) {
@@ -503,7 +509,7 @@ describe(
       ).toBeGreaterThanOrEqual(0);
     });
   },
-  { timeout: 180_000 },
+  { timeout: SANDBOX_SUITE_TIMEOUT_MS },
 );
 
 describe(
@@ -513,10 +519,7 @@ describe(
     let poolId: string;
 
     beforeAll(() => {
-      client = new SandboxClient({
-        apiUrl: process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai",
-        apiKey: process.env.TENSORLAKE_API_KEY,
-      });
+      client = createTestClient();
     });
 
     afterAll(async () => {
@@ -576,7 +579,7 @@ describe(
       ).rejects.toThrow(PoolNotFoundError);
     });
   },
-  { timeout: 120_000 },
+  { timeout: SANDBOX_LIFECYCLE_TIMEOUT_MS },
 );
 
 describe(
@@ -587,10 +590,7 @@ describe(
     let sandboxId: string;
 
     beforeAll(() => {
-      client = new SandboxClient({
-        apiUrl: process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai",
-        apiKey: process.env.TENSORLAKE_API_KEY,
-      });
+      client = createTestClient();
     });
 
     afterAll(async () => {
@@ -652,7 +652,7 @@ describe(
       poolId = undefined!;
     });
   },
-  { timeout: 120_000 },
+  { timeout: SANDBOX_LIFECYCLE_TIMEOUT_MS },
 );
 
 describe(
@@ -664,10 +664,7 @@ describe(
     let warmContainerId: string;
 
     beforeAll(() => {
-      client = new SandboxClient({
-        apiUrl: process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai",
-        apiKey: process.env.TENSORLAKE_API_KEY,
-      });
+      client = createTestClient();
     });
 
     afterAll(async () => {
@@ -767,7 +764,7 @@ describe(
       }
     });
   },
-  { timeout: 180_000 },
+  { timeout: SANDBOX_SUITE_TIMEOUT_MS },
 );
 
 describe(
@@ -778,10 +775,7 @@ describe(
     let sandboxId: string;
 
     beforeAll(() => {
-      client = new SandboxClient({
-        apiUrl: process.env.TENSORLAKE_API_URL ?? "https://api.tensorlake.ai",
-        apiKey: process.env.TENSORLAKE_API_KEY,
-      });
+      client = createTestClient();
     });
 
     afterAll(async () => {
@@ -873,5 +867,5 @@ describe(
       }
     });
   },
-  { timeout: 180_000 },
+  { timeout: SANDBOX_SUITE_TIMEOUT_MS },
 );

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -22,12 +22,16 @@ import {
 } from "../src/index.js";
 import { Sandbox } from "../src/sandbox.js";
 
-const SANDBOX_IMAGE = "tensorlake/ubuntu-minimal";
+const SANDBOX_IMAGE =
+  process.env.TENSORLAKE_SANDBOX_IMAGE ?? "docker.io/library/alpine:latest";
 const SANDBOX_CPUS = 1.0;
 const SANDBOX_MEMORY_MB = 1024;
 const SANDBOX_DISK_MB = 10240;
 const STALE_RESOURCE_GRACE_MS =
   Number(process.env.TENSORLAKE_TEST_CLEANUP_GRACE_SECS ?? "60") * 1000;
+const CLEANUP_ALL_TEST_RESOURCES = ["1", "true", "yes"].includes(
+  (process.env.TENSORLAKE_TEST_CLEANUP_ALL ?? "").toLowerCase(),
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -115,6 +119,13 @@ function sleep(ms: number): Promise<void> {
 }
 
 function isStale(createdAt: Date | undefined, cutoff: Date): boolean {
+  return createdAt == null || createdAt.getTime() < cutoff.getTime();
+}
+
+function isOlderThanCleanupGrace(
+  createdAt: Date | undefined,
+  cutoff: Date,
+): boolean {
   return createdAt != null && createdAt.getTime() < cutoff.getTime();
 }
 
@@ -149,8 +160,9 @@ async function cleanupStaleTestResources(client: SandboxClient): Promise<void> {
         .filter(
           (sandbox) =>
             sandbox.status !== SandboxStatus.TERMINATED &&
-            isTestSandbox(sandbox) &&
-            isStale(sandbox.createdAt, cutoff),
+            ((CLEANUP_ALL_TEST_RESOURCES &&
+              isOlderThanCleanupGrace(sandbox.createdAt, cutoff)) ||
+              (isTestSandbox(sandbox) && isStale(sandbox.createdAt, cutoff))),
         )
         .map((sandbox) => client.delete(sandbox.sandboxId).catch(() => {})),
     );
@@ -159,7 +171,11 @@ async function cleanupStaleTestResources(client: SandboxClient): Promise<void> {
   try {
     const pools = await client.listPools();
     for (const pool of pools) {
-      if (isTestPool(pool) && isStale(pool.createdAt, cutoff)) {
+      if (
+        (CLEANUP_ALL_TEST_RESOURCES &&
+          isOlderThanCleanupGrace(pool.createdAt, cutoff)) ||
+        (isTestPool(pool) && isStale(pool.createdAt, cutoff))
+      ) {
         poolIds.add(pool.poolId);
       }
     }
@@ -169,10 +185,21 @@ async function cleanupStaleTestResources(client: SandboxClient): Promise<void> {
 
   // Give sandbox deletes a short chance to release pool claims, then remove
   // stale pools that may still be holding warm containers against quota.
-  await sleep(2000);
-  await Promise.all(
-    [...poolIds].map((poolId) => client.deletePool(poolId).catch(() => {})),
-  );
+  for (let attempt = 0; attempt < 5 && poolIds.size > 0; attempt++) {
+    await sleep(2000);
+    const remainingPoolIds = new Set<string>();
+    await Promise.all(
+      [...poolIds].map(async (poolId) => {
+        try {
+          await client.deletePool(poolId);
+        } catch {
+          remainingPoolIds.add(poolId);
+        }
+      }),
+    );
+    poolIds.clear();
+    for (const poolId of remainingPoolIds) poolIds.add(poolId);
+  }
 }
 
 beforeAll(async () => {

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -154,6 +154,7 @@ async function ensureSandboxImage(): Promise<void> {
     new Image({ name: imageName, baseImage: TEST_IMAGE_BASE }),
     {
       registeredName: imageName,
+      cpus: SANDBOX_CPUS,
       diskMb: SANDBOX_DISK_MB,
     },
     {


### PR DESCRIPTION
## Summary
- build one default Applications runtime image for each deployed application version that has functions without an explicit Image
- register that default image as applications/{application}/versions/{version}/default so the dataplane can resolve omitted manifest images
- keep manifests clean: SDK still omits image for functions without user-specified images, with no sentinel/default string

## Verification
- /home/diptanuc/.cache/pypoetry/virtualenvs/tensorlake-uz9pTusr-py3.12/bin/black src/tensorlake/cli/deploy.py tests/cli/test_deploy.py --check
- PYTHONPATH=src /home/diptanuc/.cache/pypoetry/virtualenvs/tensorlake-uz9pTusr-py3.12/bin/python -m unittest tests.cli.test_deploy