### PR TITLE
[codex] Ensure function image executor script is on PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.35"
+version = "0.5.36"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.35"
+version = "0.5.36"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.35"
+version = "0.5.36"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.35"
+version = "0.5.36"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.35"
+version = "0.5.36"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1388,12 +1388,28 @@ async fn run_ssh_keys_command(ctx: &CliContext, subcmd: SshKeysCommands) -> erro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     #[test]
     fn clone_command_is_not_supported() {
         let result = Cli::try_parse_from(["tl", "sbx", "clone", "sbx-123"]);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_images_command_is_hidden_from_help() {
+        let mut help = Vec::new();
+        Cli::command().write_long_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(!help.contains("build-images"));
+        let missing_subcommand_error = match Cli::try_parse_from(["tl"]) {
+            Ok(_) => String::new(),
+            Err(error) => error.to_string(),
+        };
+        assert!(!missing_subcommand_error.contains("build-images"));
+        assert!(Cli::try_parse_from(["tl", "build-images", "app.py"]).is_ok());
     }
 
     #[test]

--- a/crates/cloud-sdk/src/images/models.rs
+++ b/crates/cloud-sdk/src/images/models.rs
@@ -399,20 +399,19 @@ impl Image {
             lines.push(render_build_operation(op));
         }
 
-        let install_command = if sdk_version.starts_with("~=")
+        let tensorlake_spec = if sdk_version.starts_with("~=")
             || sdk_version.starts_with(">=")
             || sdk_version.starts_with("<=")
             || sdk_version.starts_with("!=")
             || sdk_version.starts_with("==")
         {
-            format!(
-                "RUN python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake{sdk_version} && command -v function-executor"
-            )
+            format!("tensorlake{sdk_version}")
         } else {
-            format!(
-                "RUN python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake=={sdk_version} && command -v function-executor"
-            )
+            format!("tensorlake=={sdk_version}")
         };
+        let install_command = format!(
+            "RUN if [ \"$(id -u)\" = \"0\" ]; then PIP_USER=false python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir --prefix=/usr/local {tensorlake_spec}; else sudo -E env PIP_USER=false python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir --prefix=/usr/local {tensorlake_spec}; fi && test -x /usr/local/bin/function-executor"
+        );
         lines.push(install_command);
 
         lines.join("\n")
@@ -681,12 +680,17 @@ mod tests {
         assert!(
             image
                 .dockerfile_content("1.2.3", None)
-                .contains("RUN python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake==1.2.3 && command -v function-executor")
+                .contains("python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir --prefix=/usr/local tensorlake==1.2.3")
+        );
+        assert!(
+            image
+                .dockerfile_content("1.2.3", None)
+                .contains("&& test -x /usr/local/bin/function-executor")
         );
         assert!(
             image
                 .dockerfile_content(">=1.2.3", None)
-                .contains("RUN python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake>=1.2.3 && command -v function-executor")
+                .contains("python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir --prefix=/usr/local tensorlake>=1.2.3")
         );
     }
 

--- a/crates/cloud-sdk/src/images/models.rs
+++ b/crates/cloud-sdk/src/images/models.rs
@@ -405,9 +405,13 @@ impl Image {
             || sdk_version.starts_with("!=")
             || sdk_version.starts_with("==")
         {
-            format!("RUN python3 -m pip install --break-system-packages tensorlake{sdk_version}")
+            format!(
+                "RUN python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake{sdk_version} && command -v function-executor"
+            )
         } else {
-            format!("RUN python3 -m pip install --break-system-packages tensorlake=={sdk_version}")
+            format!(
+                "RUN python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake=={sdk_version} && command -v function-executor"
+            )
         };
         lines.push(install_command);
 
@@ -677,12 +681,12 @@ mod tests {
         assert!(
             image
                 .dockerfile_content("1.2.3", None)
-                .contains("RUN python3 -m pip install --break-system-packages tensorlake==1.2.3")
+                .contains("RUN python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake==1.2.3 && command -v function-executor")
         );
         assert!(
             image
                 .dockerfile_content(">=1.2.3", None)
-                .contains("RUN python3 -m pip install --break-system-packages tensorlake>=1.2.3")
+                .contains("RUN python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake>=1.2.3 && command -v function-executor")
         );
     }
 

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.35"
+version = "0.5.36"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.35"
+version = "0.5.36"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/image/utils.py
+++ b/src/tensorlake/image/utils.py
@@ -35,10 +35,18 @@ def dockerfile_content(img: Image, extra_env_vars: List[tuple] | None = None) ->
     # Run Tensorlake install after all user commands so user layers cannot
     # remove or downgrade the runtime. Force reinstall makes pip replay package
     # console scripts even when Tensorlake was already present in the base.
+    # Install into /usr/local so function-executor is visible to the root
+    # process launched by the Firecracker dataplane.
+    install_cmd = (
+        "python3 -m pip install --break-system-packages --force-reinstall "
+        f"--no-cache-dir --prefix=/usr/local tensorlake=={_SDK_VERSION}"
+    )
     dockerfile_lines.append(
-        "RUN python3 -m pip install --break-system-packages "
-        f"--force-reinstall --no-cache-dir tensorlake=={_SDK_VERSION} "
-        "&& command -v function-executor"
+        'RUN if [ "$(id -u)" = "0" ]; then '
+        f"PIP_USER=false {install_cmd}; "
+        "else "
+        f"sudo -E env PIP_USER=false {install_cmd}; "
+        "fi && test -x /usr/local/bin/function-executor"
     )
 
     return "\n".join(dockerfile_lines)

--- a/src/tensorlake/image/utils.py
+++ b/src/tensorlake/image/utils.py
@@ -32,10 +32,13 @@ def dockerfile_content(img: Image, extra_env_vars: List[tuple] | None = None) ->
     for op in img._build_operations:
         dockerfile_lines.append(render_op_line(op))
 
-    # Run tensorlake install after all user commands. There's implicit dependency
-    # of tensorlake install success on user commands right now.
+    # Run Tensorlake install after all user commands so user layers cannot
+    # remove or downgrade the runtime. Force reinstall makes pip replay package
+    # console scripts even when Tensorlake was already present in the base.
     dockerfile_lines.append(
-        f"RUN python3 -m pip install --break-system-packages tensorlake=={_SDK_VERSION}"
+        "RUN python3 -m pip install --break-system-packages "
+        f"--force-reinstall --no-cache-dir tensorlake=={_SDK_VERSION} "
+        "&& command -v function-executor"
     )
 
     return "\n".join(dockerfile_lines)

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -271,11 +271,12 @@ class TestBuildSandboxApplicationImage(unittest.TestCase):
         self.assertIsInstance(dockerfile_text, str)
         install_line = dockerfile_text.rstrip().splitlines()[-1]
         self.assertIn(
-            "--force-reinstall --no-cache-dir tensorlake==",
+            "--force-reinstall --no-cache-dir --prefix=/usr/local tensorlake==",
             install_line,
         )
+        self.assertIn("sudo -E env PIP_USER=false", install_line)
         self.assertTrue(
-            install_line.endswith("&& command -v function-executor"),
+            install_line.endswith("&& test -x /usr/local/bin/function-executor"),
             install_line,
         )
 
@@ -288,11 +289,12 @@ class TestApplicationDockerfileContent(unittest.TestCase):
     def test_sdk_install_uses_python3_module_pip(self):
         dockerfile = dockerfile_content(Image(name="install-command"))
         self.assertIn(
-            "RUN python3 -m pip install --break-system-packages "
-            "--force-reinstall --no-cache-dir tensorlake==",
+            "python3 -m pip install --break-system-packages "
+            "--force-reinstall --no-cache-dir --prefix=/usr/local tensorlake==",
             dockerfile,
         )
-        self.assertIn("&& command -v function-executor", dockerfile)
+        self.assertIn("sudo -E env PIP_USER=false", dockerfile)
+        self.assertIn("&& test -x /usr/local/bin/function-executor", dockerfile)
 
 
 if __name__ == "__main__":

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -245,6 +245,41 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
             sbm.build_sandbox_image(12345)  # type: ignore[arg-type]
 
 
+class TestBuildSandboxApplicationImage(unittest.TestCase):
+    def test_function_image_build_checks_function_executor_on_path(self):
+        ctx = _make_ctx()
+        image = Image(name="function-image", base_image="python:3.12-slim").run(
+            "python3 -m pip uninstall -y tensorlake || true"
+        )
+        build_ctx, rust_builder = _make_build_patches(ctx)
+        captured: dict[str, object] = {}
+
+        with build_ctx, rust_builder as rust_builder_mock:
+
+            def fake_rust_builder(*args, **_kwargs):
+                captured["dockerfile_text"] = args[14]
+                return '{"id":"tpl-1","snapshot_id":"snap-1"}'
+
+            rust_builder_mock.side_effect = fake_rust_builder
+            sbm.build_sandbox_application_image(
+                image,
+                cpus=BUILD_CPUS,
+                memory_mb=BUILD_MEMORY_MB,
+            )
+
+        dockerfile_text = captured["dockerfile_text"]
+        self.assertIsInstance(dockerfile_text, str)
+        install_line = dockerfile_text.rstrip().splitlines()[-1]
+        self.assertIn(
+            "--force-reinstall --no-cache-dir tensorlake==",
+            install_line,
+        )
+        self.assertTrue(
+            install_line.endswith("&& command -v function-executor"),
+            install_line,
+        )
+
+
 class TestApplicationDockerfileContent(unittest.TestCase):
     def test_default_image_uses_ubuntu_minimal_base(self):
         dockerfile = dockerfile_content(Image(name="default-base"))
@@ -253,9 +288,11 @@ class TestApplicationDockerfileContent(unittest.TestCase):
     def test_sdk_install_uses_python3_module_pip(self):
         dockerfile = dockerfile_content(Image(name="install-command"))
         self.assertIn(
-            "RUN python3 -m pip install --break-system-packages tensorlake==",
+            "RUN python3 -m pip install --break-system-packages "
+            "--force-reinstall --no-cache-dir tensorlake==",
             dockerfile,
         )
+        self.assertIn("&& command -v function-executor", dockerfile)
 
 
 if __name__ == "__main__":

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.35",
+  "version": "0.5.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.35",
+      "version": "0.5.36",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.35",
+  "version": "0.5.36",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- install the final Tensorlake runtime layer for function images into `/usr/local` so `function-executor` lands at `/usr/local/bin/function-executor`
- fail function image builds unless that exact console script exists and is executable
- keep the generated install step compatible with the sandbox image builder by using `sudo` inside the final `RUN` when the Docker build user is not root, instead of adding a rejected `USER root` instruction
- add SDK/Rust coverage for the generated function image Dockerfile contract
- hide the legacy `tl build-images` subcommand from CLI help while keeping the command parseable
- bump SDK/CLI package versions to `0.5.36`

## Why

Function images run `function-executor` through the Firecracker dataplane as `root`, with `/usr/local/bin` on the guest process `PATH`. A pip user install can place console scripts under `/home/tl-user/.local/bin`, which may be visible during image build but is not a reliable runtime contract for the root-launched function executor. The final Tensorlake install layer now forces a system-prefix install and verifies the runtime script location directly.

## Validation

- `PYTHONPATH=src python3 -m pytest tests/image/test_sandbox_builder.py -q`
- `cargo test -p tensorlake images::models::tests::test_dockerfile_installs_sdk_with_python3_module_pip`
- `cargo test -p tensorlake-cli build_images_command_is_hidden_from_help`
- `cargo run -q -p tensorlake-cli --bin tl -- --version`
- `cargo run -q -p tensorlake-cli --bin tl -- --help | rg -n "build-images|Commands:" || true`
- `git diff --check`

Note: `black` was not available in the local Python 3.14 environment, so Python formatting could not be run locally.