### PR TITLE
Add sandbox image import to Python and TypeScript SDKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.43"
+version = "0.5.44"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.43"
+version = "0.5.44"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.43"
+version = "0.5.44"
 dependencies = [
  "napi",
  "napi-build",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.43"
+version = "0.5.44"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.43"
+version = "0.5.44"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use tensorlake::sandbox_images::{
-    SandboxImageBuildEvent, SandboxImageBuildOptions, build_sandbox_image,
+    CommonBuildOptions, SandboxImageBuildEvent, SandboxImageBuildOptions, build_sandbox_image,
 };
 
 use crate::{
@@ -22,26 +22,27 @@ pub async fn run(
     output_json: bool,
 ) -> Result<()> {
     let options = SandboxImageBuildOptions {
-        api_url: ctx.api_url.clone(),
-        bearer_token: ctx.bearer_token()?,
-        use_scope_headers: ctx.personal_access_token.is_some() && ctx.api_key.is_none(),
-        organization_id: ctx.effective_organization_id(),
-        project_id: ctx.effective_project_id(),
-        namespace: ctx.namespace.clone(),
+        common: CommonBuildOptions {
+            api_url: ctx.api_url.clone(),
+            bearer_token: ctx.bearer_token()?,
+            use_scope_headers: ctx.personal_access_token.is_some() && ctx.api_key.is_none(),
+            organization_id: ctx.effective_organization_id(),
+            project_id: ctx.effective_project_id(),
+            namespace: ctx.namespace.clone(),
+            registered_name: registered_name.map(str::to_string),
+            disk_mb,
+            builder_disk_mb,
+            cpus,
+            memory_mb,
+            is_public,
+            user_agent: Some(format!(
+                "Tensorlake CLI (rust/{})",
+                env!("CARGO_PKG_VERSION")
+            )),
+        },
         dockerfile_path: PathBuf::from(dockerfile_path),
         dockerfile_text: None,
         context_dir: None,
-        import_image_reference: None,
-        registered_name: registered_name.map(str::to_string),
-        disk_mb,
-        builder_disk_mb,
-        cpus,
-        memory_mb,
-        is_public,
-        user_agent: Some(format!(
-            "Tensorlake CLI (rust/{})",
-            env!("CARGO_PKG_VERSION")
-        )),
     };
 
     let registered = build_sandbox_image(options, |event| match event {

--- a/crates/cli/src/commands/sbx/image/import.rs
+++ b/crates/cli/src/commands/sbx/image/import.rs
@@ -1,5 +1,5 @@
 use tensorlake::sandbox_images::{
-    SandboxImageBuildEvent, SandboxImageBuildOptions, build_sandbox_image,
+    CommonBuildOptions, SandboxImageBuildEvent, SandboxImageImportOptions, import_sandbox_image,
 };
 
 use crate::{
@@ -22,32 +22,29 @@ pub async fn run(
     is_public: bool,
     output_json: bool,
 ) -> Result<()> {
-    let options = SandboxImageBuildOptions {
-        api_url: ctx.api_url.clone(),
-        bearer_token: ctx.bearer_token()?,
-        use_scope_headers: ctx.personal_access_token.is_some() && ctx.api_key.is_none(),
-        organization_id: ctx.effective_organization_id(),
-        project_id: ctx.effective_project_id(),
-        namespace: ctx.namespace.clone(),
-        // Unused on the import path, but the option struct is shared with the
-        // Dockerfile build flow.
-        dockerfile_path: std::path::PathBuf::new(),
-        dockerfile_text: None,
-        context_dir: None,
-        import_image_reference: Some(image_reference.to_string()),
-        registered_name: registered_name.map(str::to_string),
-        disk_mb,
-        builder_disk_mb,
-        cpus,
-        memory_mb,
-        is_public,
-        user_agent: Some(format!(
-            "Tensorlake CLI (rust/{})",
-            env!("CARGO_PKG_VERSION")
-        )),
+    let options = SandboxImageImportOptions {
+        common: CommonBuildOptions {
+            api_url: ctx.api_url.clone(),
+            bearer_token: ctx.bearer_token()?,
+            use_scope_headers: ctx.personal_access_token.is_some() && ctx.api_key.is_none(),
+            organization_id: ctx.effective_organization_id(),
+            project_id: ctx.effective_project_id(),
+            namespace: ctx.namespace.clone(),
+            registered_name: registered_name.map(str::to_string),
+            disk_mb,
+            builder_disk_mb,
+            cpus,
+            memory_mb,
+            is_public,
+            user_agent: Some(format!(
+                "Tensorlake CLI (rust/{})",
+                env!("CARGO_PKG_VERSION")
+            )),
+        },
+        image_reference: image_reference.to_string(),
     };
 
-    let registered = build_sandbox_image(options, |event| match event {
+    let registered = import_sandbox_image(options, |event| match event {
         SandboxImageBuildEvent::Status(message) => eprintln!("⚙️  {message}"),
         SandboxImageBuildEvent::BuildLog { message, .. } => eprintln!("{message}"),
         SandboxImageBuildEvent::Warning(message) => eprintln!("⚠️  {message}"),

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -124,22 +124,18 @@ impl SandboxImageBuildError {
     }
 }
 
+/// Auth/context and resource fields shared by every sandbox-image build mode
+/// (Dockerfile build and registry import). The mode-specific public option
+/// structs (`SandboxImageBuildOptions`, `SandboxImageImportOptions`) each carry
+/// their own copy of these and hand them to the shared `run_build_plan` runner.
 #[derive(Debug, Clone)]
-pub struct SandboxImageBuildOptions {
+pub struct CommonBuildOptions {
     pub api_url: String,
     pub bearer_token: String,
     pub use_scope_headers: bool,
     pub organization_id: Option<String>,
     pub project_id: Option<String>,
     pub namespace: String,
-    pub dockerfile_path: PathBuf,
-    pub dockerfile_text: Option<String>,
-    pub context_dir: Option<PathBuf>,
-    /// When set, import this registry image reference directly into a rootfs
-    /// (no Dockerfile, no Docker daemon — the builder runs
-    /// `indexify-rootfs-materialize oci-image-to-ext4`). Mutually exclusive
-    /// with the Dockerfile build path.
-    pub import_image_reference: Option<String>,
     pub registered_name: Option<String>,
     pub disk_mb: Option<u64>,
     pub builder_disk_mb: Option<u64>,
@@ -147,6 +143,34 @@ pub struct SandboxImageBuildOptions {
     pub memory_mb: Option<i64>,
     pub is_public: bool,
     pub user_agent: Option<String>,
+}
+
+/// Options for building a sandbox image from a Dockerfile. This is the
+/// Dockerfile build path only — to import a registry image directly into a
+/// rootfs without a Dockerfile, use [`SandboxImageImportOptions`] /
+/// [`import_sandbox_image`] instead. Keeping the two modes in separate structs
+/// means a caller cannot construct an ambiguous mix of a Dockerfile and an
+/// import reference.
+#[derive(Debug, Clone)]
+pub struct SandboxImageBuildOptions {
+    pub common: CommonBuildOptions,
+    pub dockerfile_path: PathBuf,
+    pub dockerfile_text: Option<String>,
+    pub context_dir: Option<PathBuf>,
+}
+
+/// Options for importing a registry image directly into a rootfs (no
+/// Dockerfile, no Docker daemon — the builder runs
+/// `indexify-rootfs-materialize oci-image-to-ext4`). The reference is always
+/// pulled fresh from the registry; it is never resolved against the Tensorlake
+/// template registry.
+#[derive(Debug, Clone)]
+pub struct SandboxImageImportOptions {
+    pub common: CommonBuildOptions,
+    /// The registry image reference to import, e.g.
+    /// `pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime` or
+    /// `ghcr.io/org/app@sha256:...`.
+    pub image_reference: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -281,30 +305,65 @@ struct CompleteSandboxTemplateBuildRequest {
     parent_manifest_uri: Option<String>,
 }
 
+/// Build a sandbox image from a Dockerfile (path or inline text). To import a
+/// registry image directly into a rootfs without a Dockerfile, use
+/// [`import_sandbox_image`] instead.
 pub async fn build_sandbox_image<F>(options: SandboxImageBuildOptions, mut emit: F) -> Result<Value>
 where
     F: FnMut(SandboxImageBuildEvent),
 {
-    let plan = if let Some(image_ref) = &options.import_image_reference {
-        emit(SandboxImageBuildEvent::Status(format!(
-            "Importing registry image {image_ref}..."
-        )));
-        plan_image_import(image_ref, options.registered_name.as_deref())?
+    emit(SandboxImageBuildEvent::Status(
+        "Loading Dockerfile...".to_string(),
+    ));
+    let plan = if let Some(dockerfile_text) = &options.dockerfile_text {
+        load_dockerfile_text_plan(
+            &options.dockerfile_path,
+            options.context_dir.as_deref(),
+            dockerfile_text.clone(),
+            options.common.registered_name.as_deref(),
+        )?
     } else {
-        emit(SandboxImageBuildEvent::Status(
-            "Loading Dockerfile...".to_string(),
-        ));
-        if let Some(dockerfile_text) = &options.dockerfile_text {
-            load_dockerfile_text_plan(
-                &options.dockerfile_path,
-                options.context_dir.as_deref(),
-                dockerfile_text.clone(),
-                options.registered_name.as_deref(),
-            )?
-        } else {
-            load_dockerfile_plan(&options.dockerfile_path, options.registered_name.as_deref())?
-        }
+        load_dockerfile_plan(
+            &options.dockerfile_path,
+            options.common.registered_name.as_deref(),
+        )?
     };
+    run_build_plan(plan, options.common, emit).await
+}
+
+/// Import a registry image directly into a rootfs (no Dockerfile, no Docker
+/// daemon). The reference is always pulled fresh from the registry; it is
+/// never resolved against the Tensorlake template registry.
+pub async fn import_sandbox_image<F>(
+    options: SandboxImageImportOptions,
+    mut emit: F,
+) -> Result<Value>
+where
+    F: FnMut(SandboxImageBuildEvent),
+{
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Importing registry image {}...",
+        options.image_reference
+    )));
+    let plan = plan_image_import(
+        &options.image_reference,
+        options.common.registered_name.as_deref(),
+    )?;
+    run_build_plan(plan, options.common, emit).await
+}
+
+/// Shared build pipeline: provision the rootfs-builder sandbox, materialize the
+/// filesystem from `plan`, and register the resulting snapshot. Both the
+/// Dockerfile build and registry import paths funnel through here once they
+/// have produced a [`DockerfileBuildPlan`].
+async fn run_build_plan<F>(
+    plan: DockerfileBuildPlan,
+    options: CommonBuildOptions,
+    mut emit: F,
+) -> Result<Value>
+where
+    F: FnMut(SandboxImageBuildEvent),
+{
     emit(SandboxImageBuildEvent::Status(format!(
         "Selected image name: {}",
         plan.registered_name
@@ -537,7 +596,7 @@ where
     })
 }
 
-async fn resolve_build_context(options: SandboxImageBuildOptions) -> Result<ResolvedBuildContext> {
+async fn resolve_build_context(options: CommonBuildOptions) -> Result<ResolvedBuildContext> {
     let client = unscoped_client(&options)?;
     let (organization_id, project_id) = if options.use_scope_headers {
         match (options.organization_id.clone(), options.project_id.clone()) {
@@ -587,7 +646,7 @@ async fn introspect_scope(client: &Client) -> Result<IntrospectScope> {
     response.json().await.map_err(Into::into)
 }
 
-fn unscoped_client(options: &SandboxImageBuildOptions) -> Result<Client> {
+fn unscoped_client(options: &CommonBuildOptions) -> Result<Client> {
     client_builder(
         &options.api_url,
         &options.bearer_token,

--- a/crates/cloud-sdk/tests/sandbox_templates.rs
+++ b/crates/cloud-sdk/tests/sandbox_templates.rs
@@ -44,7 +44,9 @@ async fn delete_sandbox_template_sends_encoded_delete_request() {
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 async fn test_create_then_delete_sandbox_image() {
     use std::env;
-    use tensorlake::sandbox_images::{SandboxImageBuildOptions, build_sandbox_image};
+    use tensorlake::sandbox_images::{
+        CommonBuildOptions, SandboxImageBuildOptions, build_sandbox_image,
+    };
 
     let sdk = match common::create_sdk() {
         Ok(sdk) => sdk,
@@ -86,23 +88,24 @@ async fn test_create_then_delete_sandbox_image() {
     let result: Result<(), String> = async {
         build_sandbox_image(
             SandboxImageBuildOptions {
-                api_url,
-                bearer_token,
-                use_scope_headers: false,
-                organization_id: Some(organization_id),
-                project_id: Some(project_id),
-                namespace,
+                common: CommonBuildOptions {
+                    api_url,
+                    bearer_token,
+                    use_scope_headers: false,
+                    organization_id: Some(organization_id),
+                    project_id: Some(project_id),
+                    namespace,
+                    registered_name: Some(image_name.clone()),
+                    disk_mb: None,
+                    builder_disk_mb: None,
+                    cpus: Some(1.0),
+                    memory_mb: Some(1024),
+                    is_public: false,
+                    user_agent: None,
+                },
                 dockerfile_path,
                 dockerfile_text: None,
                 context_dir: None,
-                import_image_reference: None,
-                registered_name: Some(image_name.clone()),
-                disk_mb: None,
-                builder_disk_mb: None,
-                cpus: Some(1.0),
-                memory_mb: Some(1024),
-                is_public: false,
-                user_agent: None,
             },
             |_| {},
         )

--- a/crates/rust-cloud-sdk-node/src/lib.rs
+++ b/crates/rust-cloud-sdk-node/src/lib.rs
@@ -43,6 +43,9 @@ pub struct SandboxImageBuildOptionsJs {
     pub user_agent: Option<String>,
     pub dockerfile_text: Option<String>,
     pub context_dir: Option<String>,
+    /// When set, import this registry image reference directly into a rootfs
+    /// (no Dockerfile, no Docker daemon) instead of running a Dockerfile build.
+    pub import_image_reference: Option<String>,
 }
 
 #[napi(object)]
@@ -96,7 +99,7 @@ pub async fn build_sandbox_image(
         dockerfile_path: PathBuf::from(options.dockerfile_path),
         dockerfile_text: options.dockerfile_text,
         context_dir: options.context_dir.map(PathBuf::from),
-        import_image_reference: None,
+        import_image_reference: options.import_image_reference,
         registered_name: options.registered_name,
         disk_mb: options.disk_mb.map(u64::from),
         builder_disk_mb: options.builder_disk_mb.map(u64::from),

--- a/crates/rust-cloud-sdk-node/src/lib.rs
+++ b/crates/rust-cloud-sdk-node/src/lib.rs
@@ -19,8 +19,9 @@ use napi::{
 };
 use napi_derive::napi;
 use tensorlake::sandbox_images::{
-    SandboxImageBuildEvent, SandboxImageBuildOptions,
-    build_sandbox_image as rust_build_sandbox_image,
+    CommonBuildOptions, SandboxImageBuildEvent, SandboxImageBuildOptions,
+    SandboxImageImportOptions, build_sandbox_image as rust_build_sandbox_image,
+    import_sandbox_image as rust_import_sandbox_image,
 };
 
 #[napi(object)]
@@ -43,9 +44,29 @@ pub struct SandboxImageBuildOptionsJs {
     pub user_agent: Option<String>,
     pub dockerfile_text: Option<String>,
     pub context_dir: Option<String>,
-    /// When set, import this registry image reference directly into a rootfs
-    /// (no Dockerfile, no Docker daemon) instead of running a Dockerfile build.
-    pub import_image_reference: Option<String>,
+}
+
+#[napi(object)]
+pub struct SandboxImageImportOptionsJs {
+    pub api_url: String,
+    pub bearer_token: String,
+    /// Registry image reference to import directly into a rootfs (no
+    /// Dockerfile, no Docker daemon), e.g. `pytorch/pytorch:2.4.1` or
+    /// `ghcr.io/org/app@sha256:...`.
+    pub image_reference: String,
+    pub registered_name: Option<String>,
+    /// Root disk size for the generated sandbox image in MB. Capped at u32
+    /// max (~4 PiB) for napi compatibility — well above the 10 GiB default.
+    pub disk_mb: Option<u32>,
+    pub builder_disk_mb: Option<u32>,
+    pub cpus: Option<f64>,
+    pub memory_mb: Option<i64>,
+    pub is_public: Option<bool>,
+    pub organization_id: Option<String>,
+    pub project_id: Option<String>,
+    pub namespace: Option<String>,
+    pub use_scope_headers: Option<bool>,
+    pub user_agent: Option<String>,
 }
 
 #[napi(object)]
@@ -90,26 +111,69 @@ pub async fn build_sandbox_image(
     emit: Option<ThreadsafeFunction<SandboxImageBuildEventJs, ErrorStrategy::Fatal>>,
 ) -> Result<String> {
     let build_options = SandboxImageBuildOptions {
-        api_url: options.api_url,
-        bearer_token: options.bearer_token,
-        use_scope_headers: options.use_scope_headers.unwrap_or(false),
-        organization_id: options.organization_id,
-        project_id: options.project_id,
-        namespace: options.namespace.unwrap_or_else(|| "default".to_string()),
+        common: CommonBuildOptions {
+            api_url: options.api_url,
+            bearer_token: options.bearer_token,
+            use_scope_headers: options.use_scope_headers.unwrap_or(false),
+            organization_id: options.organization_id,
+            project_id: options.project_id,
+            namespace: options.namespace.unwrap_or_else(|| "default".to_string()),
+            registered_name: options.registered_name,
+            disk_mb: options.disk_mb.map(u64::from),
+            builder_disk_mb: options.builder_disk_mb.map(u64::from),
+            cpus: options.cpus,
+            memory_mb: options.memory_mb,
+            is_public: options.is_public.unwrap_or(false),
+            user_agent: options.user_agent,
+        },
         dockerfile_path: PathBuf::from(options.dockerfile_path),
         dockerfile_text: options.dockerfile_text,
         context_dir: options.context_dir.map(PathBuf::from),
-        import_image_reference: options.import_image_reference,
-        registered_name: options.registered_name,
-        disk_mb: options.disk_mb.map(u64::from),
-        builder_disk_mb: options.builder_disk_mb.map(u64::from),
-        cpus: options.cpus,
-        memory_mb: options.memory_mb,
-        is_public: options.is_public.unwrap_or(false),
-        user_agent: options.user_agent,
     };
 
     let result = rust_build_sandbox_image(build_options, move |event| {
+        if let Some(tsfn) = emit.as_ref() {
+            tsfn.call(event_to_js(event), ThreadsafeFunctionCallMode::Blocking);
+        }
+    })
+    .await
+    .map_err(|error| Error::from_reason(error.to_string()))?;
+
+    serde_json::to_string(&result).map_err(|error| Error::from_reason(error.to_string()))
+}
+
+/// Import a registry image directly into a sandbox image (no Dockerfile, no
+/// Docker daemon). Returns a JSON-encoded string with the registered
+/// sandbox-template metadata; the TS SDK is expected to parse it.
+///
+/// `emit`, if provided, is invoked for each progress event. The TypeScript
+/// wrapper must catch user callback exceptions before they cross this napi
+/// threadsafe callback boundary.
+#[napi]
+pub async fn import_sandbox_image(
+    options: SandboxImageImportOptionsJs,
+    emit: Option<ThreadsafeFunction<SandboxImageBuildEventJs, ErrorStrategy::Fatal>>,
+) -> Result<String> {
+    let import_options = SandboxImageImportOptions {
+        common: CommonBuildOptions {
+            api_url: options.api_url,
+            bearer_token: options.bearer_token,
+            use_scope_headers: options.use_scope_headers.unwrap_or(false),
+            organization_id: options.organization_id,
+            project_id: options.project_id,
+            namespace: options.namespace.unwrap_or_else(|| "default".to_string()),
+            registered_name: options.registered_name,
+            disk_mb: options.disk_mb.map(u64::from),
+            builder_disk_mb: options.builder_disk_mb.map(u64::from),
+            cpus: options.cpus,
+            memory_mb: options.memory_mb,
+            is_public: options.is_public.unwrap_or(false),
+            user_agent: options.user_agent,
+        },
+        image_reference: options.image_reference,
+    };
+
+    let result = rust_import_sandbox_image(import_options, move |event| {
         if let Some(tsfn) = emit.as_ref() {
             tsfn.call(event_to_js(event), ThreadsafeFunctionCallMode::Blocking);
         }

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.43"
+version = "0.5.44"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -2813,7 +2813,6 @@ fn create_image_context_file(
     user_agent=None,
     dockerfile_text=None,
     context_dir=None,
-    import_image_reference=None,
     emit=None,
 ))]
 fn build_sandbox_image(
@@ -2834,27 +2833,27 @@ fn build_sandbox_image(
     user_agent: Option<String>,
     dockerfile_text: Option<String>,
     context_dir: Option<String>,
-    import_image_reference: Option<String>,
     emit: Option<Py<PyAny>>,
 ) -> PyResult<String> {
     let options = tensorlake::sandbox_images::SandboxImageBuildOptions {
-        api_url,
-        bearer_token: token,
-        use_scope_headers,
-        organization_id,
-        project_id,
-        namespace: namespace.unwrap_or_else(|| "default".to_string()),
+        common: common_build_options(
+            api_url,
+            token,
+            use_scope_headers,
+            organization_id,
+            project_id,
+            namespace,
+            registered_name,
+            disk_mb,
+            builder_disk_mb,
+            cpus,
+            memory_mb,
+            is_public,
+            user_agent,
+        ),
         dockerfile_path: PathBuf::from(dockerfile_path),
         dockerfile_text,
         context_dir: context_dir.map(PathBuf::from),
-        import_image_reference,
-        registered_name,
-        disk_mb,
-        builder_disk_mb,
-        cpus,
-        memory_mb,
-        is_public,
-        user_agent,
     };
 
     let result = py
@@ -2883,6 +2882,124 @@ fn build_sandbox_image(
             error.to_string(),
         ))
     })
+}
+
+#[pyfunction]
+#[pyo3(signature = (
+    api_url,
+    token,
+    image_reference,
+    registered_name=None,
+    disk_mb=None,
+    builder_disk_mb=None,
+    cpus=None,
+    memory_mb=None,
+    is_public=false,
+    organization_id=None,
+    project_id=None,
+    namespace=None,
+    use_scope_headers=false,
+    user_agent=None,
+    emit=None,
+))]
+fn import_sandbox_image(
+    py: Python<'_>,
+    api_url: String,
+    token: String,
+    image_reference: String,
+    registered_name: Option<String>,
+    disk_mb: Option<u64>,
+    builder_disk_mb: Option<u64>,
+    cpus: Option<f64>,
+    memory_mb: Option<i64>,
+    is_public: bool,
+    organization_id: Option<String>,
+    project_id: Option<String>,
+    namespace: Option<String>,
+    use_scope_headers: bool,
+    user_agent: Option<String>,
+    emit: Option<Py<PyAny>>,
+) -> PyResult<String> {
+    let options = tensorlake::sandbox_images::SandboxImageImportOptions {
+        common: common_build_options(
+            api_url,
+            token,
+            use_scope_headers,
+            organization_id,
+            project_id,
+            namespace,
+            registered_name,
+            disk_mb,
+            builder_disk_mb,
+            cpus,
+            memory_mb,
+            is_public,
+            user_agent,
+        ),
+        image_reference,
+    };
+
+    let result = py
+        .detach(move || {
+            shared_runtime().block_on(async move {
+                tensorlake::sandbox_images::import_sandbox_image(options, |event| {
+                    if let Some(callback) = emit.as_ref() {
+                        emit_sandbox_image_event(callback, event);
+                    }
+                })
+                .await
+            })
+        })
+        .map_err(|error| {
+            CloudSandboxClientError::new_err((
+                "sandbox_image_import",
+                Option::<u16>::None,
+                error.to_string(),
+            ))
+        })?;
+
+    serde_json::to_string(&result).map_err(|error| {
+        CloudSandboxClientError::new_err((
+            "sandbox_image_import",
+            Option::<u16>::None,
+            error.to_string(),
+        ))
+    })
+}
+
+/// Assemble the auth/context + resource fields shared by the Dockerfile build
+/// and registry import paths.
+#[allow(clippy::too_many_arguments)]
+fn common_build_options(
+    api_url: String,
+    token: String,
+    use_scope_headers: bool,
+    organization_id: Option<String>,
+    project_id: Option<String>,
+    namespace: Option<String>,
+    registered_name: Option<String>,
+    disk_mb: Option<u64>,
+    builder_disk_mb: Option<u64>,
+    cpus: Option<f64>,
+    memory_mb: Option<i64>,
+    is_public: bool,
+    user_agent: Option<String>,
+) -> tensorlake::sandbox_images::CommonBuildOptions {
+    tensorlake::sandbox_images::CommonBuildOptions {
+        api_url,
+        bearer_token: token,
+        use_scope_headers,
+        organization_id,
+        project_id,
+        namespace: namespace.unwrap_or_else(|| "default".to_string()),
+        registered_name,
+        disk_mb,
+        builder_disk_mb,
+        cpus,
+        memory_mb,
+        is_public,
+        user_agent,
+    }
 }
 
 fn emit_sandbox_image_event(callback: &Py<PyAny>, event: SandboxImageBuildEvent) {
@@ -2931,5 +3048,6 @@ fn _cloud_sdk(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<CloudDocumentAIClient>()?;
     module.add_function(wrap_pyfunction!(create_image_context_file, module)?)?;
     module.add_function(wrap_pyfunction!(build_sandbox_image, module)?)?;
+    module.add_function(wrap_pyfunction!(import_sandbox_image, module)?)?;
     Ok(())
 }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -2813,6 +2813,7 @@ fn create_image_context_file(
     user_agent=None,
     dockerfile_text=None,
     context_dir=None,
+    import_image_reference=None,
     emit=None,
 ))]
 fn build_sandbox_image(
@@ -2833,6 +2834,7 @@ fn build_sandbox_image(
     user_agent: Option<String>,
     dockerfile_text: Option<String>,
     context_dir: Option<String>,
+    import_image_reference: Option<String>,
     emit: Option<Py<PyAny>>,
 ) -> PyResult<String> {
     let options = tensorlake::sandbox_images::SandboxImageBuildOptions {
@@ -2845,7 +2847,7 @@ fn build_sandbox_image(
         dockerfile_path: PathBuf::from(dockerfile_path),
         dockerfile_text,
         context_dir: context_dir.map(PathBuf::from),
-        import_image_reference: None,
+        import_image_reference,
         registered_name,
         disk_mb,
         builder_disk_mb,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.43"
+version = "0.5.44"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/__init__.py
+++ b/src/tensorlake/__init__.py
@@ -1,1 +1,1 @@
-from tensorlake.image import Image, delete_sandbox_image
+from tensorlake.image import Image, delete_sandbox_image, import_sandbox_image

--- a/src/tensorlake/image/__init__.py
+++ b/src/tensorlake/image/__init__.py
@@ -1,2 +1,2 @@
 from .image import Image
-from .sandbox_builder import delete_sandbox_image
+from .sandbox_builder import delete_sandbox_image, import_sandbox_image

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -143,6 +143,7 @@ def _run_rust_image_create(
     *,
     dockerfile_text: str | None,
     context_dir: str | None,
+    import_image_reference: str | None = None,
     cpus: float,
     memory_mb: int,
     disk_mb: int | None,
@@ -157,7 +158,18 @@ def _run_rust_image_create(
             "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
         )
 
-    emit({"type": "status", "message": f"Building image '{registered_name}'..."})
+    if import_image_reference:
+        emit(
+            {
+                "type": "status",
+                "message": (
+                    f"Importing image '{import_image_reference}' "
+                    f"as '{registered_name}'..."
+                ),
+            }
+        )
+    else:
+        emit({"type": "status", "message": f"Building image '{registered_name}'..."})
 
     def forward_event(event: dict) -> None:
         emit(dict(event))
@@ -179,6 +191,7 @@ def _run_rust_image_create(
         USER_AGENT,
         dockerfile_text,
         context_dir,
+        import_image_reference,
         forward_event,
     )
     try:
@@ -334,6 +347,89 @@ def build_sandbox_image(
         raise SandboxImageBuildError(f"{type(e).__name__}: {e}") from e
 
 
+def import_sandbox_image(
+    image_reference: str,
+    *,
+    registered_name: str | None = None,
+    cpus: float = 2.0,
+    memory_mb: int = 4096,
+    disk_mb: int | None = None,
+    builder_disk_mb: int | None = None,
+    is_public: bool = False,
+    verbose: bool = False,
+    emit: EmitFn | None = None,
+) -> dict:
+    """Import a registry image directly into a sandbox image — no Docker.
+
+    Unlike :func:`build_sandbox_image`, there is no Dockerfile and no build
+    context: the builder pulls the referenced image's layers and applies them
+    straight into the rootfs (via ``oci-image-to-ext4``), bypassing the Docker
+    daemon entirely. This is the programmatic backend for the
+    ``tl sbx image import`` CLI command. The import is always a fresh base from
+    the registry — the reference is never resolved against the template
+    registry.
+
+    Args:
+        image_reference: The registry image reference to import, e.g.
+            ``pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime`` or
+            ``ghcr.io/org/app@sha256:...``.
+        registered_name: Name to register the image under. Defaults to the
+            image reference's last path segment with any tag/digest stripped
+            (e.g. ``pytorch/pytorch:2.4.1`` -> ``pytorch``).
+        cpus: CPUs for the build sandbox.
+        memory_mb: Memory for the build sandbox in MB.
+        disk_mb: Root disk size for the generated sandbox image in MB.
+        builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
+        is_public: Make the registered image publicly accessible.
+        verbose: Print progress to stderr. Ignored if ``emit`` is provided.
+        emit: Callback invoked for each build event. Takes precedence over
+            ``verbose``.
+
+    Returns:
+        The registered sandbox template JSON response.
+
+    Raises:
+        SandboxImageBuildError: The image reference is empty, or the import
+            failed during provisioning, materialization, or registration.
+    """
+    if emit is None:
+        emit = _stderr_emit if verbose else _noop_emit
+
+    if not isinstance(image_reference, str) or not image_reference.strip():
+        raise SandboxImageBuildError("image reference to import must not be empty")
+
+    image_reference = image_reference.strip()
+    effective_registered_name = registered_name or _default_registered_name_from_image(
+        image_reference
+    )
+    if effective_registered_name == _DEFAULT_IMAGE_NAME:
+        warnings.warn(
+            f"Importing sandbox image with the default name {_DEFAULT_IMAGE_NAME!r}. "
+            "Pass `registered_name=...` to avoid collisions with other "
+            "default-named images in this project.",
+            stacklevel=2,
+        )
+
+    try:
+        return _run_rust_image_create(
+            "",
+            effective_registered_name,
+            dockerfile_text=None,
+            context_dir=None,
+            import_image_reference=image_reference,
+            cpus=cpus,
+            memory_mb=memory_mb,
+            disk_mb=disk_mb,
+            builder_disk_mb=builder_disk_mb,
+            is_public=is_public,
+            emit=emit,
+        )
+    except SandboxImageError:
+        raise
+    except Exception as e:
+        raise SandboxImageBuildError(f"{type(e).__name__}: {e}") from e
+
+
 def build_sandbox_application_image(
     image: Image,
     *,
@@ -407,3 +503,18 @@ def _default_registered_name(dockerfile_path: str) -> str:
         parent_name = path.parent.name.strip()
         return parent_name or "sandbox-image"
     return stem or "sandbox-image"
+
+
+def _default_registered_name_from_image(image_reference: str) -> str:
+    """Mirror the Rust core's default name derivation for image imports.
+
+    Returns the last path segment of the reference with any tag/digest
+    stripped (e.g. ``pytorch/pytorch:2.4.1`` -> ``pytorch``,
+    ``ghcr.io/org/app@sha256:...`` -> ``app``). Computed here so the
+    ``_DEFAULT_IMAGE_NAME`` warning can trigger before the Rust call.
+    """
+    without_digest = image_reference.split("@", 1)[0]
+    last_segment = without_digest.rsplit("/", 1)[-1]
+    repo, sep, tag = last_segment.rpartition(":")
+    name = repo if sep and tag else last_segment
+    return name or "imported-image"

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -110,6 +110,17 @@ def _rust_build_sandbox_image(*args, **kwargs) -> str:
     return rust_build_sandbox_image(*args, **kwargs)
 
 
+def _rust_import_sandbox_image(*args, **kwargs) -> str:
+    try:
+        from tensorlake._cloud_sdk import (
+            import_sandbox_image as rust_import_sandbox_image,
+        )
+    except ImportError:
+        from _cloud_sdk import import_sandbox_image as rust_import_sandbox_image
+
+    return rust_import_sandbox_image(*args, **kwargs)
+
+
 def _rust_delete_sandbox_image(
     api_url: str,
     token: str,
@@ -143,7 +154,6 @@ def _run_rust_image_create(
     *,
     dockerfile_text: str | None,
     context_dir: str | None,
-    import_image_reference: str | None = None,
     cpus: float,
     memory_mb: int,
     disk_mb: int | None,
@@ -151,28 +161,9 @@ def _run_rust_image_create(
     is_public: bool,
     emit: EmitFn,
 ) -> dict:
-    ctx = _build_context_from_env()
-    token = ctx.api_key or ctx.personal_access_token
-    if not token:
-        raise SandboxImageBuildError(
-            "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
-        )
+    ctx, token = _resolve_build_credentials()
 
-    if import_image_reference:
-        emit(
-            {
-                "type": "status",
-                "message": (
-                    f"Importing image '{import_image_reference}' "
-                    f"as '{registered_name}'..."
-                ),
-            }
-        )
-    else:
-        emit({"type": "status", "message": f"Building image '{registered_name}'..."})
-
-    def forward_event(event: dict) -> None:
-        emit(dict(event))
+    emit({"type": "status", "message": f"Building image '{registered_name}'..."})
 
     result_json = _rust_build_sandbox_image(
         ctx.api_url,
@@ -191,9 +182,73 @@ def _run_rust_image_create(
         USER_AGENT,
         dockerfile_text,
         context_dir,
-        import_image_reference,
-        forward_event,
+        _forwarder(emit),
     )
+    return _finish_image_registration(result_json, registered_name, emit)
+
+
+def _run_rust_image_import(
+    image_reference: str,
+    registered_name: str,
+    *,
+    cpus: float,
+    memory_mb: int,
+    disk_mb: int | None,
+    builder_disk_mb: int | None,
+    is_public: bool,
+    emit: EmitFn,
+) -> dict:
+    ctx, token = _resolve_build_credentials()
+
+    emit(
+        {
+            "type": "status",
+            "message": (
+                f"Importing image '{image_reference}' as '{registered_name}'..."
+            ),
+        }
+    )
+
+    result_json = _rust_import_sandbox_image(
+        ctx.api_url,
+        token,
+        image_reference,
+        registered_name,
+        disk_mb,
+        builder_disk_mb,
+        cpus,
+        memory_mb,
+        is_public,
+        ctx.organization_id,
+        ctx.project_id,
+        ctx.namespace,
+        ctx.personal_access_token is not None and ctx.api_key is None,
+        USER_AGENT,
+        _forwarder(emit),
+    )
+    return _finish_image_registration(result_json, registered_name, emit)
+
+
+def _resolve_build_credentials() -> tuple[Context, str]:
+    ctx = _build_context_from_env()
+    token = ctx.api_key or ctx.personal_access_token
+    if not token:
+        raise SandboxImageBuildError(
+            "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
+        )
+    return ctx, token
+
+
+def _forwarder(emit: EmitFn) -> EmitFn:
+    def forward_event(event: dict) -> None:
+        emit(dict(event))
+
+    return forward_event
+
+
+def _finish_image_registration(
+    result_json: str, registered_name: str, emit: EmitFn
+) -> dict:
     try:
         result = json.loads(result_json) if result_json.strip() else {}
     except json.JSONDecodeError as exc:
@@ -411,12 +466,9 @@ def import_sandbox_image(
         )
 
     try:
-        return _run_rust_image_create(
-            "",
+        return _run_rust_image_import(
+            image_reference,
             effective_registered_name,
-            dockerfile_text=None,
-            context_dir=None,
-            import_image_reference=image_reference,
             cpus=cpus,
             memory_mb=memory_mb,
             disk_mb=disk_mb,

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -38,6 +38,18 @@ def _make_build_patches(ctx):
     )
 
 
+def _make_import_patches(ctx):
+    """Common mock bundle for exercising import_sandbox_image without networking."""
+    return (
+        patch.object(sbm, "_build_context_from_env", return_value=ctx),
+        patch.object(
+            sbm,
+            "_rust_import_sandbox_image",
+            return_value='{"id":"tpl-1","snapshot_id":"snap-1"}',
+        ),
+    )
+
+
 class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
     def test_registers_snapshot_from_dockerfile(self):
         ctx = _make_ctx()
@@ -77,7 +89,6 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             "default",
             False,
             sbm.USER_AGENT,
-            None,
             None,
             None,
             ANY,
@@ -122,7 +133,6 @@ class TestBuildSandboxImageFromDockerfileOptions(unittest.TestCase):
             "default",
             False,
             sbm.USER_AGENT,
-            None,
             None,
             None,
             ANY,
@@ -197,18 +207,20 @@ class TestImportSandboxImage(unittest.TestCase):
     def test_imports_registry_image_with_reference_and_no_dockerfile(self):
         ctx = _make_ctx()
 
-        build_ctx, rust_builder = _make_build_patches(ctx)
-        with build_ctx, rust_builder as rust_builder_mock:
+        build_ctx, rust_importer = _make_import_patches(ctx)
+        with build_ctx, rust_importer as rust_importer_mock:
             sbm.import_sandbox_image(
                 "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",
                 cpus=BUILD_CPUS,
                 memory_mb=BUILD_MEMORY_MB,
             )
 
-        rust_builder_mock.assert_called_once_with(
+        # The import path delegates to the dedicated Rust entry point with no
+        # Dockerfile fields — the image reference is a first-class argument.
+        rust_importer_mock.assert_called_once_with(
             "https://api.tensorlake.test",
             "tl_apiKey_abc",
-            "",  # no dockerfile path on the import path
+            "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",  # image_reference
             "pytorch",  # default name derived from the reference
             None,
             None,
@@ -220,9 +232,6 @@ class TestImportSandboxImage(unittest.TestCase):
             "default",
             False,
             sbm.USER_AGENT,
-            None,  # dockerfile_text
-            None,  # context_dir
-            "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",  # import_image_reference
             ANY,
         )
 
@@ -242,13 +251,13 @@ class TestImportSandboxImage(unittest.TestCase):
 
     def test_explicit_registered_name_overrides_default(self):
         ctx = _make_ctx()
-        build_ctx, rust_builder = _make_build_patches(ctx)
-        with build_ctx, rust_builder as rust_builder_mock:
+        build_ctx, rust_importer = _make_import_patches(ctx)
+        with build_ctx, rust_importer as rust_importer_mock:
             sbm.import_sandbox_image(
                 "pytorch/pytorch:2.4.1",
                 registered_name="override",
             )
-        self.assertEqual(rust_builder_mock.call_args.args[3], "override")
+        self.assertEqual(rust_importer_mock.call_args.args[3], "override")
 
     def test_empty_reference_raises_build_error(self):
         with self.assertRaises(sbm.SandboxImageBuildError):

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -79,6 +79,7 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             sbm.USER_AGENT,
             None,
             None,
+            None,
             ANY,
         )
 
@@ -121,6 +122,7 @@ class TestBuildSandboxImageFromDockerfileOptions(unittest.TestCase):
             "default",
             False,
             sbm.USER_AGENT,
+            None,
             None,
             None,
             ANY,
@@ -189,6 +191,74 @@ class TestDeleteSandboxImage(unittest.TestCase):
         with patch.object(sbm, "_build_context_from_env", return_value=ctx):
             with self.assertRaises(sbm.SandboxImageDeleteError):
                 sbm.delete_sandbox_image("image")
+
+
+class TestImportSandboxImage(unittest.TestCase):
+    def test_imports_registry_image_with_reference_and_no_dockerfile(self):
+        ctx = _make_ctx()
+
+        build_ctx, rust_builder = _make_build_patches(ctx)
+        with build_ctx, rust_builder as rust_builder_mock:
+            sbm.import_sandbox_image(
+                "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",
+                cpus=BUILD_CPUS,
+                memory_mb=BUILD_MEMORY_MB,
+            )
+
+        rust_builder_mock.assert_called_once_with(
+            "https://api.tensorlake.test",
+            "tl_apiKey_abc",
+            "",  # no dockerfile path on the import path
+            "pytorch",  # default name derived from the reference
+            None,
+            None,
+            BUILD_CPUS,
+            BUILD_MEMORY_MB,
+            False,
+            "org_1",
+            "proj_1",
+            "default",
+            False,
+            sbm.USER_AGENT,
+            None,  # dockerfile_text
+            None,  # context_dir
+            "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",  # import_image_reference
+            ANY,
+        )
+
+    def test_default_name_strips_registry_path_and_digest(self):
+        self.assertEqual(
+            sbm._default_registered_name_from_image("ghcr.io/org/app@sha256:abc"),
+            "app",
+        )
+        self.assertEqual(
+            sbm._default_registered_name_from_image("pytorch/pytorch:2.4.1"),
+            "pytorch",
+        )
+        self.assertEqual(
+            sbm._default_registered_name_from_image("ubuntu"),
+            "ubuntu",
+        )
+
+    def test_explicit_registered_name_overrides_default(self):
+        ctx = _make_ctx()
+        build_ctx, rust_builder = _make_build_patches(ctx)
+        with build_ctx, rust_builder as rust_builder_mock:
+            sbm.import_sandbox_image(
+                "pytorch/pytorch:2.4.1",
+                registered_name="override",
+            )
+        self.assertEqual(rust_builder_mock.call_args.args[3], "override")
+
+    def test_empty_reference_raises_build_error(self):
+        with self.assertRaises(sbm.SandboxImageBuildError):
+            sbm.import_sandbox_image("   ")
+
+    def test_requires_credentials(self):
+        ctx = _make_ctx(api_key=None, personal_access_token=None)
+        with patch.object(sbm, "_build_context_from_env", return_value=ctx):
+            with self.assertRaises(sbm.SandboxImageBuildError):
+                sbm.import_sandbox_image("pytorch/pytorch:2.4.1")
 
 
 class TestBuildSandboxImageFromImage(unittest.TestCase):

--- a/typescript/bin/tensorlake-import-sandbox-image.cjs
+++ b/typescript/bin/tensorlake-import-sandbox-image.cjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const { runImportSandboxImageCli } = require("../dist/sandbox-image.cjs");
+
+runImportSandboxImageCli().catch((error) => {
+  const message = error && error.stack ? error.stack : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+});

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.42",
+  "version": "0.5.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.42",
+      "version": "0.5.44",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",
@@ -17,6 +17,7 @@
         "tensorlake": "bin/tensorlake.cjs",
         "tensorlake-create-sandbox-image": "bin/tensorlake-create-sandbox-image.cjs",
         "tensorlake-deploy": "bin/tensorlake-deploy.cjs",
+        "tensorlake-import-sandbox-image": "bin/tensorlake-import-sandbox-image.cjs",
         "tl": "bin/tl.cjs"
       },
       "devDependencies": {
@@ -1225,7 +1226,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1532,7 +1532,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1587,7 +1586,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2308,7 +2306,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2358,7 +2355,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2796,7 +2792,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2844,7 +2839,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.42",
+  "version": "0.5.44",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -11,6 +11,7 @@
     "tensorlake": "./bin/tensorlake.cjs",
     "tensorlake-deploy": "./bin/tensorlake-deploy.cjs",
     "tensorlake-create-sandbox-image": "./bin/tensorlake-create-sandbox-image.cjs",
+    "tensorlake-import-sandbox-image": "./bin/tensorlake-import-sandbox-image.cjs",
     "function-executor": "./bin/function-executor.cjs"
   },
   "exports": {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -6,7 +6,11 @@ export { Desktop } from "./desktop.js";
 export { TcpTunnel } from "./tunnel.js";
 export { CloudClient } from "./cloud-client.js";
 export { APIClient } from "./api-client.js";
-export { createSandboxImage, deleteSandboxImage } from "./sandbox-image.js";
+export {
+  createSandboxImage,
+  importSandboxImage,
+  deleteSandboxImage,
+} from "./sandbox-image.js";
 export { Image, dockerfileContent, ImageBuildOperationType } from "./image.js";
 export { sandboxUrlFromIngressEndpoint } from "./url.js";
 
@@ -137,6 +141,7 @@ export type {
 
 export type {
   CreateSandboxImageOptions,
+  ImportSandboxImageOptions,
   SandboxImageSource,
 } from "./sandbox-image.js";
 

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -32,6 +32,25 @@ export interface CreateSandboxImageOptions {
   verbose?: boolean;
 }
 
+export interface ImportSandboxImageOptions {
+  /**
+   * Name to register the image under. Defaults to the image reference's last
+   * path segment with any tag/digest stripped (e.g. `pytorch/pytorch:2.4.1`
+   * -> `pytorch`).
+   */
+  registeredName?: string;
+  cpus?: number;
+  memoryMb?: number;
+  diskMb?: number;
+  builderDiskMb?: number;
+  isPublic?: boolean;
+  /**
+   * Print build progress to stderr. Ignored when an explicit `emit` is
+   * passed via `deps`. Defaults to false.
+   */
+  verbose?: boolean;
+}
+
 export type SandboxImageSource = string | Image;
 
 export interface CreateSandboxImageDeps {
@@ -57,6 +76,7 @@ interface NativeBindingOptions {
   userAgent?: string | undefined | null;
   dockerfileText?: string | undefined | null;
   contextDir?: string | undefined | null;
+  importImageReference?: string | undefined | null;
 }
 
 interface NativeBindingEvent {
@@ -164,6 +184,23 @@ function defaultRegisteredName(dockerfilePath: string): string {
     return parentName || "sandbox-image";
   }
   return parsed.name || "sandbox-image";
+}
+
+/**
+ * Mirror the Rust core's default name derivation for image imports: the last
+ * path segment of the reference with any tag/digest stripped
+ * (e.g. `pytorch/pytorch:2.4.1` -> `pytorch`, `ghcr.io/org/app@sha256:...`
+ * -> `app`).
+ */
+function defaultRegisteredNameFromImage(imageReference: string): string {
+  const withoutDigest = imageReference.split("@", 1)[0] ?? imageReference;
+  const lastSegment = withoutDigest.split("/").pop() ?? withoutDigest;
+  const colonIndex = lastSegment.lastIndexOf(":");
+  const name =
+    colonIndex > 0 && colonIndex < lastSegment.length - 1
+      ? lastSegment.slice(0, colonIndex)
+      : lastSegment;
+  return name || "imported-image";
 }
 
 // --- Emit helpers ----------------------------------------------------------
@@ -303,6 +340,106 @@ export async function createSandboxImage(
   return result;
 }
 
+/**
+ * Import a registry image directly into a sandbox image — no Docker.
+ *
+ * Unlike {@link createSandboxImage}, there is no Dockerfile and no build
+ * context: the builder pulls the referenced image's layers and applies them
+ * straight into the rootfs (via `oci-image-to-ext4`), bypassing the Docker
+ * daemon entirely. This is the programmatic backend for the
+ * `tl sbx image import` CLI command. The import is always a fresh base from
+ * the registry — the reference is never resolved against the template
+ * registry.
+ */
+export async function importSandboxImage(
+  imageReference: string,
+  options: ImportSandboxImageOptions = {},
+  deps: CreateSandboxImageDeps = {},
+): Promise<Record<string, unknown>> {
+  const emit = deps.emit ?? (options.verbose ? stderrEmit : noopEmit);
+
+  if (typeof imageReference !== "string" || imageReference.trim().length === 0) {
+    throw new Error("image reference to import must not be empty");
+  }
+  const reference = imageReference.trim();
+
+  const context = buildContextFromEnv();
+  const effectiveName =
+    options.registeredName ?? defaultRegisteredNameFromImage(reference);
+
+  if (effectiveName === DEFAULT_IMAGE_NAME) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Importing sandbox image with the default name "${DEFAULT_IMAGE_NAME}". ` +
+        "Pass `registeredName` to avoid collisions with other default-named " +
+        "images in this project.",
+    );
+  }
+
+  const bearerToken = context.apiKey ?? context.personalAccessToken;
+  if (!bearerToken) {
+    throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.");
+  }
+
+  emit({
+    type: "status",
+    message: `Importing image '${reference}' as '${effectiveName}'...`,
+  });
+
+  const binding = loadNativeBinding();
+  let emitError: unknown;
+  const resultJson = await binding.buildSandboxImage(
+    {
+      apiUrl: context.apiUrl,
+      bearerToken,
+      // Unused on the import path, but the native option struct is shared with
+      // the Dockerfile build flow.
+      dockerfilePath: "",
+      registeredName: effectiveName,
+      diskMb: options.diskMb,
+      builderDiskMb: options.builderDiskMb,
+      cpus: options.cpus,
+      memoryMb: options.memoryMb,
+      isPublic: options.isPublic ?? false,
+      organizationId: context.organizationId,
+      projectId: context.projectId,
+      namespace: context.namespace,
+      useScopeHeaders:
+        context.personalAccessToken != null && context.apiKey == null,
+      userAgent: undefined,
+      dockerfileText: undefined,
+      contextDir: undefined,
+      importImageReference: reference,
+    },
+    (event) => {
+      try {
+        emit(eventToEmitDict(event));
+      } catch (error) {
+        emitError ??= error;
+      }
+    },
+  );
+
+  if (emitError != null) {
+    throw emitError;
+  }
+
+  let result: Record<string, unknown> = {};
+  if (resultJson.trim().length > 0) {
+    result = JSON.parse(resultJson) as Record<string, unknown>;
+  }
+  emit({
+    type: "image_registered",
+    name: effectiveName,
+    image_id:
+      (typeof result.id === "string" && result.id) ||
+      (typeof result.templateId === "string" && result.templateId) ||
+      "",
+  });
+  emit({ type: "done" });
+  return result;
+}
+
 export async function deleteSandboxImage(imageName: string): Promise<void> {
   if (typeof imageName !== "string" || imageName.length === 0) {
     throw new TypeError("imageName must be a non-empty string");
@@ -376,6 +513,66 @@ export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {
 
   await createSandboxImage(
     dockerfilePath,
+    {
+      registeredName: parsed.values.name,
+      cpus,
+      memoryMb,
+      diskMb,
+      builderDiskMb,
+      isPublic: parsed.values.public,
+    },
+    { emit: ndjsonStdoutEmit },
+  );
+}
+
+export async function runImportSandboxImageCli(argv = process.argv.slice(2)) {
+  const parsed = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      name: { type: "string", short: "n" },
+      cpus: { type: "string" },
+      memory: { type: "string" },
+      disk_mb: { type: "string" },
+      builder_disk_mb: { type: "string" },
+      public: { type: "boolean", default: false },
+    },
+  });
+
+  const imageReference = parsed.positionals[0];
+  if (!imageReference) {
+    throw new Error(
+      "Usage: tensorlake-import-sandbox-image <image_reference> [--name NAME] [--cpus N] [--memory MB] [--disk_mb MB] [--builder_disk_mb MB] [--public]",
+    );
+  }
+
+  const cpus =
+    parsed.values.cpus != null ? Number(parsed.values.cpus) : undefined;
+  const memoryMb =
+    parsed.values.memory != null ? Number(parsed.values.memory) : undefined;
+  const diskMb =
+    parsed.values.disk_mb != null ? Number(parsed.values.disk_mb) : undefined;
+  const builderDiskMb =
+    parsed.values.builder_disk_mb != null
+      ? Number(parsed.values.builder_disk_mb)
+      : undefined;
+  if (cpus != null && !Number.isFinite(cpus)) {
+    throw new Error(`Invalid --cpus value: ${parsed.values.cpus}`);
+  }
+  if (memoryMb != null && !Number.isInteger(memoryMb)) {
+    throw new Error(`Invalid --memory value: ${parsed.values.memory}`);
+  }
+  if (diskMb != null && !Number.isInteger(diskMb)) {
+    throw new Error(`Invalid --disk_mb value: ${parsed.values.disk_mb}`);
+  }
+  if (builderDiskMb != null && !Number.isInteger(builderDiskMb)) {
+    throw new Error(
+      `Invalid --builder_disk_mb value: ${parsed.values.builder_disk_mb}`,
+    );
+  }
+
+  await importSandboxImage(
+    imageReference,
     {
       registeredName: parsed.values.name,
       cpus,

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -59,10 +59,10 @@ export interface CreateSandboxImageDeps {
 
 // --- Native binding loader -------------------------------------------------
 
-interface NativeBindingOptions {
+/** Auth/context + resource fields shared by the build and import bindings. */
+interface NativeBindingCommonOptions {
   apiUrl: string;
   bearerToken: string;
-  dockerfilePath: string;
   registeredName?: string | undefined | null;
   diskMb?: number | undefined | null;
   builderDiskMb?: number | undefined | null;
@@ -74,9 +74,16 @@ interface NativeBindingOptions {
   namespace?: string | undefined | null;
   useScopeHeaders?: boolean | undefined | null;
   userAgent?: string | undefined | null;
+}
+
+interface NativeBindingOptions extends NativeBindingCommonOptions {
+  dockerfilePath: string;
   dockerfileText?: string | undefined | null;
   contextDir?: string | undefined | null;
-  importImageReference?: string | undefined | null;
+}
+
+interface NativeBindingImportOptions extends NativeBindingCommonOptions {
+  imageReference: string;
 }
 
 interface NativeBindingEvent {
@@ -88,6 +95,10 @@ interface NativeBindingEvent {
 interface NativeBinding {
   buildSandboxImage(
     options: NativeBindingOptions,
+    emit?: ((event: NativeBindingEvent) => void) | null | undefined,
+  ): Promise<string>;
+  importSandboxImage(
+    options: NativeBindingImportOptions,
     emit?: ((event: NativeBindingEvent) => void) | null | undefined,
   ): Promise<string>;
 }
@@ -388,13 +399,11 @@ export async function importSandboxImage(
 
   const binding = loadNativeBinding();
   let emitError: unknown;
-  const resultJson = await binding.buildSandboxImage(
+  const resultJson = await binding.importSandboxImage(
     {
       apiUrl: context.apiUrl,
       bearerToken,
-      // Unused on the import path, but the native option struct is shared with
-      // the Dockerfile build flow.
-      dockerfilePath: "",
+      imageReference: reference,
       registeredName: effectiveName,
       diskMb: options.diskMb,
       builderDiskMb: options.builderDiskMb,
@@ -407,9 +416,6 @@ export async function importSandboxImage(
       useScopeHeaders:
         context.personalAccessToken != null && context.apiKey == null,
       userAgent: undefined,
-      dockerfileText: undefined,
-      contextDir: undefined,
-      importImageReference: reference,
     },
     (event) => {
       try {

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __setNativeBindingForTest,
   createSandboxImage,
+  importSandboxImage,
 } from "../src/sandbox-image.js";
 import { Image, dockerfileContent } from "../src/image.js";
 
@@ -310,6 +311,99 @@ describe("createSandboxImage", () => {
 
     expect(warn).toHaveBeenCalledOnce();
     expect(warn.mock.calls[0]?.[0]).toMatch(/default name/);
+  });
+});
+
+describe("importSandboxImage", () => {
+  beforeEach(() => {
+    vi.stubEnv("TENSORLAKE_API_URL", "https://api.tensorlake.test");
+    vi.stubEnv("TENSORLAKE_API_KEY", "tl_key_test");
+    vi.stubEnv("INDEXIFY_NAMESPACE", "default");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    __setNativeBindingForTest(undefined);
+    vi.restoreAllMocks();
+  });
+
+  it("delegates an image reference to the native binding via importImageReference", async () => {
+    const { binding, captured } = makeFakeBinding();
+    const result = await importSandboxImage(
+      "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",
+      { isPublic: true },
+    );
+
+    expect(binding.buildSandboxImage).toHaveBeenCalledOnce();
+    expect(captured.options).toMatchObject({
+      apiUrl: "https://api.tensorlake.test",
+      bearerToken: "tl_key_test",
+      importImageReference: "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",
+      registeredName: "pytorch",
+      isPublic: true,
+      dockerfilePath: "",
+      dockerfileText: undefined,
+      contextDir: undefined,
+    });
+    expect(result).toEqual({ id: "tpl-1", snapshot_id: "snap-1" });
+  });
+
+  it("derives the registered name from the reference, stripping tag and registry path", async () => {
+    const { captured } = makeFakeBinding();
+    await importSandboxImage("ghcr.io/org/app@sha256:abc123");
+    expect(captured.options.registeredName).toBe("app");
+  });
+
+  it("uses the explicit registeredName when provided", async () => {
+    const { captured } = makeFakeBinding();
+    await importSandboxImage("pytorch/pytorch:2.4.1", {
+      registeredName: "override",
+    });
+    expect(captured.options.registeredName).toBe("override");
+  });
+
+  it("forwards native events back through the user emit callback", async () => {
+    makeFakeBinding({
+      events: [
+        { eventType: "status", message: "Pulling layers..." },
+        { eventType: "build_log", stream: "stdout", message: "applied layer" },
+      ],
+    });
+
+    const events: Array<Record<string, unknown>> = [];
+    await importSandboxImage(
+      "pytorch/pytorch:2.4.1",
+      {},
+      { emit: (e) => events.push(e) },
+    );
+
+    expect(events).toEqual([
+      {
+        type: "status",
+        message: "Importing image 'pytorch/pytorch:2.4.1' as 'pytorch'...",
+      },
+      { type: "status", message: "Pulling layers..." },
+      { type: "build_log", stream: "stdout", message: "applied layer" },
+      { type: "image_registered", name: "pytorch", image_id: "tpl-1" },
+      { type: "done" },
+    ]);
+  });
+
+  it("throws on an empty image reference", async () => {
+    makeFakeBinding();
+    await expect(importSandboxImage("   ")).rejects.toThrow(
+      /image reference to import must not be empty/,
+    );
+  });
+
+  it("throws when no credentials are configured", async () => {
+    vi.stubEnv("TENSORLAKE_API_KEY", "");
+    vi.stubEnv("TENSORLAKE_PAT", "");
+    makeFakeBinding();
+
+    await expect(importSandboxImage("pytorch/pytorch:2.4.1")).rejects.toThrow(
+      /Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT/,
+    );
   });
 });
 

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -19,22 +19,22 @@ function makeFakeBinding(opts: {
   events?: Array<{ eventType: string; stream?: string | null; message: string }>;
 } = {}) {
   const captured: CapturedCall = { options: {} };
+  const handler = async (
+    options: Record<string, unknown>,
+    emit?:
+      | ((event: { eventType: string; stream?: string | null; message: string }) => void)
+      | null,
+  ) => {
+    captured.options = options;
+    captured.emit = emit;
+    if (emit && opts.events) {
+      for (const event of opts.events) emit(event);
+    }
+    return opts.resultJson ?? '{"id":"tpl-1","snapshot_id":"snap-1"}';
+  };
   const binding = {
-    buildSandboxImage: vi.fn(
-      async (
-        options: Record<string, unknown>,
-        emit?:
-          | ((event: { eventType: string; stream?: string | null; message: string }) => void)
-          | null,
-      ) => {
-        captured.options = options;
-        captured.emit = emit;
-        if (emit && opts.events) {
-          for (const event of opts.events) emit(event);
-        }
-        return opts.resultJson ?? '{"id":"tpl-1","snapshot_id":"snap-1"}';
-      },
-    ),
+    buildSandboxImage: vi.fn(handler),
+    importSandboxImage: vi.fn(handler),
   };
   __setNativeBindingForTest(binding);
   return { binding, captured };
@@ -327,24 +327,25 @@ describe("importSandboxImage", () => {
     vi.restoreAllMocks();
   });
 
-  it("delegates an image reference to the native binding via importImageReference", async () => {
+  it("delegates an image reference to the native import binding", async () => {
     const { binding, captured } = makeFakeBinding();
     const result = await importSandboxImage(
       "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",
       { isPublic: true },
     );
 
-    expect(binding.buildSandboxImage).toHaveBeenCalledOnce();
+    expect(binding.importSandboxImage).toHaveBeenCalledOnce();
+    expect(binding.buildSandboxImage).not.toHaveBeenCalled();
     expect(captured.options).toMatchObject({
       apiUrl: "https://api.tensorlake.test",
       bearerToken: "tl_key_test",
-      importImageReference: "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",
+      imageReference: "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",
       registeredName: "pytorch",
       isPublic: true,
-      dockerfilePath: "",
-      dockerfileText: undefined,
-      contextDir: undefined,
     });
+    // The import option shape carries no Dockerfile fields.
+    expect(captured.options).not.toHaveProperty("dockerfilePath");
+    expect(captured.options).not.toHaveProperty("importImageReference");
     expect(result).toEqual({ id: "tpl-1", snapshot_id: "snap-1" });
   });
 


### PR DESCRIPTION
Wire the existing Rust import-image support through the Python and TypeScript SDK layers with validation and tests, and bump both SDKs to 0.5.44.