### PR TITLE
Don't inject tl-user; send process user only when explicitly requested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.39"
+version = "0.5.40"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.39"
+version = "0.5.40"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.39"
+version = "0.5.40"
 dependencies = [
  "napi",
  "napi-build",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.39"
+version = "0.5.40"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.39"
+version = "0.5.40"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -126,6 +126,9 @@ fn build_process_payload(
         body["timeout"] = serde_json::json!(t);
     }
     if let Some(user) = options.user {
+        if user.trim().is_empty() {
+            return Err(CliError::usage("--user must not be empty"));
+        }
         body["user"] = Value::String(user.to_string());
     }
     if let Some(name) = options.name {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -467,9 +467,10 @@ enum SbxCommands {
         #[arg(short, long)]
         env: Vec<String>,
 
-        /// Process user to run as: username, uid, or uid:gid
-        #[arg(long, default_value = "tl-user")]
-        user: String,
+        /// Process user to run as: username, uid, or uid:gid (default: the
+        /// image's configured user)
+        #[arg(long)]
+        user: Option<String>,
 
         /// Start the process and return immediately instead of streaming output
         #[arg(long)]
@@ -619,9 +620,10 @@ enum SbxCommands {
         #[arg(short, long)]
         env: Vec<String>,
 
-        /// Process user to run as: username, uid, or uid:gid
-        #[arg(long, default_value = "tl-user")]
-        user: String,
+        /// Process user to run as: username, uid, or uid:gid (default: the
+        /// image's configured user)
+        #[arg(long)]
+        user: Option<String>,
 
         /// Keep sandbox after command exits
         #[arg(short, long)]
@@ -1163,7 +1165,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 timeout,
                                 workdir: workdir.as_deref(),
                                 env: &env,
-                                user: Some(user.as_str()),
+                                user: user.as_deref(),
                                 detach,
                                 name: name.as_deref(),
                                 restart_policy: restart.map(RestartPolicyArg::as_wire_value),
@@ -1259,7 +1261,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             timeout,
                             workdir.as_deref(),
                             &env,
-                            Some(user.as_str()),
+                            user.as_deref(),
                             keep,
                             &ports,
                             allow_unauthenticated_access,
@@ -1569,7 +1571,19 @@ mod tests {
 
         match cli.command {
             Commands::Sbx(SbxCommands::Exec { user, .. }) => {
-                assert_eq!(user, "1000:1000");
+                assert_eq!(user.as_deref(), Some("1000:1000"));
+            }
+            _ => panic!("expected sbx exec command"),
+        }
+    }
+
+    #[test]
+    fn sbx_exec_omits_process_user_by_default() {
+        let cli = Cli::try_parse_from(["tl", "sbx", "exec", "sbx-123", "id"]).unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Exec { user, .. }) => {
+                assert_eq!(user, None);
             }
             _ => panic!("expected sbx exec command"),
         }
@@ -1660,7 +1674,19 @@ mod tests {
 
         match cli.command {
             Commands::Sbx(SbxCommands::Run { user, .. }) => {
-                assert_eq!(user, "ubuntu");
+                assert_eq!(user.as_deref(), Some("ubuntu"));
+            }
+            _ => panic!("expected sbx run command"),
+        }
+    }
+
+    #[test]
+    fn sbx_run_omits_process_user_by_default() {
+        let cli = Cli::try_parse_from(["tl", "sbx", "run", "id"]).unwrap();
+
+        match cli.command {
+            Commands::Sbx(SbxCommands::Run { user, .. }) => {
+                assert_eq!(user, None);
             }
             _ => panic!("expected sbx run command"),
         }

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.39"
+version = "0.5.40"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.39"
+version = "0.5.40"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -413,7 +413,7 @@ class AsyncSandbox:
         env: dict[str, str] | None = None,
         working_dir: str | None = None,
         timeout: float | None = None,
-        user: ProcessUser = "tl-user",
+        user: ProcessUser | None = None,
     ) -> Traced[CommandResult]:
         process_user = Sandbox._normalize_process_user(user)
         payload = Sandbox._build_command_payload(
@@ -470,7 +470,7 @@ class AsyncSandbox:
         stdin_mode: StdinMode = StdinMode.CLOSED,
         stdout_mode: OutputMode = OutputMode.CAPTURE,
         stderr_mode: OutputMode = OutputMode.CAPTURE,
-        user: ProcessUser = "tl-user",
+        user: ProcessUser | None = None,
         name: str | None = None,
         restart: RestartPolicyConfig | Mapping[str, object] | None = None,
         health_check: ProcessHealthCheck | Mapping[str, object] | None = None,

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -768,8 +768,13 @@ class Sandbox:
 
     @staticmethod
     def _normalize_process_user(
-        user: ProcessUser,
+        user: ProcessUser | None,
     ) -> str | dict[str, Any] | None:
+        if user is None:
+            # Caller did not request a specific user: omit the field so the
+            # sandbox resolves the image's configured user (e.g. the image
+            # ``USER`` directive, falling back to root).
+            return None
         if isinstance(user, str):
             value = user
         elif isinstance(user, ProcessUserSpec):
@@ -845,7 +850,7 @@ class Sandbox:
         env: dict[str, str] | None = None,
         working_dir: str | None = None,
         timeout: float | None = None,
-        user: ProcessUser = "tl-user",
+        user: ProcessUser | None = None,
     ) -> Traced[CommandResult]:
         """Run a command to completion and return its output.
 
@@ -859,9 +864,10 @@ class Sandbox:
             env: Environment variables
             working_dir: Working directory
             timeout: Maximum seconds to wait (enforced server-side; None = no limit)
-            user: Process user. Defaults to ``"tl-user"``. Pass a username
-                such as ``"root"``, a Docker-style id string like ``"1000:1000"``,
-                or ``ProcessUserSpec(uid=1000, gid=1000)``.
+            user: Process user. Defaults to ``None``, which runs as the image's
+                configured user (the image ``USER`` directive, falling back to
+                root). Pass a username such as ``"root"``, a Docker-style id
+                string like ``"1000:1000"``, or ``ProcessUserSpec(uid=1000, gid=1000)``.
 
         Returns:
             Traced[CommandResult] — access ``.trace_id`` for the W3C trace ID
@@ -927,7 +933,7 @@ class Sandbox:
         stdin_mode: StdinMode = StdinMode.CLOSED,
         stdout_mode: OutputMode = OutputMode.CAPTURE,
         stderr_mode: OutputMode = OutputMode.CAPTURE,
-        user: ProcessUser = "tl-user",
+        user: ProcessUser | None = None,
         name: str | None = None,
         restart: RestartPolicyConfig | Mapping[str, Any] | None = None,
         health_check: ProcessHealthCheck | Mapping[str, Any] | None = None,
@@ -942,9 +948,10 @@ class Sandbox:
             stdin_mode: StdinMode.CLOSED or StdinMode.PIPE
             stdout_mode: OutputMode.CAPTURE or OutputMode.DISCARD
             stderr_mode: OutputMode.CAPTURE or OutputMode.DISCARD
-            user: Process user. Defaults to ``"tl-user"``. Pass a username
-                such as ``"root"``, a Docker-style id string like ``"1000:1000"``,
-                or ``ProcessUserSpec(uid=1000, gid=1000)``.
+            user: Process user. Defaults to ``None``, which runs as the image's
+                configured user (the image ``USER`` directive, falling back to
+                root). Pass a username such as ``"root"``, a Docker-style id
+                string like ``"1000:1000"``, or ``ProcessUserSpec(uid=1000, gid=1000)``.
             name: Optional managed-process name. Supplying this opts the process
                 into daemon management.
             restart: Optional restart policy. Supplying this opts the process

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -198,13 +198,15 @@ class TestSandboxRustBackend(unittest.TestCase):
         payload = json.loads(fake.start_payload_json)
         self.assertEqual(payload["user"], {"uid": 1000, "gid": 1000})
 
-    def test_start_process_serializes_default_user(self):
+    def test_start_process_omits_user_by_default(self):
         sandbox, fake = _make_sandbox()
 
         sandbox.start_process(command="echo")
 
         payload = json.loads(fake.start_payload_json)
-        self.assertEqual(payload["user"], "tl-user")
+        # No user requested -> field omitted so the sandbox resolves the
+        # image's configured user (image USER, falling back to root).
+        self.assertNotIn("user", payload)
 
     def test_start_process_serializes_managed_options(self):
         sandbox, fake = _make_sandbox()

--- a/tests/sandbox/test_sandbox_rust_backend_async.py
+++ b/tests/sandbox/test_sandbox_rust_backend_async.py
@@ -249,7 +249,7 @@ class TestAsyncSandboxRustBackend(unittest.IsolatedAsyncioTestCase):
         payload = json.loads(fake.start_payload_json)
         self.assertEqual(payload["user"], {"uid": 1000, "gid": 1000})
 
-    async def test_start_process_omits_default_modes_and_serializes_default_user(self):
+    async def test_start_process_omits_default_modes_and_user(self):
         sandbox, fake = _make_async_sandbox()
 
         await sandbox.start_process(command="echo")
@@ -258,7 +258,9 @@ class TestAsyncSandboxRustBackend(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("stdin_mode", payload)
         self.assertNotIn("stdout_mode", payload)
         self.assertNotIn("stderr_mode", payload)
-        self.assertEqual(payload["user"], "tl-user")
+        # No user requested -> field omitted so the sandbox resolves the
+        # image's configured user (image USER, falling back to root).
+        self.assertNotIn("user", payload)
 
     async def test_start_process_rejects_invalid_user_spec_mapping(self):
         sandbox, _ = _make_async_sandbox()

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.39",
+  "version": "0.5.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.39",
+      "version": "0.5.40",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",
@@ -1225,6 +1225,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1531,6 +1532,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1585,6 +1587,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2305,6 +2308,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2354,6 +2358,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2791,6 +2796,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2838,6 +2844,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.39",
+  "version": "0.5.40",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -53,8 +53,6 @@ import { nowMs, logSdkTimingEvent, sdkTimingPayloadsEnabled, logSdkTiming } from
 import { resolveProxyTarget } from "./url.js";
 import WebSocket, { type RawData } from "ws";
 
-const DEFAULT_PROCESS_USER = "tl-user";
-
 class SandboxProxyConnection {
   baseUrl = "";
   wsHeaders: Record<string, string> = {};
@@ -197,9 +195,11 @@ class SandboxProxyConnection {
 
 function processUserPayload(
   user: ProcessUser | undefined,
-): ProcessUser {
+): ProcessUser | undefined {
+  // No user requested: omit the field so the sandbox resolves the image's
+  // configured user (the image USER directive, falling back to root).
   if (user == null) {
-    return DEFAULT_PROCESS_USER;
+    return undefined;
   }
   if (typeof user === "string" && user.trim() === "") {
     throw new SandboxError("process user must not be empty");
@@ -721,7 +721,7 @@ export class Sandbox {
     if (options?.workingDir) body.working_dir = options.workingDir;
     if (options?.timeout != null) body.timeout = options.timeout;
     const user = processUserPayload(options?.user);
-    body.user = user;
+    if (user !== undefined) body.user = user;
 
     logSdkTimingEvent("sandbox.run", "start", {
       sandbox_id: this.sandboxId,
@@ -765,7 +765,7 @@ export class Sandbox {
     if (options?.env != null) payload.env = options.env;
     if (options?.workingDir != null) payload.working_dir = options.workingDir;
     const user = processUserPayload(options?.user);
-    payload.user = user;
+    if (user !== undefined) payload.user = user;
     if (options?.stdinMode != null && options.stdinMode !== StdinMode.CLOSED) {
       payload.stdin_mode = options.stdinMode;
     }

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -167,12 +167,14 @@ describe("Sandbox", () => {
       sbx.close();
     });
 
-    it("sends the default process user", async () => {
+    it("omits the process user by default", async () => {
       installNativeStub({
         proxy: {
           runProcess: vi.fn(async (json: string) => {
             const body = JSON.parse(json);
-            expect(body.user).toBe("tl-user");
+            // No user requested -> field omitted so the sandbox resolves the
+            // image's configured user (image USER, falling back to root).
+            expect(body.user).toBeUndefined();
             return runEvents([
               { pid: 42, started_at: 1700000000 },
               { exit_code: 0 },
@@ -280,12 +282,14 @@ describe("Sandbox", () => {
       sbx.close();
     });
 
-    it("sends the default process user", async () => {
+    it("omits the process user by default", async () => {
       installNativeStub({
         proxy: {
           startProcess: vi.fn(async (json: string) => {
             const body = JSON.parse(json);
-            expect(body.user).toBe("tl-user");
+            // No user requested -> field omitted so the sandbox resolves the
+            // image's configured user (image USER, falling back to root).
+            expect(body.user).toBeUndefined();
             return {
               traceId: "t",
               json: JSON.stringify({


### PR DESCRIPTION
## Problem

The sandbox Process-execution APIs (Python SDK, TypeScript SDK, and CLI) hardcoded a default process user of `tl-user` and **always** serialized it into the request. On arbitrary OCI/Docker images (built from external bases like `ubuntu:24.04`, `python:*-slim`) there is no `tl-user`, so every `run` / `start_process` / `tl sbx exec` failed with:

```
HTTP 500 {"error":"user not found: tl-user"}
```

This was found during OCI/Docker runtime-compatibility validation for #697. Confirmed empirically that it's a **client-side** default, not the daemon's: when the `user` field is omitted, the daemon resolves the image's configured user correctly (image `USER`, falling back to `root`) and honors `WORKDIR`. The File API already omitted the field, which is why it was never affected.

## Fix

Send `user` **only when the caller explicitly provides one**; otherwise omit it and let the daemon resolve the image default.

- **Python SDK** (`sandbox.py`, `async_sandbox.py`): `run`/`start_process` default `user=None`; `_normalize_process_user` returns `None` for `None` (so `_build_command_payload` omits it). Docstrings updated.
- **TypeScript SDK** (`typescript/src/sandbox.ts`): `processUserPayload` returns `undefined`; `run`/`startProcess` set `body.user` only when defined; removed `DEFAULT_PROCESS_USER`.
- **CLI** (`crates/cli/src/main.rs`, `exec.rs`): `tl sbx exec` / `tl sbx run` `--user` is now `Option<String>`, omitted by default; added an empty-`--user` guard for parity with the SDKs.

The Rust core (`cloud-sdk`) and napi bindings pass the payload verbatim — no change. PTY/`tl sbx ssh` already send no user.

## Verification

- Unit tests updated to assert **omission by default** and pass: Python 66, Rust CLI 162, TS sandbox 28. TS SDK builds.
- **Managed image (no regression):** with `user` omitted, default `tensorlake/ubuntu-minimal` still resolves to `tl-user` (`uid=1000(tl-user)`).
- **Arbitrary OCI image (the fix):** with `user` omitted, resolves to `root` and honors `WORKDIR` — previously `500 user not found: tl-user`.

## Versioning

Bumped `0.5.39 → 0.5.40` across the CLI and all three SDKs (`bump_version.py` for Python/Rust/CLI + `typescript/package.json`); `Cargo.lock` / `package-lock.json` refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)