### PR TITLE
Show sandbox and build IDs in image-build failures instead of Trace-ID

### DIFF
--- a/crates/cli/src/auth/context.rs
+++ b/crates/cli/src/auth/context.rs
@@ -15,10 +15,9 @@ pub struct CliContext {
     pub organization_id: Option<String>,
     pub project_id: Option<String>,
     pub debug: bool,
-    /// W3C trace ID for this CLI invocation (32 lowercase hex chars).
+    /// W3C trace ID for this CLI invocation (32 lowercase hex chars),
+    /// injected as the `traceparent` header on every request.
     pub trace_id: String,
-    /// When true, print the trace ID to stderr after each command.
-    pub show_trace_id: bool,
     introspect_cache: Option<IntrospectResult>,
 }
 
@@ -41,7 +40,6 @@ impl CliContext {
             project_id: config.project_id,
             debug: config.debug,
             trace_id: hex::encode(rand::random::<[u8; 16]>()),
-            show_trace_id: config.show_trace_id,
             introspect_cache: None,
         }
     }

--- a/crates/cli/src/auth/guard.rs
+++ b/crates/cli/src/auth/guard.rs
@@ -31,7 +31,6 @@ pub async fn ensure_auth(ctx: &mut CliContext) -> Result<()> {
         login_result.organization_id.as_deref(),
         login_result.project_id.as_deref(),
         ctx.debug,
-        ctx.show_trace_id,
     );
     *ctx = CliContext::from_resolved(resolved);
     if !ctx.has_authentication() {
@@ -67,7 +66,6 @@ pub async fn ensure_auth_and_project(ctx: &mut CliContext) -> Result<()> {
             login_result.organization_id.as_deref(),
             login_result.project_id.as_deref(),
             ctx.debug,
-            ctx.show_trace_id,
         );
         *ctx = CliContext::from_resolved(resolved);
 
@@ -117,7 +115,6 @@ pub async fn ensure_auth_and_project(ctx: &mut CliContext) -> Result<()> {
         Some(&org_id),
         Some(&proj_id),
         ctx.debug,
-        ctx.show_trace_id,
     );
     *ctx = CliContext::from_resolved(resolved);
 

--- a/crates/cli/src/auth/login.rs
+++ b/crates/cli/src/auth/login.rs
@@ -205,7 +205,6 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
             ctx.organization_id.as_deref(),
             ctx.project_id.as_deref(),
             ctx.debug,
-            ctx.show_trace_id,
         );
         let updated_ctx = CliContext::from_resolved(resolved);
 

--- a/crates/cli/src/commands/secrets.rs
+++ b/crates/cli/src/commands/secrets.rs
@@ -271,7 +271,6 @@ mod tests {
             organization_id: organization_id.map(str::to_string),
             project_id: project_id.map(str::to_string),
             debug: false,
-            show_trace_id: false,
         })
     }
 

--- a/crates/cli/src/config/resolver.rs
+++ b/crates/cli/src/config/resolver.rs
@@ -14,7 +14,6 @@ pub struct ResolvedConfig {
     pub organization_id: Option<String>,
     pub project_id: Option<String>,
     pub debug: bool,
-    pub show_trace_id: bool,
 }
 
 /// Resolve all configuration from CLI args > env vars > local config > global config > defaults.
@@ -29,7 +28,6 @@ pub fn resolve(
     organization_id: Option<&str>,
     project_id: Option<&str>,
     debug: bool,
-    show_trace_id: bool,
 ) -> ResolvedConfig {
     let local_config = load_local_config();
     let global_config = load_global_config();
@@ -51,7 +49,6 @@ pub fn resolve(
         organization_id: org_id,
         project_id: proj_id,
         debug,
-        show_trace_id,
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -61,10 +61,6 @@ struct Cli {
     #[arg(long, env = "TENSORLAKE_PROJECT_ID")]
     project: Option<String>,
 
-    /// Print the trace ID for this command to stderr (for APM correlation)
-    #[arg(long, env = "TENSORLAKE_SHOW_TRACE_ID", global = true)]
-    show_trace_id: bool,
-
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -967,7 +963,6 @@ async fn main() {
         cli.organization.as_deref(),
         cli.project.as_deref(),
         cli.debug,
-        cli.show_trace_id,
     );
 
     let mut ctx = CliContext::from_resolved(resolved);
@@ -981,10 +976,6 @@ async fn main() {
     };
 
     let result = run_command(&mut ctx, command).await;
-
-    if ctx.show_trace_id {
-        eprintln!("Trace-ID: {}", ctx.trace_id);
-    }
 
     if let Err(e) = result {
         match &e {

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -81,6 +81,16 @@ const IGNORED_DOCKERFILE_INSTRUCTIONS: &[&str] =
 
 #[derive(Debug, Error)]
 pub enum SandboxImageBuildError {
+    /// A failure after the builder sandbox was created. Carries the IDs
+    /// support needs to find the build: the builder sandbox ID correlates
+    /// with dataplane and platform logs, the build ID with platform-api.
+    #[error("{source} (builder sandbox: {builder_sandbox_id}, build: {build_id})")]
+    BuildFailed {
+        builder_sandbox_id: String,
+        build_id: String,
+        #[source]
+        source: Box<SandboxImageBuildError>,
+    },
     #[error("{0}")]
     Usage(String),
     #[error("{0}")]
@@ -416,7 +426,11 @@ where
         )));
     }
 
-    result
+    result.map_err(|source| SandboxImageBuildError::BuildFailed {
+        builder_sandbox_id: sandbox_id,
+        build_id: prepared.build_id.clone(),
+        source: Box::new(source),
+    })
 }
 
 async fn resolve_build_context(options: SandboxImageBuildOptions) -> Result<ResolvedBuildContext> {
@@ -1991,6 +2005,21 @@ fn is_dockerignored(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn build_failed_error_names_the_builder_sandbox_and_build() {
+        let error = super::SandboxImageBuildError::BuildFailed {
+            builder_sandbox_id: "rtmmkcw33uvsbep6hn03u".to_string(),
+            build_id: "sandbox_template_build_123".to_string(),
+            source: Box::new(super::SandboxImageBuildError::Other(
+                "rootfs builder exited with status 1".to_string(),
+            )),
+        };
+        let message = error.to_string();
+        assert!(message.contains("builder sandbox: rtmmkcw33uvsbep6hn03u"));
+        assert!(message.contains("build: sandbox_template_build_123"));
+        assert!(message.contains("rootfs builder exited with status 1"));
+    }
     use super::{
         CompleteSandboxTemplateBuildRequest, PreparedRootfsBuilder, PreparedRootfsParent,
         PreparedSandboxTemplateBuild, build_rootfs_spec, collect_dir_files,


### PR DESCRIPTION
## Summary

When a customer's image build failed, the CLI handed them a `Trace-ID` — a client-minted W3C trace id that only the platform-api auth hop ever logs. Debugging from it meant timestamp archaeology. The **builder sandbox ID** is the handle that actually correlates across platform-api, dataplane serial logs, and build logs (it's how both recent prod incidents were traced).

- **SDK** (`cloud-sdk/sandbox_images`): any failure after the builder sandbox is created is wrapped in a new `BuildFailed` error variant carrying the builder sandbox ID and build ID, so every failed `tl sbx image create` message ends with:
  ```
  Error: rootfs builder exited with status 1 (builder sandbox: rtmmkcw33uvsbep6hn03u, build: sandbox_template_build_t8BK...)
  ```
- **CLI**: `--show-trace-id` / `TENSORLAKE_SHOW_TRACE_ID` and the `Trace-ID:` print are removed. The trace id still rides on every request as the `traceparent` header for server-side correlation; it just isn't what we hand users anymore.

The sandbox ID is also already announced mid-stream ("Rootfs builder sandbox <id> is running"), so successful builds remain traceable too.

## Validation

- `cargo test -p tensorlake --lib sandbox_image` — 27 passed (includes a new test pinning that the failure message names both IDs)
- `cargo test -p tensorlake-cli` — 160 passed
- `cargo build -p tensorlake -p tensorlake-cli` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)