### PR TITLE
Fix musl native addon builds

### DIFF
--- a/typescript/scripts/build-native.mjs
+++ b/typescript/scripts/build-native.mjs
@@ -76,6 +76,15 @@ const cargoArgs = [
   ...(targetTriple ? ["--target", targetTriple] : []),
 ];
 
+const cargoEnv = { ...process.env };
+if (targetTriple?.endsWith("-linux-musl")) {
+  // Node addons are shared libraries loaded by Node with dlopen(). Rust's musl
+  // targets default to a static C runtime, which disables cdylib output.
+  cargoEnv.RUSTFLAGS = [cargoEnv.RUSTFLAGS, "-C target-feature=-crt-static"]
+    .filter(Boolean)
+    .join(" ");
+}
+
 console.log(
   `Building native binding for ${targetId}${
     targetTriple ? ` (${targetTriple})` : ""
@@ -85,7 +94,7 @@ console.log(
 const cargo = spawnSync("cargo", cargoArgs, {
   cwd: repoRoot,
   stdio: "inherit",
-  env: process.env,
+  env: cargoEnv,
 });
 
 if (cargo.status !== 0) {


### PR DESCRIPTION
## Summary
- set `RUSTFLAGS=-C target-feature=-crt-static` for musl Node addon builds
- keep the flag scoped to `build-native.mjs`, so standalone musl CLI builds can remain static
- fixes the release failure where Rust rejected `cdylib` output for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`

## Validation
- npm test -- tests/runtime.test.ts
- RUSTFLAGS="-C target-feature=-crt-static" cargo build --release -p tensorlake-rust-cloud-sdk-node --target x86_64-unknown-linux-musl
  - got past the prior `target does not support cdylib` error
  - stopped locally because this macOS machine does not have `x86_64-linux-musl-gcc`; CI uses cargo-zigbuild/Zig for that toolchain

Failed job investigated: https://github.com/tensorlakeai/tensorlake/actions/runs/27571069412/job/81507412419