### PR TITLE
[codex] Add sandbox image deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,6 +3092,7 @@ dependencies = [
  "serde_json",
  "tensorlake",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]

--- a/crates/cli/src/commands/sbx/image/mod.rs
+++ b/crates/cli/src/commands/sbx/image/mod.rs
@@ -2,6 +2,7 @@ pub mod create;
 pub mod describe;
 pub mod ls;
 pub mod register;
+pub mod rm;
 
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};

--- a/crates/cli/src/commands/sbx/image/rm.rs
+++ b/crates/cli/src/commands/sbx/image/rm.rs
@@ -1,0 +1,44 @@
+use reqwest::StatusCode;
+use tensorlake::error::SdkError;
+
+use crate::auth::context::CliContext;
+use crate::error::{CliError, Result};
+
+pub async fn run(ctx: &CliContext, name_or_id: &str) -> Result<()> {
+    let templates_client = super::sandbox_templates_client(ctx)?;
+
+    match templates_client.delete(name_or_id).await {
+        Ok(_) => {
+            println!("Deleted image '{}'.", name_or_id);
+            Ok(())
+        }
+        Err(SdkError::ServerError { status, .. }) if status == StatusCode::NOT_FOUND => {
+            delete_resolved_image(ctx, name_or_id).await
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+async fn delete_resolved_image(ctx: &CliContext, name_or_id: &str) -> Result<()> {
+    let (base_url, _, _) = super::templates_base_url(ctx)?;
+    let client = ctx.client()?;
+    let item = super::find_image_item_in_paginated_list(ctx, &client, &base_url, name_or_id)
+        .await?
+        .ok_or_else(|| CliError::Other(anyhow::anyhow!("image '{}' not found", name_or_id)))?;
+
+    let name = item
+        .get("name")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "image '{}' was found but is missing a registered name",
+                name_or_id
+            ))
+        })?;
+
+    let templates_client = super::sandbox_templates_client(ctx)?;
+    templates_client.delete(name).await?;
+    println!("Deleted image '{}'.", name);
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -753,6 +753,13 @@ enum ImageCommands {
         /// Image name or ID
         name_or_id: String,
     },
+
+    /// Delete a sandbox image
+    #[command(alias = "delete")]
+    Rm {
+        /// Image name or ID
+        name_or_id: String,
+    },
 }
 
 #[derive(Parser)]
@@ -1362,6 +1369,9 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         ImageCommands::Ls => commands::sbx::image::ls::run(ctx).await,
                         ImageCommands::Describe { name_or_id } => {
                             commands::sbx::image::describe::run(ctx, &name_or_id).await
+                        }
+                        ImageCommands::Rm { name_or_id } => {
+                            commands::sbx::image::rm::run(ctx, &name_or_id).await
                         }
                     },
                     SbxCommands::Tunnel {

--- a/crates/cloud-sdk/src/sandbox_templates/mod.rs
+++ b/crates/cloud-sdk/src/sandbox_templates/mod.rs
@@ -67,4 +67,19 @@ impl SandboxTemplatesClient {
             Err(err) => Err(err),
         }
     }
+
+    /// Delete a sandbox template by registered name.
+    ///
+    /// The `name` argument is percent-encoded into the URL path so image-style
+    /// references containing `/` and `:` (e.g. `tensorlake/python:3.12-slim`)
+    /// round-trip correctly.
+    pub async fn delete(&self, name: &str) -> Result<Traced<()>, SdkError> {
+        let encoded = urlencoding::encode(name);
+        let path = format!("{}/{}", self.endpoint(), encoded);
+        let req = self.client.request(Method::DELETE, &path).build()?;
+        self.client
+            .execute_traced(req)
+            .await
+            .map(|traced| traced.map(|_| ()))
+    }
 }

--- a/crates/cloud-sdk/tests/sandbox_templates.rs
+++ b/crates/cloud-sdk/tests/sandbox_templates.rs
@@ -1,0 +1,145 @@
+use tensorlake::{ClientBuilder, sandbox_templates::SandboxTemplatesClient};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+mod common;
+
+#[tokio::test]
+async fn delete_sandbox_template_sends_encoded_delete_request() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept request");
+        let request_bytes = read_http_request(&mut socket).await;
+        let response = "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n";
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response");
+        request_bytes
+    });
+
+    let client = ClientBuilder::new(&format!("http://{}", address))
+        .build()
+        .expect("build client");
+    let templates = SandboxTemplatesClient::new(client, "org-1", "proj-1");
+
+    templates
+        .delete("tensorlake/python:3.12-slim")
+        .await
+        .expect("delete sandbox template");
+
+    let request_bytes = server.await.expect("server join");
+    let request_text = String::from_utf8_lossy(&request_bytes);
+
+    assert!(request_text.starts_with(
+        "DELETE /platform/v1/organizations/org-1/projects/proj-1/sandbox-templates/tensorlake%2Fpython%3A3.12-slim HTTP/1.1\r\n"
+    ));
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+async fn test_create_then_delete_sandbox_image() {
+    use std::env;
+    use tensorlake::sandbox_images::{SandboxImageBuildOptions, build_sandbox_image};
+
+    let sdk = match common::create_sdk() {
+        Ok(sdk) => sdk,
+        Err(msg) => {
+            eprintln!("Skipping integration test: {msg}");
+            return;
+        }
+    };
+    let (organization_id, project_id) = match common::get_org_and_project_ids() {
+        Ok(scope) => scope,
+        Err(msg) => {
+            eprintln!("Skipping integration test: {msg}");
+            return;
+        }
+    };
+    let api_url =
+        env::var("TENSORLAKE_API_URL").unwrap_or_else(|_| "https://api.tensorlake.ai".to_string());
+    let bearer_token = match env::var("TENSORLAKE_API_KEY") {
+        Ok(token) => token,
+        Err(_) => {
+            eprintln!("Skipping integration test: TENSORLAKE_API_KEY must be set");
+            return;
+        }
+    };
+    let namespace = env::var("INDEXIFY_NAMESPACE").unwrap_or_else(|_| "default".to_string());
+    let image_name = format!(
+        "sdk-rust-delete-test-{}",
+        common::random_string().to_lowercase()
+    );
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let dockerfile_path = temp_dir.path().join("Dockerfile");
+    std::fs::write(
+        &dockerfile_path,
+        "FROM tensorlake/ubuntu-minimal\nRUN printf 'rust delete acceptance\\n' > /tmp/rust-delete-acceptance\n",
+    )
+    .expect("write Dockerfile");
+
+    let templates = sdk.sandbox_templates(&organization_id, &project_id);
+    let result: Result<(), String> = async {
+        build_sandbox_image(
+            SandboxImageBuildOptions {
+                api_url,
+                bearer_token,
+                use_scope_headers: false,
+                organization_id: Some(organization_id),
+                project_id: Some(project_id),
+                namespace,
+                dockerfile_path,
+                dockerfile_text: None,
+                context_dir: None,
+                registered_name: Some(image_name.clone()),
+                disk_mb: None,
+                builder_disk_mb: None,
+                cpus: Some(1.0),
+                memory_mb: Some(1024),
+                is_public: false,
+                user_agent: None,
+            },
+            |_| {},
+        )
+        .await
+        .map_err(|error| format!("build sandbox image failed: {error}"))?;
+
+        templates
+            .delete(&image_name)
+            .await
+            .map_err(|error| format!("delete sandbox image failed: {error}"))?;
+        Ok(())
+    }
+    .await;
+
+    if result.is_err() {
+        let _ = templates.delete(&image_name).await;
+    }
+
+    if let Err(err) = result {
+        panic!("{err}");
+    }
+}
+
+async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut buf = [0_u8; 4096];
+
+    loop {
+        let read = socket.read(&mut buf).await.expect("read request");
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&buf[..read]);
+
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    request
+}

--- a/crates/rust-cloud-sdk-py/Cargo.toml
+++ b/crates/rust-cloud-sdk-py/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { workspace = true }
 reqwest = { workspace = true }
 pyo3 = { workspace = true }
 pyo3-async-runtimes = { workspace = true }
+urlencoding = { workspace = true }
 
 [build-dependencies]
 pyo3-build-config = "0.28.3"

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -140,6 +140,19 @@ impl CloudApiClient {
         })
     }
 
+    fn delete_sandbox_image(&self, image_name: String) -> PyResult<()> {
+        let namespace = self.namespace.clone();
+        self.run_with_retry(5, move |client| {
+            let encoded_image = urlencoding::encode(&image_name).into_owned();
+            let path = format!("/v1/namespaces/{namespace}/sandbox-images/{encoded_image}");
+            async move {
+                let request = client.request(Method::DELETE, &path).build()?;
+                let _response = client.execute(request).await?;
+                Ok(())
+            }
+        })
+    }
+
     fn applications_json(&self) -> PyResult<String> {
         let namespace = self.namespace.clone();
         self.run_with_retry(5, move |client| {

--- a/src/tensorlake/__init__.py
+++ b/src/tensorlake/__init__.py
@@ -1,1 +1,1 @@
-from tensorlake.image import Image
+from tensorlake.image import Image, delete_sandbox_image

--- a/src/tensorlake/image/__init__.py
+++ b/src/tensorlake/image/__init__.py
@@ -1,1 +1,2 @@
 from .image import Image
+from .sandbox_builder import delete_sandbox_image

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -48,6 +48,10 @@ class SandboxImageBuildError(SandboxImageError):
     """The build failed while provisioning, materializing, or registering."""
 
 
+class SandboxImageDeleteError(SandboxImageError):
+    """Deleting a registered sandbox image failed."""
+
+
 # --- Emit helpers -----------------------------------------------------------
 
 
@@ -104,6 +108,33 @@ def _rust_build_sandbox_image(*args, **kwargs) -> str:
         from _cloud_sdk import build_sandbox_image as rust_build_sandbox_image
 
     return rust_build_sandbox_image(*args, **kwargs)
+
+
+def _rust_delete_sandbox_image(
+    api_url: str,
+    token: str,
+    image_name: str,
+    organization_id: str | None,
+    project_id: str | None,
+    namespace: str | None,
+) -> None:
+    try:
+        from tensorlake._cloud_sdk import CloudApiClient
+    except ImportError:
+        from _cloud_sdk import CloudApiClient
+
+    client = CloudApiClient(
+        api_url=api_url,
+        api_key=token,
+        organization_id=organization_id,
+        project_id=project_id,
+        namespace=namespace,
+        user_agent=USER_AGENT,
+    )
+    try:
+        client.delete_sandbox_image(image_name)
+    finally:
+        client.close()
 
 
 def _run_rust_image_create(
@@ -168,6 +199,37 @@ def _run_rust_image_create(
 
 
 # --- Public API -----------------------------------------------------------
+
+
+def delete_sandbox_image(image_name: str) -> None:
+    """Delete a registered sandbox image by name.
+
+    Uses the same environment-based Tensorlake auth and namespace context as
+    :func:`build_sandbox_image`.
+    """
+    if not isinstance(image_name, str) or not image_name:
+        raise TypeError("image_name must be a non-empty string")
+
+    ctx = _build_context_from_env()
+    token = ctx.api_key or ctx.personal_access_token
+    if not token:
+        raise SandboxImageDeleteError(
+            "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
+        )
+
+    try:
+        _rust_delete_sandbox_image(
+            ctx.api_url,
+            token,
+            image_name,
+            ctx.organization_id,
+            ctx.project_id,
+            ctx.namespace,
+        )
+    except SandboxImageError:
+        raise
+    except Exception as e:
+        raise SandboxImageDeleteError(f"{type(e).__name__}: {e}") from e
 
 
 def build_sandbox_image(

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -82,6 +82,8 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             ANY,
         )
 
+
+class TestBuildSandboxImageFromDockerfileOptions(unittest.TestCase):
     def test_public_flag_and_registered_name(self):
         ctx = _make_ctx()
 
@@ -160,6 +162,33 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             emitted,
         )
         self.assertIn({"type": "status", "message": "builder running"}, emitted)
+
+
+class TestDeleteSandboxImage(unittest.TestCase):
+    def test_deletes_sandbox_image_with_env_context(self):
+        ctx = _make_ctx()
+
+        with (
+            patch.object(sbm, "_build_context_from_env", return_value=ctx),
+            patch.object(sbm, "_rust_delete_sandbox_image") as rust_delete,
+        ):
+            sbm.delete_sandbox_image("tensorlake/test:1")
+
+        rust_delete.assert_called_once_with(
+            "https://api.tensorlake.test",
+            "tl_apiKey_abc",
+            "tensorlake/test:1",
+            "org_1",
+            "proj_1",
+            "default",
+        )
+
+    def test_delete_requires_credentials(self):
+        ctx = _make_ctx(api_key=None, personal_access_token=None)
+
+        with patch.object(sbm, "_build_context_from_env", return_value=ctx):
+            with self.assertRaises(sbm.SandboxImageDeleteError):
+                sbm.delete_sandbox_image("image")
 
 
 class TestBuildSandboxImageFromImage(unittest.TestCase):

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -9,10 +9,14 @@ Usage:
 """
 
 import os
+import tempfile
 import time
 import unittest
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
 
+from tensorlake.image.sandbox_builder import build_sandbox_image, delete_sandbox_image
 from tensorlake.sandbox import (
     PoolContainerInfo,
     PoolInUseError,
@@ -202,6 +206,42 @@ class BaseSandboxTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.client.close()
+
+
+# ---------------------------------------------------------------------------
+# TestSandboxImages
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxImages(BaseSandboxTest):
+    def test_create_then_delete_sandbox_image(self):
+        registered_name = f"sdk-python-delete-test-{uuid4().hex[:8]}"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dockerfile_path = Path(tmpdir) / "Dockerfile"
+            dockerfile_path.write_text(
+                "FROM tensorlake/ubuntu-minimal\n"
+                "RUN printf 'python delete acceptance\\n' > /tmp/python-delete-acceptance\n",
+                encoding="utf-8",
+            )
+
+            created = False
+            try:
+                build_sandbox_image(
+                    str(dockerfile_path),
+                    registered_name=registered_name,
+                    cpus=1.0,
+                    memory_mb=1024,
+                )
+                created = True
+
+                delete_sandbox_image(registered_name)
+            finally:
+                if created:
+                    try:
+                        delete_sandbox_image(registered_name)
+                    except Exception:
+                        pass
 
 
 # ---------------------------------------------------------------------------

--- a/typescript/src/api-client.ts
+++ b/typescript/src/api-client.ts
@@ -39,6 +39,10 @@ export class APIClient {
     await this.cloudClient.deleteApplication(applicationName);
   }
 
+  async deleteSandboxImage(imageName: string): Promise<void> {
+    await this.cloudClient.deleteSandboxImage(imageName);
+  }
+
   async applications(): Promise<ApplicationSummary[]> {
     return this.cloudClient.applications();
   }

--- a/typescript/src/cloud-client.ts
+++ b/typescript/src/cloud-client.ts
@@ -81,6 +81,13 @@ export class CloudClient {
     );
   }
 
+  async deleteSandboxImage(imageName: string): Promise<void> {
+    await this.http.requestResponse(
+      "DELETE",
+      this.namespacePath(`sandbox-images/${encodeURIComponent(imageName)}`),
+    );
+  }
+
   async applications(): Promise<ApplicationSummary[]> {
     const raw = await this.http.requestJson<{ applications: Record<string, unknown>[] }>(
       "GET",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -6,7 +6,7 @@ export { Desktop } from "./desktop.js";
 export { TcpTunnel } from "./tunnel.js";
 export { CloudClient } from "./cloud-client.js";
 export { APIClient } from "./api-client.js";
-export { createSandboxImage } from "./sandbox-image.js";
+export { createSandboxImage, deleteSandboxImage } from "./sandbox-image.js";
 export { Image, dockerfileContent, ImageBuildOperationType } from "./image.js";
 export { sandboxUrlFromIngressEndpoint } from "./url.js";
 

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { existsSync } from "node:fs";
 import { parseArgs } from "node:util";
+import { CloudClient } from "./cloud-client.js";
 import { Image, dockerfileContent } from "./image.js";
 
 /**
@@ -300,6 +301,31 @@ export async function createSandboxImage(
   });
   emit({ type: "done" });
   return result;
+}
+
+export async function deleteSandboxImage(imageName: string): Promise<void> {
+  if (typeof imageName !== "string" || imageName.length === 0) {
+    throw new TypeError("imageName must be a non-empty string");
+  }
+
+  const context = buildContextFromEnv();
+  const bearerToken = context.apiKey ?? context.personalAccessToken;
+  if (!bearerToken) {
+    throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.");
+  }
+
+  const client = new CloudClient({
+    apiUrl: context.apiUrl,
+    apiKey: bearerToken,
+    organizationId: context.organizationId,
+    projectId: context.projectId,
+    namespace: context.namespace,
+  });
+  try {
+    await client.deleteSandboxImage(imageName);
+  } finally {
+    client.close();
+  }
 }
 
 export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {

--- a/typescript/tests/cloud-client.test.ts
+++ b/typescript/tests/cloud-client.test.ts
@@ -99,6 +99,20 @@ describe("CloudClient", () => {
     client.close();
   });
 
+  it("deletes sandbox images through the namespaced image route", async () => {
+    mockFetch((url, init) => {
+      expect(url).toBe(
+        "http://localhost:8900/v1/namespaces/default/sandbox-images/tensorlake%2Ftest%3A1",
+      );
+      expect(init?.method).toBe("DELETE");
+      return new Response(null, { status: 204 });
+    });
+
+    const client = new CloudClient({ apiUrl: "http://localhost:8900" });
+    await client.deleteSandboxImage("tensorlake/test:1");
+    client.close();
+  });
+
   it("streams build logs as camel-cased events", async () => {
     mockFetch(() =>
       new Response(

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -8,6 +8,9 @@
  *   TENSORLAKE_API_KEY=... npm run test:integration
  */
 
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   PoolInUseError,
@@ -19,6 +22,8 @@ import {
   type SandboxInfo,
   type SandboxPoolInfo,
   type PoolContainerInfo,
+  createSandboxImage,
+  deleteSandboxImage,
 } from "../src/index.js";
 import { Sandbox } from "../src/sandbox.js";
 
@@ -122,6 +127,10 @@ function claimedContainers(
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function randomSuffix(): string {
+  return Math.random().toString(36).slice(2, 10);
 }
 
 function createTestClient(): SandboxClient {
@@ -231,6 +240,44 @@ beforeAll(async () => {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("Sandbox Images", () => {
+  it(
+    "creates and deletes a sandbox image",
+    async () => {
+      const registeredName = `sdk-ts-delete-test-${randomSuffix()}`;
+      const tempDir = await mkdir(
+        path.join(os.tmpdir(), `tensorlake-image-${registeredName}`),
+        { recursive: true },
+      );
+      const dockerfilePath = path.join(tempDir, "Dockerfile");
+      await writeFile(
+        dockerfilePath,
+        "FROM tensorlake/ubuntu-minimal\nRUN printf 'ts delete acceptance\\n' > /tmp/ts-delete-acceptance\n",
+        "utf8",
+      );
+
+      let created = false;
+      try {
+        await createSandboxImage(dockerfilePath, {
+          registeredName,
+          cpus: 1.0,
+          memoryMb: 1024,
+        });
+        created = true;
+
+        await deleteSandboxImage(registeredName);
+      } finally {
+        if (created) {
+          await deleteSandboxImage(registeredName).catch(() => {});
+        }
+      }
+
+      expect(created).toBe(true);
+    },
+    SANDBOX_SUITE_TIMEOUT_MS,
+  );
+});
 
 describe(
   "Sandbox Lifecycle",


### PR DESCRIPTION
## Summary

Adds sandbox image deletion across the CLI, Rust SDK, Python SDK, and TypeScript SDK.

## Changes

- Adds `tl sbx image rm` with `delete` as an alias.
- Adds sandbox template deletion support in the Rust cloud SDK, including encoded image-name paths.
- Exposes `delete_sandbox_image` in Python and `deleteSandboxImage` in TypeScript.
- Adds unit and integration coverage for image create/delete flows.

## Impact

Users can now remove registered sandbox images programmatically or through the CLI using the same auth and namespace context as image creation.

## Validation

- `PYTHONPATH=/Users/tensorlake/src/tensorlakeai/tensorlake/.worktrees/delete-images/src python3 -m pytest tests/image/test_sandbox_builder.py`
- `cargo test -p tensorlake delete_sandbox_template_sends_encoded_delete_request`
- `cargo check -p tensorlake-cli -p tensorlake-rust-cloud-sdk-py`
- `npm test -- --run tests/cloud-client.test.ts`

Rebased onto `origin/main` before opening this PR.