### PR TITLE
Increase SDK request timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.24"
+version = "0.5.26"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.24"
+version = "0.5.26"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.24"
+version = "0.5.26"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.24"
+version = "0.5.26"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.26"
+version = "0.5.28"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.26"
+version = "0.5.28"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.26"
+version = "0.5.28"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.26"
+version = "0.5.28"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.26"
+version = "0.5.28"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -12,6 +12,7 @@ use std::{
     pin::Pin,
     result::Result,
     sync::{Arc, Once},
+    time::Duration,
 };
 
 use crate::error::SdkError;
@@ -91,6 +92,7 @@ pub struct ClientBuilder {
     organization_id: Option<String>,
     project_id: Option<String>,
     user_agent: Option<String>,
+    timeout: Option<Duration>,
 }
 
 impl ClientBuilder {
@@ -111,6 +113,7 @@ impl ClientBuilder {
             organization_id: None,
             project_id: None,
             user_agent: None,
+            timeout: None,
         }
     }
 
@@ -122,6 +125,12 @@ impl ClientBuilder {
     /// by SDK language.
     pub fn user_agent(mut self, ua: &str) -> Self {
         self.user_agent = Some(ua.to_string());
+        self
+    }
+
+    /// Set the total timeout for each HTTP request.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
         self
     }
 
@@ -178,7 +187,7 @@ impl ClientBuilder {
             .user_agent
             .as_deref()
             .unwrap_or(concat!("tensorlake-rust-sdk/", env!("CARGO_PKG_VERSION")));
-        let base_client = new_base_client(&default_headers, ua)?;
+        let base_client = new_base_client(&default_headers, ua, self.timeout)?;
         let mut builder = ReqwestClientBuilder::new(base_client.clone());
 
         for middleware in &self.middlewares {
@@ -418,13 +427,20 @@ fn ensure_rustls_provider() {
     });
 }
 
-fn new_base_client(headers: &HeaderMap, user_agent: &str) -> Result<reqwest::Client, SdkError> {
+fn new_base_client(
+    headers: &HeaderMap,
+    user_agent: &str,
+    timeout: Option<Duration>,
+) -> Result<reqwest::Client, SdkError> {
     ensure_rustls_provider();
 
-    let client = reqwest::Client::builder()
+    let mut builder = reqwest::Client::builder()
         .user_agent(user_agent)
-        .default_headers(headers.clone())
-        .build()?;
+        .default_headers(headers.clone());
+    if let Some(timeout) = timeout {
+        builder = builder.timeout(timeout);
+    }
+    let client = builder.build()?;
     Ok(client)
 }
 

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.26"
+version = "0.5.28"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -38,7 +38,7 @@ create_exception!(_cloud_sdk, CloudApiClientError, PyException);
 create_exception!(_cloud_sdk, CloudSandboxClientError, PyException);
 create_exception!(_cloud_sdk, CloudDocumentAIClientError, PyException);
 
-const DEFAULT_HTTP_REQUEST_TIMEOUT_SEC: f64 = 5.0;
+const DEFAULT_HTTP_REQUEST_TIMEOUT_SEC: f64 = 300.0;
 
 // Single tokio runtime for the whole process: pyo3-async-runtimes' runtime,
 // which `future_into_py` already drives. Routing sync `block_on` through here
@@ -538,7 +538,7 @@ pub struct CloudSandboxClient {
 #[pymethods]
 impl CloudSandboxClient {
     #[new]
-    #[pyo3(signature = (api_url, api_key=None, organization_id=None, project_id=None, namespace=None, user_agent=None))]
+    #[pyo3(signature = (api_url, api_key=None, organization_id=None, project_id=None, namespace=None, user_agent=None, request_timeout_sec=None))]
     fn new(
         api_url: String,
         api_key: Option<String>,
@@ -546,6 +546,7 @@ impl CloudSandboxClient {
         project_id: Option<String>,
         namespace: Option<String>,
         user_agent: Option<String>,
+        request_timeout_sec: Option<f64>,
     ) -> PyResult<Self> {
         let lifecycle_url = resolve_sandbox_lifecycle_url(&api_url);
         let mut builder = ClientBuilder::new(&lifecycle_url);
@@ -561,6 +562,9 @@ impl CloudSandboxClient {
 
         if let Some(ua) = user_agent.as_deref() {
             builder = builder.user_agent(ua);
+        }
+        if let Some(seconds) = request_timeout_sec {
+            builder = builder.timeout(duration_from_seconds("request_timeout_sec", seconds)?);
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.27"
+version = "0.5.28"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/applications/request_context/http_client/context.py
+++ b/src/tensorlake/applications/request_context/http_client/context.py
@@ -17,8 +17,7 @@ from .progress import FunctionProgressHTTPClient
 from .state import RequestStateHTTPClient
 from .transport import RequestContextHTTPTransport
 
-# No long running HTTP requests are done in request context HTTP client.
-_DEFAULT_HTTP_REQUEST_TIMEOUT_SEC: float = 5.0
+_DEFAULT_HTTP_REQUEST_TIMEOUT_SEC: float = 300.0
 
 
 class RequestContextHTTPClient(RequestContext):

--- a/src/tensorlake/sandbox/_defaults.py
+++ b/src/tensorlake/sandbox/_defaults.py
@@ -14,7 +14,7 @@ SANDBOX_PROXY_URL: str = os.getenv(
 
 # Sandbox operations (create, get, list) may take several seconds when the
 # server is performing container scheduling or image pulls.
-DEFAULT_HTTP_TIMEOUT_SEC: float = 30.0
+DEFAULT_HTTP_TIMEOUT_SEC: float = 300.0
 
 # Retry configuration for transient errors (connection failures, 429/502/503/504).
 MAX_RETRIES: int = 3

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -107,6 +107,7 @@ class AsyncSandboxClient:
                 project_id=project_id,
                 namespace=namespace,
                 user_agent=USER_AGENT,
+                request_timeout_sec=_defaults.DEFAULT_HTTP_TIMEOUT_SEC,
             )
         except Exception as e:
             _raise_as_sandbox_error(e)

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -236,6 +236,7 @@ class SandboxClient:
                 project_id=self._project_id,
                 namespace=self._namespace,
                 user_agent=USER_AGENT,
+                request_timeout_sec=_defaults.DEFAULT_HTTP_TIMEOUT_SEC,
             )
         except Exception as e:
             _raise_as_sandbox_error(e)

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from tensorlake.sandbox import (
+    _defaults,
     PoolInUseError,
     SandboxNotFoundError,
     SnapshotStatus,
@@ -120,6 +121,27 @@ class _FakeRustClient:
 
 
 class TestSandboxClientRustBackend(unittest.TestCase):
+    def test_constructor_passes_default_request_timeout_to_rust_backend(self):
+        class _RecordingRustClient:
+            kwargs = None
+
+            def __init__(self, **kwargs):
+                type(self).kwargs = kwargs
+
+            def close(self):
+                return None
+
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClient",
+            _RecordingRustClient,
+        ):
+            SandboxClient(api_url="http://localhost:8900", api_key="k", _internal=True)
+
+        self.assertEqual(
+            _RecordingRustClient.kwargs["request_timeout_sec"],
+            _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
+        )
+
     def test_connect_accepts_sandbox_name(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
 

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -3,12 +3,12 @@ import unittest
 from unittest.mock import patch
 
 from tensorlake.sandbox import (
-    _defaults,
     PoolInUseError,
     SandboxNotFoundError,
     SnapshotStatus,
     SnapshotType,
     SnapshotWaitCondition,
+    _defaults,
 )
 from tensorlake.sandbox.client import SandboxClient
 from tensorlake.sandbox.exceptions import SandboxError

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from tensorlake.sandbox import (
+    _defaults,
     PoolInUseError,
     SandboxNotFoundError,
     SnapshotStatus,
@@ -175,6 +176,29 @@ class _StatusSequenceRustClient(_FakeAsyncRustClient):
 
 
 class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
+    async def test_constructor_passes_default_request_timeout_to_rust_backend(self):
+        class _RecordingRustClient:
+            kwargs = None
+
+            def __init__(self, **kwargs):
+                type(self).kwargs = kwargs
+
+            def close(self):
+                return None
+
+        with patch(
+            "tensorlake.sandbox.async_client.RustCloudSandboxClient",
+            _RecordingRustClient,
+        ):
+            AsyncSandboxClient(
+                api_url="http://localhost:8900", api_key="k", _internal=True
+            )
+
+        self.assertEqual(
+            _RecordingRustClient.kwargs["request_timeout_sec"],
+            _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
+        )
+
     async def test_connect_accepts_sandbox_name(self):
         client = _make_client()
 

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -3,12 +3,12 @@ import unittest
 from unittest.mock import patch
 
 from tensorlake.sandbox import (
-    _defaults,
     PoolInUseError,
     SandboxNotFoundError,
     SnapshotStatus,
     SnapshotType,
     SnapshotWaitCondition,
+    _defaults,
 )
 from tensorlake.sandbox.async_client import AsyncSandboxClient
 from tensorlake.sandbox.exceptions import SandboxError

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.25",
+  "version": "0.5.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.25",
+      "version": "0.5.28",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.27",
+  "version": "0.5.28",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/defaults.ts
+++ b/typescript/src/defaults.ts
@@ -8,7 +8,7 @@ export const NAMESPACE = process.env.INDEXIFY_NAMESPACE ?? "default";
 export const SANDBOX_PROXY_URL =
   process.env.TENSORLAKE_SANDBOX_PROXY_URL ?? "https://sandbox.tensorlake.ai";
 
-export const DEFAULT_HTTP_TIMEOUT_MS = 30_000;
+export const DEFAULT_HTTP_TIMEOUT_MS = 300_000;
 export const MAX_RETRIES = 3;
 export const RETRY_BACKOFF_MS = 500;
 export const RETRYABLE_STATUS_CODES = new Set([429, 502, 503, 504]);


### PR DESCRIPTION
## Summary
- increase TypeScript and Python SDK HTTP request defaults to 300 seconds
- plumb Python sandbox lifecycle timeout through the Rust ClientBuilder and PyO3 binding
- add sync and async Python tests that assert the timeout reaches the Rust client

## Verification
- npm run typecheck (typescript)
- cargo fmt --check
- cargo check -p tensorlake-rust-cloud-sdk-py
- cargo check -p tensorlake
- PYTHONPATH=src python3 -m unittest tests.sandbox.test_client_rust_backend.TestSandboxClientRustBackend.test_constructor_passes_default_request_timeout_to_rust_backend tests.sandbox.test_client_rust_backend_async.TestAsyncSandboxClientRustBackend.test_constructor_passes_default_request_timeout_to_rust_backend