### PR TITLE
Add tl version command and show the version in help

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,7 +19,7 @@ use error::CliError;
 #[derive(Parser)]
 #[command(
     name = "tl",
-    about = "Tensorlake CLI",
+    about = concat!("Tensorlake CLI v", env!("CARGO_PKG_VERSION")),
     version,
     infer_subcommands = true,
     after_help = "\
@@ -77,6 +77,9 @@ enum OutputFormat {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Print the CLI version
+    Version,
+
     /// Login to TensorLake
     Login,
 
@@ -1008,6 +1011,10 @@ fn missing_subcommand_error() -> &'static str {
 
 async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<()> {
     match command {
+        Commands::Version => {
+            println!("tl {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
         Commands::Login => commands::login::run(ctx).await,
         Commands::Whoami { output } => {
             commands::whoami::run(ctx, matches!(output, OutputFormat::Json)).await


### PR DESCRIPTION
## Summary

- New `tl version` subcommand printing `tl <version>` (same output as `--version`; `tl v` also works via subcommand inference).
- The help header now shows the version at a glance:
  ```
  Tensorlake CLI v0.5.39

  Usage: tl [OPTIONS] <COMMAND>

  Commands:
    version  Print the CLI version
    login    Login to TensorLake
    ...
  ```

Useful for support flows: "what does `tl version` say?" is now a one-word ask, and every `--help` paste includes the version.

## Validation

- `cargo build -p tensorlake-cli` clean; verified `tl version`, `tl v`, `tl --version`, and `tl --help` output locally
- `cargo test -p tensorlake-cli` — 160 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)