### PR TITLE
fix(cloud-sdk): classify malformed invoke success body as decode error

### DIFF
--- a/crates/cloud-sdk/src/applications/mod.rs
+++ b/crates/cloud-sdk/src/applications/mod.rs
@@ -134,15 +134,12 @@ impl ApplicationsClient {
             .header(ACCEPT, "application/json")
             .json(&request.body)
             .build()?;
-        let resp = self.client.execute_json::<serde_json::Value>(req).await?;
+        let resp = self
+            .client
+            .execute_json::<models::InvokeApplicationResponse>(req)
+            .await?;
         let trace_id = resp.trace_id.clone();
-        let request_id = resp["request_id"]
-            .as_str()
-            .ok_or_else(|| SdkError::ServerError {
-                status: reqwest::StatusCode::OK,
-                message: "Missing request_id in response".to_string(),
-            })?
-            .to_string();
+        let request_id = resp.into_inner().request_id;
         Ok(Traced::new(
             trace_id,
             models::InvokeResponse::RequestId(request_id),

--- a/crates/cloud-sdk/src/applications/models.rs
+++ b/crates/cloud-sdk/src/applications/models.rs
@@ -1232,6 +1232,11 @@ impl InvokeApplicationRequest {
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct InvokeApplicationResponse {
+    pub(super) request_id: String,
+}
+
 /// Response from invoking an application
 pub enum InvokeResponse {
     /// The request ID of the invocation
@@ -1451,6 +1456,29 @@ mod tests {
         assert!(result.is_ok());
         let event = result.unwrap();
         assert!(event.created_at.is_some());
+    }
+
+    #[test]
+    fn invoke_application_response_deserializes_request_id() {
+        let json = json!({"request_id": "req-123"});
+        let response: InvokeApplicationResponse = serde_json::from_value(json).unwrap();
+
+        assert_eq!(response.request_id, "req-123");
+    }
+
+    #[test]
+    fn invoke_application_response_rejects_missing_request_id() {
+        let result: Result<InvokeApplicationResponse, _> = serde_json::from_value(json!({}));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invoke_application_response_rejects_non_string_request_id() {
+        let result: Result<InvokeApplicationResponse, _> =
+            serde_json::from_value(json!({"request_id": 123}));
+
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`ApplicationsClient::invoke` (`crates/cloud-sdk/src/applications/mod.rs`) decodes the response
as a raw `serde_json::Value` and returns `SdkError::ServerError { status: 200 OK }` when
`request_id` is missing or not a string. That status is contradictory, since `execute_json`
only returns `Ok` on a successful (2xx) response.

This change decodes the success body into a typed (internal) struct, so a malformed body
surfaces as a regular decode error rather than a fabricated server error. It brings `invoke`
in line with the other typed client methods, removes the manual `Value` indexing, and adds no
public API surface or new error variant.

## Validation

Tests cover a present, missing, and non-string `request_id`.

- `cargo nextest run -p tensorlake`
- `cargo fmt -p tensorlake --check`

Related: #528
