### PR TITLE
Harden function image runtime install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.37"
+version = "0.5.38"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.37"
+version = "0.5.38"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.37"
+version = "0.5.38"
 dependencies = [
  "napi",
  "napi-build",
@@ -3079,7 +3079,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.37"
+version = "0.5.38"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.37"
+version = "0.5.38"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/images/models.rs
+++ b/crates/cloud-sdk/src/images/models.rs
@@ -409,8 +409,9 @@ impl Image {
         } else {
             format!("tensorlake=={sdk_version}")
         };
+        lines.push("USER root".to_string());
         let install_command = format!(
-            "RUN if [ \"$(id -u)\" = \"0\" ]; then PIP_USER=false python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir --prefix=/usr/local {tensorlake_spec}; else sudo -E env PIP_USER=false python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir --prefix=/usr/local {tensorlake_spec}; fi && test -x /usr/local/bin/function-executor"
+            "RUN PIP_USER=false python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir {tensorlake_spec} && test -x /usr/local/bin/function-executor"
         );
         lines.push(install_command);
 
@@ -677,20 +678,17 @@ mod tests {
             .build()
             .unwrap();
 
-        assert!(
-            image
-                .dockerfile_content("1.2.3", None)
-                .contains("python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir --prefix=/usr/local tensorlake==1.2.3")
-        );
-        assert!(
-            image
-                .dockerfile_content("1.2.3", None)
-                .contains("&& test -x /usr/local/bin/function-executor")
-        );
+        let dockerfile = image.dockerfile_content("1.2.3", None);
+        assert!(dockerfile.contains("python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake==1.2.3"));
+        assert!(!dockerfile.contains("--prefix=/usr/local"));
+        assert!(!dockerfile.contains("sudo"));
+        assert!(!dockerfile.contains("id -u"));
+        assert!(dockerfile.contains("\nUSER root\nRUN PIP_USER=false python3 -m pip install"));
+        assert!(dockerfile.contains("&& test -x /usr/local/bin/function-executor"));
         assert!(
             image
                 .dockerfile_content(">=1.2.3", None)
-                .contains("python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir --prefix=/usr/local tensorlake>=1.2.3")
+                .contains("python3 -m pip install --break-system-packages --force-reinstall --no-cache-dir tensorlake>=1.2.3")
         );
     }
 

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -70,13 +70,8 @@ const UNSUPPORTED_DOCKERFILE_INSTRUCTIONS: &[&str] = &["ONBUILD", "SHELL"];
 /// etc.) rather than the filesystem. `docker build --output type=tar` discards
 /// the image config, so these are effectively no-ops on the rootfs path — we
 /// warn to surface that to the user and pass them through to the builder.
-const IGNORED_DOCKERFILE_INSTRUCTIONS: &[&str] = &[
-    "EXPOSE",
-    "HEALTHCHECK",
-    "LABEL",
-    "STOPSIGNAL",
-    "VOLUME",
-];
+const IGNORED_DOCKERFILE_INSTRUCTIONS: &[&str] =
+    &["EXPOSE", "HEALTHCHECK", "LABEL", "STOPSIGNAL", "VOLUME"];
 
 #[derive(Debug, Error)]
 pub enum SandboxImageBuildError {
@@ -1980,13 +1975,7 @@ mod tests {
             .collect();
         assert_eq!(
             keywords,
-            vec![
-                "LABEL",
-                "EXPOSE",
-                "HEALTHCHECK",
-                "STOPSIGNAL",
-                "VOLUME",
-            ]
+            vec!["LABEL", "EXPOSE", "HEALTHCHECK", "STOPSIGNAL", "VOLUME",]
         );
         // Dockerfile text is preserved verbatim so the rootfs builder still
         // sees the same instructions.

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.37"
+version = "0.5.38"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.37"
+version = "0.5.38"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/image/utils.py
+++ b/src/tensorlake/image/utils.py
@@ -35,18 +35,19 @@ def dockerfile_content(img: Image, extra_env_vars: List[tuple] | None = None) ->
     # Run Tensorlake install after all user commands so user layers cannot
     # remove or downgrade the runtime. Force reinstall makes pip replay package
     # console scripts even when Tensorlake was already present in the base.
-    # Install into /usr/local so function-executor is visible to the root
-    # process launched by the Firecracker dataplane.
+    # Run the SDK install as root so the generated Dockerfile does not depend
+    # on base images providing passwordless sudo. Let pip use the interpreter's
+    # default global install scheme. On Debian and Ubuntu Python, explicitly
+    # passing --prefix=/usr/local nests scripts under /usr/local/local/bin
+    # instead of the dataplane contract path.
     install_cmd = (
         "python3 -m pip install --break-system-packages --force-reinstall "
-        f"--no-cache-dir --prefix=/usr/local tensorlake=={_SDK_VERSION}"
+        f"--no-cache-dir tensorlake=={_SDK_VERSION}"
     )
+    dockerfile_lines.append("USER root")
     dockerfile_lines.append(
-        'RUN if [ "$(id -u)" = "0" ]; then '
-        f"PIP_USER=false {install_cmd}; "
-        "else "
-        f"sudo -E env PIP_USER=false {install_cmd}; "
-        "fi && test -x /usr/local/bin/function-executor"
+        f"RUN PIP_USER=false {install_cmd} "
+        "&& test -x /usr/local/bin/function-executor"
     )
 
     return "\n".join(dockerfile_lines)

--- a/tests/e2e/test_function_executor_path.py
+++ b/tests/e2e/test_function_executor_path.py
@@ -1,0 +1,139 @@
+import os
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+BASE_IMAGES = (
+    "tensorlake/ubuntu-minimal",
+    "python:3.12-slim",
+)
+
+
+def _require_e2e() -> None:
+    if os.environ.get("TENSORLAKE_E2E") != "1":
+        pytest.skip("set TENSORLAKE_E2E=1 to run cloud e2e tests")
+    if not os.environ.get("TENSORLAKE_API_KEY"):
+        pytest.skip("TENSORLAKE_API_KEY is required for cloud e2e tests")
+    if _tl_bin() is None:
+        pytest.skip("tl binary is required for cloud e2e tests")
+
+
+def _tl_bin() -> str | None:
+    return os.environ.get("TL_BIN") or shutil.which("tl")
+
+
+def _run_tl(args: list[str], *, cwd: Path, timeout: int) -> subprocess.CompletedProcess:
+    tl_bin = _tl_bin()
+    assert tl_bin is not None
+    env = os.environ.copy()
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    result = subprocess.run(
+        [tl_bin, *args],
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            "tl command failed\n"
+            f"command: tl {' '.join(args)}\n"
+            f"exit code: {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _write_application(tmp_path: Path, image_names: dict[str, str]) -> Path:
+    image_defs = "\n".join(
+        f'{name} = Image(name="{image_names[base_image]}", base_image="{base_image}")'
+        for name, base_image in (
+            ("UBUNTU_IMAGE", "tensorlake/ubuntu-minimal"),
+            ("PYTHON_IMAGE", "python:3.12-slim"),
+        )
+    )
+    app_path = tmp_path / "function_executor_path_app.py"
+    app_path.write_text(
+        f"""from tensorlake.applications import Image, application, function
+
+{image_defs}
+
+
+@application()
+@function(image=UBUNTU_IMAGE)
+def function_executor_path_app(value: int) -> int:
+    return python_worker(value)
+
+
+@function(image=PYTHON_IMAGE)
+def python_worker(value: int) -> int:
+    return value
+""",
+        encoding="utf-8",
+    )
+    return app_path
+
+
+def test_deployed_function_images_boot_function_executor_by_name(
+    tmp_path: Path,
+) -> None:
+    _require_e2e()
+    run_id = uuid.uuid4().hex[:12]
+    image_names = {
+        image: f"e2e-function-executor-{index}-{run_id}"
+        for index, image in enumerate(BASE_IMAGES)
+    }
+    app_path = _write_application(tmp_path, image_names)
+    sandbox_ids: list[str] = []
+
+    try:
+        _run_tl(["deploy", str(app_path)], cwd=tmp_path, timeout=900)
+
+        for base_image in BASE_IMAGES:
+            create = _run_tl(
+                [
+                    "sbx",
+                    "create",
+                    "--image",
+                    image_names[base_image],
+                    "--cpus",
+                    "1",
+                    "--memory",
+                    "1024",
+                ],
+                cwd=tmp_path,
+                timeout=240,
+            )
+            sandbox_id = create.stdout.strip().splitlines()[-1]
+            assert sandbox_id, create.stdout
+            sandbox_ids.append(sandbox_id)
+
+            exec_result = _run_tl(
+                ["sbx", "exec", sandbox_id, "function-executor", "--help"],
+                cwd=tmp_path,
+                timeout=120,
+            )
+
+            output = exec_result.stdout + exec_result.stderr
+            assert "Runs Function Executor" in output
+            assert "--executor-id" in output
+            assert "--address" in output
+    finally:
+        tl_bin = _tl_bin()
+        for sandbox_id in sandbox_ids:
+            subprocess.run(
+                [tl_bin, "sbx", "terminate", sandbox_id],
+                cwd=tmp_path,
+                env=os.environ.copy(),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=60,
+                check=False,
+            )

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -269,12 +269,17 @@ class TestBuildSandboxApplicationImage(unittest.TestCase):
 
         dockerfile_text = captured["dockerfile_text"]
         self.assertIsInstance(dockerfile_text, str)
-        install_line = dockerfile_text.rstrip().splitlines()[-1]
+        dockerfile_lines = dockerfile_text.rstrip().splitlines()
+        self.assertEqual(dockerfile_lines[-2], "USER root")
+        install_line = dockerfile_lines[-1]
         self.assertIn(
-            "--force-reinstall --no-cache-dir --prefix=/usr/local tensorlake==",
+            "--force-reinstall --no-cache-dir tensorlake==",
             install_line,
         )
-        self.assertIn("sudo -E env PIP_USER=false", install_line)
+        self.assertNotIn("--prefix=/usr/local", install_line)
+        self.assertNotIn("sudo", install_line)
+        self.assertNotIn("id -u", install_line)
+        self.assertIn("RUN PIP_USER=false python3 -m pip install", install_line)
         self.assertTrue(
             install_line.endswith("&& test -x /usr/local/bin/function-executor"),
             install_line,
@@ -290,10 +295,15 @@ class TestApplicationDockerfileContent(unittest.TestCase):
         dockerfile = dockerfile_content(Image(name="install-command"))
         self.assertIn(
             "python3 -m pip install --break-system-packages "
-            "--force-reinstall --no-cache-dir --prefix=/usr/local tensorlake==",
+            "--force-reinstall --no-cache-dir tensorlake==",
             dockerfile,
         )
-        self.assertIn("sudo -E env PIP_USER=false", dockerfile)
+        self.assertNotIn("--prefix=/usr/local", dockerfile)
+        self.assertIn(
+            "\nUSER root\nRUN PIP_USER=false python3 -m pip install", dockerfile
+        )
+        self.assertNotIn("sudo", dockerfile)
+        self.assertNotIn("id -u", dockerfile)
         self.assertIn("&& test -x /usr/local/bin/function-executor", dockerfile)
 
 

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.37",
+  "version": "0.5.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.37",
+      "version": "0.5.38",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.37",
+  "version": "0.5.38",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Harden generated function-image Dockerfiles so the Tensorlake runtime is installed deterministically and `function-executor` is available by command name.

The previous install command used `pip --prefix=/usr/local` and then checked `/usr/local/bin/function-executor`. On Debian/Ubuntu Python install schemes, that prefix can place console scripts under `/usr/local/local/bin`, which made the final executable probe fail even though `tensorlake` installed successfully.

This PR now:

- Switches to `USER root` before the SDK install, using the Dockerfile `USER` support now available on `main`.
- Removes the `sudo` / `id -u` runtime branch from generated function-image installs.
- Removes `--prefix=/usr/local` so pip uses the interpreter default global scheme and places console scripts on the expected path.
- Keeps the explicit `test -x /usr/local/bin/function-executor` contract check.
- Bumps published package versions to `0.5.38`.

## E2E Coverage

Adds an opt-in cloud e2e test that verifies the real workflow rather than a local Docker smoke test:

1. Generate a temporary app with function images based on:
   - `tensorlake/ubuntu-minimal`
   - `python:3.12-slim`
2. Run `tl deploy <app.py>`.
3. Run `tl sbx create --image <registered-image-name>` for each deployed image.
4. Run `tl sbx exec <sandbox-id> function-executor --help`.
5. Assert `function-executor` boots by name and exposes the expected CLI help.

The e2e test is gated by `TENSORLAKE_E2E=1` so default local/CI test runs do not create cloud builds or sandboxes.

## Validation

- `PYTHONPATH=src python3 -m pytest tests/image/test_sandbox_builder.py tests/e2e/test_function_executor_path.py -q`
- `cargo test -p tensorlake images::models::tests::test_dockerfile_installs_sdk_with_python3_module_pip`
- `cargo fmt --check`
- `poetry run black --check tests/e2e/test_function_executor_path.py tests/image/test_sandbox_builder.py`
- `poetry run isort tests/e2e/test_function_executor_path.py tests/image/test_sandbox_builder.py --check-only --profile black`
