### PR TITLE
fix(ts): surface incomplete sandbox run instead of silent success

### DIFF
--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -4,7 +4,7 @@ import {
   Desktop,
 } from "./desktop.js";
 import * as defaults from "./defaults.js";
-import { SandboxError } from "./errors.js";
+import { SandboxError, SandboxConnectionError } from "./errors.js";
 import { type HttpRequestOptions, type Traced, HttpClient } from "./http.js";
 import {
   type CheckpointOptions,
@@ -719,6 +719,7 @@ export class Sandbox {
     const stdoutLines: string[] = [];
     const stderrLines: string[] = [];
     let exitCode = -1;
+    let sawExit = false;
 
     for await (const raw of parseSSEStream<Record<string, unknown>>(sseStream)) {
       if (typeof raw.line === "string") {
@@ -728,12 +729,23 @@ export class Sandbox {
           stdoutLines.push(raw.line);
         }
       } else if ("exit_code" in raw || "signal" in raw) {
+        sawExit = true;
         if (typeof raw.exit_code === "number") {
           exitCode = raw.exit_code;
         } else if (typeof raw.signal === "number") {
           exitCode = -raw.signal;
         }
       }
+    }
+
+    // A completed run always terminates with an exit_code/signal event. If the
+    // stream ends without one, the command never finished — e.g. the sandbox was
+    // unreachable and the proxy closed the stream after a timeout. Surface that
+    // as an error instead of returning a misleading success with empty output.
+    if (!sawExit) {
+      throw new SandboxConnectionError(
+        `Command "${command}" did not complete: the process stream ended without an exit status.`,
+      );
     }
 
     return Object.assign(

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -87,6 +87,25 @@ describe("Sandbox", () => {
       await sbx.run("echo");
       sbx.close();
     });
+
+    it("throws when the stream ends without an exit event", async () => {
+      // Reproduces the unreachable-sandbox case: the proxy closes the run
+      // stream after a timeout without ever delivering an exit_code, so the
+      // command never actually executed. This must surface as an error rather
+      // than a silent success with empty output.
+      mockFetch((url) => {
+        if (url.includes("/api/v1/processes/run")) {
+          return sseResponse([{ pid: 42, started_at: 1700000000 }]);
+        }
+        return new Response("", { status: 404 });
+      });
+
+      const sbx = makeSandbox();
+      await expect(sbx.run("node", { args: ["-v"] })).rejects.toThrow(
+        /did not complete/,
+      );
+      sbx.close();
+    });
   });
 
   describe("listProcesses", () => {


### PR DESCRIPTION
## Problem

`Sandbox.run()` (the method behind `runCommand`) streams `POST /api/v1/processes/run` and only sets `exitCode` when it observes an `exit_code`/`signal` event. When the SSE stream **ends without a terminal event**, it fell through to:

```ts
return { exitCode: -1, stdout: "", stderr: "" };
```

…and **never threw**. Callers got a *successful* `CommandResult` with empty output for a command that never actually ran.

### How it shows up

Running a sandbox benchmark against a **dev** endpoint, every `exec` returned "success" with empty stdout after a fixed ~48s. Tracing it end-to-end:

- The in-VM daemon executes `node -v` in ~11ms (direct and via the dataplane's own http_proxy).
- During the 48s, the executor dataplane saw **zero** connections and **no process was ever spawned** (`Failed to send signal: No processes spawned`).
- The exec request goes to the sandbox-proxy host (`sandbox.<env>`), which couldn't route to the executor; it closed the stream after a timeout without any `exit_code`.
- The SDK returned `{ exitCode: -1, stdout: "" }` → the harness counted **100/100 "ok"** for commands that never executed.

The underlying routing problem is dev infrastructure (separate issue), but the SDK **masking** it as success is a real correctness bug.

## Fix

Track whether a terminal (`exit_code`/`signal`) event arrived; if the stream ends without one, throw `SandboxConnectionError` instead of returning a misleading success.

This matches the canonical behavior already in the repo's Rust CLI (`crates/cli/src/commands/sbx/exec.rs`), which treats a missing exit event as failure (`exit_code.unwrap_or(1)` → non-zero → error).

## Tests

- New unit test in `tests/sandbox.test.ts` reproducing the unreachable case (run stream with no `exit_code`) → asserts `run()` rejects.
- `tsc --noEmit` clean; full suite green (189 tests, unit + integration).

## Out of scope

- The dev sandbox-proxy ↔ executor routing/latency (infra).
- Signal-exit code convention: TS uses `-signal` while the Rust CLI uses `128 + signal`; worth aligning separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)