### PR TITLE
chore: bump version to 0.5.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.41"
+version = "0.5.42"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.41"
+version = "0.5.42"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.41"
+version = "0.5.42"
 dependencies = [
  "napi",
  "napi-build",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.41"
+version = "0.5.42"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.41"
+version = "0.5.42"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.41"
+version = "0.5.42"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.41"
+version = "0.5.42"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.40",
+  "version": "0.5.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.40",
+      "version": "0.5.42",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.40",
+  "version": "0.5.42",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Unifies all package tracks at **0.5.42** and releases the support-diagnostics CLI work:

- #740 — image-build failures name the builder sandbox and build IDs instead of a Trace-ID
- #742 — `tl version` command + version shown in `--help`

The tracks had diverged on `main`: the Rust workspace and Python packages were already at **0.5.41** (matching the `cli-v0.5.41` tag) while npm was still **0.5.40** — this moves everything past the already-cut `cli-v0.5.40`/`cli-v0.5.41` tags to one number.

Merge #740 and #742 first; this releases them across all tracks.

## Changes

- `Cargo.toml` workspace version (all crates inherit) + `Cargo.lock`
- `pyproject.toml` (PyPI `tensorlake`)
- `crates/rust-cloud-sdk-py/pyproject.toml` (Python wheel)
- `typescript/package.json` + `package-lock.json` (version fields only — no npm metadata churn)

## Validation

- `cargo build -p tensorlake-cli` clean; `tl --version` → `tl 0.5.42`
- Lockfile diffs are exactly the workspace crate / package version fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)