### PR TITLE
[codex] Align sandbox request timeout behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.30"
+version = "0.5.31"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.30"
+version = "0.5.31"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.30"
+version = "0.5.31"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.30"
+version = "0.5.31"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.30"
+version = "0.5.31"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -17,6 +17,8 @@ use std::{
 
 use crate::error::SdkError;
 
+pub const REQUEST_TIMEOUT_HEADER: &str = "X-Tensorlake-Request-Timeout-Ms";
+
 /// Wraps any SDK operation result with the W3C `trace_id` so callers can
 /// correlate the request with its server-side spans in Datadog APM or any
 /// other OTEL-compatible backend.
@@ -80,6 +82,10 @@ pub struct Client {
     client: ClientWithMiddleware,
     /// Default headers configured on the underlying clients.
     default_headers: HeaderMap,
+    /// User-Agent configured on the underlying client.
+    user_agent: String,
+    /// Total request timeout configured for this client.
+    timeout: Option<Duration>,
 }
 
 /// Builder for creating a [`Client`] with a fluent API.
@@ -201,6 +207,8 @@ impl ClientBuilder {
             base_client,
             client,
             default_headers,
+            user_agent: ua.to_string(),
+            timeout: self.timeout,
         })
     }
 }
@@ -227,6 +235,64 @@ impl Client {
             base_client: self.base_client.clone(),
             client,
             default_headers: self.default_headers.clone(),
+            user_agent: self.user_agent.clone(),
+            timeout: self.timeout,
+        }
+    }
+
+    /// Create a new client for a different base URL without a total request timeout.
+    ///
+    /// Sandbox proxy clients use this for long-running process and follow streams,
+    /// where the server-side process timeout is independent from lifecycle HTTP deadlines.
+    pub fn with_base_url_without_timeout(&self, new_url: &str) -> Result<Self, SdkError> {
+        self.with_base_url_and_timeout(new_url, None)
+    }
+
+    /// Create a new client for a different base URL with an explicit total request timeout.
+    pub fn with_base_url_and_timeout(
+        &self,
+        new_url: &str,
+        timeout: Option<Duration>,
+    ) -> Result<Self, SdkError> {
+        let base_client = new_base_client(&self.default_headers, &self.user_agent, timeout)?;
+        let client = ReqwestClientBuilder::new(base_client.clone()).build();
+        Ok(Self {
+            base_url: new_url.to_string(),
+            base_client,
+            client,
+            default_headers: self.default_headers.clone(),
+            user_agent: self.user_agent.clone(),
+            timeout,
+        })
+    }
+
+    fn prepare_request(&self, request: &mut Request) {
+        let (traceparent, _) = generate_traceparent();
+        if let Ok(value) = traceparent.parse::<HeaderValue>() {
+            request.headers_mut().insert("traceparent", value);
+        }
+        self.insert_request_timeout_header(request);
+    }
+
+    fn prepare_traced_request(&self, request: &mut Request) -> String {
+        let (traceparent, trace_id) = generate_traceparent();
+        if let Ok(value) = traceparent.parse::<HeaderValue>() {
+            request.headers_mut().insert("traceparent", value);
+        }
+        self.insert_request_timeout_header(request);
+        trace_id
+    }
+
+    fn insert_request_timeout_header(&self, request: &mut Request) {
+        let Some(timeout) = self.timeout else {
+            return;
+        };
+        let millis = timeout.as_millis();
+        if millis == 0 {
+            return;
+        }
+        if let Ok(value) = HeaderValue::from_str(&millis.to_string()) {
+            request.headers_mut().insert(REQUEST_TIMEOUT_HEADER, value);
         }
     }
 
@@ -234,10 +300,7 @@ impl Client {
     /// correlation. Use [`execute_traced`] or [`execute_json`] when you need the
     /// `trace_id` returned to the caller.
     pub async fn execute(&self, mut request: Request) -> Result<Response, SdkError> {
-        let (traceparent, _) = generate_traceparent();
-        if let Ok(value) = traceparent.parse::<HeaderValue>() {
-            request.headers_mut().insert("traceparent", value);
-        }
+        self.prepare_request(&mut request);
         let response = self.client.execute(request).await?;
         self.handle_response(response).await
     }
@@ -245,10 +308,7 @@ impl Client {
     /// Execute an HTTP request without mapping non-success statuses to [`SdkError`].
     /// Injects a W3C `traceparent` header for server-side correlation.
     pub async fn execute_raw(&self, mut request: Request) -> Result<Response, SdkError> {
-        let (traceparent, _) = generate_traceparent();
-        if let Ok(value) = traceparent.parse::<HeaderValue>() {
-            request.headers_mut().insert("traceparent", value);
-        }
+        self.prepare_request(&mut request);
         let response = self.client.execute(request).await?;
         Ok(response)
     }
@@ -257,10 +317,7 @@ impl Client {
     /// the raw response alongside the `trace_id`. Use this when you need the
     /// `trace_id` but want to handle the response body yourself.
     pub async fn execute_traced(&self, mut request: Request) -> Result<Traced<Response>, SdkError> {
-        let (traceparent, trace_id) = generate_traceparent();
-        if let Ok(value) = traceparent.parse::<HeaderValue>() {
-            request.headers_mut().insert("traceparent", value);
-        }
+        let trace_id = self.prepare_traced_request(&mut request);
         let response = self.client.execute(request).await?;
         let response = self.handle_response(response).await?;
         Ok(Traced::new(trace_id, response))
@@ -277,6 +334,30 @@ impl Client {
         request: Request,
     ) -> Result<Traced<T>, SdkError> {
         let traced = self.execute_traced(request).await?;
+        Self::decode_traced_json(traced).await
+    }
+
+    /// Execute an HTTP request and deserialize JSON if the status is success or
+    /// explicitly listed in `allowed_statuses`.
+    pub async fn execute_json_allow_status<T: DeserializeOwned>(
+        &self,
+        mut request: Request,
+        allowed_statuses: &[StatusCode],
+    ) -> Result<Traced<T>, SdkError> {
+        let trace_id = self.prepare_traced_request(&mut request);
+        let response = self.client.execute(request).await?;
+        let response =
+            if response.status().is_success() || allowed_statuses.contains(&response.status()) {
+                response
+            } else {
+                self.handle_response(response).await?
+            };
+        Self::decode_traced_json(Traced::new(trace_id, response)).await
+    }
+
+    async fn decode_traced_json<T: DeserializeOwned>(
+        traced: Traced<Response>,
+    ) -> Result<Traced<T>, SdkError> {
         let trace_id = traced.trace_id.clone();
         let bytes = traced.into_inner().bytes().await?;
         let jd = &mut serde_json::Deserializer::from_slice(bytes.as_ref());
@@ -300,13 +381,19 @@ impl Client {
         T: DeserializeOwned,
     {
         let (traceparent, trace_id) = generate_traceparent();
-        let response = self
+        let mut request_builder = self
             .base_client
             .get(self.base_url.clone() + path)
             .header(ACCEPT, "text/event-stream")
-            .header("traceparent", traceparent)
-            .send()
-            .await?;
+            .header("traceparent", traceparent);
+        if let Some(timeout) = self.timeout {
+            let millis = timeout.as_millis();
+            if millis > 0 {
+                request_builder =
+                    request_builder.header(REQUEST_TIMEOUT_HEADER, millis.to_string());
+            }
+        }
+        let response = request_builder.send().await?;
 
         let stream = response
             .bytes_stream()

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -4,6 +4,7 @@ pub mod models;
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::Method;
+use reqwest::StatusCode;
 use reqwest::header::{ACCEPT, CONTENT_LENGTH};
 use serde_json::Value;
 use std::path::Path;
@@ -71,13 +72,17 @@ impl SandboxesClient {
         let req = self
             .client
             .build_post_json_request(Method::POST, &uri, request)?;
-        self.client.execute_json(req).await
+        self.client
+            .execute_json_allow_status(req, &[StatusCode::GATEWAY_TIMEOUT])
+            .await
     }
 
     pub async fn claim(&self, pool_id: &str) -> Result<Traced<CreateSandboxResponse>, SdkError> {
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}/sandboxes"));
         let req = self.client.request(Method::POST, &uri).build()?;
-        self.client.execute_json(req).await
+        self.client
+            .execute_json_allow_status(req, &[StatusCode::GATEWAY_TIMEOUT])
+            .await
     }
 
     pub async fn get(&self, sandbox_id: &str) -> Result<Traced<SandboxInfo>, SdkError> {

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.30"
+version = "0.5.31"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -586,27 +586,27 @@ impl CloudSandboxClient {
 
     fn create_sandbox(&self, request_json: String) -> PyResult<(String, String)> {
         let request: CreateSandboxRequest = parse_json_payload(&request_json)?;
-        self.run_with_retry(5, move |client| {
-            let request = request.clone();
-            async move {
+        let client = self.client.clone();
+        shared_runtime()
+            .block_on(async move {
                 let traced = client.create(&request).await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
                 Ok((trace_id, json))
-            }
-        })
+            })
+            .map_err(into_sandbox_py_error)
     }
 
     fn claim_sandbox(&self, pool_id: String) -> PyResult<(String, String)> {
-        self.run_with_retry(5, move |client| {
-            let pool_id = pool_id.clone();
-            async move {
+        let client = self.client.clone();
+        shared_runtime()
+            .block_on(async move {
                 let traced = client.claim(&pool_id).await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
                 Ok((trace_id, json))
-            }
-        })
+            })
+            .map_err(into_sandbox_py_error)
     }
 
     fn get_sandbox_json(&self, sandbox_id: String) -> PyResult<(String, String)> {
@@ -828,12 +828,10 @@ impl CloudSandboxClient {
         let request: CreateSandboxRequest = parse_json_payload(&request_json)?;
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| {
-                let request = request.clone();
-                async move { c.create(&request).await }
-            })
-            .await
-            .map_err(into_sandbox_py_error)?;
+            let traced = client
+                .create(&request)
+                .await
+                .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
@@ -847,12 +845,10 @@ impl CloudSandboxClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| {
-                let pool_id = pool_id.clone();
-                async move { c.claim(&pool_id).await }
-            })
-            .await
-            .map_err(into_sandbox_py_error)?;
+            let traced = client
+                .claim(&pool_id)
+                .await
+                .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
@@ -1182,16 +1178,30 @@ impl CloudSandboxClient {
     /// pool. All proxy clients created this way reuse the same underlying reqwest::Client,
     /// so HTTP/2 connections can be coalesced: only the first sandbox in a session pays the
     /// TCP+TLS handshake cost.
-    #[pyo3(signature = (proxy_url, sandbox_id, routing_hint=None))]
+    #[pyo3(signature = (proxy_url, sandbox_id, routing_hint=None, request_timeout_sec=None))]
     fn connect_proxy(
         &self,
         proxy_url: String,
         sandbox_id: String,
         routing_hint: Option<String>,
+        request_timeout_sec: Option<f64>,
     ) -> PyResult<CloudSandboxProxyClient> {
         let (base_url, host_override, sandbox_id_header) =
             resolve_proxy_target(&proxy_url, &sandbox_id)?;
-        let shared_client = self.client.http_client().with_base_url(&base_url);
+        let shared_client = if let Some(seconds) = request_timeout_sec {
+            self.client
+                .http_client()
+                .with_base_url_and_timeout(
+                    &base_url,
+                    Some(duration_from_seconds("request_timeout_sec", seconds)?),
+                )
+                .map_err(into_sandbox_py_error)?
+        } else {
+            self.client
+                .http_client()
+                .with_base_url_without_timeout(&base_url)
+                .map_err(into_sandbox_py_error)?
+        };
         let proxy = SandboxProxyClient::new(shared_client, host_override)
             .with_sandbox_id(sandbox_id_header)
             .with_routing_hint(routing_hint);
@@ -1227,7 +1237,7 @@ pub struct CloudSandboxProxyClient {
 #[pymethods]
 impl CloudSandboxProxyClient {
     #[new]
-    #[pyo3(signature = (proxy_url, sandbox_id, api_key=None, organization_id=None, project_id=None, routing_hint=None, user_agent=None))]
+    #[pyo3(signature = (proxy_url, sandbox_id, api_key=None, organization_id=None, project_id=None, routing_hint=None, user_agent=None, request_timeout_sec=None))]
     fn new(
         proxy_url: String,
         sandbox_id: String,
@@ -1236,6 +1246,7 @@ impl CloudSandboxProxyClient {
         project_id: Option<String>,
         routing_hint: Option<String>,
         user_agent: Option<String>,
+        request_timeout_sec: Option<f64>,
     ) -> PyResult<Self> {
         let (base_url, host_override, sandbox_id_header) =
             resolve_proxy_target(&proxy_url, &sandbox_id)?;
@@ -1253,6 +1264,9 @@ impl CloudSandboxProxyClient {
 
         if let Some(ua) = user_agent.as_deref() {
             builder = builder.user_agent(ua);
+        }
+        if let Some(seconds) = request_timeout_sec {
+            builder = builder.timeout(duration_from_seconds("request_timeout_sec", seconds)?);
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.30"
+version = "0.5.31"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -28,6 +28,7 @@ from .client import (
     _resolve_sandbox_identifier,
     _rust_status_code,
     _startup_failure_message,
+    _unsupported_request_timeout_kwarg,
 )
 from .exceptions import (
     PoolInUseError,
@@ -79,6 +80,7 @@ class AsyncSandboxClient:
         namespace: str | None = _defaults.NAMESPACE,
         max_retries: int = _defaults.MAX_RETRIES,
         retry_backoff_sec: float = _defaults.RETRY_BACKOFF_SEC,
+        request_timeout: float = _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
         _internal: bool = False,
     ) -> None:
         if not _internal:
@@ -94,21 +96,29 @@ class AsyncSandboxClient:
         self._namespace = namespace
         self._max_retries = max_retries
         self._retry_backoff_sec = retry_backoff_sec
+        self._request_timeout = request_timeout
         if not _RUST_SANDBOX_CLIENT_AVAILABLE:
             raise SandboxError(
                 "Rust Cloud SDK sandbox client is required but unavailable. "
                 "Build/install it with `make build_rust_py_client`."
             )
+        kwargs = {
+            "api_url": api_url,
+            "api_key": api_key,
+            "organization_id": organization_id,
+            "project_id": project_id,
+            "namespace": namespace,
+            "user_agent": USER_AGENT,
+            "request_timeout_sec": self._request_timeout,
+        }
         try:
-            self._rust_client = RustCloudSandboxClient(
-                api_url=api_url,
-                api_key=api_key,
-                organization_id=organization_id,
-                project_id=project_id,
-                namespace=namespace,
-                user_agent=USER_AGENT,
-                request_timeout_sec=_defaults.DEFAULT_HTTP_TIMEOUT_SEC,
-            )
+            try:
+                self._rust_client = RustCloudSandboxClient(**kwargs)
+            except TypeError as e:
+                if not _unsupported_request_timeout_kwarg(e):
+                    raise
+                kwargs.pop("request_timeout_sec")
+                self._rust_client = RustCloudSandboxClient(**kwargs)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -119,12 +129,14 @@ class AsyncSandboxClient:
         organization_id: str | None = None,
         project_id: str | None = None,
         api_url: str = "https://api.tensorlake.ai",
+        request_timeout: float = _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
     ) -> "AsyncSandboxClient":
         return cls(
             api_url=api_url,
             api_key=api_key,
             organization_id=organization_id,
             project_id=project_id,
+            request_timeout=request_timeout,
             _internal=True,
         )
 
@@ -133,8 +145,14 @@ class AsyncSandboxClient:
         cls,
         api_url: str = "http://localhost:8900",
         namespace: str = "default",
+        request_timeout: float = _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
     ) -> "AsyncSandboxClient":
-        return cls(api_url=api_url, namespace=namespace, _internal=True)
+        return cls(
+            api_url=api_url,
+            namespace=namespace,
+            request_timeout=request_timeout,
+            _internal=True,
+        )
 
     async def __aenter__(self) -> "AsyncSandboxClient":
         return self
@@ -162,6 +180,21 @@ class AsyncSandboxClient:
         if host.startswith("api."):
             return f"{parsed.scheme}://sandbox.{host[4:]}"
         return _defaults.SANDBOX_PROXY_URL
+
+    def _with_request_timeout(self, request_timeout: float) -> "AsyncSandboxClient":
+        if request_timeout == self._request_timeout:
+            return self
+        return AsyncSandboxClient(
+            api_url=self._api_url,
+            api_key=self._api_key,
+            organization_id=self._organization_id,
+            project_id=self._project_id,
+            namespace=self._namespace,
+            max_retries=self._max_retries,
+            retry_backoff_sec=self._retry_backoff_sec,
+            request_timeout=request_timeout,
+            _internal=True,
+        )
 
     # --- Sandbox lifecycle ---
 
@@ -617,6 +650,7 @@ class AsyncSandboxClient:
         proxy_url: str | None = None,
         sandbox_id: str | None = None,
         routing_hint: str | None = None,
+        request_timeout: float | None = None,
     ) -> "AsyncSandbox":
         from .async_sandbox import AsyncSandbox
 
@@ -630,11 +664,14 @@ class AsyncSandboxClient:
             proxy_url = info.ingress_endpoint or self._resolve_proxy_url()
             proxy_sandbox_id = info.sandbox_id
             routing_hint = routing_hint or info.routing_hint
-        proxy_rust_client = self._rust_client.connect_proxy(
-            proxy_url=proxy_url,
-            sandbox_id=proxy_sandbox_id,
-            routing_hint=routing_hint,
-        )
+        connect_proxy_kwargs = {
+            "proxy_url": proxy_url,
+            "sandbox_id": proxy_sandbox_id,
+            "routing_hint": routing_hint,
+        }
+        if request_timeout is not None:
+            connect_proxy_kwargs["request_timeout_sec"] = request_timeout
+        proxy_rust_client = self._rust_client.connect_proxy(**connect_proxy_kwargs)
         sandbox = AsyncSandbox(
             identifier=proxy_sandbox_id,
             proxy_url=proxy_url,
@@ -666,14 +703,26 @@ class AsyncSandboxClient:
         pool_id: str | None = None,
         snapshot_id: str | None = None,
         proxy_url: str | None = None,
-        startup_timeout: float = 60,
+        request_timeout: float | None = None,
+        startup_timeout: float | None = None,
         name: str | None = None,
     ) -> "AsyncSandbox":
+        wait_timeout = (
+            request_timeout
+            if request_timeout is not None
+            else (
+                startup_timeout
+                if startup_timeout is not None
+                else self._request_timeout
+            )
+        )
+        request_client = self._with_request_timeout(wait_timeout)
+
         requested_name = None if pool_id is not None else name
         if pool_id is not None:
-            result = await self.claim(pool_id)
+            result = await request_client.claim(pool_id)
         else:
-            result = await self.create(
+            result = await request_client.create(
                 image=image,
                 cpus=cpus,
                 memory_mb=memory_mb,
@@ -689,7 +738,7 @@ class AsyncSandboxClient:
             )
 
         if result.status == SandboxStatus.RUNNING:
-            sandbox = await self.connect(
+            sandbox = await request_client.connect(
                 result.sandbox_id,
                 proxy_url=proxy_url
                 or result.ingress_endpoint
@@ -698,7 +747,7 @@ class AsyncSandboxClient:
             )
             sandbox._sandbox_id = result.sandbox_id
             sandbox._owns_sandbox = True
-            sandbox._lifecycle_client = self
+            sandbox._lifecycle_client = request_client
             sandbox._trace_id = result.trace_id
             sandbox._cached_info = SandboxInfo.model_construct(
                 sandbox_id=result.sandbox_id,
@@ -716,12 +765,20 @@ class AsyncSandboxClient:
                     termination_reason=result.termination_reason,
                 )
             )
+        if result.status == SandboxStatus.TIMEOUT:
+            try:
+                await request_client.delete(result.sandbox_id)
+            except Exception:
+                pass
+            raise SandboxError(
+                f"Sandbox {result.sandbox_id} did not start within {wait_timeout}s"
+            )
 
-        deadline = asyncio.get_running_loop().time() + startup_timeout
+        deadline = asyncio.get_running_loop().time() + wait_timeout
         while asyncio.get_running_loop().time() < deadline:
-            info = await self.get(result.sandbox_id)
+            info = await request_client.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
-                sandbox = await self.connect(
+                sandbox = await request_client.connect(
                     result.sandbox_id,
                     proxy_url=proxy_url
                     or info.ingress_endpoint
@@ -731,7 +788,7 @@ class AsyncSandboxClient:
                 sandbox._sandbox_id = info.sandbox_id
                 sandbox._cached_info = info.value
                 sandbox._owns_sandbox = True
-                sandbox._lifecycle_client = self
+                sandbox._lifecycle_client = request_client
                 sandbox._trace_id = result.trace_id
                 return sandbox
             if info.status in (SandboxStatus.SUSPENDED, SandboxStatus.TERMINATED):
@@ -746,9 +803,9 @@ class AsyncSandboxClient:
             await asyncio.sleep(0.5)
 
         try:
-            await self.delete(result.sandbox_id)
+            await request_client.delete(result.sandbox_id)
         except Exception:
             pass
         raise SandboxError(
-            f"Sandbox {result.sandbox_id} did not start within {startup_timeout}s"
+            f"Sandbox {result.sandbox_id} did not start within {wait_timeout}s"
         )

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -67,6 +67,7 @@ class AsyncSandbox:
         *,
         sandbox_id: str | None = None,
         routing_hint: str | None = None,
+        request_timeout: float | None = None,
         _proxy_rust_client: object | None = None,
     ) -> None:
         if identifier and sandbox_id and identifier != sandbox_id:
@@ -89,6 +90,7 @@ class AsyncSandbox:
         self._api_key = api_key
         self._organization_id = organization_id
         self._project_id = project_id
+        self._request_timeout = request_timeout
         parsed_proxy = urlparse(proxy_url)
         self._host_header = None
         if parsed_proxy.hostname in ("localhost", "127.0.0.1"):
@@ -115,15 +117,18 @@ class AsyncSandbox:
             )
         else:
             try:
-                self._rust_client = RustCloudSandboxProxyClient(
-                    proxy_url=proxy_url,
-                    sandbox_id=sandbox_identifier,
-                    api_key=api_key,
-                    organization_id=organization_id,
-                    project_id=project_id,
-                    routing_hint=routing_hint,
-                    user_agent=USER_AGENT,
-                )
+                kwargs = {
+                    "proxy_url": proxy_url,
+                    "sandbox_id": sandbox_identifier,
+                    "api_key": api_key,
+                    "organization_id": organization_id,
+                    "project_id": project_id,
+                    "routing_hint": routing_hint,
+                    "user_agent": USER_AGENT,
+                }
+                if request_timeout is not None:
+                    kwargs["request_timeout_sec"] = request_timeout
+                self._rust_client = RustCloudSandboxProxyClient(**kwargs)
                 self._base_url = self._rust_client.base_url()
             except Exception as e:
                 _raise_as_sandbox_error(e)
@@ -146,7 +151,8 @@ class AsyncSandbox:
         pool_id: str | None = None,
         snapshot_id: str | None = None,
         proxy_url: str | None = None,
-        startup_timeout: float = 60,
+        request_timeout: float | None = None,
+        startup_timeout: float | None = None,
         name: str | None = None,
         api_key: str | None = _defaults.API_KEY,
         api_url: str = _defaults.API_URL,
@@ -156,12 +162,22 @@ class AsyncSandbox:
     ) -> "AsyncSandbox":
         from .async_client import AsyncSandboxClient
 
+        effective_request_timeout = (
+            startup_timeout
+            if startup_timeout is not None
+            else (
+                request_timeout
+                if request_timeout is not None
+                else _defaults.DEFAULT_HTTP_TIMEOUT_SEC
+            )
+        )
         client = AsyncSandboxClient(
             api_url=api_url,
             api_key=api_key,
             organization_id=organization_id,
             project_id=project_id,
             namespace=namespace,
+            request_timeout=effective_request_timeout,
             _internal=True,
         )
         return await client.create_and_connect(
@@ -178,7 +194,7 @@ class AsyncSandbox:
             pool_id=pool_id,
             snapshot_id=snapshot_id,
             proxy_url=proxy_url,
-            startup_timeout=startup_timeout,
+            request_timeout=effective_request_timeout,
             name=name,
         )
 
@@ -194,6 +210,7 @@ class AsyncSandbox:
         organization_id: str | None = None,
         project_id: str | None = None,
         namespace: str | None = _defaults.NAMESPACE,
+        request_timeout: float | None = None,
     ) -> "AsyncSandbox":
         from .async_client import AsyncSandboxClient
 
@@ -203,10 +220,18 @@ class AsyncSandbox:
             organization_id=organization_id,
             project_id=project_id,
             namespace=namespace,
+            request_timeout=(
+                request_timeout
+                if request_timeout is not None
+                else _defaults.DEFAULT_HTTP_TIMEOUT_SEC
+            ),
             _internal=True,
         )
         return await client.connect(
-            sandbox_id, proxy_url=proxy_url, routing_hint=routing_hint
+            sandbox_id,
+            proxy_url=proxy_url,
+            routing_hint=routing_hint,
+            request_timeout=request_timeout,
         )
 
     # --- Lifecycle ---

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -128,6 +128,10 @@ def _raise_as_sandbox_error(e: Exception) -> NoReturn:
     raise SandboxError(str(e)) from e
 
 
+def _unsupported_request_timeout_kwarg(e: TypeError) -> bool:
+    return "request_timeout_sec" in str(e)
+
+
 _RESERVED_SANDBOX_MANAGEMENT_PORT = 9501
 
 
@@ -207,6 +211,7 @@ class SandboxClient:
         namespace: str | None = _defaults.NAMESPACE,
         max_retries: int = _defaults.MAX_RETRIES,
         retry_backoff_sec: float = _defaults.RETRY_BACKOFF_SEC,
+        request_timeout: float = _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
         _internal: bool = False,
     ):
         if not _internal:
@@ -222,22 +227,30 @@ class SandboxClient:
         self._namespace: str | None = namespace
         self._max_retries = max_retries
         self._retry_backoff_sec = retry_backoff_sec
+        self._request_timeout = request_timeout
         if not _RUST_SANDBOX_CLIENT_AVAILABLE:
             raise SandboxError(
                 "Rust Cloud SDK sandbox client is required but unavailable. "
                 "Build/install it with `make build_rust_py_client`."
             )
 
+        kwargs = {
+            "api_url": self._api_url,
+            "api_key": self._api_key,
+            "organization_id": self._organization_id,
+            "project_id": self._project_id,
+            "namespace": self._namespace,
+            "user_agent": USER_AGENT,
+            "request_timeout_sec": self._request_timeout,
+        }
         try:
-            self._rust_client = RustCloudSandboxClient(
-                api_url=self._api_url,
-                api_key=self._api_key,
-                organization_id=self._organization_id,
-                project_id=self._project_id,
-                namespace=self._namespace,
-                user_agent=USER_AGENT,
-                request_timeout_sec=_defaults.DEFAULT_HTTP_TIMEOUT_SEC,
-            )
+            try:
+                self._rust_client = RustCloudSandboxClient(**kwargs)
+            except TypeError as e:
+                if not _unsupported_request_timeout_kwarg(e):
+                    raise
+                kwargs.pop("request_timeout_sec")
+                self._rust_client = RustCloudSandboxClient(**kwargs)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
@@ -248,6 +261,7 @@ class SandboxClient:
         organization_id: str | None = None,
         project_id: str | None = None,
         api_url: str = "https://api.tensorlake.ai",
+        request_timeout: float = _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
     ) -> "SandboxClient":
         """Create a client for the Tensorlake cloud platform.
 
@@ -266,6 +280,7 @@ class SandboxClient:
             api_key=api_key,
             organization_id=organization_id,
             project_id=project_id,
+            request_timeout=request_timeout,
         )
 
     @classmethod
@@ -273,6 +288,7 @@ class SandboxClient:
         cls,
         api_url: str = "http://localhost:8900",
         namespace: str = "default",
+        request_timeout: float = _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
     ) -> "SandboxClient":
         """Create a client for a local Indexify server.
 
@@ -283,7 +299,9 @@ class SandboxClient:
             api_url: Local server URL
             namespace: Namespace for resource scoping
         """
-        return cls(api_url=api_url, namespace=namespace)
+        return cls(
+            api_url=api_url, namespace=namespace, request_timeout=request_timeout
+        )
 
     def __enter__(self) -> "SandboxClient":
         """Context manager entry."""
@@ -327,6 +345,21 @@ class SandboxClient:
             proxy_host = "sandbox." + host[4:]
             return f"{parsed.scheme}://{proxy_host}"
         return _defaults.SANDBOX_PROXY_URL
+
+    def _with_request_timeout(self, request_timeout: float) -> "SandboxClient":
+        if request_timeout == self._request_timeout:
+            return self
+        return SandboxClient(
+            api_url=self._api_url,
+            api_key=self._api_key,
+            organization_id=self._organization_id,
+            project_id=self._project_id,
+            namespace=self._namespace,
+            max_retries=self._max_retries,
+            retry_backoff_sec=self._retry_backoff_sec,
+            request_timeout=request_timeout,
+            _internal=True,
+        )
 
     def create(
         self,
@@ -1087,6 +1120,7 @@ class SandboxClient:
         proxy_url: str | None = None,
         sandbox_id: str | None = None,
         routing_hint: str | None = None,
+        request_timeout: float | None = None,
     ) -> "Sandbox":
         """Connect to a running sandbox for process and file operations.
 
@@ -1116,11 +1150,14 @@ class SandboxClient:
             proxy_sandbox_id = info.sandbox_id
             routing_hint = routing_hint or info.routing_hint
 
-        proxy_rust_client = self._rust_client.connect_proxy(
-            proxy_url=proxy_url,
-            sandbox_id=proxy_sandbox_id,
-            routing_hint=routing_hint,
-        )
+        connect_proxy_kwargs = {
+            "proxy_url": proxy_url,
+            "sandbox_id": proxy_sandbox_id,
+            "routing_hint": routing_hint,
+        }
+        if request_timeout is not None:
+            connect_proxy_kwargs["request_timeout_sec"] = request_timeout
+        proxy_rust_client = self._rust_client.connect_proxy(**connect_proxy_kwargs)
 
         sandbox = Sandbox(
             identifier=proxy_sandbox_id,
@@ -1153,7 +1190,8 @@ class SandboxClient:
         pool_id: str | None = None,
         snapshot_id: str | None = None,
         proxy_url: str | None = None,
-        startup_timeout: float = 60,
+        request_timeout: float | None = None,
+        startup_timeout: float | None = None,
         name: str | None = None,
     ) -> "Sandbox":
         """Create a sandbox, wait for it to start, and return a connected Sandbox.
@@ -1184,7 +1222,9 @@ class SandboxClient:
             pool_id: Pool ID to use for warm containers (optional)
             snapshot_id: ID of a completed snapshot to restore from
             proxy_url: Override the sandbox proxy URL
-            startup_timeout: Max seconds to wait for Running status (default 60)
+            request_timeout: Max seconds to wait for Running status.
+                Defaults to the client request timeout.
+            startup_timeout: Deprecated alias for ``request_timeout``.
             name: Optional name for the sandbox. Named sandboxes support
                 suspend/resume. When absent the sandbox is ephemeral.
 
@@ -1195,13 +1235,24 @@ class SandboxClient:
             SandboxError: If sandbox fails to start or times out
             SandboxConnectionError: If the server is unreachable
         """
+        wait_timeout = (
+            request_timeout
+            if request_timeout is not None
+            else (
+                startup_timeout
+                if startup_timeout is not None
+                else self._request_timeout
+            )
+        )
+        request_client = self._with_request_timeout(wait_timeout)
+
         # claim() never sends `name` to the server, so only the create() path
         # may fall back to the requested name when caching info locally.
         requested_name = None if pool_id is not None else name
         if pool_id is not None:
-            result = self.claim(pool_id)
+            result = request_client.claim(pool_id)
         else:
-            result = self.create(
+            result = request_client.create(
                 image=image,
                 cpus=cpus,
                 memory_mb=memory_mb,
@@ -1220,7 +1271,7 @@ class SandboxClient:
         # and a short-lived routing hint. Use it immediately to skip an extra poll RTT
         # and let the proxy route the first request without a placement lookup.
         if result.status == SandboxStatus.RUNNING:
-            sandbox = self.connect(
+            sandbox = request_client.connect(
                 result.sandbox_id,
                 proxy_url=proxy_url
                 or result.ingress_endpoint
@@ -1229,7 +1280,7 @@ class SandboxClient:
             )
             sandbox._sandbox_id = result.sandbox_id
             sandbox._owns_sandbox = True
-            sandbox._lifecycle_client = self
+            sandbox._lifecycle_client = request_client
             sandbox._trace_id = result.trace_id
             sandbox._cached_info = SandboxInfo.model_construct(
                 sandbox_id=result.sandbox_id,
@@ -1247,12 +1298,20 @@ class SandboxClient:
                     termination_reason=result.termination_reason,
                 )
             )
+        if result.status == SandboxStatus.TIMEOUT:
+            try:
+                request_client.delete(result.sandbox_id)
+            except Exception:
+                pass
+            raise SandboxError(
+                f"Sandbox {result.sandbox_id} did not start within {wait_timeout}s"
+            )
 
-        deadline = time.time() + startup_timeout
+        deadline = time.time() + wait_timeout
         while time.time() < deadline:
-            info = self.get(result.sandbox_id)
+            info = request_client.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
-                sandbox = self.connect(
+                sandbox = request_client.connect(
                     result.sandbox_id,
                     proxy_url=proxy_url
                     or info.ingress_endpoint
@@ -1262,7 +1321,7 @@ class SandboxClient:
                 sandbox._sandbox_id = info.sandbox_id
                 sandbox._cached_info = info.value
                 sandbox._owns_sandbox = True
-                sandbox._lifecycle_client = self
+                sandbox._lifecycle_client = request_client
                 sandbox._trace_id = result.trace_id
                 return sandbox
             if info.status in (SandboxStatus.SUSPENDED, SandboxStatus.TERMINATED):
@@ -1279,9 +1338,9 @@ class SandboxClient:
 
         # Timed out — clean up the pending sandbox
         try:
-            self.delete(result.sandbox_id)
+            request_client.delete(result.sandbox_id)
         except Exception:
             pass
         raise SandboxError(
-            f"Sandbox {result.sandbox_id} did not start within {startup_timeout}s"
+            f"Sandbox {result.sandbox_id} did not start within {wait_timeout}s"
         )

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -72,6 +72,7 @@ class SandboxStatus(str, Enum):
     SUSPENDING = "suspending"
     SUSPENDED = "suspended"
     TERMINATED = "terminated"
+    TIMEOUT = "timeout"
 
 
 class SnapshotStatus(str, Enum):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -132,6 +132,7 @@ class Sandbox:
         *,
         sandbox_id: str | None = None,
         routing_hint: str | None = None,
+        request_timeout: float | None = None,
         _proxy_rust_client: object | None = None,
     ):
         if identifier and sandbox_id and identifier != sandbox_id:
@@ -154,6 +155,7 @@ class Sandbox:
         self._api_key = api_key
         self._organization_id = organization_id
         self._project_id = project_id
+        self._request_timeout = request_timeout
         parsed_proxy = urlparse(proxy_url)
         self._host_header = None
         if parsed_proxy.hostname in ("localhost", "127.0.0.1"):
@@ -180,15 +182,18 @@ class Sandbox:
             )
         else:
             try:
-                self._rust_client = RustCloudSandboxProxyClient(
-                    proxy_url=proxy_url,
-                    sandbox_id=sandbox_identifier,
-                    api_key=api_key,
-                    organization_id=organization_id,
-                    project_id=project_id,
-                    routing_hint=routing_hint,
-                    user_agent=USER_AGENT,
-                )
+                kwargs = {
+                    "proxy_url": proxy_url,
+                    "sandbox_id": sandbox_identifier,
+                    "api_key": api_key,
+                    "organization_id": organization_id,
+                    "project_id": project_id,
+                    "routing_hint": routing_hint,
+                    "user_agent": USER_AGENT,
+                }
+                if request_timeout is not None:
+                    kwargs["request_timeout_sec"] = request_timeout
+                self._rust_client = RustCloudSandboxProxyClient(**kwargs)
                 self._base_url = self._rust_client.base_url()
             except Exception as e:
                 _raise_as_sandbox_error(e)
@@ -211,7 +216,8 @@ class Sandbox:
         pool_id: str | None = None,
         snapshot_id: str | None = None,
         proxy_url: str | None = None,
-        startup_timeout: float = 60,
+        request_timeout: float | None = None,
+        startup_timeout: float | None = None,
         name: str | None = None,
         api_key: str | None = _defaults.API_KEY,
         api_url: str = _defaults.API_URL,
@@ -240,7 +246,8 @@ class Sandbox:
             pool_id: Pool ID to claim a warm container from.
             snapshot_id: Restore from this snapshot ID.
             proxy_url: Override the sandbox proxy URL.
-            startup_timeout: Max seconds to wait for Running status (default 60).
+            request_timeout: Max seconds to wait for HTTP operations.
+            startup_timeout: Deprecated alias for ``request_timeout``.
             name: Optional name; named sandboxes support suspend/resume.
             api_key: Tensorlake API key (defaults to TENSORLAKE_API_KEY env var).
             api_url: API server URL (defaults to TENSORLAKE_API_URL env var).
@@ -256,12 +263,22 @@ class Sandbox:
         """
         from .client import SandboxClient
 
+        effective_request_timeout = (
+            startup_timeout
+            if startup_timeout is not None
+            else (
+                request_timeout
+                if request_timeout is not None
+                else _defaults.DEFAULT_HTTP_TIMEOUT_SEC
+            )
+        )
         client = SandboxClient(
             api_url=api_url,
             api_key=api_key,
             organization_id=organization_id,
             project_id=project_id,
             namespace=namespace,
+            request_timeout=effective_request_timeout,
             _internal=True,
         )
         return client.create_and_connect(
@@ -278,7 +295,7 @@ class Sandbox:
             pool_id=pool_id,
             snapshot_id=snapshot_id,
             proxy_url=proxy_url,
-            startup_timeout=startup_timeout,
+            request_timeout=effective_request_timeout,
             name=name,
         )
 
@@ -294,6 +311,7 @@ class Sandbox:
         organization_id: str | None = None,
         project_id: str | None = None,
         namespace: str | None = _defaults.NAMESPACE,
+        request_timeout: float | None = None,
     ) -> "Sandbox":
         """Attach to an existing sandbox and return a connected handle.
 
@@ -322,12 +340,18 @@ class Sandbox:
             organization_id=organization_id,
             project_id=project_id,
             namespace=namespace,
+            request_timeout=(
+                request_timeout
+                if request_timeout is not None
+                else _defaults.DEFAULT_HTTP_TIMEOUT_SEC
+            ),
             _internal=True,
         )
         return client.connect(
             sandbox_id,
             proxy_url=proxy_url,
             routing_hint=routing_hint,
+            request_timeout=request_timeout,
         )
 
     # --- Class-level snapshot management ---
@@ -341,6 +365,7 @@ class Sandbox:
         organization_id: str | None = None,
         project_id: str | None = None,
         namespace: str | None = _defaults.NAMESPACE,
+        request_timeout: float = _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
     ) -> SnapshotInfo:
         """Get information about a snapshot by ID.
 
@@ -365,6 +390,7 @@ class Sandbox:
             organization_id=organization_id,
             project_id=project_id,
             namespace=namespace,
+            request_timeout=request_timeout,
             _internal=True,
         )
         return client.get_snapshot(snapshot_id).value
@@ -378,6 +404,7 @@ class Sandbox:
         organization_id: str | None = None,
         project_id: str | None = None,
         namespace: str | None = _defaults.NAMESPACE,
+        request_timeout: float = _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
     ) -> None:
         """Delete a snapshot by ID.
 
@@ -399,6 +426,7 @@ class Sandbox:
             organization_id=organization_id,
             project_id=project_id,
             namespace=namespace,
+            request_timeout=request_timeout,
             _internal=True,
         )
         client.delete_snapshot(snapshot_id)
@@ -411,6 +439,7 @@ class Sandbox:
         organization_id: str | None = None,
         project_id: str | None = None,
         namespace: str | None = _defaults.NAMESPACE,
+        request_timeout: float = _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
     ) -> TracedIterator[SandboxInfo]:
         """List all sandboxes in the namespace.
 
@@ -434,6 +463,7 @@ class Sandbox:
             organization_id=organization_id,
             project_id=project_id,
             namespace=namespace,
+            request_timeout=request_timeout,
             _internal=True,
         )
         return client.list()

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -365,6 +365,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                 "sbx-1",
                 api_url="http://localhost:8900",
                 api_key="k",
+                proxy_url="https://sandbox.tensorlake.ai",
                 request_timeout=10.0,
             )
             sandbox.close()
@@ -398,6 +399,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                 "sbx-1",
                 api_url="http://localhost:8900",
                 api_key="k",
+                proxy_url="https://sandbox.tensorlake.ai",
             )
             sandbox.close()
 

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -141,7 +141,45 @@ class _FakeRustClient:
         return ("trace-update-sandbox", json.dumps(response))
 
 
+class _FakeProxyClient:
+    def base_url(self):
+        return "https://sandbox.tensorlake.ai"
+
+    def close(self):
+        return None
+
+
+class _RecordingCreateRustClient:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.create_calls = 0
+        self.delete_calls: list[str] = []
+        type(self).instances.append(self)
+
+    def close(self):
+        return None
+
+    def create_sandbox(self, request_json):
+        self.create_calls += 1
+        return (
+            "trace-create-sandbox",
+            '{"sandbox_id":"sbx-1","status":"running"}',
+        )
+
+    def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):
+        return _FakeProxyClient()
+
+    def delete_sandbox(self, *, sandbox_id):
+        self.delete_calls.append(sandbox_id)
+        return "trace-delete"
+
+
 class TestSandboxClientRustBackend(unittest.TestCase):
+    def setUp(self):
+        _RecordingCreateRustClient.instances = []
+
     def test_constructor_passes_default_request_timeout_to_rust_backend(self):
         class _RecordingRustClient:
             kwargs = None
@@ -161,6 +199,239 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(
             _RecordingRustClient.kwargs["request_timeout_sec"],
             _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
+        )
+
+    def test_constructor_passes_custom_request_timeout_to_rust_backend(self):
+        class _RecordingRustClient:
+            kwargs = None
+
+            def __init__(self, **kwargs):
+                type(self).kwargs = kwargs
+
+            def close(self):
+                return None
+
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClient",
+            _RecordingRustClient,
+        ):
+            SandboxClient(
+                api_url="http://localhost:8900",
+                api_key="k",
+                request_timeout=123.0,
+                _internal=True,
+            )
+
+        self.assertEqual(_RecordingRustClient.kwargs["request_timeout_sec"], 123.0)
+
+    def test_create_and_connect_uses_per_call_request_timeout_for_initial_create(self):
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClient",
+            _RecordingCreateRustClient,
+        ):
+            client = SandboxClient(
+                api_url="http://localhost:8900",
+                api_key="k",
+                request_timeout=300.0,
+                _internal=True,
+            )
+            client.create_and_connect(image="python:3.11", request_timeout=10.0)
+
+        self.assertEqual(len(_RecordingCreateRustClient.instances), 2)
+        self.assertEqual(
+            _RecordingCreateRustClient.instances[0].kwargs["request_timeout_sec"],
+            300.0,
+        )
+        self.assertEqual(
+            _RecordingCreateRustClient.instances[1].kwargs["request_timeout_sec"],
+            10.0,
+        )
+        self.assertEqual(_RecordingCreateRustClient.instances[1].create_calls, 1)
+
+    def test_sandbox_create_uses_startup_timeout_for_initial_create(self):
+        from tensorlake.sandbox.sandbox import Sandbox
+
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClient",
+            _RecordingCreateRustClient,
+        ):
+            Sandbox.create(
+                image="python:3.11",
+                api_url="http://localhost:8900",
+                api_key="k",
+                startup_timeout=10.0,
+            )
+
+        self.assertEqual(len(_RecordingCreateRustClient.instances), 1)
+        self.assertEqual(
+            _RecordingCreateRustClient.instances[0].kwargs["request_timeout_sec"],
+            10.0,
+        )
+        self.assertEqual(_RecordingCreateRustClient.instances[0].create_calls, 1)
+
+    def test_sandbox_create_uses_default_request_timeout_when_unspecified(self):
+        from tensorlake.sandbox.sandbox import Sandbox
+
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClient",
+            _RecordingCreateRustClient,
+        ):
+            Sandbox.create(
+                image="python:3.11",
+                api_url="http://localhost:8900",
+                api_key="k",
+            )
+
+        self.assertEqual(len(_RecordingCreateRustClient.instances), 1)
+        self.assertEqual(
+            _RecordingCreateRustClient.instances[0].kwargs["request_timeout_sec"],
+            _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
+        )
+        self.assertEqual(_RecordingCreateRustClient.instances[0].create_calls, 1)
+
+    def test_sandbox_proxy_client_does_not_receive_default_request_timeout(self):
+        from tensorlake.sandbox.sandbox import Sandbox
+
+        class _RecordingProxyRustClient:
+            kwargs = None
+
+            def __init__(self, **kwargs):
+                type(self).kwargs = kwargs
+
+            def base_url(self):
+                return "https://sbx-1.sandbox.tensorlake.ai"
+
+        with patch(
+            "tensorlake.sandbox.sandbox.RustCloudSandboxProxyClient",
+            _RecordingProxyRustClient,
+        ):
+            Sandbox(
+                identifier="sbx-1",
+                proxy_url="https://sandbox.tensorlake.ai",
+                api_key="k",
+            )
+
+        self.assertNotIn("request_timeout_sec", _RecordingProxyRustClient.kwargs)
+
+    def test_sandbox_proxy_client_receives_explicit_request_timeout(self):
+        from tensorlake.sandbox.sandbox import Sandbox
+
+        class _RecordingProxyRustClient:
+            kwargs = None
+
+            def __init__(self, **kwargs):
+                type(self).kwargs = kwargs
+
+            def base_url(self):
+                return "https://sbx-1.sandbox.tensorlake.ai"
+
+        with patch(
+            "tensorlake.sandbox.sandbox.RustCloudSandboxProxyClient",
+            _RecordingProxyRustClient,
+        ):
+            Sandbox(
+                identifier="sbx-1",
+                proxy_url="https://sandbox.tensorlake.ai",
+                api_key="k",
+                request_timeout=10.0,
+            )
+
+        self.assertEqual(
+            _RecordingProxyRustClient.kwargs["request_timeout_sec"],
+            10.0,
+        )
+
+    def test_sandbox_connect_forwards_explicit_proxy_request_timeout(self):
+        from tensorlake.sandbox.sandbox import Sandbox
+
+        class _RecordingRustClient:
+            connect_proxy_kwargs = None
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def close(self):
+                return None
+
+            def connect_proxy(self, **kwargs):
+                type(self).connect_proxy_kwargs = kwargs
+                return _FakeProxyClient()
+
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClient",
+            _RecordingRustClient,
+        ):
+            sandbox = Sandbox.connect(
+                "sbx-1",
+                api_url="http://localhost:8900",
+                api_key="k",
+                request_timeout=10.0,
+            )
+            sandbox.close()
+
+        self.assertEqual(
+            _RecordingRustClient.connect_proxy_kwargs["request_timeout_sec"],
+            10.0,
+        )
+
+    def test_sandbox_connect_does_not_forward_default_proxy_request_timeout(self):
+        from tensorlake.sandbox.sandbox import Sandbox
+
+        class _RecordingRustClient:
+            connect_proxy_kwargs = None
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def close(self):
+                return None
+
+            def connect_proxy(self, **kwargs):
+                type(self).connect_proxy_kwargs = kwargs
+                return _FakeProxyClient()
+
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClient",
+            _RecordingRustClient,
+        ):
+            sandbox = Sandbox.connect(
+                "sbx-1",
+                api_url="http://localhost:8900",
+                api_key="k",
+            )
+            sandbox.close()
+
+        self.assertNotIn(
+            "request_timeout_sec",
+            _RecordingRustClient.connect_proxy_kwargs,
+        )
+
+    def test_create_and_connect_deletes_sandbox_from_timeout_response(self):
+        class _TimeoutCreateRustClient(_RecordingCreateRustClient):
+            def create_sandbox(self, request_json):
+                self.create_calls += 1
+                return (
+                    "trace-create-sandbox",
+                    '{"sandbox_id":"sbx-timeout","status":"timeout"}',
+                )
+
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClient",
+            _TimeoutCreateRustClient,
+        ):
+            client = SandboxClient(
+                api_url="http://localhost:8900",
+                api_key="k",
+                request_timeout=300.0,
+                _internal=True,
+            )
+            with self.assertRaisesRegex(SandboxError, "did not start"):
+                client.create_and_connect(image="python:3.11", request_timeout=10.0)
+
+        self.assertEqual(len(_TimeoutCreateRustClient.instances), 2)
+        self.assertEqual(
+            _TimeoutCreateRustClient.instances[1].delete_calls,
+            ["sbx-timeout"],
         )
 
     def test_connect_accepts_sandbox_name(self):

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -413,6 +413,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
                 "sbx-1",
                 api_url="http://localhost:8900",
                 api_key="k",
+                proxy_url="https://sandbox.tensorlake.ai",
                 request_timeout=10.0,
             )
             sandbox.close()
@@ -446,6 +447,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
                 "sbx-1",
                 api_url="http://localhost:8900",
                 api_key="k",
+                proxy_url="https://sandbox.tensorlake.ai",
             )
             sandbox.close()
 

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -146,6 +146,41 @@ class _FakeAsyncRustClient:
         return ("trace-update-sandbox", json.dumps(response))
 
 
+class _FakeProxyClient:
+    def base_url(self):
+        return "https://sandbox.tensorlake.ai"
+
+    def close(self):
+        return None
+
+
+class _RecordingCreateRustClient:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.create_calls = 0
+        self.delete_calls: list[str] = []
+        type(self).instances.append(self)
+
+    def close(self):
+        return None
+
+    async def create_sandbox_async(self, *, request_json):
+        self.create_calls += 1
+        return (
+            "trace-create-sandbox",
+            '{"sandbox_id":"sbx-1","status":"running"}',
+        )
+
+    def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):
+        return _FakeProxyClient()
+
+    async def delete_sandbox_async(self, *, sandbox_id):
+        self.delete_calls.append(sandbox_id)
+        return "trace-delete"
+
+
 def _make_client(fake: object | None = None) -> AsyncSandboxClient:
     client = AsyncSandboxClient(
         api_url="http://localhost:8900", api_key="k", _internal=True
@@ -186,6 +221,9 @@ class _StatusSequenceRustClient(_FakeAsyncRustClient):
 
 
 class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        _RecordingCreateRustClient.instances = []
+
     async def test_constructor_passes_default_request_timeout_to_rust_backend(self):
         class _RecordingRustClient:
             kwargs = None
@@ -207,6 +245,244 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             _RecordingRustClient.kwargs["request_timeout_sec"],
             _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
+        )
+
+    async def test_constructor_passes_custom_request_timeout_to_rust_backend(self):
+        class _RecordingRustClient:
+            kwargs = None
+
+            def __init__(self, **kwargs):
+                type(self).kwargs = kwargs
+
+            def close(self):
+                return None
+
+        with patch(
+            "tensorlake.sandbox.async_client.RustCloudSandboxClient",
+            _RecordingRustClient,
+        ):
+            AsyncSandboxClient(
+                api_url="http://localhost:8900",
+                api_key="k",
+                request_timeout=123.0,
+                _internal=True,
+            )
+
+        self.assertEqual(_RecordingRustClient.kwargs["request_timeout_sec"], 123.0)
+
+    async def test_create_and_connect_uses_per_call_request_timeout_for_initial_create(
+        self,
+    ):
+        with patch(
+            "tensorlake.sandbox.async_client.RustCloudSandboxClient",
+            _RecordingCreateRustClient,
+        ):
+            client = AsyncSandboxClient(
+                api_url="http://localhost:8900",
+                api_key="k",
+                request_timeout=300.0,
+                _internal=True,
+            )
+            await client.create_and_connect(image="python:3.11", request_timeout=10.0)
+
+        self.assertEqual(len(_RecordingCreateRustClient.instances), 2)
+        self.assertEqual(
+            _RecordingCreateRustClient.instances[0].kwargs["request_timeout_sec"],
+            300.0,
+        )
+        self.assertEqual(
+            _RecordingCreateRustClient.instances[1].kwargs["request_timeout_sec"],
+            10.0,
+        )
+        self.assertEqual(_RecordingCreateRustClient.instances[1].create_calls, 1)
+
+    async def test_sandbox_create_uses_startup_timeout_for_initial_create(self):
+        from tensorlake.sandbox.async_sandbox import AsyncSandbox
+
+        with patch(
+            "tensorlake.sandbox.async_client.RustCloudSandboxClient",
+            _RecordingCreateRustClient,
+        ):
+            await AsyncSandbox.create(
+                image="python:3.11",
+                api_url="http://localhost:8900",
+                api_key="k",
+                startup_timeout=10.0,
+            )
+
+        self.assertEqual(len(_RecordingCreateRustClient.instances), 1)
+        self.assertEqual(
+            _RecordingCreateRustClient.instances[0].kwargs["request_timeout_sec"],
+            10.0,
+        )
+        self.assertEqual(_RecordingCreateRustClient.instances[0].create_calls, 1)
+
+    async def test_sandbox_create_uses_default_request_timeout_when_unspecified(self):
+        from tensorlake.sandbox.async_sandbox import AsyncSandbox
+
+        with patch(
+            "tensorlake.sandbox.async_client.RustCloudSandboxClient",
+            _RecordingCreateRustClient,
+        ):
+            await AsyncSandbox.create(
+                image="python:3.11",
+                api_url="http://localhost:8900",
+                api_key="k",
+            )
+
+        self.assertEqual(len(_RecordingCreateRustClient.instances), 1)
+        self.assertEqual(
+            _RecordingCreateRustClient.instances[0].kwargs["request_timeout_sec"],
+            _defaults.DEFAULT_HTTP_TIMEOUT_SEC,
+        )
+        self.assertEqual(_RecordingCreateRustClient.instances[0].create_calls, 1)
+
+    async def test_sandbox_proxy_client_does_not_receive_default_request_timeout(self):
+        from tensorlake.sandbox.async_sandbox import AsyncSandbox
+
+        class _RecordingProxyRustClient:
+            kwargs = None
+
+            def __init__(self, **kwargs):
+                type(self).kwargs = kwargs
+
+            def base_url(self):
+                return "https://sbx-1.sandbox.tensorlake.ai"
+
+        with patch(
+            "tensorlake.sandbox.async_sandbox.RustCloudSandboxProxyClient",
+            _RecordingProxyRustClient,
+        ):
+            AsyncSandbox(
+                identifier="sbx-1",
+                proxy_url="https://sandbox.tensorlake.ai",
+                api_key="k",
+            )
+
+        self.assertNotIn("request_timeout_sec", _RecordingProxyRustClient.kwargs)
+
+    async def test_sandbox_proxy_client_receives_explicit_request_timeout(self):
+        from tensorlake.sandbox.async_sandbox import AsyncSandbox
+
+        class _RecordingProxyRustClient:
+            kwargs = None
+
+            def __init__(self, **kwargs):
+                type(self).kwargs = kwargs
+
+            def base_url(self):
+                return "https://sbx-1.sandbox.tensorlake.ai"
+
+        with patch(
+            "tensorlake.sandbox.async_sandbox.RustCloudSandboxProxyClient",
+            _RecordingProxyRustClient,
+        ):
+            AsyncSandbox(
+                identifier="sbx-1",
+                proxy_url="https://sandbox.tensorlake.ai",
+                api_key="k",
+                request_timeout=10.0,
+            )
+
+        self.assertEqual(
+            _RecordingProxyRustClient.kwargs["request_timeout_sec"],
+            10.0,
+        )
+
+    async def test_sandbox_connect_forwards_explicit_proxy_request_timeout(self):
+        from tensorlake.sandbox.async_sandbox import AsyncSandbox
+
+        class _RecordingRustClient:
+            connect_proxy_kwargs = None
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def close(self):
+                return None
+
+            def connect_proxy(self, **kwargs):
+                type(self).connect_proxy_kwargs = kwargs
+                return _FakeProxyClient()
+
+        with patch(
+            "tensorlake.sandbox.async_client.RustCloudSandboxClient",
+            _RecordingRustClient,
+        ):
+            sandbox = await AsyncSandbox.connect(
+                "sbx-1",
+                api_url="http://localhost:8900",
+                api_key="k",
+                request_timeout=10.0,
+            )
+            sandbox.close()
+
+        self.assertEqual(
+            _RecordingRustClient.connect_proxy_kwargs["request_timeout_sec"],
+            10.0,
+        )
+
+    async def test_sandbox_connect_does_not_forward_default_proxy_request_timeout(self):
+        from tensorlake.sandbox.async_sandbox import AsyncSandbox
+
+        class _RecordingRustClient:
+            connect_proxy_kwargs = None
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def close(self):
+                return None
+
+            def connect_proxy(self, **kwargs):
+                type(self).connect_proxy_kwargs = kwargs
+                return _FakeProxyClient()
+
+        with patch(
+            "tensorlake.sandbox.async_client.RustCloudSandboxClient",
+            _RecordingRustClient,
+        ):
+            sandbox = await AsyncSandbox.connect(
+                "sbx-1",
+                api_url="http://localhost:8900",
+                api_key="k",
+            )
+            sandbox.close()
+
+        self.assertNotIn(
+            "request_timeout_sec",
+            _RecordingRustClient.connect_proxy_kwargs,
+        )
+
+    async def test_create_and_connect_deletes_sandbox_from_timeout_response(self):
+        class _TimeoutCreateRustClient(_RecordingCreateRustClient):
+            async def create_sandbox_async(self, *, request_json):
+                self.create_calls += 1
+                return (
+                    "trace-create-sandbox",
+                    '{"sandbox_id":"sbx-timeout","status":"timeout"}',
+                )
+
+        with patch(
+            "tensorlake.sandbox.async_client.RustCloudSandboxClient",
+            _TimeoutCreateRustClient,
+        ):
+            client = AsyncSandboxClient(
+                api_url="http://localhost:8900",
+                api_key="k",
+                request_timeout=300.0,
+                _internal=True,
+            )
+            with self.assertRaisesRegex(SandboxError, "did not start"):
+                await client.create_and_connect(
+                    image="python:3.11",
+                    request_timeout=10.0,
+                )
+
+        self.assertEqual(len(_TimeoutCreateRustClient.instances), 2)
+        self.assertEqual(
+            _TimeoutCreateRustClient.instances[1].delete_calls,
+            ["sbx-timeout"],
         )
 
     async def test_connect_accepts_sandbox_name(self):

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.30",
+      "version": "0.5.31",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "^8.1.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -32,6 +32,9 @@ import {
 import { Sandbox } from "./sandbox.js";
 import { isLocalhost, lifecyclePath, resolveProxyUrl, resolveSandboxLifecycleUrl } from "./url.js";
 
+const CREATE_SANDBOX_RETRYABLE_STATUS_CODES = new Set([429, 502, 503]);
+const CREATE_SANDBOX_ALLOWED_ERROR_STATUS_CODES = new Set([504]);
+
 /**
  * Client for managing TensorLake sandboxes, pools, and snapshots.
  *
@@ -46,6 +49,9 @@ export class SandboxClient {
   private readonly projectId: string | undefined;
   private readonly namespace: string;
   private readonly local: boolean;
+  private readonly maxRetries: number;
+  private readonly retryBackoffMs: number;
+  private readonly requestTimeoutMs: number;
 
   /** @internal Pass `true` to suppress the deprecation warning when used by `Sandbox.create()` / `Sandbox.connect()`. */
   constructor(options?: SandboxClientOptions, _internal = false) {
@@ -60,14 +66,18 @@ export class SandboxClient {
     this.projectId = options?.projectId;
     this.namespace = options?.namespace ?? defaults.NAMESPACE;
     this.local = isLocalhost(this.apiUrl);
+    this.maxRetries = options?.maxRetries ?? defaults.MAX_RETRIES;
+    this.retryBackoffMs = options?.retryBackoffMs ?? defaults.RETRY_BACKOFF_MS;
+    this.requestTimeoutMs = resolveRequestTimeoutMs(options);
 
     this.http = new HttpClient({
       baseUrl: resolveSandboxLifecycleUrl(this.apiUrl),
       apiKey: this.apiKey,
       organizationId: this.organizationId,
       projectId: this.projectId,
-      maxRetries: options?.maxRetries ?? defaults.MAX_RETRIES,
-      retryBackoffMs: options?.retryBackoffMs ?? defaults.RETRY_BACKOFF_MS,
+      maxRetries: this.maxRetries,
+      retryBackoffMs: this.retryBackoffMs,
+      timeoutMs: this.requestTimeoutMs,
     });
   }
 
@@ -77,12 +87,16 @@ export class SandboxClient {
     organizationId?: string;
     projectId?: string;
     apiUrl?: string;
+    requestTimeout?: number;
+    timeoutMs?: number;
   }): SandboxClient {
     return new SandboxClient({
       apiUrl: options?.apiUrl ?? "https://api.tensorlake.ai",
       apiKey: options?.apiKey,
       organizationId: options?.organizationId,
       projectId: options?.projectId,
+      requestTimeout: options?.requestTimeout,
+      timeoutMs: options?.timeoutMs,
     });
   }
 
@@ -90,15 +104,39 @@ export class SandboxClient {
   static forLocalhost(options?: {
     apiUrl?: string;
     namespace?: string;
+    requestTimeout?: number;
+    timeoutMs?: number;
   }): SandboxClient {
     return new SandboxClient({
       apiUrl: options?.apiUrl ?? "http://localhost:8900",
       namespace: options?.namespace ?? "default",
+      requestTimeout: options?.requestTimeout,
+      timeoutMs: options?.timeoutMs,
     });
   }
 
   close(): void {
     this.http.close();
+  }
+
+  private withRequestTimeout(requestTimeout: number | undefined): SandboxClient {
+    if (requestTimeout == null) {
+      return this;
+    }
+    const timeoutMs = secondsToMillis(requestTimeout);
+    if (timeoutMs === this.requestTimeoutMs) {
+      return this;
+    }
+    return new SandboxClient({
+      apiUrl: this.apiUrl,
+      apiKey: this.apiKey,
+      organizationId: this.organizationId,
+      projectId: this.projectId,
+      namespace: this.namespace,
+      maxRetries: this.maxRetries,
+      retryBackoffMs: this.retryBackoffMs,
+      timeoutMs,
+    }, /* _internal */ true);
   }
 
   // --- Path helper ---
@@ -141,7 +179,11 @@ export class SandboxClient {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "POST",
       this.path("sandboxes"),
-      { body },
+      {
+        body,
+        retryableStatusCodes: CREATE_SANDBOX_RETRYABLE_STATUS_CODES,
+        allowedErrorStatusCodes: CREATE_SANDBOX_ALLOWED_ERROR_STATUS_CODES,
+      },
     );
     const result = fromSnakeKeys(raw, "sandboxId") as CreateSandboxResponse;
     return Object.assign(result, { traceId: raw.traceId }) as Traced<CreateSandboxResponse>;
@@ -365,6 +407,10 @@ export class SandboxClient {
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "POST",
       this.path(`sandbox-pools/${poolId}/sandboxes`),
+      {
+        retryableStatusCodes: CREATE_SANDBOX_RETRYABLE_STATUS_CODES,
+        allowedErrorStatusCodes: CREATE_SANDBOX_ALLOWED_ERROR_STATUS_CODES,
+      },
     );
     const result = fromSnakeKeys(raw, "sandboxId") as CreateSandboxResponse;
     return Object.assign(result, { traceId: raw.traceId }) as Traced<CreateSandboxResponse>;
@@ -560,7 +606,12 @@ export class SandboxClient {
   // --- Connect ---
 
   /** Return a `Sandbox` handle for an existing running sandbox without verifying it exists. */
-  connect(identifier: string, proxyUrl?: string, routingHint?: string): Sandbox {
+  connect(
+    identifier: string,
+    proxyUrl?: string,
+    routingHint?: string,
+    requestTimeout?: number,
+  ): Sandbox {
     const resolvedProxy = proxyUrl ?? resolveProxyUrl(this.apiUrl);
     return new Sandbox({
       sandboxId: identifier,
@@ -572,28 +623,34 @@ export class SandboxClient {
       resolveProxyInfo: proxyUrl == null
         ? async (currentIdentifier) => this.get(currentIdentifier)
         : undefined,
+      requestTimeout,
     });
   }
 
   /**
    * Create a sandbox, wait for it to reach `Running`, and return a connected handle.
    *
-   * Blocks until the sandbox is ready or `startupTimeout` elapses. The returned
+   * Blocks until the sandbox is ready or `requestTimeout` elapses. The returned
    * `Sandbox` auto-terminates when `terminate()` is called.
    *
-   * @param options.startupTimeout - Max seconds to wait for `Running` status (default 60).
+   * @param options.requestTimeout - Max seconds to wait for `Running` status (default: client requestTimeout).
+   * @param options.startupTimeout - Deprecated alias for `requestTimeout`.
    * @throws {SandboxError} If the sandbox terminates during startup or the timeout elapses.
    */
   async createAndConnect(
     options?: CreateAndConnectOptions,
   ): Promise<Sandbox> {
-    const startupTimeout = options?.startupTimeout ?? 60;
+    const requestTimeout =
+      options?.requestTimeout ??
+      options?.startupTimeout ??
+      this.requestTimeoutMs / 1000;
+    const requestClient = this.withRequestTimeout(requestTimeout);
 
     // claim() never sends options.name to the server, so only create() should fall
     // back to it locally when the server response omits a name.
     const result = options?.poolId != null
-      ? await this.claim(options.poolId)
-      : await this.create(options);
+      ? await requestClient.claim(options.poolId)
+      : await requestClient.create(options);
     const requestedName = options?.poolId != null ? null : options?.name ?? null;
 
     const finishConnect = (
@@ -601,12 +658,13 @@ export class SandboxClient {
       name: string | null | undefined,
       ingressEndpoint: string | undefined,
     ) => {
-      const sandbox = this.connect(
+      const sandbox = requestClient.connect(
         result.sandboxId,
         options?.proxyUrl ?? ingressEndpoint,
         routingHint,
+        requestTimeout,
       );
-      sandbox._setOwner(this);
+      sandbox._setOwner(requestClient);
       sandbox.traceId = result.traceId;
       sandbox._setLifecycleIdentifier(result.sandboxId);
       sandbox._setName(name ?? requestedName);
@@ -630,11 +688,21 @@ export class SandboxClient {
         }),
       );
     }
+    if (result.status === SandboxStatus.TIMEOUT) {
+      try {
+        await requestClient.delete(result.sandboxId);
+      } catch {
+        // ignore cleanup failures
+      }
+      throw new SandboxError(
+        `Sandbox ${result.sandboxId} did not start within ${requestTimeout}s`,
+      );
+    }
 
-    const deadline = Date.now() + startupTimeout * 1000;
+    const deadline = Date.now() + secondsToMillis(requestTimeout);
 
     while (Date.now() < deadline) {
-      const info = await this.get(result.sandboxId);
+      const info = await requestClient.get(result.sandboxId);
       if (info.status === SandboxStatus.RUNNING) {
         return finishConnect(info.routingHint, info.name, info.ingressEndpoint);
       }
@@ -654,13 +722,39 @@ export class SandboxClient {
 
     // Timed out — clean up
     try {
-      await this.delete(result.sandboxId);
+      await requestClient.delete(result.sandboxId);
     } catch {
       // ignore cleanup failures
     }
     throw new SandboxError(
-      `Sandbox ${result.sandboxId} did not start within ${startupTimeout}s`,
+      `Sandbox ${result.sandboxId} did not start within ${requestTimeout}s`,
     );
+  }
+}
+
+function resolveRequestTimeoutMs(
+  options?: { requestTimeout?: number; timeoutMs?: number },
+): number {
+  if (options?.requestTimeout != null) {
+    return secondsToMillis(options.requestTimeout);
+  }
+  if (options?.timeoutMs != null) {
+    validateTimeoutMs(options.timeoutMs);
+    return options.timeoutMs;
+  }
+  return defaults.DEFAULT_HTTP_TIMEOUT_MS;
+}
+
+function secondsToMillis(seconds: number): number {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new SandboxError("requestTimeout must be a positive number of seconds");
+  }
+  return Math.ceil(seconds * 1000);
+}
+
+function validateTimeoutMs(timeoutMs: number): void {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new SandboxError("timeoutMs must be a positive number of milliseconds");
   }
 }
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -32,7 +32,7 @@ import {
 import { Sandbox } from "./sandbox.js";
 import { isLocalhost, lifecyclePath, resolveProxyUrl, resolveSandboxLifecycleUrl } from "./url.js";
 
-const CREATE_SANDBOX_RETRYABLE_STATUS_CODES = new Set([429, 502, 503]);
+const CREATE_SANDBOX_RETRYABLE_STATUS_CODES = new Set([502, 503]);
 const CREATE_SANDBOX_ALLOWED_ERROR_STATUS_CODES = new Set([504]);
 
 /**

--- a/typescript/src/http.ts
+++ b/typescript/src/http.ts
@@ -13,6 +13,8 @@ import {
   SandboxNotFoundError,
 } from "./errors.js";
 
+const REQUEST_TIMEOUT_HEADER = "X-Tensorlake-Request-Timeout-Ms";
+
 export interface HttpClientOptions {
   baseUrl: string;
   apiKey?: string;
@@ -23,7 +25,7 @@ export interface HttpClientOptions {
   routingHint?: string;
   maxRetries?: number;
   retryBackoffMs?: number;
-  timeoutMs?: number;
+  timeoutMs?: number | null;
 }
 
 setGlobalDispatcher(
@@ -42,6 +44,8 @@ export interface HttpRequestOptions {
   json?: unknown;
   signal?: AbortSignal;
   allowHttpErrors?: boolean;
+  retryableStatusCodes?: Set<number>;
+  allowedErrorStatusCodes?: Set<number>;
 }
 
 /**
@@ -79,7 +83,7 @@ export class HttpClient {
   private readonly headers: Record<string, string>;
   private readonly maxRetries: number;
   private readonly retryBackoffMs: number;
-  private readonly timeoutMs: number;
+  private readonly timeoutMs: number | null;
   private abortController: AbortController | null = null;
 
   constructor(options: HttpClientOptions) {
@@ -87,11 +91,16 @@ export class HttpClient {
     this.baseUrl = url.endsWith("/") ? url.slice(0, -1) : url;
     this.maxRetries = options.maxRetries ?? defaults.MAX_RETRIES;
     this.retryBackoffMs = options.retryBackoffMs ?? defaults.RETRY_BACKOFF_MS;
-    this.timeoutMs = options.timeoutMs ?? defaults.DEFAULT_HTTP_TIMEOUT_MS;
+    this.timeoutMs = options.timeoutMs === undefined
+      ? defaults.DEFAULT_HTTP_TIMEOUT_MS
+      : options.timeoutMs;
 
     this.headers = {
       "User-Agent": `tensorlake-typescript-sdk/${defaults.SDK_VERSION}`,
     };
+    if (this.timeoutMs != null) {
+      this.headers[REQUEST_TIMEOUT_HEADER] = String(this.timeoutMs);
+    }
     if (options.apiKey) {
       this.headers["Authorization"] = `Bearer ${options.apiKey}`;
     }
@@ -125,12 +134,18 @@ export class HttpClient {
       body?: unknown;
       headers?: Record<string, string>;
       signal?: AbortSignal;
+      retryableStatusCodes?: Set<number>;
+      allowedErrorStatusCodes?: Set<number>;
+      allowHttpErrors?: boolean;
     },
   ): Promise<Traced<T>> {
     const response = await this.requestResponse(method, path, {
       json: options?.body,
       headers: options?.headers,
       signal: options?.signal,
+      retryableStatusCodes: options?.retryableStatusCodes,
+      allowedErrorStatusCodes: options?.allowedErrorStatusCodes,
+      allowHttpErrors: options?.allowHttpErrors,
     });
     const text = await response.text();
     const data = (text ? JSON.parse(text) : undefined) as T;
@@ -208,6 +223,8 @@ export class HttpClient {
       headers,
       options?.signal,
       options?.allowHttpErrors ?? false,
+      options?.retryableStatusCodes ?? defaults.RETRYABLE_STATUS_CODES,
+      options?.allowedErrorStatusCodes ?? new Set(),
     );
     return withTraceId(response, traceId);
   }
@@ -229,6 +246,8 @@ export class HttpClient {
     headers: Record<string, string>,
     signal?: AbortSignal,
     allowHttpErrors = false,
+    retryableStatusCodes: Set<number> = defaults.RETRYABLE_STATUS_CODES,
+    allowedErrorStatusCodes: Set<number> = new Set(),
   ): Promise<{ response: Response; traceId: string }> {
     const url = `${this.baseUrl}${path}`;
     const { traceparent, traceId } = HttpClient.makeTraceparent();
@@ -242,10 +261,9 @@ export class HttpClient {
       }
 
       this.abortController = new AbortController();
-      const timeoutId = setTimeout(
-        () => this.abortController?.abort(),
-        this.timeoutMs,
-      );
+      const timeoutId = this.timeoutMs == null
+        ? null
+        : setTimeout(() => this.abortController?.abort(), this.timeoutMs);
 
       // Combine external signal with internal timeout
       const combinedSignal = signal
@@ -260,13 +278,13 @@ export class HttpClient {
           signal: combinedSignal,
         })) as Response;
 
-        clearTimeout(timeoutId);
+        if (timeoutId != null) clearTimeout(timeoutId);
 
         if (response.ok) return { response, traceId };
 
         // Check if retryable
         if (
-          defaults.RETRYABLE_STATUS_CODES.has(response.status) &&
+          retryableStatusCodes.has(response.status) &&
           attempt < this.maxRetries
         ) {
           lastError = new RemoteAPIError(
@@ -276,7 +294,7 @@ export class HttpClient {
           continue;
         }
 
-        if (allowHttpErrors) {
+        if (allowHttpErrors || allowedErrorStatusCodes.has(response.status)) {
           return { response, traceId };
         }
 
@@ -284,7 +302,7 @@ export class HttpClient {
         const errorBody = await response.text().catch(() => "");
         throwMappedError(response.status, errorBody, path);
       } catch (err) {
-        clearTimeout(timeoutId);
+        if (timeoutId != null) clearTimeout(timeoutId);
 
         if (
           err instanceof RemoteAPIError ||

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -7,6 +7,7 @@ export enum SandboxStatus {
   SUSPENDING = "suspending",
   SUSPENDED = "suspended",
   TERMINATED = "terminated",
+  TIMEOUT = "timeout",
 }
 
 export enum SnapshotStatus {
@@ -377,6 +378,10 @@ export interface SandboxClientOptions {
   namespace?: string;
   maxRetries?: number;
   retryBackoffMs?: number;
+  /** Total HTTP request timeout in seconds. Default: 300. */
+  requestTimeout?: number;
+  /** @deprecated Use requestTimeout. Total HTTP request timeout in milliseconds. */
+  timeoutMs?: number;
 }
 
 export interface SandboxOptions {
@@ -389,11 +394,18 @@ export interface SandboxOptions {
   resolveProxyInfo?: (
     identifier: string,
   ) => Promise<SandboxInfo & { readonly traceId: string }>;
+  /** Optional total HTTP request timeout in seconds for sandbox proxy operations. Omit for no total proxy timeout. */
+  requestTimeout?: number;
+  /** @deprecated Use requestTimeout. Optional total HTTP request timeout in milliseconds for sandbox proxy operations. */
+  timeoutMs?: number;
 }
 
 export interface CreateAndConnectOptions extends CreateSandboxOptions {
   poolId?: string;
   proxyUrl?: string;
+  /** Total HTTP request timeout in seconds for sandbox startup. Default: client requestTimeout. */
+  requestTimeout?: number;
+  /** @deprecated Use requestTimeout. */
   startupTimeout?: number;
 }
 

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -181,6 +181,9 @@ class SandboxProxyConnection {
       hostHeader,
       sandboxIdHeader,
       routingHint,
+      timeoutMs: this.options.requestTimeout != null
+        ? secondsToMillis(this.options.requestTimeout)
+        : (this.options.timeoutMs ?? null),
     });
   }
 }
@@ -438,6 +441,13 @@ function sendPtyFrame(socket: WebSocket, frame: Buffer): Promise<void> {
   });
 }
 
+function secondsToMillis(seconds: number): number {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new SandboxError("requestTimeout must be a positive number of seconds");
+  }
+  return Math.ceil(seconds * 1000);
+}
+
 /**
  * Client for interacting with a running sandbox.
  *
@@ -508,9 +518,7 @@ export class Sandbox {
     // Dynamic import to break the circular dependency (client.ts imports Sandbox).
     const { SandboxClient } = await import("./client.js");
     const client = new SandboxClient(options, /* _internal */ true);
-    const sandbox = await client.createAndConnect(options);
-    sandbox.lifecycleClient = client;
-    return sandbox;
+    return client.createAndConnect(options);
   }
 
   /**
@@ -529,6 +537,7 @@ export class Sandbox {
       options.sandboxId,
       options.proxyUrl,
       options.routingHint,
+      options.requestTimeout,
     );
     sandbox.lifecycleClient = client;
     return sandbox;

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -139,6 +139,19 @@ describe("SandboxClient", () => {
       expect(attempts).toBe(1);
       client.close();
     });
+
+    it("does not retry rate-limited create responses", async () => {
+      let attempts = 0;
+      mockFetch(() => {
+        attempts++;
+        return new Response("rate limited", { status: 429 });
+      });
+
+      const client = SandboxClient.forLocalhost();
+      await expect(client.create()).rejects.toThrow("rate limited");
+      expect(attempts).toBe(1);
+      client.close();
+    });
   });
 
   describe("get", () => {
@@ -586,6 +599,19 @@ describe("SandboxClient", () => {
       const result = await client.claim("pool-1");
       expect(result.sandboxId).toBe("sbx-timeout");
       expect(result.status).toBe(SandboxStatus.TIMEOUT);
+      expect(attempts).toBe(1);
+      client.close();
+    });
+
+    it("does not retry rate-limited claim responses", async () => {
+      let attempts = 0;
+      mockFetch(() => {
+        attempts++;
+        return new Response("rate limited", { status: 429 });
+      });
+
+      const client = SandboxClient.forLocalhost();
+      await expect(client.claim("pool-1")).rejects.toThrow("rate limited");
       expect(attempts).toBe(1);
       client.close();
     });

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -121,6 +121,24 @@ describe("SandboxClient", () => {
       await client.create();
       client.close();
     });
+
+    it("returns readiness timeout responses without retrying", async () => {
+      let attempts = 0;
+      mockFetch(() => {
+        attempts++;
+        return new Response(
+          JSON.stringify({ sandbox_id: "sbx-timeout", status: "timeout" }),
+          { status: 504 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost();
+      const result = await client.create();
+      expect(result.sandboxId).toBe("sbx-timeout");
+      expect(result.status).toBe(SandboxStatus.TIMEOUT);
+      expect(attempts).toBe(1);
+      client.close();
+    });
   });
 
   describe("get", () => {
@@ -553,6 +571,24 @@ describe("SandboxClient", () => {
       expect(result.sandboxId).toBe("sbx-3");
       client.close();
     });
+
+    it("returns readiness timeout responses without retrying", async () => {
+      let attempts = 0;
+      mockFetch(() => {
+        attempts++;
+        return new Response(
+          JSON.stringify({ sandbox_id: "sbx-timeout", status: "timeout" }),
+          { status: 504 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost();
+      const result = await client.claim("pool-1");
+      expect(result.sandboxId).toBe("sbx-timeout");
+      expect(result.status).toBe(SandboxStatus.TIMEOUT);
+      expect(attempts).toBe(1);
+      client.close();
+    });
   });
 
   describe("createAndConnect", () => {
@@ -576,6 +612,83 @@ describe("SandboxClient", () => {
         "https://sandbox.us-east-1.aws.tensorlake.ai",
       );
       sandbox.close();
+      client.close();
+    });
+
+    it("uses per-call requestTimeout for the initial create request", async () => {
+      mockFetch((_url, init) => {
+        const headers = init?.headers as Record<string, string>;
+        expect(headers["X-Tensorlake-Request-Timeout-Ms"]).toBe("10000");
+        return new Response(
+          JSON.stringify({ sandbox_id: "sbx-1", status: "running" }),
+          { status: 200 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost({ requestTimeout: 300 });
+      const sandbox = await client.createAndConnect({ requestTimeout: 10 });
+      expect(sandbox.sandboxId).toBe("sbx-1");
+      client.close();
+      sandbox.close();
+    });
+
+    it("uses startupTimeout as a compatibility alias for requestTimeout", async () => {
+      mockFetch((_url, init) => {
+        const headers = init?.headers as Record<string, string>;
+        expect(headers["X-Tensorlake-Request-Timeout-Ms"]).toBe("12000");
+        return new Response(
+          JSON.stringify({ sandbox_id: "sbx-1", status: "running" }),
+          { status: 200 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost({ requestTimeout: 300 });
+      const sandbox = await client.createAndConnect({ startupTimeout: 12 });
+      expect(sandbox.sandboxId).toBe("sbx-1");
+      client.close();
+      sandbox.close();
+    });
+
+    it("prefers requestTimeout over startupTimeout", async () => {
+      mockFetch((_url, init) => {
+        const headers = init?.headers as Record<string, string>;
+        expect(headers["X-Tensorlake-Request-Timeout-Ms"]).toBe("15000");
+        return new Response(
+          JSON.stringify({ sandbox_id: "sbx-1", status: "running" }),
+          { status: 200 },
+        );
+      });
+
+      const client = SandboxClient.forLocalhost({ requestTimeout: 300 });
+      const sandbox = await client.createAndConnect({
+        requestTimeout: 15,
+        startupTimeout: 12,
+      });
+      expect(sandbox.sandboxId).toBe("sbx-1");
+      client.close();
+      sandbox.close();
+    });
+
+    it("deletes the sandbox returned by a readiness timeout response", async () => {
+      const calls: string[] = [];
+      mockFetch((url, init) => {
+        calls.push(`${init?.method ?? "GET"} ${url}`);
+        if (init?.method === "POST") {
+          return new Response(
+            JSON.stringify({ sandbox_id: "sbx-timeout", status: "timeout" }),
+            { status: 504 },
+          );
+        }
+        expect(init?.method).toBe("DELETE");
+        expect(url).toContain("/sandboxes/sbx-timeout");
+        return new Response("{}", { status: 200 });
+      });
+
+      const client = SandboxClient.forLocalhost({ requestTimeout: 300 });
+      await expect(
+        client.createAndConnect({ requestTimeout: 10 }),
+      ).rejects.toThrow("Sandbox sbx-timeout did not start within 10s");
+      expect(calls).toHaveLength(2);
       client.close();
     });
 

--- a/typescript/tests/http.test.ts
+++ b/typescript/tests/http.test.ts
@@ -55,6 +55,48 @@ describe("HttpClient", () => {
     client.close();
   });
 
+  it("sends the default request timeout header", async () => {
+    mockFetch((_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["X-Tensorlake-Request-Timeout-Ms"]).toBe("300000");
+      return new Response("{}", { status: 200 });
+    });
+
+    const client = new HttpClient({ baseUrl: "http://localhost:8900" });
+    await client.requestJson("GET", "/test");
+    client.close();
+  });
+
+  it("sends a custom request timeout header", async () => {
+    mockFetch((_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["X-Tensorlake-Request-Timeout-Ms"]).toBe("120000");
+      return new Response("{}", { status: 200 });
+    });
+
+    const client = new HttpClient({
+      baseUrl: "http://localhost:8900",
+      timeoutMs: 120_000,
+    });
+    await client.requestJson("GET", "/test");
+    client.close();
+  });
+
+  it("omits the request timeout header when the timeout is disabled", async () => {
+    mockFetch((_url, init) => {
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["X-Tensorlake-Request-Timeout-Ms"]).toBeUndefined();
+      return new Response("{}", { status: 200 });
+    });
+
+    const client = new HttpClient({
+      baseUrl: "http://localhost:8900",
+      timeoutMs: null,
+    });
+    await client.requestJson("GET", "/test");
+    client.close();
+  });
+
   it("adds JSON content type only when sending JSON bodies", async () => {
     mockFetch((_url, init) => {
       const headers = init?.headers as Record<string, string>;

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -36,6 +36,22 @@ describe("Sandbox", () => {
       expect(sbx.sandboxId).toBe("sbx-abc");
       sbx.close();
     });
+
+    it("uses explicit requestTimeout for proxy operations", async () => {
+      mockFetch((_url, init) => {
+        const headers = init?.headers as Record<string, string>;
+        expect(headers["X-Tensorlake-Request-Timeout-Ms"]).toBe("10000");
+        return new Response(JSON.stringify({ healthy: true }), { status: 200 });
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-abc",
+        proxyUrl: "http://localhost:9443",
+        requestTimeout: 10,
+      });
+      await sbx.health();
+      sbx.close();
+    });
   });
 
   describe("run", () => {


### PR DESCRIPTION
## Summary

- Propagate sandbox lifecycle request timeouts from SDK clients via `X-Tensorlake-Request-Timeout-Ms`.
- Align Python, TypeScript, and Rust SDK behavior around `requestTimeout`/`request_timeout` defaults and per-call overrides.
- Avoid retrying sandbox create/claim readiness timeouts, parse structured timeout responses, and clean up persisted sandboxes from `create_and_connect`.
- Keep sandbox proxy operation streams unbounded by default while honoring explicit proxy timeouts.

## Validation

- `npm run typecheck`
- `npm test`
- `PYTHONPATH=src python3 -m pytest tests/sandbox/test_client_rust_backend.py tests/sandbox/test_client_rust_backend_async.py`
- `cargo check -p tensorlake -p tensorlake-rust-cloud-sdk-py`
- `python3 -m py_compile src/tensorlake/sandbox/client.py src/tensorlake/sandbox/async_client.py src/tensorlake/sandbox/sandbox.py src/tensorlake/sandbox/async_sandbox.py src/tensorlake/sandbox/models.py`
- `git diff --check`
