### PR TITLE
Allow USER/CMD/ENTRYPOINT in sandbox image Dockerfiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.36"
+version = "0.5.37"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -55,23 +55,22 @@ const ROOTFS_BUILDER_PATH: &str = "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 const ROOTFS_BUILDER_COMMAND: &str = "tl-rootfs-build";
 const ROOTFS_BUILDER_PROCESS_USER: &str = "root";
 
-/// Dockerfile instructions rejected during sandbox-image build. The rootfs
-/// builder hands the Dockerfile to `docker build` verbatim, so without this
-/// allowlist these instructions would silently take effect inside the
-/// resulting rootfs. Mirrors the historical Python/TS SDK behavior.
-// Instructions the SDK refuses to forward to the rootfs builder. ARG used to
-// be in this list; it is accepted at top-level scope so a Dockerfile can
-// declare global defaults that Docker resolves at build time, but the SDK
-// does not substitute ARG values at parse time.
-const UNSUPPORTED_DOCKERFILE_INSTRUCTIONS: &[&str] = &["ONBUILD", "SHELL", "USER"];
+/// Dockerfile instructions rejected during sandbox-image build. `ONBUILD`
+/// registers deferred triggers that only fire when the image is used as a base
+/// in a downstream build, and `SHELL` changes the shell used for shell-form
+/// `RUN`/`CMD`/`ENTRYPOINT`; neither has a meaningful effect on the rootfs path
+/// (`docker build --output type=tar` discards image config and there is no
+/// child build), so we reject them rather than accept a silent no-op.
+// ARG used to be in this list; it is accepted at top-level scope so a
+// Dockerfile can declare global defaults that Docker resolves at build time,
+// but the SDK does not substitute ARG values at parse time.
+const UNSUPPORTED_DOCKERFILE_INSTRUCTIONS: &[&str] = &["ONBUILD", "SHELL"];
 
-/// Dockerfile instructions that affect image config (CMD, ENTRYPOINT, etc.)
-/// rather than the filesystem. `docker build --output type=tar` discards the
-/// image config, so these are effectively no-ops on the rootfs path — we warn
-/// to surface that to the user and pass them through to the builder.
+/// Dockerfile instructions that affect image config (exposed ports, labels,
+/// etc.) rather than the filesystem. `docker build --output type=tar` discards
+/// the image config, so these are effectively no-ops on the rootfs path — we
+/// warn to surface that to the user and pass them through to the builder.
 const IGNORED_DOCKERFILE_INSTRUCTIONS: &[&str] = &[
-    "CMD",
-    "ENTRYPOINT",
     "EXPOSE",
     "HEALTHCHECK",
     "LABEL",
@@ -1877,7 +1876,7 @@ mod tests {
 
     #[test]
     fn load_dockerfile_plan_rejects_unsupported_instructions() {
-        for instruction in ["ONBUILD RUN echo", "SHELL [\"/bin/bash\"]", "USER app"] {
+        for instruction in ["ONBUILD RUN echo", "SHELL [\"/bin/bash\"]"] {
             let temp_dir = tempfile::tempdir().unwrap();
             let dockerfile_path = temp_dir.path().join("Dockerfile");
             std::fs::write(
@@ -1966,8 +1965,6 @@ mod tests {
             "FROM python:3.12-slim\n\
              LABEL maintainer=alice\n\
              EXPOSE 8080\n\
-             CMD [\"python\", \"-m\", \"http.server\"]\n\
-             ENTRYPOINT [\"/usr/bin/env\"]\n\
              HEALTHCHECK CMD echo ok\n\
              STOPSIGNAL SIGTERM\n\
              VOLUME /data\n\
@@ -1986,8 +1983,6 @@ mod tests {
             vec![
                 "LABEL",
                 "EXPOSE",
-                "CMD",
-                "ENTRYPOINT",
                 "HEALTHCHECK",
                 "STOPSIGNAL",
                 "VOLUME",
@@ -1996,6 +1991,34 @@ mod tests {
         // Dockerfile text is preserved verbatim so the rootfs builder still
         // sees the same instructions.
         assert!(plan.dockerfile_text.contains("EXPOSE 8080"));
+    }
+
+    #[test]
+    fn load_dockerfile_plan_accepts_user_cmd_entrypoint() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dockerfile_path = temp_dir.path().join("Dockerfile");
+        std::fs::write(
+            &dockerfile_path,
+            "FROM python:3.12-slim\n\
+             USER app\n\
+             CMD [\"python\", \"-m\", \"http.server\"]\n\
+             ENTRYPOINT [\"/usr/bin/env\"]\n\
+             RUN echo hi\n",
+        )
+        .unwrap();
+
+        // USER, CMD, and ENTRYPOINT are now supported: the plan loads without
+        // error and none of them land in the ignored set.
+        let plan = load_dockerfile_plan(&dockerfile_path, None).unwrap();
+        let keywords: Vec<&str> = plan
+            .ignored_instructions
+            .iter()
+            .map(|(_, kw)| kw.as_str())
+            .collect();
+        assert!(
+            keywords.is_empty(),
+            "expected no ignored instructions, got {keywords:?}",
+        );
     }
 
     #[test]

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.36"
+version = "0.5.37"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.36"
+version = "0.5.37"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -8,9 +8,9 @@ the snapshot as a named sandbox template
 
 This is the programmatic backend for :meth:`Image.build` and the
 ``tl sbx image create`` CLI command. The Rust core owns parsing, the
-Dockerfile-instruction allowlist (``ARG``/``ONBUILD``/``SHELL``/``USER`` are
-rejected) and ignored-set warnings (``CMD``/``ENTRYPOINT``/``EXPOSE``/
-``HEALTHCHECK``/``LABEL``/``STOPSIGNAL``/``VOLUME``).
+Dockerfile-instruction allowlist (``ONBUILD``/``SHELL`` are rejected) and
+ignored-set warnings (``EXPOSE``/``HEALTHCHECK``/``LABEL``/``STOPSIGNAL``/
+``VOLUME``).
 """
 
 from __future__ import annotations

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.36",
+      "version": "0.5.37",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -11,8 +11,8 @@ import { Image, dockerfileContent } from "./image.js";
  * Dockerfile path/text + context to the Rust core via `@tensorlake/native`,
  * which parses, validates, materializes, and registers the image. The Rust
  * core owns parsing, the Dockerfile-instruction allowlist
- * (`ARG`/`ONBUILD`/`SHELL`/`USER` are rejected) and ignored-set warnings
- * (`CMD`/`ENTRYPOINT`/`EXPOSE`/`HEALTHCHECK`/`LABEL`/`STOPSIGNAL`/`VOLUME`).
+ * (`ONBUILD`/`SHELL` are rejected) and ignored-set warnings
+ * (`EXPOSE`/`HEALTHCHECK`/`LABEL`/`STOPSIGNAL`/`VOLUME`).
  */
 
 export interface CreateSandboxImageOptions {


### PR DESCRIPTION
## Context

`tl sbx image create <Dockerfile>` failed with:

```
Error: line 6: Dockerfile instruction 'USER' is not supported for sandbox image creation
```

The rootfs builder now supports the full set of common Dockerfile instructions (`ENV`, `WORKDIR`, `CMD`, `ENTRYPOINT`, `USER`, `RUN`, `COPY`, `ARG`), so the SDK-side gating in the Rust cloud-sdk was no longer correct.

## Changes

All Dockerfile-instruction gating lives in `crates/cloud-sdk/src/sandbox_images.rs`; the Python and TypeScript SDKs only delegate to the Rust core and carry doc-comments.

- **`UNSUPPORTED_DOCKERFILE_INSTRUCTIONS`** — dropped `USER`. `ONBUILD` and `SHELL` stay rejected (deferred triggers / shell-form-only — no meaningful effect on the rootfs path), now with a comment explaining why.
- **`IGNORED_DOCKERFILE_INSTRUCTIONS`** — dropped `CMD` and `ENTRYPOINT`. `EXPOSE`, `HEALTHCHECK`, `LABEL`, `STOPSIGNAL`, `VOLUME` stay ignored — config-only instructions discarded by `docker build --output type=tar`, so the warning is still accurate.
- Updated the two existing unit tests and added `load_dockerfile_plan_accepts_user_cmd_entrypoint` asserting `USER`/`CMD`/`ENTRYPOINT` now plan without error or warning.
- Refreshed the stale allowlist doc-comments in `src/tensorlake/image/sandbox_builder.py` and `typescript/src/sandbox-image.ts` (also dropped the stale `ARG`-rejected claim — `ARG` is already accepted).

## Testing

`cargo test -p tensorlake sandbox_images` → 26 passed, 0 failed.

> Note: version bumps not included yet — pending decision on target versions for the Python/CLI and TypeScript SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)