### PR TITLE
Resolve sandbox ingress endpoints in SDKs

### DIFF
--- a/.github/workflows/publish_test_pypi.yaml
+++ b/.github/workflows/publish_test_pypi.yaml
@@ -26,7 +26,10 @@ jobs:
         id: version
         run: |
           base=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          echo "version=${base}-dev$(date +%s)" >> $GITHUB_OUTPUT
+          version="${base}-dev$(date +%s)"
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "## TestPyPI release version" >> $GITHUB_STEP_SUMMARY
+          echo "\`${version}\`" >> $GITHUB_STEP_SUMMARY
 
   build-sdist:
     needs: [prepare]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.29"
+version = "0.5.30"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.29"
+version = "0.5.30"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/cp.rs
+++ b/crates/cli/src/commands/sbx/cp.rs
@@ -6,7 +6,7 @@ use tokio::io::AsyncWriteExt;
 use tokio_util::io::ReaderStream;
 
 use crate::auth::context::CliContext;
-use crate::commands::sbx::{parse_sandbox_path, sandbox_proxy_base, with_sandbox_headers};
+use crate::commands::sbx::{parse_sandbox_path, resolve_sandbox_proxy_target, with_sandbox_headers};
 use crate::error::{CliError, Result};
 
 pub async fn run(ctx: &CliContext, src: &str, dest: &str) -> Result<()> {
@@ -26,17 +26,16 @@ pub async fn run(ctx: &CliContext, src: &str, dest: &str) -> Result<()> {
 
     if let Some(sandbox_id) = src_sbx {
         // Download: sandbox -> local
-        let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
+        let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
         let client = ctx.client()?;
 
         let resp = with_sandbox_headers(
             client.get(format!(
                 "{}/api/v1/files?path={}",
-                proxy_base,
+                target.proxy_base,
                 urlencoding::encode(src_path)
             )),
-            sandbox_id,
-            host_override,
+            &target,
         )
         .send()
         .await
@@ -83,20 +82,19 @@ pub async fn run(ctx: &CliContext, src: &str, dest: &str) -> Result<()> {
         let file = tokio::fs::File::open(src_path).await?;
         let size = file.metadata().await?.len();
         let stream = ReaderStream::new(file);
-        let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
+        let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
         let client = ctx.client()?;
 
         let resp = with_sandbox_headers(
             client
                 .put(format!(
                     "{}/api/v1/files?path={}",
-                    proxy_base,
+                    target.proxy_base,
                     urlencoding::encode(dest_path)
                 ))
                 .header(CONTENT_LENGTH, size)
                 .body(reqwest::Body::wrap_stream(stream)),
-            sandbox_id,
-            host_override,
+            &target,
         )
         .send()
         .await

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -3,7 +3,7 @@ use futures::StreamExt;
 use reqwest::header::ACCEPT;
 
 use crate::auth::context::CliContext;
-use crate::commands::sbx::{parse_env_vars, sandbox_proxy_base, with_sandbox_headers};
+use crate::commands::sbx::{parse_env_vars, resolve_sandbox_proxy_target, with_sandbox_headers};
 use crate::error::{CliError, Result};
 
 #[allow(clippy::too_many_arguments)]
@@ -18,7 +18,7 @@ pub async fn run(
     user: Option<&str>,
 ) -> Result<()> {
     let env_dict = parse_env_vars(env)?;
-    let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
+    let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
     let client = ctx.client()?;
 
     // Build request body
@@ -44,11 +44,10 @@ pub async fn run(
     // Single streaming POST: start process + stream output + get exit code
     let resp = with_sandbox_headers(
         client
-            .post(format!("{}/api/v1/processes/run", proxy_base))
+            .post(format!("{}/api/v1/processes/run", target.proxy_base))
             .header(ACCEPT, "text/event-stream")
             .json(&body),
-        sandbox_id,
-        host_override,
+        &target,
     )
     .send()
     .await

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -24,6 +24,15 @@ use crate::error::{CliError, Result};
 use chrono::{DateTime, Local, TimeZone, Utc};
 use tokio::time::{Duration, Instant};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSandboxProxyTarget {
+    pub sandbox_id: String,
+    pub proxy_base: String,
+    pub host_override: Option<String>,
+    pub routing_hint: Option<String>,
+    pub ingress_endpoint: Option<String>,
+}
+
 /// Build the lifecycle API base URL for sandbox CRUD operations.
 ///
 /// Cloud mode: `{sandbox_url}/sandboxes` where sandbox_url = `sandbox.tensorlake.*`
@@ -149,13 +158,16 @@ pub async fn wait_for_sandbox_status(
 /// Localhost: returns the proxy URL as-is with a `Host` header override.
 pub fn sandbox_proxy_base(ctx: &CliContext, sandbox_id: &str) -> (String, Option<String>) {
     let proxy_url = resolve_proxy_url(&ctx.api_url);
+    proxy_base_from_url(&proxy_url, sandbox_id)
+}
 
+fn proxy_base_from_url(proxy_url: &str, sandbox_id: &str) -> (String, Option<String>) {
     if let Ok(parsed) = url::Url::parse(&proxy_url) {
         let host = parsed.host_str().unwrap_or("");
         if host == "localhost" || host == "127.0.0.1" {
             // Localhost: keep URL as-is, set Host header to {sandbox_id}.local
-            let host_header = format!("{}.local", sandbox_id);
-            return (proxy_url, Some(host_header));
+            let host_header = format!("{sandbox_id}.local");
+            return (proxy_url.to_string(), Some(host_header));
         }
         // Cloud: use apex domain; sandbox routing is via X-Tensorlake-Sandbox-Id header
         let port_part = parsed.port().map(|p| format!(":{}", p)).unwrap_or_default();
@@ -164,7 +176,74 @@ pub fn sandbox_proxy_base(ctx: &CliContext, sandbox_id: &str) -> (String, Option
     }
 
     // Fallback
-    (proxy_url, None)
+    (proxy_url.to_string(), None)
+}
+
+pub async fn resolve_sandbox_proxy_target(
+    ctx: &CliContext,
+    identifier: &str,
+) -> Result<ResolvedSandboxProxyTarget> {
+    if is_localhost(&ctx.api_url) {
+        let proxy_url = resolve_proxy_url(&ctx.api_url);
+        let (proxy_base, host_override) = proxy_base_from_url(&proxy_url, identifier);
+        return Ok(ResolvedSandboxProxyTarget {
+            sandbox_id: identifier.to_string(),
+            proxy_base,
+            host_override,
+            routing_hint: None,
+            ingress_endpoint: None,
+        });
+    }
+
+    let client = ctx.client()?;
+    let resp = client
+        .get(sandbox_endpoint(ctx, &format!("sandboxes/{identifier}")))
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to resolve sandbox {} (HTTP {}): {}",
+            identifier,
+            status,
+            body
+        )));
+    }
+
+    let info: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
+    let sandbox_id = info
+        .get("sandbox_id")
+        .or_else(|| info.get("id"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or(identifier)
+        .to_string();
+    let routing_hint = info
+        .get("routing_hint")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let ingress_endpoint = info
+        .get("ingress_endpoint")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let proxy_url = explicit_proxy_url_override()
+        .or_else(|| ingress_endpoint.clone())
+        .unwrap_or_else(|| resolve_proxy_url(&ctx.api_url));
+    let (proxy_base, host_override) = proxy_base_from_url(&proxy_url, &sandbox_id);
+
+    Ok(ResolvedSandboxProxyTarget {
+        sandbox_id,
+        proxy_base,
+        host_override,
+        routing_hint,
+        ingress_endpoint,
+    })
 }
 
 /// Apply sandbox routing headers to a request builder.
@@ -173,12 +252,16 @@ pub fn sandbox_proxy_base(ctx: &CliContext, sandbox_id: &str) -> (String, Option
 /// For cloud (host_override is None): sets `X-Tensorlake-Sandbox-Id`.
 pub fn with_sandbox_headers(
     req: reqwest::RequestBuilder,
-    sandbox_id: &str,
-    host_override: Option<String>,
+    target: &ResolvedSandboxProxyTarget,
 ) -> reqwest::RequestBuilder {
-    match host_override {
+    let req = match target.host_override.as_deref() {
         Some(host) => req.header(reqwest::header::HOST, host),
-        None => req.header("X-Tensorlake-Sandbox-Id", sandbox_id),
+        None => req.header("X-Tensorlake-Sandbox-Id", &target.sandbox_id),
+    };
+    if let Some(hint) = target.routing_hint.as_deref() {
+        req.header("X-Tensorlake-Route-Hint", hint)
+    } else {
+        req
     }
 }
 
@@ -200,7 +283,7 @@ pub fn resolve_sandbox_lifecycle_url(api_url: &str) -> String {
 
 /// Resolve the sandbox proxy URL from env or api_url.
 fn resolve_proxy_url(api_url: &str) -> String {
-    if let Ok(url) = std::env::var("TENSORLAKE_SANDBOX_PROXY_URL") {
+    if let Some(url) = explicit_proxy_url_override() {
         return url;
     }
     if is_localhost(api_url) {
@@ -214,6 +297,13 @@ fn resolve_proxy_url(api_url: &str) -> String {
         }
     }
     "https://sandbox.tensorlake.ai".to_string()
+}
+
+fn explicit_proxy_url_override() -> Option<String> {
+    std::env::var("TENSORLAKE_SANDBOX_PROXY_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn is_localhost(url: &str) -> bool {

--- a/crates/cli/src/commands/sbx/pty.rs
+++ b/crates/cli/src/commands/sbx/pty.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 use crate::auth::context::CliContext;
 use crate::cache::KvCache;
-use crate::commands::sbx::{sandbox_proxy_base, with_sandbox_headers};
+use crate::commands::sbx::{resolve_sandbox_proxy_target, with_sandbox_headers};
 use crate::config::files::normalize_api_url;
 use crate::error::{CliError, Result};
 use crate::output::table::new_table;
@@ -27,11 +27,10 @@ pub async fn list(
     output_json: bool,
 ) -> Result<()> {
     let client = ctx.client()?;
-    let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
+    let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
     let resp = with_sandbox_headers(
-        client.get(format!("{proxy_base}/api/v1/pty")),
-        sandbox_id,
-        host_override,
+        client.get(format!("{}/api/v1/pty", target.proxy_base)),
+        &target,
     )
     .send()
     .await
@@ -50,7 +49,7 @@ pub async fn list(
     let response: Value = resp.json().await.map_err(CliError::Http)?;
     let mut sessions = parse_session_listing(&response)?;
 
-    hydrate_session_tokens(ctx, sandbox_id, &mut sessions).await;
+    hydrate_session_tokens(ctx, &target.sandbox_id, &mut sessions).await;
 
     if sessions.is_empty() {
         if output_json {
@@ -98,19 +97,19 @@ pub async fn attach(
     session_id: &str,
     token: &str,
 ) -> Result<()> {
-    cache_pty_token(ctx, sandbox_id, session_id, token).await;
-    super::ssh::attach_to_session(ctx, sandbox_id, session_id, token, "pty attach").await
+    let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
+    cache_pty_token(ctx, &target.sandbox_id, session_id, token).await;
+    super::ssh::attach_to_session(ctx, &target.sandbox_id, session_id, token, "pty attach").await
 }
 
 pub async fn remove(ctx: &CliContext, sandbox_id: &str, session_ids: &[String]) -> Result<()> {
     let client = ctx.client()?;
-    let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
+    let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
 
     for session_id in session_ids {
         let resp = with_sandbox_headers(
-            client.delete(format!("{proxy_base}/api/v1/pty/{session_id}")),
-            sandbox_id,
-            host_override.clone(),
+            client.delete(format!("{}/api/v1/pty/{session_id}", target.proxy_base)),
+            &target,
         )
         .send()
         .await
@@ -127,7 +126,7 @@ pub async fn remove(ctx: &CliContext, sandbox_id: &str, session_ids: &[String]) 
             )));
         }
 
-        delete_cached_pty_token(ctx, sandbox_id, session_id).await;
+        delete_cached_pty_token(ctx, &target.sandbox_id, session_id).await;
     }
 
     if session_ids.len() == 1 {

--- a/crates/cli/src/commands/sbx/ssh.rs
+++ b/crates/cli/src/commands/sbx/ssh.rs
@@ -3,7 +3,10 @@ use std::time::Duration;
 
 use crate::auth::context::CliContext;
 use crate::commands::sbx::pty::cache_pty_token;
-use crate::commands::sbx::{parse_env_vars, sandbox_proxy_base, with_sandbox_headers};
+use crate::commands::sbx::{
+    ResolvedSandboxProxyTarget, parse_env_vars, resolve_sandbox_proxy_target,
+    with_sandbox_headers,
+};
 use crate::error::{CliError, Result};
 use reqwest::header::{AUTHORIZATION, HOST, HeaderMap, HeaderName, HeaderValue};
 use tokio::sync::mpsc;
@@ -31,7 +34,7 @@ pub async fn run(
     ensure_interactive_terminal("ssh")?;
 
     let env_dict = parse_env_vars(env)?;
-    let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
+    let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
     let client = ctx.client()?;
 
     // Get terminal size
@@ -73,10 +76,9 @@ pub async fn run(
 
     let pty_resp = with_sandbox_headers(
         client
-            .post(format!("{}/api/v1/pty", proxy_base))
+            .post(format!("{}/api/v1/pty", target.proxy_base))
             .json(&pty_payload),
-        sandbox_id,
-        host_override.clone(),
+        &target,
     )
     .send()
     .await
@@ -102,15 +104,17 @@ pub async fn run(
         .and_then(|v| v.as_str())
         .ok_or_else(|| CliError::Other(anyhow::anyhow!("missing token in PTY response")))?;
 
-    cache_pty_token(ctx, sandbox_id, session_id, token).await;
+    cache_pty_token(ctx, &target.sandbox_id, session_id, token).await;
+
+    let resolved_sandbox_id = target.sandbox_id.clone();
 
     attach_to_session_unchecked(
         ctx,
-        sandbox_id,
+        &resolved_sandbox_id,
         session_id,
         token,
         "ssh",
-        Some((proxy_base, host_override)),
+        Some(target),
     )
     .await
 }
@@ -138,8 +142,7 @@ fn ensure_interactive_terminal(command_name: &str) -> Result<()> {
 
 fn build_ws_headers(
     ctx: &CliContext,
-    sandbox_id: &str,
-    host_override: Option<&str>,
+    target: &ResolvedSandboxProxyTarget,
 ) -> Result<HeaderMap> {
     let mut ws_headers = HeaderMap::new();
 
@@ -167,7 +170,7 @@ fn build_ws_headers(
             })?,
         );
     }
-    if let Some(host) = host_override {
+    if let Some(host) = target.host_override.as_deref() {
         ws_headers.insert(
             HOST,
             HeaderValue::from_str(host)
@@ -176,8 +179,16 @@ fn build_ws_headers(
     } else {
         ws_headers.insert(
             HeaderName::from_static("x-tensorlake-sandbox-id"),
-            HeaderValue::from_str(sandbox_id).map_err(|e| {
+            HeaderValue::from_str(&target.sandbox_id).map_err(|e| {
                 CliError::Other(anyhow::anyhow!("invalid sandbox id header: {}", e))
+            })?,
+        );
+    }
+    if let Some(hint) = target.routing_hint.as_deref() {
+        ws_headers.insert(
+            HeaderName::from_static("x-tensorlake-route-hint"),
+            HeaderValue::from_str(hint).map_err(|e| {
+                CliError::Other(anyhow::anyhow!("invalid route hint header: {}", e))
             })?,
         );
     }
@@ -201,12 +212,14 @@ async fn attach_to_session_unchecked(
     session_id: &str,
     token: &str,
     _command_name: &str,
-    proxy_details: Option<(String, Option<String>)>,
+    target: Option<ResolvedSandboxProxyTarget>,
 ) -> Result<()> {
-    let (proxy_base, host_override) =
-        proxy_details.unwrap_or_else(|| sandbox_proxy_base(ctx, sandbox_id));
-    let ws_headers = build_ws_headers(ctx, sandbox_id, host_override.as_deref())?;
-    let ws_url = build_ws_url(&proxy_base, session_id, token);
+    let target = match target {
+        Some(target) => target,
+        None => resolve_sandbox_proxy_target(ctx, sandbox_id).await?,
+    };
+    let ws_headers = build_ws_headers(ctx, &target)?;
+    let ws_url = build_ws_url(&target.proxy_base, session_id, token);
 
     // Connect WebSocket
     use tokio_tungstenite::tungstenite;

--- a/crates/cli/src/commands/sbx/tunnel.rs
+++ b/crates/cli/src/commands/sbx/tunnel.rs
@@ -14,7 +14,7 @@ use tokio_tungstenite::tungstenite::{self, Message, client::IntoClientRequest};
 use url::Url;
 
 use crate::auth::context::CliContext;
-use crate::commands::sbx::sandbox_proxy_base;
+use crate::commands::sbx::{ResolvedSandboxProxyTarget, resolve_sandbox_proxy_target};
 use crate::error::{CliError, Result};
 
 const TUNNEL_BUFFER_SIZE: usize = 16 * 1024;
@@ -26,9 +26,9 @@ pub async fn run(
     listen_port: Option<u16>,
 ) -> Result<()> {
     let listen_port = listen_port.unwrap_or(remote_port);
-    let (proxy_base, host_override) = sandbox_proxy_base(ctx, sandbox_id);
-    let ws_url = build_tunnel_url(&proxy_base, remote_port)?;
-    let headers = build_proxy_headers(ctx, sandbox_id, host_override.as_deref())?;
+    let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
+    let ws_url = build_tunnel_url(&target.proxy_base, remote_port)?;
+    let headers = build_proxy_headers(ctx, &target)?;
 
     let listen_addr = format!("127.0.0.1:{listen_port}");
     let listener = TcpListener::bind(&listen_addr).await.map_err(|error| {
@@ -86,8 +86,7 @@ fn build_tunnel_url(proxy_base: &str, remote_port: u16) -> Result<String> {
 
 fn build_proxy_headers(
     ctx: &CliContext,
-    sandbox_id: &str,
-    host_override: Option<&str>,
+    target: &ResolvedSandboxProxyTarget,
 ) -> Result<HeaderMap> {
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -114,7 +113,7 @@ fn build_proxy_headers(
         );
     }
 
-    if let Some(host) = host_override {
+    if let Some(host) = target.host_override.as_deref() {
         headers.insert(
             HOST,
             HeaderValue::from_str(host)
@@ -123,8 +122,16 @@ fn build_proxy_headers(
     } else {
         headers.insert(
             HeaderName::from_static("x-tensorlake-sandbox-id"),
-            HeaderValue::from_str(sandbox_id).map_err(|error| {
+            HeaderValue::from_str(&target.sandbox_id).map_err(|error| {
                 CliError::Other(anyhow!("invalid sandbox id header: {}", error))
+            })?,
+        );
+    }
+    if let Some(hint) = target.routing_hint.as_deref() {
+        headers.insert(
+            HeaderName::from_static("x-tensorlake-route-hint"),
+            HeaderValue::from_str(hint).map_err(|error| {
+                CliError::Other(anyhow!("invalid route hint header: {}", error))
             })?,
         );
     }

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -19,7 +19,7 @@ use crate::{
     resolve_sandbox_lifecycle_url,
     sandboxes::{
         SandboxProxyClient, SandboxesClient,
-        models::{CreateSandboxRequest, CreateSandboxResources, ProcessInfo},
+        models::{CreateSandboxRequest, CreateSandboxResources, ProcessInfo, SandboxInfo},
     },
 };
 
@@ -340,18 +340,28 @@ where
     let routing_hint = created.routing_hint.clone();
 
     let result = async {
-        wait_for_sandbox_status(
+        let running_info = wait_for_sandbox_status(
             &sandboxes,
             &sandbox_id,
             "running",
             DEFAULT_SANDBOX_WAIT_TIMEOUT,
         )
         .await?;
+        let ingress_endpoint = created
+            .ingress_endpoint
+            .clone()
+            .or_else(|| running_info.ingress_endpoint.clone());
         emit(SandboxImageBuildEvent::Status(format!(
             "Rootfs builder sandbox {sandbox_id} is running"
         )));
 
-        let proxy = sandbox_proxy_client(&ctx, &client, &sandbox_id, routing_hint)?;
+        let proxy = sandbox_proxy_client(
+            &ctx,
+            &client,
+            &sandbox_id,
+            ingress_endpoint.as_deref(),
+            routing_hint,
+        )?;
         wait_for_proxy_ready(&proxy).await?;
         upload_build_inputs(
             &proxy,
@@ -524,7 +534,7 @@ async fn wait_for_sandbox_status(
     sandbox_id: &str,
     target_status: &str,
     timeout: Duration,
-) -> Result<String> {
+) -> Result<SandboxInfo> {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         if tokio::time::Instant::now() > deadline {
@@ -539,7 +549,7 @@ async fn wait_for_sandbox_status(
         let info = sandboxes.get(sandbox_id).await?;
         let current_status = info.status.clone();
         if current_status == target_status {
-            return Ok(current_status);
+            return Ok(info.into_inner());
         }
         if current_status == "terminated" && target_status != "terminated" {
             return Err(SandboxImageBuildError::other(format!(
@@ -718,8 +728,14 @@ fn sandbox_template_builds_path(ctx: &ResolvedBuildContext) -> String {
     )
 }
 
-fn sandbox_proxy_base(api_url: &str, sandbox_id: &str) -> (String, Option<String>) {
-    let proxy_url = resolve_proxy_url(api_url);
+fn sandbox_proxy_base(
+    api_url: &str,
+    sandbox_id: &str,
+    ingress_endpoint: Option<&str>,
+) -> (String, Option<String>) {
+    let proxy_url = ingress_endpoint
+        .map(str::to_string)
+        .unwrap_or_else(|| resolve_proxy_url(api_url));
 
     if let Ok(parsed) = url::Url::parse(&proxy_url) {
         let host = parsed.host_str().unwrap_or("");
@@ -754,9 +770,11 @@ fn sandbox_proxy_client(
     ctx: &ResolvedBuildContext,
     client: &Client,
     sandbox_id: &str,
+    ingress_endpoint: Option<&str>,
     routing_hint: Option<String>,
 ) -> Result<SandboxProxyClient> {
-    let (proxy_base, host_override) = sandbox_proxy_base(&ctx.api_url, sandbox_id);
+    let (proxy_base, host_override) =
+        sandbox_proxy_base(&ctx.api_url, sandbox_id, ingress_endpoint);
     let sandbox_id_header = host_override.is_none().then(|| sandbox_id.to_string());
     Ok(
         SandboxProxyClient::new(client.with_base_url(&proxy_base), host_override)

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -85,6 +85,8 @@ pub struct CreateSandboxResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing_hint: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ingress_endpoint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub termination_reason: Option<String>,
@@ -128,6 +130,8 @@ pub struct SandboxInfo {
     pub allow_unauthenticated_access: bool,
     #[serde(default)]
     pub exposed_ports: Option<Vec<u16>>,
+    #[serde(default)]
+    pub ingress_endpoint: Option<String>,
     #[serde(default)]
     pub sandbox_url: Option<String>,
 }

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.29"
+version = "0.5.30"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -2604,7 +2604,7 @@ fn parse_archived_sandboxes_params(
 ///
 /// Returns `(base_url, host_override, sandbox_id_header)`:
 /// - localhost: `base_url` = proxy URL as-is; `host_override` = `{sandbox_id}.local`; no sandbox_id header
-/// - cloud: `base_url` = apex proxy domain (no sandbox subdomain); `sandbox_id_header` = sandbox_id for `X-Tensorlake-Sandbox-Id` header
+/// - cloud: `base_url` = the server-selected ingress endpoint; `sandbox_id_header` = sandbox_id for `X-Tensorlake-Sandbox-Id` header
 fn resolve_proxy_target(
     proxy_url: &str,
     sandbox_id: &str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.29"
+version = "0.5.30"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/__init__.py
+++ b/src/tensorlake/sandbox/__init__.py
@@ -45,6 +45,7 @@ from .models import (
     SnapshotType,
     SnapshotWaitCondition,
     StdinMode,
+    sandbox_url_from_ingress_endpoint,
 )
 from .pty import AsyncPty, Pty
 from .sandbox import Sandbox
@@ -71,6 +72,7 @@ __all__ = [
     "NetworkConfig",
     "ArchivedSandboxInfo",
     "ListArchivedSandboxesResponse",
+    "sandbox_url_from_ingress_endpoint",
     # Snapshot models
     "SnapshotStatus",
     "SnapshotType",

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -316,6 +316,7 @@ class AsyncSandboxClient:
         port_access = SandboxPortAccess(
             allow_unauthenticated_access=traced.allow_unauthenticated_access,
             exposed_ports=sorted(set(traced.exposed_ports or [])),
+            ingress_endpoint=traced.ingress_endpoint,
             sandbox_url=traced.sandbox_url,
         )
         return Traced(traced.trace_id, port_access)
@@ -622,15 +623,20 @@ class AsyncSandboxClient:
         sandbox_identifier = _resolve_sandbox_identifier(
             identifier, sandbox_id, parameter_name="identifier"
         )
+        info: Traced[SandboxInfo] | None = None
+        proxy_sandbox_id = sandbox_identifier
         if proxy_url is None:
-            proxy_url = self._resolve_proxy_url()
+            info = await self.get(sandbox_identifier)
+            proxy_url = info.ingress_endpoint or self._resolve_proxy_url()
+            proxy_sandbox_id = info.sandbox_id
+            routing_hint = routing_hint or info.routing_hint
         proxy_rust_client = self._rust_client.connect_proxy(
             proxy_url=proxy_url,
-            sandbox_id=sandbox_identifier,
+            sandbox_id=proxy_sandbox_id,
             routing_hint=routing_hint,
         )
         sandbox = AsyncSandbox(
-            identifier=sandbox_identifier,
+            identifier=proxy_sandbox_id,
             proxy_url=proxy_url,
             api_key=self._api_key,
             organization_id=self._organization_id,
@@ -639,6 +645,10 @@ class AsyncSandboxClient:
             _proxy_rust_client=proxy_rust_client,
         )
         sandbox._lifecycle_client = self
+        if info is not None:
+            sandbox._sandbox_id = info.sandbox_id
+            sandbox._cached_info = info.value
+            sandbox._trace_id = info.trace_id
         return sandbox
 
     async def create_and_connect(
@@ -681,7 +691,9 @@ class AsyncSandboxClient:
         if result.status == SandboxStatus.RUNNING:
             sandbox = await self.connect(
                 result.sandbox_id,
-                proxy_url=proxy_url,
+                proxy_url=proxy_url
+                or result.ingress_endpoint
+                or self._resolve_proxy_url(),
                 routing_hint=result.routing_hint,
             )
             sandbox._sandbox_id = result.sandbox_id
@@ -691,6 +703,7 @@ class AsyncSandboxClient:
             sandbox._cached_info = SandboxInfo.model_construct(
                 sandbox_id=result.sandbox_id,
                 status=result.status,
+                ingress_endpoint=result.ingress_endpoint,
                 name=result.name or requested_name,
             )
             return sandbox
@@ -710,7 +723,9 @@ class AsyncSandboxClient:
             if info.status == SandboxStatus.RUNNING:
                 sandbox = await self.connect(
                     result.sandbox_id,
-                    proxy_url=proxy_url,
+                    proxy_url=proxy_url
+                    or info.ingress_endpoint
+                    or self._resolve_proxy_url(),
                     routing_hint=info.routing_hint,
                 )
                 sandbox._sandbox_id = info.sandbox_id

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -601,6 +601,7 @@ class SandboxClient:
         port_access = SandboxPortAccess(
             allow_unauthenticated_access=traced.allow_unauthenticated_access,
             exposed_ports=sorted(set(traced.exposed_ports or [])),
+            ingress_endpoint=traced.ingress_endpoint,
             sandbox_url=traced.sandbox_url,
         )
         return Traced(traced.trace_id, port_access)
@@ -1107,17 +1108,22 @@ class SandboxClient:
             parameter_name="identifier",
         )
 
+        info: Traced[SandboxInfo] | None = None
+        proxy_sandbox_id = sandbox_identifier
         if proxy_url is None:
-            proxy_url = self._resolve_proxy_url()
+            info = self.get(sandbox_identifier)
+            proxy_url = info.ingress_endpoint or self._resolve_proxy_url()
+            proxy_sandbox_id = info.sandbox_id
+            routing_hint = routing_hint or info.routing_hint
 
         proxy_rust_client = self._rust_client.connect_proxy(
             proxy_url=proxy_url,
-            sandbox_id=sandbox_identifier,
+            sandbox_id=proxy_sandbox_id,
             routing_hint=routing_hint,
         )
 
         sandbox = Sandbox(
-            identifier=sandbox_identifier,
+            identifier=proxy_sandbox_id,
             proxy_url=proxy_url,
             api_key=self._api_key,
             organization_id=self._organization_id,
@@ -1126,6 +1132,10 @@ class SandboxClient:
             _proxy_rust_client=proxy_rust_client,
         )
         sandbox._lifecycle_client = self
+        if info is not None:
+            sandbox._sandbox_id = info.sandbox_id
+            sandbox._cached_info = info.value
+            sandbox._trace_id = info.trace_id
         return sandbox
 
     def create_and_connect(
@@ -1212,7 +1222,9 @@ class SandboxClient:
         if result.status == SandboxStatus.RUNNING:
             sandbox = self.connect(
                 result.sandbox_id,
-                proxy_url=proxy_url,
+                proxy_url=proxy_url
+                or result.ingress_endpoint
+                or self._resolve_proxy_url(),
                 routing_hint=result.routing_hint,
             )
             sandbox._sandbox_id = result.sandbox_id
@@ -1222,6 +1234,7 @@ class SandboxClient:
             sandbox._cached_info = SandboxInfo.model_construct(
                 sandbox_id=result.sandbox_id,
                 status=result.status,
+                ingress_endpoint=result.ingress_endpoint,
                 name=result.name or requested_name,
             )
             return sandbox
@@ -1241,11 +1254,13 @@ class SandboxClient:
             if info.status == SandboxStatus.RUNNING:
                 sandbox = self.connect(
                     result.sandbox_id,
-                    proxy_url=proxy_url,
+                    proxy_url=proxy_url
+                    or info.ingress_endpoint
+                    or self._resolve_proxy_url(),
                     routing_hint=info.routing_hint,
                 )
                 sandbox._sandbox_id = info.sandbox_id
-                sandbox._cached_info = info
+                sandbox._cached_info = info.value
                 sandbox._owns_sandbox = True
                 sandbox._lifecycle_client = self
                 sandbox._trace_id = result.trace_id

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -3,8 +3,41 @@
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Annotated, Any
+from urllib.parse import urlparse, urlunparse
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+
+_SANDBOX_MANAGEMENT_PORT = 9501
+
+
+def sandbox_url_from_ingress_endpoint(
+    ingress_endpoint: str,
+    sandbox_id: str,
+    port: int | None = None,
+) -> str:
+    """Build a public sandbox URL from a server-provided ingress endpoint.
+
+    ``port`` omitted or ``9501`` returns the sandbox management URL:
+    ``https://<sandbox-id>.<ingress-host>``. User ports use the public
+    ``<port>-<sandbox-id>.<ingress-host>`` form.
+    """
+
+    parsed = urlparse(ingress_endpoint)
+    if parsed.scheme not in ("http", "https") or parsed.hostname is None:
+        raise ValueError("ingress_endpoint must be an absolute http(s) URL")
+
+    label = (
+        sandbox_id
+        if port is None or port == _SANDBOX_MANAGEMENT_PORT
+        else f"{port}-{sandbox_id}"
+    )
+    host = parsed.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = f"{label}.{host}"
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse((parsed.scheme, netloc, "", "", "", ""))
 
 
 def _parse_timestamp(v: int | float | datetime | None) -> datetime | None:
@@ -204,6 +237,7 @@ class CreateSandboxResponse(BaseModel):
     sandbox_id: str
     status: SandboxStatus
     routing_hint: str | None = None
+    ingress_endpoint: str | None = None
     name: str | None = None
     termination_reason: str | None = None
     error_details: Any | None = None
@@ -230,10 +264,24 @@ class SandboxInfo(BaseModel):
     name: str | None = None
     allow_unauthenticated_access: bool = False
     exposed_ports: list[int] | None = None
+    ingress_endpoint: str | None = None
     sandbox_url: str | None = None
     routing_hint: str | None = None
 
     model_config = {"populate_by_name": True}
+
+    def url_for_port(self, port: int = _SANDBOX_MANAGEMENT_PORT) -> str | None:
+        """Return the public URL for the management API or an exposed user port."""
+
+        if self.ingress_endpoint is not None:
+            return sandbox_url_from_ingress_endpoint(
+                self.ingress_endpoint,
+                self.sandbox_id,
+                port,
+            )
+        if port == _SANDBOX_MANAGEMENT_PORT:
+            return self.sandbox_url
+        return None
 
 
 class SandboxPortAccess(BaseModel):
@@ -241,6 +289,7 @@ class SandboxPortAccess(BaseModel):
 
     allow_unauthenticated_access: bool = False
     exposed_ports: list[int] = Field(default_factory=list)
+    ingress_endpoint: str | None = None
     sandbox_url: str | None = None
 
 

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -297,9 +297,9 @@ class Sandbox:
     ) -> "Sandbox":
         """Attach to an existing sandbox and return a connected handle.
 
-        Returns immediately without contacting the server. Call ``sandbox.info()``
-        to fetch the current state on demand.  Does **not** auto-resume a
-        suspended sandbox — call ``sandbox.resume()`` explicitly.
+        When ``proxy_url`` is omitted, resolves the sandbox first so the handle
+        uses the correct cloud/region ingress endpoint. Does **not** auto-resume
+        a suspended sandbox — call ``sandbox.resume()`` explicitly.
 
         Args:
             sandbox_id: ID or name of the sandbox to attach to.

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -14,6 +14,14 @@ from tensorlake.sandbox.client import SandboxClient
 from tensorlake.sandbox.exceptions import SandboxError
 
 
+class _FakeRustProxyClient:
+    def __init__(self, base_url: str):
+        self._base_url = base_url
+
+    def base_url(self):
+        return self._base_url
+
+
 class _FakeRustClient:
     def __init__(self):
         self.create_request_json = None
@@ -22,6 +30,7 @@ class _FakeRustClient:
         self.create_snapshot_calls: list[tuple[str, str | None]] = []
         self.suspend_calls: list[str] = []
         self.resume_calls: list[str] = []
+        self.connect_proxy_calls: list[dict] = []
 
     def close(self):
         return None
@@ -31,6 +40,16 @@ class _FakeRustClient:
 
     def resume_sandbox(self, sandbox_id):
         self.resume_calls.append(sandbox_id)
+
+    def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):
+        self.connect_proxy_calls.append(
+            {
+                "proxy_url": proxy_url,
+                "sandbox_id": sandbox_id,
+                "routing_hint": routing_hint,
+            }
+        )
+        return _FakeRustProxyClient(proxy_url)
 
     def create_snapshot(self, sandbox_id, snapshot_type=None):
         self.create_snapshot_calls.append((sandbox_id, snapshot_type))
@@ -91,6 +110,7 @@ class _FakeRustClient:
   "secret_names": [],
   "allow_unauthenticated_access": false,
   "exposed_ports": [8080],
+  "ingress_endpoint": "https://sandbox.us-east-1.aws.tensorlake.ai",
   "sandbox_url": "https://sbx-1.sandbox.tensorlake.ai"
 }
 """,
@@ -115,6 +135,7 @@ class _FakeRustClient:
                 "allow_unauthenticated_access", False
             ),
             "exposed_ports": payload.get("exposed_ports", []),
+            "ingress_endpoint": "https://sandbox.us-east-1.aws.tensorlake.ai",
             "sandbox_url": f"https://{sandbox_id}.sandbox.tensorlake.ai",
         }
         return ("trace-update-sandbox", json.dumps(response))
@@ -159,6 +180,26 @@ class TestSandboxClientRustBackend(unittest.TestCase):
 
         with self.assertRaisesRegex(SandboxError, "Provide only one of"):
             client.connect("stable-name", sandbox_id="sbx-123")
+
+    def test_connect_resolves_ingress_endpoint_when_proxy_url_omitted(self):
+        client = SandboxClient(api_url="https://api.tensorlake.ai", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        sandbox = client.connect("stable-name")
+
+        self.assertEqual(fake.last_get_sandbox_id, "stable-name")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": None,
+                }
+            ],
+        )
+        self.assertEqual(sandbox.sandbox_id, "sbx-1")
 
     def test_create_uses_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
@@ -217,6 +258,40 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         ):
             client.create_and_connect(image="tensorlake/missing-image")
 
+    def test_create_and_connect_uses_ingress_endpoint_from_running_response(self):
+        class _RunningRustClient(_FakeRustClient):
+            def create_sandbox(self, request_json):
+                self.create_request_json = request_json
+                return (
+                    "trace-create-sandbox",
+                    json.dumps(
+                        {
+                            "sandbox_id": "sbx-1",
+                            "status": "running",
+                            "routing_hint": "hint-1",
+                            "ingress_endpoint": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                        }
+                    ),
+                )
+
+        client = SandboxClient(api_url="https://api.tensorlake.ai", api_key="k")
+        fake = _RunningRustClient()
+        client._rust_client = fake
+
+        sandbox = client.create_and_connect(image="python:3.11")
+
+        self.assertEqual(sandbox.sandbox_id, "sbx-1")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": "hint-1",
+                }
+            ],
+        )
+
     def test_list_uses_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         client._rust_client = _FakeRustClient()
@@ -255,6 +330,10 @@ class TestSandboxClientRustBackend(unittest.TestCase):
 
         self.assertFalse(access.allow_unauthenticated_access)
         self.assertEqual(access.exposed_ports, [8080])
+        self.assertEqual(
+            access.ingress_endpoint,
+            "https://sandbox.us-east-1.aws.tensorlake.ai",
+        )
         self.assertEqual(access.sandbox_url, "https://sbx-1.sandbox.tensorlake.ai")
 
     def test_expose_ports_merges_existing_ports(self):

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -14,6 +14,14 @@ from tensorlake.sandbox.async_client import AsyncSandboxClient
 from tensorlake.sandbox.exceptions import SandboxError
 
 
+class _FakeAsyncRustProxyClient:
+    def __init__(self, base_url: str):
+        self._base_url = base_url
+
+    def base_url(self):
+        return self._base_url
+
+
 class _FakeAsyncRustClient:
     def __init__(self):
         self.create_request_json: str = ""
@@ -35,7 +43,7 @@ class _FakeAsyncRustClient:
                 "routing_hint": routing_hint,
             }
         )
-        return None
+        return _FakeAsyncRustProxyClient(proxy_url)
 
     async def suspend_sandbox_async(self, *, sandbox_id):
         self.suspend_calls.append(sandbox_id)
@@ -107,6 +115,7 @@ class _FakeAsyncRustClient:
   "secret_names": [],
   "allow_unauthenticated_access": false,
   "exposed_ports": [8080],
+  "ingress_endpoint": "https://sandbox.us-east-1.aws.tensorlake.ai",
   "sandbox_url": "https://sbx-1.sandbox.tensorlake.ai"
 }
 """,
@@ -131,6 +140,7 @@ class _FakeAsyncRustClient:
                 "allow_unauthenticated_access", False
             ),
             "exposed_ports": payload.get("exposed_ports", []),
+            "ingress_endpoint": "https://sandbox.us-east-1.aws.tensorlake.ai",
             "sandbox_url": f"https://{sandbox_id}.sandbox.tensorlake.ai",
         }
         return ("trace-update-sandbox", json.dumps(response))
@@ -219,6 +229,25 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(SandboxError, "Provide only one of"):
             await client.connect("stable-name", sandbox_id="sbx-123")
 
+    async def test_connect_resolves_ingress_endpoint_when_proxy_url_omitted(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        sandbox = await client.connect("stable-name")
+
+        self.assertEqual(fake.last_get_sandbox_id, "stable-name")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": None,
+                }
+            ],
+        )
+        self.assertEqual(sandbox.sandbox_id, "sbx-1")
+
     async def test_create_uses_rust_backend(self):
         fake = _FakeAsyncRustClient()
         client = _make_client(fake)
@@ -276,6 +305,39 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         ):
             await client.create_and_connect(image="tensorlake/missing-image")
 
+    async def test_create_and_connect_uses_ingress_endpoint_from_running_response(self):
+        class _RunningRustClient(_FakeAsyncRustClient):
+            async def create_sandbox_async(self, *, request_json):
+                self.create_request_json = request_json
+                return (
+                    "trace-create-sandbox",
+                    json.dumps(
+                        {
+                            "sandbox_id": "sbx-1",
+                            "status": "running",
+                            "routing_hint": "hint-1",
+                            "ingress_endpoint": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                        }
+                    ),
+                )
+
+        fake = _RunningRustClient()
+        client = _make_client(fake)
+
+        sandbox = await client.create_and_connect(image="python:3.11")
+
+        self.assertEqual(sandbox.sandbox_id, "sbx-1")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": "hint-1",
+                }
+            ],
+        )
+
     async def test_create_and_connect_polls_until_running(self):
         fake = _StatusSequenceRustClient(["pending", "running"])
         client = _make_client(fake)
@@ -326,6 +388,10 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(access.allow_unauthenticated_access)
         self.assertEqual(access.exposed_ports, [8080])
+        self.assertEqual(
+            access.ingress_endpoint,
+            "https://sandbox.us-east-1.aws.tensorlake.ai",
+        )
         self.assertEqual(access.sandbox_url, "https://sbx-1.sandbox.tensorlake.ai")
 
     async def test_expose_ports_merges_existing_ports(self):

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.29",
+      "version": "0.5.30",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.29",
+  "version": "0.5.30",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -243,6 +243,7 @@ export class SandboxClient {
     return {
       allowUnauthenticatedAccess: info.allowUnauthenticatedAccess ?? false,
       exposedPorts: dedupeAndSortPorts(info.exposedPorts ?? []),
+      ingressEndpoint: info.ingressEndpoint,
       sandboxUrl: info.sandboxUrl,
     };
   }
@@ -568,6 +569,9 @@ export class SandboxClient {
       organizationId: this.organizationId,
       projectId: this.projectId,
       routingHint,
+      resolveProxyInfo: proxyUrl == null
+        ? async (currentIdentifier) => this.get(currentIdentifier)
+        : undefined,
     });
   }
 
@@ -592,8 +596,16 @@ export class SandboxClient {
       : await this.create(options);
     const requestedName = options?.poolId != null ? null : options?.name ?? null;
 
-    const finishConnect = (routingHint: string | undefined, name: string | null | undefined) => {
-      const sandbox = this.connect(result.sandboxId, options?.proxyUrl, routingHint);
+    const finishConnect = (
+      routingHint: string | undefined,
+      name: string | null | undefined,
+      ingressEndpoint: string | undefined,
+    ) => {
+      const sandbox = this.connect(
+        result.sandboxId,
+        options?.proxyUrl ?? ingressEndpoint,
+        routingHint,
+      );
       sandbox._setOwner(this);
       sandbox.traceId = result.traceId;
       sandbox._setLifecycleIdentifier(result.sandboxId);
@@ -605,7 +617,7 @@ export class SandboxClient {
     // and a short-lived routing hint. Use it immediately to skip an extra poll RTT
     // and let the proxy route the first request without a placement lookup.
     if (result.status === SandboxStatus.RUNNING) {
-      return finishConnect(result.routingHint, result.name);
+      return finishConnect(result.routingHint, result.name, result.ingressEndpoint);
     }
     if (
       result.status === SandboxStatus.SUSPENDED ||
@@ -624,7 +636,7 @@ export class SandboxClient {
     while (Date.now() < deadline) {
       const info = await this.get(result.sandboxId);
       if (info.status === SandboxStatus.RUNNING) {
-        return finishConnect(info.routingHint, info.name);
+        return finishConnect(info.routingHint, info.name, info.ingressEndpoint);
       }
       if (
         info.status === SandboxStatus.SUSPENDED ||

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -8,6 +8,7 @@ export { CloudClient } from "./cloud-client.js";
 export { APIClient } from "./api-client.js";
 export { createSandboxImage } from "./sandbox-image.js";
 export { Image, dockerfileContent, ImageBuildOperationType } from "./image.js";
+export { sandboxUrlFromIngressEndpoint } from "./url.js";
 
 export type {
   PtyDataHandler,

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -108,6 +108,7 @@ export interface CreateSandboxResponse {
   sandboxId: string;
   status: SandboxStatus;
   routingHint?: string;
+  ingressEndpoint?: string;
   name?: string | null;
   terminationReason?: string;
   errorDetails?: unknown;
@@ -133,6 +134,7 @@ export interface SandboxInfo {
   name?: string;
   allowUnauthenticatedAccess?: boolean;
   exposedPorts?: number[];
+  ingressEndpoint?: string;
   sandboxUrl?: string;
   routingHint?: string;
 }
@@ -140,6 +142,7 @@ export interface SandboxInfo {
 export interface SandboxPortAccess {
   allowUnauthenticatedAccess: boolean;
   exposedPorts: number[];
+  ingressEndpoint?: string;
   sandboxUrl?: string;
 }
 
@@ -383,6 +386,9 @@ export interface SandboxOptions {
   organizationId?: string;
   projectId?: string;
   routingHint?: string;
+  resolveProxyInfo?: (
+    identifier: string,
+  ) => Promise<SandboxInfo & { readonly traceId: string }>;
 }
 
 export interface CreateAndConnectOptions extends CreateSandboxOptions {

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -5,7 +5,7 @@ import {
 } from "./desktop.js";
 import * as defaults from "./defaults.js";
 import { SandboxError } from "./errors.js";
-import { type Traced, HttpClient } from "./http.js";
+import { type HttpRequestOptions, type Traced, HttpClient } from "./http.js";
 import {
   type CheckpointOptions,
   type CommandResult,
@@ -44,6 +44,146 @@ import { resolveProxyTarget } from "./url.js";
 import WebSocket, { type RawData } from "ws";
 
 const DEFAULT_PROCESS_USER = "tl-user";
+
+class SandboxProxyConnection {
+  baseUrl = "";
+  wsHeaders: Record<string, string> = {};
+
+  private http: HttpClient;
+  private resolveProxyInfo?: (
+    identifier: string,
+  ) => Promise<Traced<SandboxInfo>>;
+  private resolvePromise: Promise<void> | null = null;
+  private routingHint?: string;
+
+  constructor(
+    private readonly sandbox: Sandbox,
+    private readonly options: SandboxOptions,
+  ) {
+    this.routingHint = options.routingHint;
+    this.http = this.configureProxy(
+      options.proxyUrl ?? defaults.SANDBOX_PROXY_URL,
+      options.sandboxId,
+      options.routingHint,
+    );
+    this.resolveProxyInfo = options.resolveProxyInfo;
+  }
+
+  async ensureResolved(): Promise<void> {
+    if (this.resolveProxyInfo == null) {
+      return;
+    }
+    if (this.resolvePromise != null) {
+      return this.resolvePromise;
+    }
+
+    this.resolvePromise = this.resolveProxyInfo(this.sandbox._getLifecycleIdentifier())
+      .then((info) => {
+        this.resolveProxyInfo = undefined;
+        this.sandbox.traceId = info.traceId;
+        this.sandbox._setLifecycleIdentifier(info.sandboxId);
+        this.sandbox._setName(info.name ?? null);
+        this.routingHint = this.routingHint ?? info.routingHint;
+        const proxyUrl =
+          info.ingressEndpoint ?? this.options.proxyUrl ?? defaults.SANDBOX_PROXY_URL;
+        const nextHttp = this.configureProxy(proxyUrl, info.sandboxId, this.routingHint);
+        this.http.close();
+        this.http = nextHttp;
+      })
+      .finally(() => {
+        this.resolvePromise = null;
+      });
+
+    return this.resolvePromise;
+  }
+
+  async requestJson<T>(
+    method: string,
+    path: string,
+    options?: {
+      body?: unknown;
+      headers?: Record<string, string>;
+      signal?: AbortSignal;
+    },
+  ): Promise<Traced<T>> {
+    await this.ensureResolved();
+    return this.http.requestJson<T>(method, path, options);
+  }
+
+  async requestBytes(
+    method: string,
+    path: string,
+    options?: {
+      body?: BodyInit | Uint8Array | ArrayBuffer | null;
+      contentType?: string;
+      headers?: Record<string, string>;
+      signal?: AbortSignal;
+    },
+  ): Promise<Traced<Uint8Array>> {
+    await this.ensureResolved();
+    return this.http.requestBytes(method, path, options);
+  }
+
+  async requestStream(
+    method: string,
+    path: string,
+    options?: { signal?: AbortSignal; json?: unknown },
+  ): Promise<Traced<ReadableStream<Uint8Array>>> {
+    await this.ensureResolved();
+    return this.http.requestStream(method, path, options);
+  }
+
+  async requestResponse(
+    method: string,
+    path: string,
+    options?: HttpRequestOptions,
+  ): Promise<Traced<Response>> {
+    await this.ensureResolved();
+    return this.http.requestResponse(method, path, options);
+  }
+
+  close(): void {
+    this.http.close();
+  }
+
+  private configureProxy(
+    proxyUrl: string,
+    sandboxId: string,
+    routingHint?: string,
+  ): HttpClient {
+    const { baseUrl, hostHeader, sandboxIdHeader } = resolveProxyTarget(
+      proxyUrl,
+      sandboxId,
+    );
+    this.baseUrl = baseUrl;
+    this.wsHeaders = {};
+    if (this.options.apiKey) {
+      this.wsHeaders.Authorization = `Bearer ${this.options.apiKey}`;
+    }
+    if (this.options.organizationId) {
+      this.wsHeaders["X-Forwarded-Organization-Id"] = this.options.organizationId;
+    }
+    if (this.options.projectId) {
+      this.wsHeaders["X-Forwarded-Project-Id"] = this.options.projectId;
+    }
+    if (hostHeader) {
+      this.wsHeaders.Host = hostHeader;
+    }
+    if (sandboxIdHeader) {
+      this.wsHeaders["X-Tensorlake-Sandbox-Id"] = sandboxIdHeader;
+    }
+
+    return new HttpClient({
+      baseUrl,
+      apiKey: this.options.apiKey,
+      organizationId: this.options.organizationId,
+      projectId: this.options.projectId,
+      hostHeader,
+      sandboxIdHeader,
+      routingHint,
+    });
+  }
+}
 
 function processUserPayload(
   user: ProcessUser | undefined,
@@ -307,9 +447,8 @@ function sendPtyFrame(socket: WebSocket, frame: Buffer): Promise<void> {
 export class Sandbox {
   readonly sandboxId: string;
   traceId: string | null = null;
-  private readonly http: HttpClient;
-  private readonly baseUrl: string;
-  private readonly wsHeaders: Record<string, string>;
+  private readonly proxy: SandboxProxyConnection;
+  private readonly http: SandboxProxyConnection;
   private ownsSandbox = false;
   private lifecycleClient: SandboxClient | null = null;
   private lifecycleIdentifier: string;
@@ -318,36 +457,16 @@ export class Sandbox {
   constructor(options: SandboxOptions) {
     this.sandboxId = options.sandboxId;
     this.lifecycleIdentifier = options.sandboxId;
+    this.proxy = new SandboxProxyConnection(this, options);
+    this.http = this.proxy;
+  }
 
-    const proxyUrl = options.proxyUrl ?? defaults.SANDBOX_PROXY_URL;
-    const { baseUrl, hostHeader, sandboxIdHeader } = resolveProxyTarget(proxyUrl, options.sandboxId);
-    this.baseUrl = baseUrl;
-    this.wsHeaders = {};
-    if (options.apiKey) {
-      this.wsHeaders.Authorization = `Bearer ${options.apiKey}`;
-    }
-    if (options.organizationId) {
-      this.wsHeaders["X-Forwarded-Organization-Id"] = options.organizationId;
-    }
-    if (options.projectId) {
-      this.wsHeaders["X-Forwarded-Project-Id"] = options.projectId;
-    }
-    if (hostHeader) {
-      this.wsHeaders.Host = hostHeader;
-    }
-    if (sandboxIdHeader) {
-      this.wsHeaders["X-Tensorlake-Sandbox-Id"] = sandboxIdHeader;
-    }
+  private get baseUrl(): string {
+    return this.proxy.baseUrl;
+  }
 
-    this.http = new HttpClient({
-      baseUrl,
-      apiKey: options.apiKey,
-      organizationId: options.organizationId,
-      projectId: options.projectId,
-      hostHeader,
-      sandboxIdHeader,
-      routingHint: options.routingHint,
-    });
+  private get wsHeaders(): Record<string, string> {
+    return this.proxy.wsHeaders;
   }
 
   get name(): string | null {
@@ -362,6 +481,11 @@ export class Sandbox {
   /** @internal Used by lifecycle operations to pin to canonical sandbox ID. */
   _setLifecycleIdentifier(identifier: string): void {
     this.lifecycleIdentifier = identifier;
+  }
+
+  /** @internal Used by the lazy proxy resolver. */
+  _getLifecycleIdentifier(): string {
+    return this.lifecycleIdentifier;
   }
 
   /** @internal Used by SandboxClient.createAndConnect to set ownership. */
@@ -392,9 +516,9 @@ export class Sandbox {
   /**
    * Attach to an existing sandbox and return a connected handle.
    *
-   * Returns immediately without contacting the server. Call `sandbox.info()`
-   * to fetch the current state on demand. Does **not** auto-resume a suspended
-   * sandbox — call `sandbox.resume()` explicitly.
+   * When `proxyUrl` is omitted, resolves the sandbox first so the handle uses
+   * the correct cloud/region ingress endpoint. Does **not** auto-resume a
+   * suspended sandbox — call `sandbox.resume()` explicitly.
    */
   static async connect(
     options: ConnectOptions & Partial<SandboxClientOptions>,
@@ -867,6 +991,7 @@ export class Sandbox {
     token: string,
     options?: PtyConnectionOptions,
   ): Promise<Pty> {
+    await this.proxy.ensureResolved();
     const wsUrl = new URL(this.ptyWsUrl(sessionId, token));
     const authToken = wsUrl.searchParams.get("token") ?? token;
 
@@ -899,6 +1024,7 @@ export class Sandbox {
     remotePort: number,
     options?: CreateTunnelOptions,
   ): Promise<TcpTunnel> {
+    await this.proxy.ensureResolved();
     return TcpTunnel.listen({
       baseUrl: this.baseUrl,
       wsHeaders: this.wsHeaders,
@@ -911,6 +1037,7 @@ export class Sandbox {
 
   /** Connect to a sandbox VNC session for programmatic desktop control. */
   async connectDesktop(options?: ConnectDesktopOptions): Promise<Desktop> {
+    await this.proxy.ensureResolved();
     const port = options?.port ?? 5901;
     const connectTimeout = options?.connectTimeout ?? 10;
 

--- a/typescript/src/url.ts
+++ b/typescript/src/url.ts
@@ -84,6 +84,26 @@ export function resolveProxyTarget(
 }
 
 /**
+ * Build a public sandbox URL from a server-provided ingress endpoint.
+ *
+ * `port` omitted or `9501` returns the management URL:
+ * `https://<sandbox-id>.<ingress-host>`. User ports use the public
+ * `<port>-<sandbox-id>.<ingress-host>` form.
+ */
+export function sandboxUrlFromIngressEndpoint(
+  ingressEndpoint: string,
+  sandboxId: string,
+  port = 9501,
+): string {
+  const parsed = new URL(ingressEndpoint);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("ingressEndpoint must be an absolute http(s) URL");
+  }
+  const label = port === 9501 ? sandboxId : `${port}-${sandboxId}`;
+  return `${parsed.protocol}//${label}.${parsed.host}`;
+}
+
+/**
  * Derive the sandbox lifecycle URL from the API URL.
  *
  * Transforms `api.X` → `sandbox.X` for cloud. Returns the URL unchanged for

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -179,6 +179,7 @@ describe("SandboxClient", () => {
             secret_names: [],
             allow_unauthenticated_access: true,
             exposed_ports: [8080, 3000],
+            ingress_endpoint: "https://sandbox.us-east-1.aws.tensorlake.ai",
             sandbox_url: "https://sbx-ports.sandbox.tensorlake.ai",
           }),
           { status: 200 },
@@ -189,6 +190,7 @@ describe("SandboxClient", () => {
       const info = await client.get("sbx-ports");
       expect(info.allowUnauthenticatedAccess).toBe(true);
       expect(info.exposedPorts).toEqual([8080, 3000]);
+      expect(info.ingressEndpoint).toBe("https://sandbox.us-east-1.aws.tensorlake.ai");
       expect(info.sandboxUrl).toBe("https://sbx-ports.sandbox.tensorlake.ai");
       client.close();
     });
@@ -338,6 +340,7 @@ describe("SandboxClient", () => {
             secret_names: [],
             allow_unauthenticated_access: false,
             exposed_ports: [8080],
+            ingress_endpoint: "https://sandbox.us-east-1.aws.tensorlake.ai",
             sandbox_url: "https://sbx-1.sandbox.tensorlake.ai",
           }),
           { status: 200 },
@@ -348,6 +351,7 @@ describe("SandboxClient", () => {
       const access = await client.getPortAccess("sbx-1");
       expect(access.allowUnauthenticatedAccess).toBe(false);
       expect(access.exposedPorts).toEqual([8080]);
+      expect(access.ingressEndpoint).toBe("https://sandbox.us-east-1.aws.tensorlake.ai");
       expect(access.sandboxUrl).toBe("https://sbx-1.sandbox.tensorlake.ai");
       client.close();
     });
@@ -552,6 +556,29 @@ describe("SandboxClient", () => {
   });
 
   describe("createAndConnect", () => {
+    it("uses ingress endpoint from running create response", async () => {
+      mockFetch(() =>
+        new Response(
+          JSON.stringify({
+            sandbox_id: "sbx-1",
+            status: "running",
+            routing_hint: "hint-1",
+            ingress_endpoint: "https://sandbox.us-east-1.aws.tensorlake.ai",
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const client = SandboxClient.forCloud({ apiKey: "key" });
+      const sandbox = await client.createAndConnect();
+      expect(sandbox.sandboxId).toBe("sbx-1");
+      expect((sandbox as unknown as { baseUrl: string }).baseUrl).toBe(
+        "https://sandbox.us-east-1.aws.tensorlake.ai",
+      );
+      sandbox.close();
+      client.close();
+    });
+
     it("includes sandbox errorDetails in startup failures", async () => {
       vi.mocked(undici.fetch)
         .mockResolvedValueOnce(
@@ -837,6 +864,49 @@ describe("SandboxClient", () => {
       const client = SandboxClient.forLocalhost();
       const sandbox = client.connect("sbx-1");
       expect(sandbox.sandboxId).toBe("sbx-1");
+      sandbox.close();
+      client.close();
+    });
+
+    it("resolves ingress endpoint before first proxy request", async () => {
+      const calls: string[] = [];
+      mockFetch((url, init) => {
+        calls.push(url);
+        if (url.includes("/sandboxes/stable-name")) {
+          return new Response(
+            JSON.stringify({
+              sandbox_id: "sbx-1",
+              status: "running",
+              ingress_endpoint: "https://sandbox.us-east-1.aws.tensorlake.ai",
+              routing_hint: "hint-1",
+            }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/api/v1/health")) {
+          expect(url).toBe(
+            "https://sandbox.us-east-1.aws.tensorlake.ai/api/v1/health",
+          );
+          expect(
+            (init?.headers as Record<string, string>)["X-Tensorlake-Sandbox-Id"],
+          ).toBe("sbx-1");
+          expect(
+            (init?.headers as Record<string, string>)["X-Tensorlake-Route-Hint"],
+          ).toBe("hint-1");
+          return new Response(JSON.stringify({ healthy: true }), { status: 200 });
+        }
+        return new Response("", { status: 404 });
+      });
+
+      const client = SandboxClient.forCloud({ apiKey: "key" });
+      const sandbox = client.connect("stable-name");
+      const health = await sandbox.health();
+
+      expect(health.healthy).toBe(true);
+      expect(calls[0]).toContain("/sandboxes/stable-name");
+      expect(calls[1]).toBe(
+        "https://sandbox.us-east-1.aws.tensorlake.ai/api/v1/health",
+      );
       sandbox.close();
       client.close();
     });

--- a/typescript/tests/url.test.ts
+++ b/typescript/tests/url.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, afterEach, vi } from "vitest";
-import { isLocalhost, resolveProxyUrl, resolveProxyTarget, lifecyclePath } from "../src/url.js";
+import {
+  isLocalhost,
+  resolveProxyUrl,
+  resolveProxyTarget,
+  lifecyclePath,
+  sandboxUrlFromIngressEndpoint,
+} from "../src/url.js";
 
 describe("isLocalhost", () => {
   it("returns true for localhost", () => {
@@ -87,6 +93,36 @@ describe("resolveProxyTarget", () => {
   it("strips trailing slash from localhost", () => {
     const result = resolveProxyTarget("http://localhost:9443/", "sbx-123");
     expect(result.baseUrl).toBe("http://localhost:9443");
+  });
+});
+
+describe("sandboxUrlFromIngressEndpoint", () => {
+  it("builds management URL from ingress endpoint", () => {
+    expect(
+      sandboxUrlFromIngressEndpoint(
+        "https://sandbox.us-east-1.aws.tensorlake.ai",
+        "sbx-123",
+      ),
+    ).toBe("https://sbx-123.sandbox.us-east-1.aws.tensorlake.ai");
+  });
+
+  it("builds user port URL from ingress endpoint", () => {
+    expect(
+      sandboxUrlFromIngressEndpoint(
+        "https://sandbox.us-east-1.aws.tensorlake.ai",
+        "sbx-123",
+        8080,
+      ),
+    ).toBe("https://8080-sbx-123.sandbox.us-east-1.aws.tensorlake.ai");
+  });
+
+  it("preserves ingress endpoint port", () => {
+    expect(
+      sandboxUrlFromIngressEndpoint(
+        "https://sandbox.us-east-1.aws.tensorlake.ai:9443",
+        "sbx-123",
+      ),
+    ).toBe("https://sbx-123.sandbox.us-east-1.aws.tensorlake.ai:9443");
   });
 });
 


### PR DESCRIPTION
Summary
- Add ingress_endpoint / ingressEndpoint to sandbox API models across Python, Rust, and TypeScript SDKs.
- Resolve sandbox metadata before connect when no explicit proxy URL is provided so SDKs choose the correct regional sandbox proxy.
- Add helpers for deriving wildcard sandbox URLs from server-provided ingress endpoints.

Validation
- cargo fmt
- poetry run black src/tensorlake/sandbox tests/sandbox/test_client_rust_backend.py tests/sandbox/test_client_rust_backend_async.py
- poetry run python -m unittest tests.sandbox.test_client_rust_backend tests.sandbox.test_client_rust_backend_async
- cargo test -p tensorlake sandboxes::models --lib
- cargo check -p tensorlake
- npm run typecheck
- git diff --check

Local tooling notes
- npm test -- tests/url.test.ts tests/client.test.ts: url tests pass, client suite fails before running with ReferenceError: File is not defined from undici in this Node/runtime.
- npm run lint -- ...: blocked because ESLint v9 cannot find eslint.config.* in the repo.