### PR TITLE
TS SDK: surface inner transport errors in SandboxConnectionError

### DIFF
--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -14,12 +14,59 @@ export class SandboxError extends SandboxException {
   }
 }
 
-/** Raised when the client cannot connect to the API server. */
+/**
+ * Raised when the client cannot complete a request against the API server.
+ *
+ * The original transport error (typically undici's `TypeError: fetch failed`,
+ * whose real reason — `ECONNREFUSED`, `UND_ERR_CONNECT_TIMEOUT`, `EMFILE`, … —
+ * lives in `.cause`) is preserved on this error's {@link cause} for programmatic
+ * inspection, and its full chain is folded into the message so it survives
+ * wrappers that only forward `error.message`. No interpretation of the failure
+ * (client vs server) is applied — the raw inner error is surfaced as-is so the
+ * reader can judge.
+ */
 export class SandboxConnectionError extends SandboxError {
-  constructor(message: string) {
+  constructor(message: string, options?: { cause?: unknown }) {
     super(`Connection error: ${message}`);
     this.name = "SandboxConnectionError";
+    if (options?.cause !== undefined) this.cause = options.cause;
   }
+}
+
+/**
+ * Flatten an error and its `cause` chain into a single readable line, appending
+ * each level's `code` when it is not already present in the message. undici
+ * reports `fetch failed` at the top and the real reason one or more levels down
+ * in `.cause`, so this surfaces the part that actually identifies the failure.
+ *
+ * @example "fetch failed: connect ECONNREFUSED 10.0.0.1:443"
+ * @example "fetch failed: Connect Timeout Error (UND_ERR_CONNECT_TIMEOUT)"
+ */
+export function describeError(err: unknown): string {
+  const parts: string[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+
+  for (let depth = 0; depth < 6; depth++) {
+    if (current == null || typeof current !== "object" || seen.has(current)) {
+      break;
+    }
+    seen.add(current);
+    const e = current as { message?: unknown; code?: unknown; cause?: unknown };
+    const message = typeof e.message === "string" ? e.message.trim() : "";
+    const code = typeof e.code === "string" ? e.code : undefined;
+
+    let segment = message;
+    if (code && (!message || !message.includes(code))) {
+      segment = segment ? `${segment} (${code})` : code;
+    }
+    if (segment && !parts.includes(segment)) parts.push(segment);
+
+    current = e.cause;
+  }
+
+  if (parts.length > 0) return parts.join(": ");
+  return err instanceof Error ? err.message : String(err);
 }
 
 /** Raised when a sandbox is not found. */

--- a/typescript/src/http.ts
+++ b/typescript/src/http.ts
@@ -6,6 +6,7 @@ import {
 } from "undici";
 import * as defaults from "./defaults.js";
 import {
+  describeError,
   PoolInUseError,
   PoolNotFoundError,
   RemoteAPIError,
@@ -261,9 +262,15 @@ export class HttpClient {
       }
 
       this.abortController = new AbortController();
+      // Track whether *our* deadline fired, so we can tell a client-imposed
+      // timeout apart from a network rejection or a caller-initiated abort.
+      let timedOut = false;
       const timeoutId = this.timeoutMs == null
         ? null
-        : setTimeout(() => this.abortController?.abort(), this.timeoutMs);
+        : setTimeout(() => {
+            timedOut = true;
+            this.abortController?.abort();
+          }, this.timeoutMs);
 
       // Combine external signal with internal timeout
       const combinedSignal = signal
@@ -313,20 +320,30 @@ export class HttpClient {
           throw err;
         }
 
-        if (signal?.aborted) {
-          throw new SandboxConnectionError("Request aborted");
+        // A caller-supplied signal fired (and it wasn't our own deadline).
+        if (signal?.aborted && !timedOut) {
+          throw new SandboxConnectionError("request aborted by caller", {
+            cause: err,
+          });
         }
 
         // Network / timeout error
         lastError = err instanceof Error ? err : new Error(String(err));
 
         if (attempt >= this.maxRetries) {
-          throw new SandboxConnectionError(lastError.message);
+          // Surface the real inner cause; for our own deadline, say so plainly.
+          const detail = timedOut
+            ? `request timed out after ${this.timeoutMs}ms`
+            : describeError(err);
+          throw new SandboxConnectionError(detail, { cause: err });
         }
       }
     }
 
-    throw new SandboxConnectionError(lastError?.message ?? "Request failed");
+    throw new SandboxConnectionError(
+      lastError ? describeError(lastError) : "request failed",
+      { cause: lastError },
+    );
   }
 }
 

--- a/typescript/tests/http.test.ts
+++ b/typescript/tests/http.test.ts
@@ -215,6 +215,89 @@ describe("HttpClient", () => {
     client.close();
   });
 
+  it("bubbles the inner cause into the connection error", async () => {
+    mockFetch(() => {
+      const cause = Object.assign(
+        new Error("connect ECONNREFUSED 127.0.0.1:8900"),
+        { code: "ECONNREFUSED" },
+      );
+      throw Object.assign(new TypeError("fetch failed"), { cause });
+    });
+
+    const client = new HttpClient({
+      baseUrl: "http://localhost:8900",
+      maxRetries: 0,
+    });
+    try {
+      await client.requestJson("GET", "/test");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SandboxConnectionError);
+      const ce = err as SandboxConnectionError;
+      // The inner reason is surfaced in the message, not just "fetch failed".
+      expect(ce.message).toContain("fetch failed");
+      expect(ce.message).toContain("connect ECONNREFUSED 127.0.0.1:8900");
+      // The full raw cause chain is preserved for programmatic inspection.
+      expect((ce.cause as { cause?: { code?: string } })?.cause?.code).toBe(
+        "ECONNREFUSED",
+      );
+    }
+    client.close();
+  });
+
+  it("appends the inner code when absent from the message", async () => {
+    mockFetch(() => {
+      const cause = Object.assign(new Error("Connect Timeout Error"), {
+        code: "UND_ERR_CONNECT_TIMEOUT",
+      });
+      throw Object.assign(new TypeError("fetch failed"), { cause });
+    });
+
+    const client = new HttpClient({
+      baseUrl: "http://localhost:8900",
+      maxRetries: 0,
+    });
+    try {
+      await client.requestJson("GET", "/test");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const ce = err as SandboxConnectionError;
+      expect(ce.message).toContain(
+        "Connect Timeout Error (UND_ERR_CONNECT_TIMEOUT)",
+      );
+    }
+    client.close();
+  });
+
+  it("reports the request deadline when the client timeout fires", async () => {
+    mockFetch((_url, init) => {
+      // Hang until our internal timeout aborts the request.
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(
+            Object.assign(new Error("This operation was aborted"), {
+              name: "AbortError",
+            }),
+          );
+        });
+      }) as Promise<Response>;
+    });
+
+    const client = new HttpClient({
+      baseUrl: "http://localhost:8900",
+      maxRetries: 0,
+      timeoutMs: 20,
+    });
+    try {
+      await client.requestJson("GET", "/test");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      const ce = err as SandboxConnectionError;
+      expect(ce.message).toContain("request timed out after 20ms");
+    }
+    client.close();
+  });
+
   it("retries on network failure then succeeds", async () => {
     let attempts = 0;
     mockFetch(() => {


### PR DESCRIPTION
## Problem

Every transport-level failure in the TypeScript SDK collapsed into the opaque message `Connection error: fetch failed`, discarding undici's underlying `cause`. In a recent 10K-sandbox burst run, all 10,000 failures logged as either `fetch failed` or `This operation was aborted` — with no way to tell apart DNS failure, connection-refused, peer reset, local socket/FD exhaustion, or a client-imposed timeout. That makes it impossible to judge whether a load test is bottlenecked on the client or the server.

## Change

Surface the real inner error instead of swallowing it. **No client/server classification is applied** — the raw underlying error is surfaced so the reader can judge.

- **`src/errors.ts`**
  - `SandboxConnectionError(message, { cause })` now preserves the original error on `.cause` (full nested chain intact).
  - New `describeError(err)` flattens an error + its `.cause` chain into one line, appending each level's `code` when it's not already in the message.
- **`src/http.ts`**
  - Throws `describeError(err)` with the raw `cause` attached.
  - A client-side deadline now reports `request timed out after <ms>ms` instead of the ambiguous `This operation was aborted`; a caller-initiated abort reports `request aborted by caller`.
- **`tests/http.test.ts`** — cover cause bubbling, code appending, and the timeout message.

## Before / After

| Raw failure | Before | After |
|---|---|---|
| `ECONNREFUSED` | `Connection error: fetch failed` | `Connection error: fetch failed: connect ECONNREFUSED 10.0.0.1:443` |
| `UND_ERR_CONNECT_TIMEOUT` | `Connection error: fetch failed` | `Connection error: fetch failed: Connect Timeout Error (UND_ERR_CONNECT_TIMEOUT)` |
| local `EMFILE` | `Connection error: fetch failed` | `Connection error: fetch failed: connect EMFILE` |
| our deadline fired | `Connection error: This operation was aborted` | `Connection error: request timed out after 300000ms` |

The message survives wrappers that only forward `error.message` (e.g. the `@computesdk/tensorlake` adapter → benchmark logs), and `err.cause` is available for programmatic inspection.

## Compatibility

Backward compatible: bare `new SandboxConnectionError(msg)` still yields `Connection error: <msg>`; all other error types (`RemoteAPIError`, `SandboxNotFoundError`, …) are unchanged.

## Testing

- `tsc --noEmit`: clean
- `vitest run` (unit + http): 163 unit + 18 http tests pass
- Repo `lint` script is broken on `main` (missing `eslint.config.js`, ESLint v9) — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)