### PR TITLE
Document private container registry auth for sandbox image builds

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -621,7 +621,18 @@ enum ImageCommands {
         public: bool,
     },
 
-    /// Register a sandbox image from a Dockerfile
+    /// Register a sandbox image from a Dockerfile.
+    ///
+    /// Private base images: to pull `FROM` or `COPY --from=` an image in a
+    /// private container registry, provide credentials in the standard Docker
+    /// config file — `$DOCKER_CONFIG/config.json`, defaulting to
+    /// `~/.docker/config.json`. Populate it with `docker login` (or a
+    /// daemonless tool like `skopeo`/`crane`/`oras login`, or by writing the
+    /// JSON directly). Set `DOCKER_CONFIG` to point at a directory to scope
+    /// credentials to a single build in CI without touching global docker
+    /// state. Credential helpers (`credsStore`/`credHelpers`) are resolved on
+    /// this machine and inlined before the build; the target registry must
+    /// appear under `auths` or `credHelpers`.
     Create {
         /// Path to the Dockerfile
         dockerfile_path: String,

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -125,6 +125,14 @@ class Image:
 
         Returns:
             The registered sandbox template response as a dict.
+
+        Private container registries:
+            If the image's ``base_image`` (or a ``COPY --from=``) references a
+            private registry, provide credentials via the standard Docker config
+            file (``$DOCKER_CONFIG/config.json``, default
+            ``~/.docker/config.json``) — e.g. ``docker login``. See
+            :func:`tensorlake.image.sandbox_builder.build_sandbox_image` for the
+            full details.
         """
         from .sandbox_builder import build_sandbox_image
 

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -7,10 +7,22 @@ the snapshot as a named sandbox template
 (``POST /platform/v1/.../sandbox-templates``).
 
 This is the programmatic backend for :meth:`Image.build` and the
-``tl sbx image create`` CLI command. The Rust core owns parsing, the
-Dockerfile-instruction allowlist (``ARG``/``ONBUILD``/``SHELL``/``USER`` are
-rejected) and ignored-set warnings (``CMD``/``ENTRYPOINT``/``EXPOSE``/
-``HEALTHCHECK``/``LABEL``/``STOPSIGNAL``/``VOLUME``).
+``tl sbx image create`` CLI command. The Rust core owns parsing and the
+Dockerfile-instruction allowlist:
+
+* **Rejected** (the build errors): ``ONBUILD``, ``SHELL``, ``USER``.
+* **Accepted but not materialized** (warned; image-config metadata discarded by
+  ``docker build --output type=tar``): ``CMD``, ``ENTRYPOINT``, ``EXPOSE``,
+  ``HEALTHCHECK``, ``LABEL``, ``STOPSIGNAL``, ``VOLUME``.
+* **Supported**: ``FROM``, ``RUN``, ``WORKDIR``, ``ENV``, ``COPY``, ``ADD``,
+  multi-stage builds (``FROM ... AS``, ``COPY --from=``), and top-level ``ARG``
+  (accepted and forwarded to ``docker build``, though the SDK does not
+  substitute ``ARG`` values at parse time).
+
+Private registries: when a Dockerfile pulls ``FROM`` / ``COPY --from=`` an image
+in a private container registry, credentials are read from the standard Docker
+config file (``$DOCKER_CONFIG/config.json``, default ``~/.docker/config.json``)
+and shipped to the builder. See :func:`build_sandbox_image` for details.
 """
 
 from __future__ import annotations
@@ -215,6 +227,23 @@ def build_sandbox_image(
         SandboxImageBuildError: The build failed during parsing, provisioning,
             materialization, or registration.
         TypeError: ``source`` is neither an ``Image`` nor a path.
+
+    Private container registries:
+        To pull ``FROM`` or ``COPY --from=`` an image in a private registry,
+        provide credentials in the standard Docker config file —
+        ``$DOCKER_CONFIG/config.json``, defaulting to ``~/.docker/config.json``.
+        Populate it with ``docker login`` (or a daemonless tool such as
+        ``skopeo``/``crane``/``oras login``, or by writing the JSON directly).
+        Set the ``DOCKER_CONFIG`` environment variable to point at a directory
+        to scope credentials to a single build in CI without touching global
+        docker state. Basic auth (including an API key/token used as the
+        password) and identity tokens are supported; credential helpers
+        (``credsStore``/``credHelpers``) are resolved on this machine and
+        inlined before the build. The target registry must appear under
+        ``auths`` or ``credHelpers`` in the config. Credentials are uploaded
+        only into the ephemeral builder sandbox (not sent to the
+        sandbox-template API, not persisted server-side) and are not baked into
+        the resulting image.
     """
     if emit is None:
         emit = _stderr_emit if verbose else _noop_emit
@@ -291,6 +320,10 @@ def build_sandbox_application_image(
     Unlike :func:`build_sandbox_image`, this uses the Applications Dockerfile
     wrapper so deployed functions get the SDK runtime, default workdir, and
     deploy-time build environment variables.
+
+    Private container registries are supported the same way as
+    :func:`build_sandbox_image` — provide credentials via
+    ``$DOCKER_CONFIG/config.json`` (default ``~/.docker/config.json``).
     """
     if emit is None:
         emit = _stderr_emit if verbose else _noop_emit

--- a/typescript/src/image.ts
+++ b/typescript/src/image.ts
@@ -139,6 +139,11 @@ export class Image {
    *
    * Materializes the image in a build sandbox, snapshots the filesystem,
    * and registers the snapshot as a named sandbox template.
+   *
+   * Private container registries: if `baseImage` (or a `COPY --from=`)
+   * references a private registry, provide credentials via the standard Docker
+   * config file (`$DOCKER_CONFIG/config.json`, default `~/.docker/config.json`)
+   * — e.g. `docker login`. See {@link createSandboxImage} for full details.
    */
   async build(
     options: CreateSandboxImageOptions = {},

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -10,9 +10,21 @@ import { Image, dockerfileContent } from "./image.js";
  * Renders the source to a Dockerfile (for `Image` inputs) and hands the
  * Dockerfile path/text + context to the Rust core via `@tensorlake/native`,
  * which parses, validates, materializes, and registers the image. The Rust
- * core owns parsing, the Dockerfile-instruction allowlist
- * (`ARG`/`ONBUILD`/`SHELL`/`USER` are rejected) and ignored-set warnings
- * (`CMD`/`ENTRYPOINT`/`EXPOSE`/`HEALTHCHECK`/`LABEL`/`STOPSIGNAL`/`VOLUME`).
+ * core owns parsing and the Dockerfile-instruction allowlist:
+ *
+ * - Rejected (the build errors): `ONBUILD`, `SHELL`, `USER`.
+ * - Accepted but not materialized (warned; image-config metadata discarded by
+ *   `docker build --output type=tar`): `CMD`, `ENTRYPOINT`, `EXPOSE`,
+ *   `HEALTHCHECK`, `LABEL`, `STOPSIGNAL`, `VOLUME`.
+ * - Supported: `FROM`, `RUN`, `WORKDIR`, `ENV`, `COPY`, `ADD`, multi-stage
+ *   builds (`FROM ... AS`, `COPY --from=`), and top-level `ARG` (forwarded to
+ *   `docker build`; values are not substituted at parse time).
+ *
+ * Private registries: when a Dockerfile pulls `FROM` / `COPY --from=` an image
+ * in a private container registry, credentials are read from the standard
+ * Docker config file (`$DOCKER_CONFIG/config.json`, default
+ * `~/.docker/config.json`) and shipped to the builder. See
+ * {@link createSandboxImage}.
  */
 
 export interface CreateSandboxImageOptions {
@@ -195,6 +207,24 @@ function eventToEmitDict(event: NativeBindingEvent): Record<string, unknown> {
 
 // --- Public API ------------------------------------------------------------
 
+/**
+ * Build a sandbox image from a Dockerfile path or an {@link Image} and register
+ * it as a named sandbox template.
+ *
+ * Private container registries: to pull `FROM` / `COPY --from=` an image in a
+ * private registry, provide credentials in the standard Docker config file —
+ * `$DOCKER_CONFIG/config.json`, defaulting to `~/.docker/config.json`. Populate
+ * it with `docker login` (or a daemonless tool like `skopeo`/`crane`/`oras
+ * login`, or by writing the JSON directly). Set the `DOCKER_CONFIG` environment
+ * variable to scope credentials to a single build in CI without touching global
+ * docker state. Basic auth (including an API key/token used as the password)
+ * and identity tokens are supported; credential helpers
+ * (`credsStore`/`credHelpers`) are resolved on this machine and inlined before
+ * the build, and the target registry must appear under `auths`/`credHelpers`.
+ * Credentials are uploaded only into the ephemeral builder sandbox (not sent to
+ * the sandbox-template API, not persisted server-side) and are not baked into
+ * the resulting image.
+ */
 export async function createSandboxImage(
   source: SandboxImageSource,
   options: CreateSandboxImageOptions = {},


### PR DESCRIPTION
## What

Documents how to authenticate **private container registry** pulls (`FROM` / `COPY --from=`) in sandbox and application image builds, and corrects stale Dockerfile-instruction claims in the SDK docstrings/CLI help.

The credential mechanism already exists in the shared Rust builder (it reads `$DOCKER_CONFIG/config.json`, resolves helpers host-side, and ships inline `auths` to the builder sandbox) — it was just undocumented. **No behavior change.**

## Surfaces updated

- **CLI help** (`crates/cli/src/main.rs`, `tl sbx image create`): private-registry note pointing at `$DOCKER_CONFIG/config.json`.
- **Python docstrings** (`sandbox_builder.py`, `image.py`): private-registry section on `build_sandbox_image` / `build_sandbox_application_image` / `Image.build`.
- **TypeScript docstrings** (`sandbox-image.ts`, `image.ts`): same on `createSandboxImage` / `Image.build`.

## Accuracy fixes

The docstrings claimed `ARG` was rejected and (implicitly) that multi-stage was unsupported. Corrected to match `crates/cloud-sdk/src/sandbox_images.rs`:

- **Rejected** (build errors): `ONBUILD`, `SHELL`, `USER`.
- **Accepted, not materialized** (warned): `CMD`, `ENTRYPOINT`, `EXPOSE`, `HEALTHCHECK`, `LABEL`, `STOPSIGNAL`, `VOLUME`.
- **Supported**: `FROM`/`RUN`/`WORKDIR`/`ENV`/`COPY`/`ADD`, multi-stage, and top-level `ARG` (forwarded, not substituted at parse time).

## Test plan

- `cargo build -p tensorlake-cli` and `tl sbx image create --help` renders the new guidance.
- Python files byte-compile; doc-comment-only TS change.
- End-to-end private-registry build validated via a new test in `indexify-deployment` (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
