### PR TITLE
Pin TypeScript SDK undici dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.31"
+version = "0.5.33"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.31"
+version = "0.5.33"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.31"
+version = "0.5.33"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.31"
+version = "0.5.33"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.32"
+version = "0.5.33"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.32"
+version = "0.5.33"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.32"
+version = "0.5.33"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.31",
+  "version": "0.5.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.31",
+      "version": "0.5.33",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.31",
       "license": "Apache-2.0",
       "dependencies": {
-        "undici": "^8.1.0",
+        "undici": "8.3.0",
         "ws": "^8.20.0"
       },
       "bin": {
@@ -2813,9 +2813,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.1.0.tgz",
-      "integrity": "sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.32",
+  "version": "0.5.33",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -68,7 +68,7 @@
     "vitest": "^2.0.0"
   },
   "dependencies": {
-    "undici": "^8.1.0",
+    "undici": "8.3.0",
     "ws": "^8.20.0"
   }
 }

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       undici:
-        specifier: ^8.1.0
-        version: 8.1.0
+        specifier: 8.3.0
+        version: 8.3.0
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -1084,8 +1084,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@8.1.0:
-    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
+  undici@8.3.0:
+    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
     engines: {node: '>=22.19.0'}
 
   uri-js@4.4.1:
@@ -2063,7 +2063,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@8.1.0: {}
+  undici@8.3.0: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Pin the TypeScript SDK's `undici` dependency to `8.3.0` instead of allowing `^8.1.0` to float.
- Bump SDK and CLI release versions to `0.5.33`.

## Why

`undici@8.4.0` changed HTTP/2 pooling behavior so requests consolidate onto an H2 session more aggressively. For our sandbox proxy `POST /api/v1/processes/run` path, which returns an SSE-style stream, that exposes Undici's H2 `busy()` guards for non-idempotent/stream-body requests and serializes concurrent run requests.

With `undici@8.3.0`, the same burst path fans out across multiple H2 sessions and sends requests immediately, avoiding the client-side serialization seen in benchmarks.

## Validation

- `npm run typecheck`
- `npm test`
- `cargo metadata --locked --format-version 1`