### PR TITLE
Fix Linux native packaging for TypeScript SDK

### DIFF
--- a/.github/workflows/publish_npm.yaml
+++ b/.github/workflows/publish_npm.yaml
@@ -57,12 +57,40 @@ jobs:
         include:
           - os: ubuntu-latest
             target_id: linux-x64
+            rust_target: x86_64-unknown-linux-gnu.2.28
+            rust_target_base: x86_64-unknown-linux-gnu
+            libc: gnu
+            cli_build_tool: cargo-zigbuild
           - os: ubuntu-24.04-arm
             target_id: linux-arm64
+            rust_target: aarch64-unknown-linux-gnu.2.28
+            rust_target_base: aarch64-unknown-linux-gnu
+            libc: gnu
+            cli_build_tool: cargo-zigbuild
+          - os: ubuntu-latest
+            target_id: linux-x64-musl
+            rust_target: x86_64-unknown-linux-musl
+            rust_target_base: x86_64-unknown-linux-musl
+            libc: musl
+            cli_build_tool: cargo-zigbuild
+          - os: ubuntu-24.04-arm
+            target_id: linux-arm64-musl
+            rust_target: aarch64-unknown-linux-musl
+            rust_target_base: aarch64-unknown-linux-musl
+            libc: musl
+            cli_build_tool: cargo-zigbuild
           - os: macos-14
             target_id: darwin-arm64
+            rust_target: ""
+            rust_target_base: ""
+            libc: ""
+            cli_build_tool: cargo
           - os: windows-latest
             target_id: win32-x64
+            rust_target: ""
+            rust_target_base: ""
+            libc: ""
+            cli_build_tool: cargo
     steps:
       - uses: actions/checkout@v4
 
@@ -76,20 +104,56 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup Zig
+        if: matrix.cli_build_tool == 'cargo-zigbuild'
+        uses: mlugg/setup-zig@v2
+
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust-no-bin
           cache-bin: false
 
+      - name: Install cargo-zigbuild
+        if: matrix.cli_build_tool == 'cargo-zigbuild'
+        run: cargo install cargo-zigbuild --locked
+
+      - name: Install Rust target
+        if: matrix.rust_target_base != ''
+        run: rustup target add ${{ matrix.rust_target_base }}
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build CLI
         run: npm run build:cli
+        env:
+          TENSORLAKE_CLI_TARGET_ID: ${{ matrix.target_id }}
+          TENSORLAKE_CLI_TARGET_TRIPLE: ${{ matrix.rust_target }}
+          TENSORLAKE_CLI_BUILD_TOOL: ${{ matrix.cli_build_tool }}
 
       - name: Verify packaged CLI binary
-        run: node ./bin/tl.cjs --help
+        run: |
+          node -e "const cp = require('node:child_process'); const path = require('node:path'); const ext = process.platform === 'win32' ? '.exe' : ''; const binary = path.join('dist', 'bin', process.env.TARGET_ID, 'tl' + ext); const result = cp.spawnSync(binary, ['--help'], { stdio: 'inherit' }); if (result.error) throw result.error; process.exit(result.status ?? 1);"
+        env:
+          TARGET_ID: ${{ matrix.target_id }}
+
+      - name: Verify Linux CLI libc compatibility
+        if: startsWith(matrix.target_id, 'linux-')
+        run: |
+          set -euo pipefail
+          binary="dist/bin/${{ matrix.target_id }}/tl"
+          required_versions="$(readelf --version-info "$binary" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -Vu || true)"
+          max_glibc="$(printf '%s\n' "$required_versions" | tail -n1)"
+          echo "Maximum required glibc: ${max_glibc:-none}"
+          if [ "${{ matrix.libc }}" = "musl" ] && [ -n "$max_glibc" ]; then
+            echo "Musl CLI unexpectedly references glibc symbols."
+            exit 1
+          fi
+          if [ "${{ matrix.libc }}" = "gnu" ] && [ -n "$max_glibc" ] && [ "$(printf '%s\n%s\n' "GLIBC_2.28" "$max_glibc" | sort -V | tail -n1)" != "GLIBC_2.28" ]; then
+            echo "CLI requires $max_glibc, above the GLIBC_2.28 compatibility floor."
+            exit 1
+          fi
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4
@@ -106,12 +170,40 @@ jobs:
         include:
           - os: ubuntu-latest
             target_id: linux-x64
+            rust_target: x86_64-unknown-linux-gnu.2.28
+            rust_target_base: x86_64-unknown-linux-gnu
+            libc: gnu
+            native_build_tool: cargo-zigbuild
           - os: ubuntu-24.04-arm
             target_id: linux-arm64
+            rust_target: aarch64-unknown-linux-gnu.2.28
+            rust_target_base: aarch64-unknown-linux-gnu
+            libc: gnu
+            native_build_tool: cargo-zigbuild
+          - os: ubuntu-latest
+            target_id: linux-x64-musl
+            rust_target: x86_64-unknown-linux-musl
+            rust_target_base: x86_64-unknown-linux-musl
+            libc: musl
+            native_build_tool: cargo-zigbuild
+          - os: ubuntu-24.04-arm
+            target_id: linux-arm64-musl
+            rust_target: aarch64-unknown-linux-musl
+            rust_target_base: aarch64-unknown-linux-musl
+            libc: musl
+            native_build_tool: cargo-zigbuild
           - os: macos-14
             target_id: darwin-arm64
+            rust_target: ""
+            rust_target_base: ""
+            libc: ""
+            native_build_tool: cargo
           - os: windows-latest
             target_id: win32-x64
+            rust_target: ""
+            rust_target_base: ""
+            libc: ""
+            native_build_tool: cargo
     steps:
       - uses: actions/checkout@v4
 
@@ -125,17 +217,50 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup Zig
+        if: matrix.native_build_tool == 'cargo-zigbuild'
+        uses: mlugg/setup-zig@v2
+
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust-no-bin
           cache-bin: false
 
+      - name: Install cargo-zigbuild
+        if: matrix.native_build_tool == 'cargo-zigbuild'
+        run: cargo install cargo-zigbuild --locked
+
+      - name: Install Rust target
+        if: matrix.rust_target_base != ''
+        run: rustup target add ${{ matrix.rust_target_base }}
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build native binding
         run: npm run build:native
+        env:
+          TENSORLAKE_NODE_TARGET_ID: ${{ matrix.target_id }}
+          TENSORLAKE_NODE_TARGET_TRIPLE: ${{ matrix.rust_target }}
+          TENSORLAKE_NODE_BUILD_TOOL: ${{ matrix.native_build_tool }}
+
+      - name: Verify Linux native libc compatibility
+        if: startsWith(matrix.target_id, 'linux-')
+        run: |
+          set -euo pipefail
+          binding="dist/native/${{ matrix.target_id }}/tensorlake-node.node"
+          required_versions="$(readelf --version-info "$binding" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -Vu || true)"
+          max_glibc="$(printf '%s\n' "$required_versions" | tail -n1)"
+          echo "Maximum required glibc: ${max_glibc:-none}"
+          if [ "${{ matrix.libc }}" = "musl" ] && [ -n "$max_glibc" ]; then
+            echo "Musl native binding unexpectedly references glibc symbols."
+            exit 1
+          fi
+          if [ "${{ matrix.libc }}" = "gnu" ] && [ -n "$max_glibc" ] && [ "$(printf '%s\n%s\n' "GLIBC_2.28" "$max_glibc" | sort -V | tail -n1)" != "GLIBC_2.28" ]; then
+            echo "Native binding requires $max_glibc, above the GLIBC_2.28 compatibility floor."
+            exit 1
+          fi
 
       - name: Upload native artifact
         uses: actions/upload-artifact@v4
@@ -187,6 +312,18 @@ jobs:
           name: cli-linux-arm64
           path: typescript/dist/bin/linux-arm64
 
+      - name: Download Linux musl CLI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-linux-x64-musl
+          path: typescript/dist/bin/linux-x64-musl
+
+      - name: Download Linux arm64 musl CLI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-linux-arm64-musl
+          path: typescript/dist/bin/linux-arm64-musl
+
       - name: Download macOS arm64 CLI artifact
         uses: actions/download-artifact@v4
         with:
@@ -210,6 +347,18 @@ jobs:
         with:
           name: native-linux-arm64
           path: typescript/dist/native/linux-arm64
+
+      - name: Download Linux musl native artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: native-linux-x64-musl
+          path: typescript/dist/native/linux-x64-musl
+
+      - name: Download Linux arm64 musl native artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: native-linux-arm64-musl
+          path: typescript/dist/native/linux-arm64-musl
 
       - name: Download macOS arm64 native artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -48,11 +48,20 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust-no-bin
           cache-bin: false
+
+      - name: Install cargo-zigbuild
+        run: cargo install cargo-zigbuild --locked
+
+      - name: Install Rust target
+        run: rustup target add x86_64-unknown-linux-gnu x86_64-unknown-linux-musl
 
       - name: Install dependencies
         run: npm ci
@@ -66,8 +75,42 @@ jobs:
       - name: Run snapshot-focused SDK unit tests
         run: npm test -- tests/client.test.ts tests/sandbox-image.test.ts
 
-      - name: Build native binding (smoke)
+      - name: Build native binding (glibc compatibility smoke)
         run: npm run build:native
+        env:
+          TENSORLAKE_NODE_TARGET_ID: linux-x64
+          TENSORLAKE_NODE_TARGET_TRIPLE: x86_64-unknown-linux-gnu.2.28
+          TENSORLAKE_NODE_BUILD_TOOL: cargo-zigbuild
+
+      - name: Verify native glibc floor
+        run: |
+          set -euo pipefail
+          binding="dist/native/linux-x64/tensorlake-node.node"
+          required_versions="$(readelf --version-info "$binding" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -Vu || true)"
+          max_glibc="$(printf '%s\n' "$required_versions" | tail -n1)"
+          echo "Maximum required glibc: ${max_glibc:-none}"
+          if [ -n "$max_glibc" ] && [ "$(printf '%s\n%s\n' "GLIBC_2.28" "$max_glibc" | sort -V | tail -n1)" != "GLIBC_2.28" ]; then
+            echo "Native binding requires $max_glibc, above the GLIBC_2.28 compatibility floor."
+            exit 1
+          fi
+
+      - name: Build native binding (musl smoke)
+        run: npm run build:native
+        env:
+          TENSORLAKE_NODE_TARGET_ID: linux-x64-musl
+          TENSORLAKE_NODE_TARGET_TRIPLE: x86_64-unknown-linux-musl
+          TENSORLAKE_NODE_BUILD_TOOL: cargo-zigbuild
+
+      - name: Verify musl native binding does not require glibc
+        run: |
+          set -euo pipefail
+          binding="dist/native/linux-x64-musl/tensorlake-node.node"
+          required_versions="$(readelf --version-info "$binding" | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sort -Vu || true)"
+          if [ -n "$required_versions" ]; then
+            echo "Musl native binding unexpectedly references glibc symbols:"
+            printf '%s\n' "$required_versions"
+            exit 1
+          fi
 
   integration-tests:
     name: Integration tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.44"
+version = "0.5.45"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.44"
+version = "0.5.45"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.44"
+version = "0.5.45"
 dependencies = [
  "napi",
  "napi-build",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.44"
+version = "0.5.45"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.44"
+version = "0.5.45"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.44"
+version = "0.5.45"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.44"
+version = "0.5.45"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/lib/runtime.cjs
+++ b/typescript/lib/runtime.cjs
@@ -12,26 +12,75 @@ function binaryTargetId(platform = process.platform, arch = process.arch) {
   return `${platform}-${arch}`;
 }
 
+function linuxLibcFamily(options = {}) {
+  if (options.libc === "gnu" || options.libc === "musl") {
+    return options.libc;
+  }
+
+  try {
+    const report =
+      options.report ?? (process.report?.getReport ? process.report.getReport() : undefined);
+    if (!report) {
+      return "gnu";
+    }
+    if (report?.header?.glibcVersionRuntime) {
+      return "gnu";
+    }
+  } catch {
+    return "gnu";
+  }
+
+  return "musl";
+}
+
+function packageTargetId(platform = process.platform, arch = process.arch, options = {}) {
+  const baseTargetId = binaryTargetId(platform, arch);
+  if (platform !== "linux") {
+    return baseTargetId;
+  }
+  if (!options.libc && !options.report && platform !== process.platform) {
+    return baseTargetId;
+  }
+  return linuxLibcFamily(options) === "musl" ? `${baseTargetId}-musl` : baseTargetId;
+}
+
+function nativeTargetId(platform = process.platform, arch = process.arch, options = {}) {
+  return packageTargetId(platform, arch, options);
+}
+
 function binaryPath(binaryName, options = {}) {
   const platform = options.platform ?? process.platform;
   const arch = options.arch ?? process.arch;
   const extension = platform === "win32" ? ".exe" : "";
   const root = options.packageRoot ?? packageRoot();
-  return path.join(root, "dist", "bin", binaryTargetId(platform, arch), `${binaryName}${extension}`);
+  return path.join(
+    root,
+    "dist",
+    "bin",
+    packageTargetId(platform, arch, options),
+    `${binaryName}${extension}`,
+  );
 }
 
 function nativeBindingPath(options = {}) {
   const platform = options.platform ?? process.platform;
   const arch = options.arch ?? process.arch;
   const root = options.packageRoot ?? packageRoot();
-  return path.join(root, "dist", "native", binaryTargetId(platform, arch), "tensorlake-node.node");
+  return path.join(
+    root,
+    "dist",
+    "native",
+    nativeTargetId(platform, arch, options),
+    "tensorlake-node.node",
+  );
 }
 
 function loadNative() {
+  const targetId = nativeTargetId();
   const bindingPath = nativeBindingPath();
   if (!fs.existsSync(bindingPath)) {
     throw new Error(
-      `Missing native binding for ${binaryTargetId()}. Run 'npm run build' in tensorlake before packaging or install a package published with support for your platform.`,
+      `Missing native binding for ${targetId}. Run 'npm run build' in tensorlake before packaging or install a package published with support for your platform.`,
     );
   }
   return require(bindingPath);
@@ -46,10 +95,11 @@ function exitWithSpawnResult(result) {
 }
 
 function runBinary(binaryName) {
+  const targetId = packageTargetId();
   const executable = binaryPath(binaryName);
   if (!fs.existsSync(executable)) {
     console.error(
-      `Missing packaged binary '${binaryName}' for ${binaryTargetId()}. Run 'npm run build' in tensorlake before packaging or install a package published with support for your platform.`,
+      `Missing packaged binary '${binaryName}' for ${targetId}. Run 'npm run build' in tensorlake before packaging or install a package published with support for your platform.`,
     );
     process.exit(1);
   }
@@ -108,6 +158,7 @@ module.exports = {
   binaryPath,
   binaryTargetId,
   loadNative,
+  nativeTargetId,
   nativeBindingPath,
   runBinary,
   runPythonModule,

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.44",
+  "version": "0.5.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.44",
+      "version": "0.5.45",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.44",
+  "version": "0.5.45",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/scripts/build-native.mjs
+++ b/typescript/scripts/build-native.mjs
@@ -7,32 +7,86 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const packageRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(packageRoot, "..");
+const nativePackageName = "tensorlake-rust-cloud-sdk-node";
+const targetId =
+  process.env.TENSORLAKE_NODE_TARGET_ID ?? `${process.platform}-${process.arch}`;
+const targetTriple = process.env.TENSORLAKE_NODE_TARGET_TRIPLE || undefined;
+const buildTool = process.env.TENSORLAKE_NODE_BUILD_TOOL ?? "cargo";
 
 const outputDir = path.join(
   packageRoot,
   "dist",
   "native",
-  `${process.platform}-${process.arch}`,
+  targetId,
 );
 
 // The cdylib's filename varies by platform; the staged copy is always
 // `tensorlake-node.node` so the Node loader can require() it uniformly.
+const targetPlatform = targetId.split("-")[0];
 const sourceFilename =
-  process.platform === "win32"
+  targetPlatform === "win32"
     ? "tensorlake_node.dll"
-    : process.platform === "darwin"
+    : targetPlatform === "darwin"
       ? "libtensorlake_node.dylib"
       : "libtensorlake_node.so";
 
-const cargo = spawnSync(
-  "cargo",
-  ["build", "--release", "-p", "tensorlake-rust-cloud-sdk-node"],
-  {
-    cwd: repoRoot,
-    stdio: "inherit",
-    env: process.env,
-  },
+function cargoTargetRoot() {
+  if (!process.env.CARGO_TARGET_DIR) {
+    return path.join(repoRoot, "target");
+  }
+  return path.resolve(repoRoot, process.env.CARGO_TARGET_DIR);
+}
+
+function cargoReleaseDirs() {
+  if (!targetTriple) {
+    return [path.join(cargoTargetRoot(), "release")];
+  }
+
+  // cargo-zigbuild accepts glibc-versioned triples such as
+  // `x86_64-unknown-linux-gnu.2.28`; today it stages artifacts under the
+  // unversioned target directory, but also check the exact target string.
+  const targetDirNames = [
+    targetTriple.replace(/\.\d+(?:\.\d+)?$/, ""),
+    targetTriple,
+  ];
+  return [...new Set(targetDirNames)].map((targetDirName) =>
+    path.join(cargoTargetRoot(), targetDirName, "release"),
+  );
+}
+
+const cargoSubcommand =
+  buildTool === "cargo-zigbuild"
+    ? "zigbuild"
+    : buildTool === "cargo"
+      ? "build"
+      : undefined;
+
+if (!cargoSubcommand) {
+  console.error(
+    `Unsupported TENSORLAKE_NODE_BUILD_TOOL '${buildTool}'. Expected 'cargo' or 'cargo-zigbuild'.`,
+  );
+  process.exit(1);
+}
+
+const cargoArgs = [
+  cargoSubcommand,
+  "--release",
+  "-p",
+  nativePackageName,
+  ...(targetTriple ? ["--target", targetTriple] : []),
+];
+
+console.log(
+  `Building native binding for ${targetId}${
+    targetTriple ? ` (${targetTriple})` : ""
+  } with cargo ${cargoSubcommand}`,
 );
+
+const cargo = spawnSync("cargo", cargoArgs, {
+  cwd: repoRoot,
+  stdio: "inherit",
+  env: process.env,
+});
 
 if (cargo.status !== 0) {
   process.exit(cargo.status ?? 1);
@@ -40,13 +94,19 @@ if (cargo.status !== 0) {
 
 mkdirSync(outputDir, { recursive: true });
 
-const source = path.join(repoRoot, "target", "release", sourceFilename);
+const source = cargoReleaseDirs()
+  .map((releaseDir) => path.join(releaseDir, sourceFilename))
+  .find((candidate) => existsSync(candidate));
 const destination = path.join(outputDir, "tensorlake-node.node");
-if (!existsSync(source)) {
-  console.error(`Expected compiled native binding at ${source}`);
+if (!source) {
+  console.error(
+    `Expected compiled native binding in one of: ${cargoReleaseDirs()
+      .map((releaseDir) => path.join(releaseDir, sourceFilename))
+      .join(", ")}`,
+  );
   process.exit(1);
 }
 copyFileSync(source, destination);
-if (process.platform !== "win32") {
+if (targetPlatform !== "win32") {
   chmodSync(destination, 0o644);
 }

--- a/typescript/scripts/prepare-package.mjs
+++ b/typescript/scripts/prepare-package.mjs
@@ -7,10 +7,65 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const packageRoot = path.resolve(__dirname, "..");
 const repoRoot = path.resolve(packageRoot, "..");
-const outputDir = path.join(packageRoot, "dist", "bin", `${process.platform}-${process.arch}`);
-const extension = process.platform === "win32" ? ".exe" : "";
+const cliPackageName = "tensorlake-cli";
+const targetId =
+  process.env.TENSORLAKE_CLI_TARGET_ID ?? `${process.platform}-${process.arch}`;
+const targetTriple = process.env.TENSORLAKE_CLI_TARGET_TRIPLE || undefined;
+const buildTool = process.env.TENSORLAKE_CLI_BUILD_TOOL ?? "cargo";
+const outputDir = path.join(packageRoot, "dist", "bin", targetId);
+const targetPlatform = targetId.split("-")[0];
+const extension = targetPlatform === "win32" ? ".exe" : "";
 
-const cargo = spawnSync("cargo", ["build", "--release", "-p", "tensorlake-cli"], {
+function cargoTargetRoot() {
+  if (!process.env.CARGO_TARGET_DIR) {
+    return path.join(repoRoot, "target");
+  }
+  return path.resolve(repoRoot, process.env.CARGO_TARGET_DIR);
+}
+
+function cargoReleaseDirs() {
+  if (!targetTriple) {
+    return [path.join(cargoTargetRoot(), "release")];
+  }
+
+  const targetDirNames = [
+    targetTriple.replace(/\.\d+(?:\.\d+)?$/, ""),
+    targetTriple,
+  ];
+  return [...new Set(targetDirNames)].map((targetDirName) =>
+    path.join(cargoTargetRoot(), targetDirName, "release"),
+  );
+}
+
+const cargoSubcommand =
+  buildTool === "cargo-zigbuild"
+    ? "zigbuild"
+    : buildTool === "cargo"
+      ? "build"
+      : undefined;
+
+if (!cargoSubcommand) {
+  console.error(
+    `Unsupported TENSORLAKE_CLI_BUILD_TOOL '${buildTool}'. Expected 'cargo' or 'cargo-zigbuild'.`,
+  );
+  process.exit(1);
+}
+
+const cargoArgs = [
+  cargoSubcommand,
+  "--release",
+  "-p",
+  cliPackageName,
+  ...(targetTriple ? ["--target", targetTriple] : []),
+];
+
+console.log(
+  `Building CLI binaries for ${targetId}${
+    targetTriple ? ` (${targetTriple})` : ""
+  } with cargo ${cargoSubcommand}`,
+);
+
+const cargo = spawnSync("cargo", cargoArgs, {
   cwd: repoRoot,
   stdio: "inherit",
   env: process.env,
@@ -23,14 +78,20 @@ if (cargo.status !== 0) {
 mkdirSync(outputDir, { recursive: true });
 
 for (const binaryName of ["tl", "tensorlake"]) {
-  const source = path.join(repoRoot, "target", "release", `${binaryName}${extension}`);
+  const source = cargoReleaseDirs()
+    .map((releaseDir) => path.join(releaseDir, `${binaryName}${extension}`))
+    .find((candidate) => existsSync(candidate));
   const destination = path.join(outputDir, `${binaryName}${extension}`);
-  if (!existsSync(source)) {
-    console.error(`Expected compiled binary at ${source}`);
+  if (!source) {
+    console.error(
+      `Expected compiled binary in one of: ${cargoReleaseDirs()
+        .map((releaseDir) => path.join(releaseDir, `${binaryName}${extension}`))
+        .join(", ")}`,
+    );
     process.exit(1);
   }
   copyFileSync(source, destination);
-  if (process.platform !== "win32") {
+  if (targetPlatform !== "win32") {
     chmodSync(destination, 0o755);
   }
 }

--- a/typescript/tests/runtime.test.ts
+++ b/typescript/tests/runtime.test.ts
@@ -3,7 +3,8 @@ import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
-const { binaryPath, binaryTargetId } = require("../lib/runtime.cjs");
+const { binaryPath, binaryTargetId, nativeBindingPath, nativeTargetId } =
+  require("../lib/runtime.cjs");
 
 describe("runtime binary selection", () => {
   it("maps supported platform and arch pairs into package target ids", () => {
@@ -24,5 +25,33 @@ describe("runtime binary selection", () => {
     expect(
       binaryPath("tl", { packageRoot: root, platform: "win32", arch: "x64" }),
     ).toBe(path.join(root, "dist", "bin", "win32-x64", "tl.exe"));
+    expect(
+      binaryPath("tl", { packageRoot: root, platform: "linux", arch: "x64", libc: "musl" }),
+    ).toBe(path.join(root, "dist", "bin", "linux-x64-musl", "tl"));
+  });
+
+  it("selects libc-specific native binding targets on Linux", () => {
+    expect(nativeTargetId("linux", "x64", { libc: "gnu" })).toBe("linux-x64");
+    expect(nativeTargetId("linux", "x64", { libc: "musl" })).toBe("linux-x64-musl");
+    expect(
+      nativeTargetId("linux", "x64", {
+        report: { header: { glibcVersionRuntime: "2.35" } },
+      }),
+    ).toBe("linux-x64");
+    expect(nativeTargetId("linux", "x64", { report: { header: {} } })).toBe(
+      "linux-x64-musl",
+    );
+    expect(nativeTargetId("darwin", "arm64", { libc: "musl" })).toBe("darwin-arm64");
+  });
+
+  it("builds libc-specific native binding paths", () => {
+    const root = path.join(path.sep, "tmp", "tensorlake");
+
+    expect(
+      nativeBindingPath({ packageRoot: root, platform: "linux", arch: "x64", libc: "gnu" }),
+    ).toBe(path.join(root, "dist", "native", "linux-x64", "tensorlake-node.node"));
+    expect(
+      nativeBindingPath({ packageRoot: root, platform: "linux", arch: "x64", libc: "musl" }),
+    ).toBe(path.join(root, "dist", "native", "linux-x64-musl", "tensorlake-node.node"));
   });
 });


### PR DESCRIPTION
## Summary
- build Linux TypeScript native addons and CLI binaries with explicit GNU and musl targets
- select musl package artifacts at runtime on musl/Alpine Linux, while keeping GNU artifacts for glibc Node
- verify GNU builds stay at or below GLIBC_2.28 and musl builds do not reference GLIBC symbols
- bump release metadata to 0.5.45

## Validation
- npm test
- npm run typecheck
- npm run build:native
- npm run build:cli
- npm pack --dry-run --ignore-scripts
- cargo metadata --locked --no-deps --format-version 1