### PR TITLE
Add tl sbx image import: import a registry image without Docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "napi",
  "napi-build",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.42"
+version = "0.5.43"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/image/import.rs
+++ b/crates/cli/src/commands/sbx/image/import.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use tensorlake::sandbox_images::{
     SandboxImageBuildEvent, SandboxImageBuildOptions, build_sandbox_image,
 };
@@ -9,10 +7,13 @@ use crate::{
     error::{CliError, Result},
 };
 
+/// Import a registry image directly into a Tensorlake sandbox image, with no
+/// Dockerfile and no Docker daemon: the builder pulls the image's layers and
+/// writes them straight into the rootfs.
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     ctx: &CliContext,
-    dockerfile_path: &str,
+    image_reference: &str,
     registered_name: Option<&str>,
     disk_mb: Option<u64>,
     builder_disk_mb: Option<u64>,
@@ -28,10 +29,12 @@ pub async fn run(
         organization_id: ctx.effective_organization_id(),
         project_id: ctx.effective_project_id(),
         namespace: ctx.namespace.clone(),
-        dockerfile_path: PathBuf::from(dockerfile_path),
+        // Unused on the import path, but the option struct is shared with the
+        // Dockerfile build flow.
+        dockerfile_path: std::path::PathBuf::new(),
         dockerfile_text: None,
         context_dir: None,
-        import_image_reference: None,
+        import_image_reference: Some(image_reference.to_string()),
         registered_name: registered_name.map(str::to_string),
         disk_mb,
         builder_disk_mb,

--- a/crates/cli/src/commands/sbx/image/mod.rs
+++ b/crates/cli/src/commands/sbx/image/mod.rs
@@ -1,5 +1,6 @@
 pub mod create;
 pub mod describe;
+pub mod import;
 pub mod ls;
 pub mod register;
 pub mod rm;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -781,6 +781,43 @@ enum ImageCommands {
         json: bool,
     },
 
+    /// Import a registry image directly into a sandbox image (no Dockerfile,
+    /// no Docker daemon — the image's layers are written straight into the
+    /// rootfs)
+    Import {
+        /// Registry image reference to import (e.g. ubuntu:24.04,
+        /// pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime, ghcr.io/org/app:v1)
+        image_reference: String,
+
+        /// Registered image name (defaults to the image's last path segment)
+        #[arg(short = 'n', long)]
+        registered_name: Option<String>,
+
+        /// Root disk size in MB for the generated sandbox image (default: 10240)
+        #[arg(long = "disk_mb")]
+        disk_mb: Option<u64>,
+
+        /// Root disk size in MB for the temporary builder sandbox
+        #[arg(long = "builder_disk_mb")]
+        builder_disk_mb: Option<u64>,
+
+        /// CPUs for the temporary build sandbox
+        #[arg(long)]
+        cpus: Option<f64>,
+
+        /// Memory in MB for the temporary build sandbox
+        #[arg(long)]
+        memory: Option<i64>,
+
+        /// Make this sandbox image publicly accessible
+        #[arg(short, long)]
+        public: bool,
+
+        /// Print the registered sandbox image JSON response to stdout
+        #[arg(long = "json", hide = true)]
+        json: bool,
+    },
+
     /// List all sandbox images
     Ls,
 
@@ -1367,6 +1404,29 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             commands::sbx::image::create::run(
                                 ctx,
                                 &dockerfile_path,
+                                registered_name.as_deref(),
+                                disk_mb,
+                                builder_disk_mb,
+                                cpus,
+                                memory,
+                                public,
+                                json,
+                            )
+                            .await
+                        }
+                        ImageCommands::Import {
+                            image_reference,
+                            registered_name,
+                            disk_mb,
+                            builder_disk_mb,
+                            cpus,
+                            memory,
+                            public,
+                            json,
+                        } => {
+                            commands::sbx::image::import::run(
+                                ctx,
+                                &image_reference,
                                 registered_name.as_deref(),
                                 disk_mb,
                                 builder_disk_mb,

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -132,6 +132,11 @@ pub struct SandboxImageBuildOptions {
     pub dockerfile_path: PathBuf,
     pub dockerfile_text: Option<String>,
     pub context_dir: Option<PathBuf>,
+    /// When set, import this registry image reference directly into a rootfs
+    /// (no Dockerfile, no Docker daemon — the builder runs
+    /// `indexify-rootfs-materialize oci-image-to-ext4`). Mutually exclusive
+    /// with the Dockerfile build path.
+    pub import_image_reference: Option<String>,
     pub registered_name: Option<String>,
     pub disk_mb: Option<u64>,
     pub builder_disk_mb: Option<u64>,
@@ -189,6 +194,12 @@ struct DockerfileBuildPlan {
     /// Surfaced as warnings by the caller; preserved in `dockerfile_text` and
     /// forwarded to `docker build`.
     ignored_instructions: Vec<(usize, String)>,
+    /// When set, this is an image-import build rather than a Dockerfile build:
+    /// the builder pulls this registry reference directly into the rootfs with
+    /// no Docker daemon. There is no build context to upload and the base is
+    /// never resolved against the template registry (import always pulls from
+    /// the registry, producing a fresh base rootfs).
+    import_image_reference: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -256,18 +267,25 @@ pub async fn build_sandbox_image<F>(options: SandboxImageBuildOptions, mut emit:
 where
     F: FnMut(SandboxImageBuildEvent),
 {
-    emit(SandboxImageBuildEvent::Status(
-        "Loading Dockerfile...".to_string(),
-    ));
-    let plan = if let Some(dockerfile_text) = &options.dockerfile_text {
-        load_dockerfile_text_plan(
-            &options.dockerfile_path,
-            options.context_dir.as_deref(),
-            dockerfile_text.clone(),
-            options.registered_name.as_deref(),
-        )?
+    let plan = if let Some(image_ref) = &options.import_image_reference {
+        emit(SandboxImageBuildEvent::Status(format!(
+            "Importing registry image {image_ref}..."
+        )));
+        plan_image_import(image_ref, options.registered_name.as_deref())?
     } else {
-        load_dockerfile_plan(&options.dockerfile_path, options.registered_name.as_deref())?
+        emit(SandboxImageBuildEvent::Status(
+            "Loading Dockerfile...".to_string(),
+        ));
+        if let Some(dockerfile_text) = &options.dockerfile_text {
+            load_dockerfile_text_plan(
+                &options.dockerfile_path,
+                options.context_dir.as_deref(),
+                dockerfile_text.clone(),
+                options.registered_name.as_deref(),
+            )?
+        } else {
+            load_dockerfile_plan(&options.dockerfile_path, options.registered_name.as_deref())?
+        }
     };
     emit(SandboxImageBuildEvent::Status(format!(
         "Selected image name: {}",
@@ -658,8 +676,11 @@ async fn prepare_rootfs_build(
     // the value is an internal reference to an earlier-defined stage, not
     // an external image we should resolve as a template. Also skip when
     // the base image contains `$` (build-arg) or `@` (digest pin); those
-    // were already recorded as unresolvable and warned about.
-    let parent_template_payload = if plan.base_image_is_internal_stage
+    // were already recorded as unresolvable and warned about. Import builds
+    // never resolve a parent — they always pull a fresh base from the
+    // registry, even if the reference happens to match a template name.
+    let parent_template_payload = if plan.import_image_reference.is_some()
+        || plan.base_image_is_internal_stage
         || plan.base_image.contains('$')
         || plan.base_image.contains('@')
     {
@@ -841,9 +862,6 @@ async fn upload_build_inputs(
     disk_mb: Option<u64>,
     emit: &mut impl FnMut(SandboxImageBuildEvent),
 ) -> Result<()> {
-    emit(SandboxImageBuildEvent::Status(
-        "Uploading build context...".to_string(),
-    ));
     // Pre-create REMOTE_BUILD_DIR with permissive mode as root so the
     // sandbox-user file API can write into it. The path lives under
     // /var/lib/tensorlake/ which is root-owned in the rootfs-builder image,
@@ -853,7 +871,14 @@ async fn upload_build_inputs(
     // `PUT /api/v1/files` calls (both running as the sandbox user) succeed
     // without further root involvement.
     ensure_remote_build_root(proxy).await?;
-    copy_local_path(proxy, &plan.context_dir, REMOTE_CONTEXT_DIR).await?;
+    // Import builds have no local build context — the rootfs comes straight
+    // from the registry image — so there is nothing to upload.
+    if plan.import_image_reference.is_none() {
+        emit(SandboxImageBuildEvent::Status(
+            "Uploading build context...".to_string(),
+        ));
+        copy_local_path(proxy, &plan.context_dir, REMOTE_CONTEXT_DIR).await?;
+    }
 
     let docker_config_json = resolved_docker_config_json().await?;
     let spec = build_rootfs_spec(prepared_spec, prepared, plan, disk_mb, docker_config_json)?;
@@ -888,6 +913,14 @@ fn build_rootfs_spec(
         "baseImage".to_string(),
         Value::String(plan.base_image.clone()),
     );
+    // Routes the builder to `oci-image-to-ext4` instead of docker build; the
+    // builder pulls this reference straight into the rootfs.
+    if let Some(import_image_reference) = &plan.import_image_reference {
+        object.insert(
+            "importImageReference".to_string(),
+            Value::String(import_image_reference.clone()),
+        );
+    }
     object.insert(
         "rootfsDiskBytes".to_string(),
         Value::Number(rootfs_disk_bytes(disk_mb, prepared)?.into()),
@@ -1478,6 +1511,55 @@ fn is_localhost(url: &str) -> bool {
     false
 }
 
+/// Build a plan for importing a registry image directly (no Dockerfile).
+/// The stored "dockerfile" is a synthetic `FROM <ref>` so the template
+/// registry records a faithful provenance, but the build never runs Docker:
+/// the spec's `importImageReference` routes the builder to
+/// `oci-image-to-ext4`. Import is always a fresh base from the registry, so
+/// the base is not resolved against the template registry.
+fn plan_image_import(
+    image_ref: &str,
+    registered_name: Option<&str>,
+) -> Result<DockerfileBuildPlan> {
+    let image_ref = image_ref.trim();
+    if image_ref.is_empty() {
+        return Err(SandboxImageBuildError::usage(
+            "image reference to import must not be empty",
+        ));
+    }
+    let registered_name = registered_name
+        .map(str::to_string)
+        .unwrap_or_else(|| default_registered_name_from_image(image_ref));
+    Ok(DockerfileBuildPlan {
+        context_dir: PathBuf::new(),
+        registered_name,
+        dockerfile_text: format!("FROM {image_ref}\n"),
+        base_image: image_ref.to_string(),
+        base_image_is_internal_stage: false,
+        additional_image_references: Vec::new(),
+        unresolvable_image_references: Vec::new(),
+        ignored_instructions: Vec::new(),
+        import_image_reference: Some(image_ref.to_string()),
+    })
+}
+
+/// Derive a registered name from an image reference: the last path segment
+/// with any tag/digest stripped (e.g. `pytorch/pytorch:2.4.1` -> `pytorch`,
+/// `ghcr.io/org/app@sha256:...` -> `app`).
+fn default_registered_name_from_image(image_ref: &str) -> String {
+    let without_digest = image_ref.split('@').next().unwrap_or(image_ref);
+    let last_segment = without_digest.rsplit('/').next().unwrap_or(without_digest);
+    let name = match last_segment.rsplit_once(':') {
+        Some((repo, tag)) if !tag.is_empty() => repo,
+        _ => last_segment,
+    };
+    if name.is_empty() {
+        "imported-image".to_string()
+    } else {
+        name.to_string()
+    }
+}
+
 fn load_dockerfile_plan(
     dockerfile_path: &Path,
     registered_name: Option<&str>,
@@ -1646,6 +1728,7 @@ fn load_dockerfile_text_plan(
         additional_image_references: additional_refs,
         unresolvable_image_references,
         ignored_instructions,
+        import_image_reference: None,
     })
 }
 
@@ -2051,6 +2134,70 @@ mod tests {
     }
 
     #[test]
+    fn plan_image_import_synthesizes_from_and_marks_import() {
+        let plan = super::plan_image_import("ubuntu:24.04", None).unwrap();
+        assert_eq!(plan.dockerfile_text, "FROM ubuntu:24.04\n");
+        assert_eq!(plan.base_image, "ubuntu:24.04");
+        assert_eq!(plan.import_image_reference.as_deref(), Some("ubuntu:24.04"));
+        assert!(plan.additional_image_references.is_empty());
+        // Last path segment with the tag stripped.
+        assert_eq!(plan.registered_name, "ubuntu");
+    }
+
+    #[test]
+    fn plan_image_import_honors_explicit_name_and_rejects_empty() {
+        let plan = super::plan_image_import("ghcr.io/org/app:v1", Some("my-image")).unwrap();
+        assert_eq!(plan.registered_name, "my-image");
+        assert!(super::plan_image_import("   ", None).is_err());
+    }
+
+    #[test]
+    fn default_registered_name_from_image_strips_path_tag_and_digest() {
+        assert_eq!(
+            super::default_registered_name_from_image("pytorch/pytorch:2.4.1-runtime"),
+            "pytorch"
+        );
+        assert_eq!(
+            super::default_registered_name_from_image(&format!(
+                "ghcr.io/org/app@sha256:{}",
+                "a".repeat(64)
+            )),
+            "app"
+        );
+        assert_eq!(
+            super::default_registered_name_from_image("ubuntu"),
+            "ubuntu"
+        );
+    }
+
+    #[test]
+    fn build_rootfs_spec_sets_import_reference_for_import_plans() {
+        let prepared_spec = json!({});
+        let prepared: super::PreparedSandboxTemplateBuild = serde_json::from_value(json!({
+            "buildId": "build-1",
+            "snapshotId": "snap-1",
+            "snapshotUri": "s3://bucket/snap-1",
+            "rootfsNodeKind": "base",
+            "builder": {
+                "image": "tensorlake/rootfs-builder",
+                "command": "tl-rootfs-build",
+                "cpus": 2.0,
+                "memoryMb": 2048,
+                "diskMb": 20480
+            },
+            "parent": null
+        }))
+        .unwrap();
+        let plan = super::plan_image_import("ubuntu:24.04", None).unwrap();
+
+        let spec =
+            super::build_rootfs_spec(&prepared_spec, &prepared, &plan, Some(10240), None).unwrap();
+        assert_eq!(spec["importImageReference"], "ubuntu:24.04");
+        assert_eq!(spec["baseImage"], "ubuntu:24.04");
+        assert_eq!(spec["dockerfile"], "FROM ubuntu:24.04\n");
+    }
+
+    #[test]
     fn load_dockerfile_plan_reads_base_image_and_name() {
         let temp_dir = tempfile::tempdir().unwrap();
         let dockerfile_path = temp_dir.path().join("Dockerfile");
@@ -2385,6 +2532,7 @@ mod tests {
             base_image_is_internal_stage: false,
             unresolvable_image_references: Vec::new(),
             ignored_instructions: Vec::new(),
+            import_image_reference: None,
         };
 
         let spec = build_rootfs_spec(
@@ -2417,6 +2565,7 @@ mod tests {
             base_image_is_internal_stage: false,
             unresolvable_image_references: Vec::new(),
             ignored_instructions: Vec::new(),
+            import_image_reference: None,
         };
 
         let spec = build_rootfs_spec(&prepared_spec, &prepared, &plan, None, None).unwrap();

--- a/crates/cloud-sdk/tests/sandbox_templates.rs
+++ b/crates/cloud-sdk/tests/sandbox_templates.rs
@@ -95,6 +95,7 @@ async fn test_create_then_delete_sandbox_image() {
                 dockerfile_path,
                 dockerfile_text: None,
                 context_dir: None,
+                import_image_reference: None,
                 registered_name: Some(image_name.clone()),
                 disk_mb: None,
                 builder_disk_mb: None,

--- a/crates/rust-cloud-sdk-node/src/lib.rs
+++ b/crates/rust-cloud-sdk-node/src/lib.rs
@@ -96,6 +96,7 @@ pub async fn build_sandbox_image(
         dockerfile_path: PathBuf::from(options.dockerfile_path),
         dockerfile_text: options.dockerfile_text,
         context_dir: options.context_dir.map(PathBuf::from),
+        import_image_reference: None,
         registered_name: options.registered_name,
         disk_mb: options.disk_mb.map(u64::from),
         builder_disk_mb: options.builder_disk_mb.map(u64::from),

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.42"
+version = "0.5.43"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -2845,6 +2845,7 @@ fn build_sandbox_image(
         dockerfile_path: PathBuf::from(dockerfile_path),
         dockerfile_text,
         context_dir: context_dir.map(PathBuf::from),
+        import_image_reference: None,
         registered_name,
         disk_mb,
         builder_disk_mb,

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.42"
+version = "0.5.43"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]


### PR DESCRIPTION
## Summary

New SDK + CLI path that imports a registry image **directly into a Tensorlake sandbox image, bypassing Docker entirely**:

```
tl sbx image import pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime -n pytorch
```

This creates a builder sandbox whose spec carries `importImageReference`, which routes the rootfs builder to `indexify-rootfs-materialize oci-image-to-ext4` (the no-Docker layer applier) instead of `docker build` + overlay materialization.

**Why:** for a `FROM <image>` import, Docker contributes nothing but cost — it unpacks every layer into its store and we copy that out again, so a 26 GB image needs ~50+ GB of builder scratch and ~130 GB of I/O. The import path pulls each layer, applies it straight into the rootfs, and deletes it — content exists on disk once, peak disk ≈ rootfs + one compressed layer.

## Changes (SDK / CLI only)

- `SandboxImageBuildOptions.import_image_reference` selects the import path; `plan_image_import` synthesizes a `FROM <ref>` plan (recorded in the template registry for provenance) with no build context. Import is always a fresh base — the reference is never resolved against the template registry.
- The build spec gains `importImageReference`; build-context upload is skipped for imports. The whole create-sandbox → run-builder → complete → register orchestration is reused unchanged.
- CLI `tl sbx image import <ref> [-n name] [--disk_mb] [--builder_disk_mb] [--cpus] [--memory] [--public]`, mirroring `tl sbx image create`.
- Version bumped to 0.5.43.

## Companion change required

This is the SDK half. End-to-end it needs the provisioner `tl-rootfs-build.py` to honor `importImageReference` (run `oci-image-to-ext4` instead of docker), and the builder image to carry an `indexify-rootfs-materialize` with the `oci-image-to-ext4` subcommand — compute-engine-internal branch `oci-image-to-ext4` (the Rust materializer + whiteout-aware layer applier + attribute-fidelity tests are done there).

## Validation

- `cargo test -p tensorlake --lib sandbox_image` — 32 passed (4 new: import planner, default-name derivation, empty-ref rejection, spec carries `importImageReference`)
- `cargo test -p tensorlake-cli` — 166 passed
- All four crates build (cloud-sdk, cli, py + node bindings); clippy clean on touched code; `tl sbx image import --help` renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)