### PR TITLE
Add sandbox image list and find-by-name lookups to SDKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.45"
+version = "0.5.46"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.45"
+version = "0.5.46"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.45"
+version = "0.5.46"
 dependencies = [
  "napi",
  "napi-build",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.45"
+version = "0.5.46"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.45"
+version = "0.5.46"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/sandbox_templates/mod.rs
+++ b/crates/cloud-sdk/src/sandbox_templates/mod.rs
@@ -1,4 +1,5 @@
 use reqwest::{Method, StatusCode};
+use serde::Deserialize;
 
 use crate::{
     client::{Client, Traced},
@@ -8,6 +9,40 @@ use crate::{
 pub mod models;
 
 use models::{CreateSandboxTemplateRequest, SandboxTemplate};
+
+/// One page of the paginated sandbox-templates list response.
+#[derive(Debug, Default, Deserialize)]
+struct SandboxTemplatesPage {
+    #[serde(default)]
+    items: Vec<SandboxTemplate>,
+    #[serde(default)]
+    pagination: Option<Pagination>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Pagination {
+    #[serde(default)]
+    next: Option<String>,
+}
+
+/// Reduce a `pagination.next` link to a base-URL-relative request path.
+///
+/// The server may hand back either an absolute URL or an absolute path; the
+/// SDK client always prepends its base URL, so absolute URLs must be reduced
+/// to their path+query first.
+fn next_request_path(next: &str) -> String {
+    if let Some(idx) = next.find("://") {
+        let after = &next[idx + 3..];
+        match after.find('/') {
+            Some(slash) => after[slash..].to_string(),
+            None => "/".to_string(),
+        }
+    } else if next.starts_with('/') {
+        next.to_string()
+    } else {
+        format!("/{next}")
+    }
+}
 
 #[derive(Clone)]
 pub struct SandboxTemplatesClient {
@@ -46,6 +81,29 @@ impl SandboxTemplatesClient {
         self.client.execute_json(req).await
     }
 
+    /// List all registered sandbox templates, following pagination to the end.
+    ///
+    /// Pages through `?pageSize=100` results, accumulating every entry. The
+    /// returned `Traced` carries the trace id of the final page request.
+    pub async fn list(&self) -> Result<Traced<Vec<SandboxTemplate>>, SdkError> {
+        let mut path = format!("{}?pageSize=100", self.endpoint());
+        let mut items: Vec<SandboxTemplate> = Vec::new();
+        loop {
+            let req = self.client.build_get_json_request(&path, None)?;
+            let traced = self
+                .client
+                .execute_json::<SandboxTemplatesPage>(req)
+                .await?;
+            let trace_id = traced.trace_id.clone();
+            let page = traced.into_inner();
+            items.extend(page.items);
+            match page.pagination.and_then(|p| p.next) {
+                Some(next) if !next.is_empty() => path = next_request_path(&next),
+                _ => return Ok(Traced::new(trace_id, items)),
+            }
+        }
+    }
+
     /// Look up a sandbox template by its registered name.
     ///
     /// Returns `Ok(None)` when no template with that name is found. The
@@ -81,5 +139,31 @@ impl SandboxTemplatesClient {
             .execute_traced(req)
             .await
             .map(|traced| traced.map(|_| ()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::next_request_path;
+
+    #[test]
+    fn next_request_path_keeps_absolute_path_and_query() {
+        let next = "/platform/v1/organizations/org/projects/proj/sandbox-templates?pageSize=100&next=abc";
+        assert_eq!(next_request_path(next), next);
+    }
+
+    #[test]
+    fn next_request_path_reduces_absolute_url_to_path_and_query() {
+        let next =
+            "https://api.tensorlake.ai/platform/v1/organizations/org/projects/proj/sandbox-templates?next=abc";
+        assert_eq!(
+            next_request_path(next),
+            "/platform/v1/organizations/org/projects/proj/sandbox-templates?next=abc"
+        );
+    }
+
+    #[test]
+    fn next_request_path_prefixes_bare_relative_links() {
+        assert_eq!(next_request_path("sandbox-templates?next=abc"), "/sandbox-templates?next=abc");
     }
 }

--- a/crates/cloud-sdk/tests/sandbox_templates.rs
+++ b/crates/cloud-sdk/tests/sandbox_templates.rs
@@ -41,6 +41,66 @@ async fn delete_sandbox_template_sends_encoded_delete_request() {
 }
 
 #[tokio::test]
+async fn list_sandbox_templates_follows_pagination() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+    let base_path = "/platform/v1/organizations/org-1/projects/proj-1/sandbox-templates";
+
+    let server = tokio::spawn(async move {
+        // Page 1: two templates and a `next` link pointing at page 2.
+        let (mut socket, _) = listener.accept().await.expect("accept page 1");
+        let request_1 = read_http_request(&mut socket).await;
+        let page_1 = serde_json::json!({
+            "items": [
+                { "id": "tpl-1", "name": "image-a", "snapshotId": "snap-a" },
+                { "id": "tpl-2", "name": "image-b", "snapshotId": "snap-b" }
+            ],
+            "pagination": {
+                "next": "/platform/v1/organizations/org-1/projects/proj-1/sandbox-templates?pageSize=100&cursor=abc"
+            }
+        })
+        .to_string();
+        write_json_response(&mut socket, &page_1).await;
+
+        // Page 2: one template and no further pages.
+        let (mut socket, _) = listener.accept().await.expect("accept page 2");
+        let request_2 = read_http_request(&mut socket).await;
+        let page_2 = serde_json::json!({
+            "items": [
+                { "id": "tpl-3", "name": "image-c", "snapshotId": "snap-c" }
+            ],
+            "pagination": { "next": serde_json::Value::Null }
+        })
+        .to_string();
+        write_json_response(&mut socket, &page_2).await;
+
+        (request_1, request_2)
+    });
+
+    let client = ClientBuilder::new(&format!("http://{}", address))
+        .build()
+        .expect("build client");
+    let templates = SandboxTemplatesClient::new(client, "org-1", "proj-1");
+
+    let listed = templates.list().await.expect("list sandbox templates");
+    let names: Vec<String> = listed
+        .iter()
+        .filter_map(|template| template.name.clone())
+        .collect();
+    assert_eq!(names, vec!["image-a", "image-b", "image-c"]);
+
+    let (request_1, request_2) = server.await.expect("server join");
+    let request_1_text = String::from_utf8_lossy(&request_1);
+    let request_2_text = String::from_utf8_lossy(&request_2);
+    assert!(request_1_text.starts_with(&format!("GET {base_path}?pageSize=100 HTTP/1.1\r\n")));
+    assert!(request_2_text.starts_with(&format!(
+        "GET {base_path}?pageSize=100&cursor=abc HTTP/1.1\r\n"
+    )));
+}
+
+#[tokio::test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 async fn test_create_then_delete_sandbox_image() {
     use std::env;
@@ -127,6 +187,18 @@ async fn test_create_then_delete_sandbox_image() {
     if let Err(err) = result {
         panic!("{err}");
     }
+}
+
+async fn write_json_response(socket: &mut tokio::net::TcpStream, body: &str) {
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    socket
+        .write_all(response.as_bytes())
+        .await
+        .expect("write response");
 }
 
 async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Vec<u8> {

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.45"
+version = "0.5.46"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -28,6 +28,7 @@ use tensorlake::sandboxes::models::{
     ArchivedSandboxesPaginationDirection, CreateSandboxRequest, ListArchivedSandboxesParams,
     SandboxPoolRequest, SnapshotType, UpdateSandboxRequest,
 };
+use tensorlake::sandbox_templates::SandboxTemplatesClient;
 use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
 };
@@ -149,6 +150,56 @@ impl CloudApiClient {
                 let request = client.request(Method::DELETE, &path).build()?;
                 let _response = client.execute(request).await?;
                 Ok(())
+            }
+        })
+    }
+
+    /// Look up a registered sandbox image (template) by name.
+    ///
+    /// Returns the template JSON, or `None` when no image with that name
+    /// exists. Routed through the platform sandbox-templates API, which
+    /// requires the organization/project scope passed here.
+    fn find_sandbox_image_by_name(
+        &self,
+        organization_id: String,
+        project_id: String,
+        image_name: String,
+    ) -> PyResult<Option<String>> {
+        self.run_with_retry(5, move |client| {
+            let organization_id = organization_id.clone();
+            let project_id = project_id.clone();
+            let image_name = image_name.clone();
+            async move {
+                let templates =
+                    SandboxTemplatesClient::new(client, organization_id, project_id);
+                match templates.find_by_name(&image_name).await? {
+                    Some(traced) => {
+                        let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                        Ok(Some(json))
+                    }
+                    None => Ok(None),
+                }
+            }
+        })
+    }
+
+    /// List all registered sandbox images (templates) for the given scope.
+    ///
+    /// Returns a JSON array of templates. Routed through the platform
+    /// sandbox-templates API, which requires the organization/project scope.
+    fn list_sandbox_images(
+        &self,
+        organization_id: String,
+        project_id: String,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |client| {
+            let organization_id = organization_id.clone();
+            let project_id = project_id.clone();
+            async move {
+                let templates =
+                    SandboxTemplatesClient::new(client, organization_id, project_id);
+                let traced = templates.list().await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
             }
         })
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.45"
+version = "0.5.46"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/__init__.py
+++ b/src/tensorlake/__init__.py
@@ -1,1 +1,7 @@
-from tensorlake.image import Image, delete_sandbox_image, import_sandbox_image
+from tensorlake.image import (
+    Image,
+    delete_sandbox_image,
+    find_sandbox_image_by_name,
+    import_sandbox_image,
+    list_sandbox_images,
+)

--- a/src/tensorlake/image/__init__.py
+++ b/src/tensorlake/image/__init__.py
@@ -1,2 +1,7 @@
 from .image import Image
-from .sandbox_builder import delete_sandbox_image, import_sandbox_image
+from .sandbox_builder import (
+    delete_sandbox_image,
+    find_sandbox_image_by_name,
+    import_sandbox_image,
+    list_sandbox_images,
+)

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import warnings
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 from tensorlake._tracing import USER_AGENT
 from tensorlake.cli._common import Context
@@ -50,6 +51,10 @@ class SandboxImageBuildError(SandboxImageError):
 
 class SandboxImageDeleteError(SandboxImageError):
     """Deleting a registered sandbox image failed."""
+
+
+class SandboxImageLookupError(SandboxImageError):
+    """Looking up a registered sandbox image failed."""
 
 
 # --- Emit helpers -----------------------------------------------------------
@@ -144,6 +149,61 @@ def _rust_delete_sandbox_image(
     )
     try:
         client.delete_sandbox_image(image_name)
+    finally:
+        client.close()
+
+
+def _rust_find_sandbox_image_by_name(
+    api_url: str,
+    token: str,
+    image_name: str,
+    organization_id: str,
+    project_id: str,
+    namespace: str | None,
+) -> str | None:
+    try:
+        from tensorlake._cloud_sdk import CloudApiClient
+    except ImportError:
+        from _cloud_sdk import CloudApiClient
+
+    client = CloudApiClient(
+        api_url=api_url,
+        api_key=token,
+        organization_id=organization_id,
+        project_id=project_id,
+        namespace=namespace,
+        user_agent=USER_AGENT,
+    )
+    try:
+        return client.find_sandbox_image_by_name(
+            organization_id, project_id, image_name
+        )
+    finally:
+        client.close()
+
+
+def _rust_list_sandbox_images(
+    api_url: str,
+    token: str,
+    organization_id: str,
+    project_id: str,
+    namespace: str | None,
+) -> str:
+    try:
+        from tensorlake._cloud_sdk import CloudApiClient
+    except ImportError:
+        from _cloud_sdk import CloudApiClient
+
+    client = CloudApiClient(
+        api_url=api_url,
+        api_key=token,
+        organization_id=organization_id,
+        project_id=project_id,
+        namespace=namespace,
+        user_agent=USER_AGENT,
+    )
+    try:
+        return client.list_sandbox_images(organization_id, project_id)
     finally:
         client.close()
 
@@ -298,6 +358,134 @@ def delete_sandbox_image(image_name: str) -> None:
         raise
     except Exception as e:
         raise SandboxImageDeleteError(f"{type(e).__name__}: {e}") from e
+
+
+_CAMEL_TO_SNAKE_RE = re.compile(r"(?<!^)(?<![A-Z])([A-Z])")
+
+
+def _camel_to_snake(name: str) -> str:
+    """Convert a single camelCase key to snake_case."""
+    return _CAMEL_TO_SNAKE_RE.sub(r"_\1", name).lower()
+
+
+def _snake_case_keys(value: Any) -> Any:
+    """Recursively rewrite dict keys from camelCase to snake_case.
+
+    The platform sandbox-templates API (and therefore the Rust core that
+    proxies it) emits camelCase field names such as ``snapshotId`` and
+    ``rootfsDiskBytes``. The Python SDK conventionally exposes snake_case keys,
+    so normalize the template payloads before handing them back to callers.
+    """
+    if isinstance(value, dict):
+        return {
+            _camel_to_snake(key): _snake_case_keys(val) for key, val in value.items()
+        }
+    if isinstance(value, list):
+        return [_snake_case_keys(item) for item in value]
+    return value
+
+
+def find_sandbox_image_by_name(image_name: str) -> dict | None:
+    """Look up a registered sandbox image by its registered name.
+
+    Returns the registered sandbox template as a dict, or ``None`` if no image
+    with that name exists. Uses the same environment-based Tensorlake auth as
+    :func:`build_sandbox_image`, and requires organization/project context
+    (``TENSORLAKE_ORGANIZATION_ID`` and ``TENSORLAKE_PROJECT_ID``) since the
+    lookup is routed through the platform sandbox-templates API.
+
+    Raises:
+        TypeError: ``image_name`` is not a non-empty string.
+        SandboxImageLookupError: Credentials or project context are missing, or
+            the lookup request failed.
+    """
+    if not isinstance(image_name, str) or not image_name:
+        raise TypeError("image_name must be a non-empty string")
+
+    ctx = _build_context_from_env()
+    token = ctx.api_key or ctx.personal_access_token
+    if not token:
+        raise SandboxImageLookupError(
+            "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
+        )
+    if not ctx.organization_id or not ctx.project_id:
+        raise SandboxImageLookupError(
+            "Looking up a sandbox image by name requires organization and "
+            "project context (TENSORLAKE_ORGANIZATION_ID and "
+            "TENSORLAKE_PROJECT_ID)."
+        )
+
+    try:
+        result_json = _rust_find_sandbox_image_by_name(
+            ctx.api_url,
+            token,
+            image_name,
+            ctx.organization_id,
+            ctx.project_id,
+            ctx.namespace,
+        )
+    except SandboxImageError:
+        raise
+    except Exception as e:
+        raise SandboxImageLookupError(f"{type(e).__name__}: {e}") from e
+
+    if not result_json:
+        return None
+    try:
+        return _snake_case_keys(json.loads(result_json))
+    except json.JSONDecodeError as exc:
+        raise SandboxImageLookupError(
+            f"Rust image lookup returned invalid JSON: {result_json.strip()}"
+        ) from exc
+
+
+def list_sandbox_images() -> list[dict]:
+    """List all registered sandbox images for the current project.
+
+    Returns the registered sandbox templates as a list of dicts (each with
+    ``id``, ``name``, ``snapshot_id``, ``public``, etc.). Uses the same
+    environment-based Tensorlake auth as :func:`build_sandbox_image`, and
+    requires organization/project context (``TENSORLAKE_ORGANIZATION_ID`` and
+    ``TENSORLAKE_PROJECT_ID``) since the listing is routed through the platform
+    sandbox-templates API.
+
+    Raises:
+        SandboxImageLookupError: Credentials or project context are missing, or
+            the list request failed.
+    """
+    ctx = _build_context_from_env()
+    token = ctx.api_key or ctx.personal_access_token
+    if not token:
+        raise SandboxImageLookupError(
+            "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
+        )
+    if not ctx.organization_id or not ctx.project_id:
+        raise SandboxImageLookupError(
+            "Listing sandbox images requires organization and project context "
+            "(TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID)."
+        )
+
+    try:
+        result_json = _rust_list_sandbox_images(
+            ctx.api_url,
+            token,
+            ctx.organization_id,
+            ctx.project_id,
+            ctx.namespace,
+        )
+    except SandboxImageError:
+        raise
+    except Exception as e:
+        raise SandboxImageLookupError(f"{type(e).__name__}: {e}") from e
+
+    if not result_json:
+        return []
+    try:
+        return _snake_case_keys(json.loads(result_json))
+    except json.JSONDecodeError as exc:
+        raise SandboxImageLookupError(
+            f"Rust image list returned invalid JSON: {result_json.strip()}"
+        ) from exc
 
 
 def build_sandbox_image(

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -203,6 +203,129 @@ class TestDeleteSandboxImage(unittest.TestCase):
                 sbm.delete_sandbox_image("image")
 
 
+class TestFindSandboxImageByName(unittest.TestCase):
+    def test_returns_template_dict_with_env_context(self):
+        ctx = _make_ctx()
+
+        with (
+            patch.object(sbm, "_build_context_from_env", return_value=ctx),
+            patch.object(
+                sbm,
+                "_rust_find_sandbox_image_by_name",
+                # The Rust core proxies the platform API verbatim, which uses
+                # camelCase keys (e.g. snapshotId, rootfsDiskBytes).
+                return_value=(
+                    '{"id":"tpl-1","name":"tensorlake/test:1",'
+                    '"snapshotId":"snap-1","rootfsDiskBytes":1024}'
+                ),
+            ) as rust_find,
+        ):
+            result = sbm.find_sandbox_image_by_name("tensorlake/test:1")
+
+        # The public Python API normalizes keys to snake_case.
+        self.assertEqual(
+            result,
+            {
+                "id": "tpl-1",
+                "name": "tensorlake/test:1",
+                "snapshot_id": "snap-1",
+                "rootfs_disk_bytes": 1024,
+            },
+        )
+        rust_find.assert_called_once_with(
+            "https://api.tensorlake.test",
+            "tl_apiKey_abc",
+            "tensorlake/test:1",
+            "org_1",
+            "proj_1",
+            "default",
+        )
+
+    def test_returns_none_when_not_found(self):
+        ctx = _make_ctx()
+
+        with (
+            patch.object(sbm, "_build_context_from_env", return_value=ctx),
+            patch.object(sbm, "_rust_find_sandbox_image_by_name", return_value=None),
+        ):
+            self.assertIsNone(sbm.find_sandbox_image_by_name("missing"))
+
+    def test_requires_credentials(self):
+        ctx = _make_ctx(api_key=None, personal_access_token=None)
+
+        with patch.object(sbm, "_build_context_from_env", return_value=ctx):
+            with self.assertRaises(sbm.SandboxImageLookupError):
+                sbm.find_sandbox_image_by_name("image")
+
+    def test_requires_org_and_project_context(self):
+        ctx = _make_ctx(organization_id=None, project_id=None)
+
+        with patch.object(sbm, "_build_context_from_env", return_value=ctx):
+            with self.assertRaises(sbm.SandboxImageLookupError):
+                sbm.find_sandbox_image_by_name("image")
+
+    def test_empty_name_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            sbm.find_sandbox_image_by_name("")
+
+
+class TestListSandboxImages(unittest.TestCase):
+    def test_returns_template_list_with_env_context(self):
+        ctx = _make_ctx()
+
+        with (
+            patch.object(sbm, "_build_context_from_env", return_value=ctx),
+            patch.object(
+                sbm,
+                "_rust_list_sandbox_images",
+                # The Rust core proxies the platform API verbatim, which uses
+                # camelCase keys (e.g. snapshotId).
+                return_value='[{"id":"tpl-1","name":"image-a","snapshotId":"snap-a"},'
+                '{"id":"tpl-2","name":"image-b","snapshotId":"snap-b"}]',
+            ) as rust_list,
+        ):
+            result = sbm.list_sandbox_images()
+
+        # The public Python API normalizes keys to snake_case.
+        self.assertEqual(
+            result,
+            [
+                {"id": "tpl-1", "name": "image-a", "snapshot_id": "snap-a"},
+                {"id": "tpl-2", "name": "image-b", "snapshot_id": "snap-b"},
+            ],
+        )
+        rust_list.assert_called_once_with(
+            "https://api.tensorlake.test",
+            "tl_apiKey_abc",
+            "org_1",
+            "proj_1",
+            "default",
+        )
+
+    def test_returns_empty_list_when_no_images(self):
+        ctx = _make_ctx()
+
+        with (
+            patch.object(sbm, "_build_context_from_env", return_value=ctx),
+            patch.object(sbm, "_rust_list_sandbox_images", return_value="[]"),
+        ):
+            self.assertEqual(sbm.list_sandbox_images(), [])
+
+    def test_requires_credentials(self):
+        ctx = _make_ctx(api_key=None, personal_access_token=None)
+
+        with patch.object(sbm, "_build_context_from_env", return_value=ctx):
+            with self.assertRaises(sbm.SandboxImageLookupError):
+                sbm.list_sandbox_images()
+
+    def test_requires_org_and_project_context(self):
+        ctx = _make_ctx(organization_id=None, project_id=None)
+
+        with patch.object(sbm, "_build_context_from_env", return_value=ctx):
+            with self.assertRaises(sbm.SandboxImageLookupError):
+                sbm.list_sandbox_images()
+
+
 class TestImportSandboxImage(unittest.TestCase):
     def test_imports_registry_image_with_reference_and_no_dockerfile(self):
         ctx = _make_ctx()

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.45",
+  "version": "0.5.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.45",
+      "version": "0.5.46",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.45",
+  "version": "0.5.46",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/cloud-client.ts
+++ b/typescript/src/cloud-client.ts
@@ -17,6 +17,7 @@ import type {
   RequestInput,
   RequestMetadata,
   RequestOutput,
+  SandboxTemplate,
   Secret,
   SecretsList,
   StartImageBuildRequest,
@@ -86,6 +87,56 @@ export class CloudClient {
       "DELETE",
       this.namespacePath(`sandbox-images/${encodeURIComponent(imageName)}`),
     );
+  }
+
+  /**
+   * Look up a registered sandbox image (template) by its registered name.
+   *
+   * Returns the template, or `null` when no image with that name exists.
+   * Routed through the platform sandbox-templates API, which requires the
+   * organization/project scope (from the client or the `options` override).
+   */
+  async findSandboxImageByName(
+    imageName: string,
+    options?: { organizationId?: string; projectId?: string },
+  ): Promise<SandboxTemplate | null> {
+    const scope = this.resolveScope(options?.organizationId, options?.projectId);
+    const response = await this.http.requestResponse(
+      "GET",
+      `/platform/v1/organizations/${encodeURIComponent(scope.organizationId)}/projects/${encodeURIComponent(scope.projectId)}/sandbox-templates/by-name/${encodeURIComponent(imageName)}`,
+      { allowedErrorStatusCodes: new Set([404]) },
+    );
+    if (response.status === 404) {
+      return null;
+    }
+    const raw = await parseJsonResponse<Record<string, unknown>>(response);
+    return fromSnakeKeys(raw) as SandboxTemplate;
+  }
+
+  /**
+   * List all registered sandbox images (templates), following pagination to
+   * the end. Routed through the platform sandbox-templates API, which requires
+   * the organization/project scope (from the client or the `options` override).
+   */
+  async listSandboxImages(
+    options?: { organizationId?: string; projectId?: string },
+  ): Promise<SandboxTemplate[]> {
+    const scope = this.resolveScope(options?.organizationId, options?.projectId);
+    const base = `/platform/v1/organizations/${encodeURIComponent(scope.organizationId)}/projects/${encodeURIComponent(scope.projectId)}/sandbox-templates`;
+    let path: string | null = `${base}?pageSize=100`;
+    const templates: SandboxTemplate[] = [];
+    while (path !== null) {
+      const page: SandboxTemplatesPage = await this.http.requestJson<SandboxTemplatesPage>(
+        "GET",
+        path,
+      );
+      for (const item of page.items ?? []) {
+        templates.push(fromSnakeKeys(item) as SandboxTemplate);
+      }
+      const next = page.pagination?.next;
+      path = next ? nextRequestPath(next) : null;
+    }
+    return templates;
   }
 
   async applications(): Promise<ApplicationSummary[]> {
@@ -433,6 +484,28 @@ function createApplicationBuildForm(
 
 function trimTrailingSlashes(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+/** One page of the paginated sandbox-templates list response. */
+interface SandboxTemplatesPage {
+  items?: Record<string, unknown>[];
+  pagination?: { next?: string };
+}
+
+/**
+ * Reduce a `pagination.next` link to a base-URL-relative request path. The
+ * server may return either an absolute URL or an absolute path; the HTTP
+ * client always prepends its base URL, so absolute URLs must be reduced to
+ * their path+query first.
+ */
+function nextRequestPath(next: string): string {
+  const schemeIndex = next.indexOf("://");
+  if (schemeIndex !== -1) {
+    const afterScheme = next.slice(schemeIndex + 3);
+    const slashIndex = afterScheme.indexOf("/");
+    return slashIndex === -1 ? "/" : afterScheme.slice(slashIndex);
+  }
+  return next.startsWith("/") ? next : `/${next}`;
 }
 
 function toBlobPart(data: BinaryPayload): string | Blob | ArrayBuffer {

--- a/typescript/src/cloud-models.ts
+++ b/typescript/src/cloud-models.ts
@@ -156,3 +156,17 @@ export interface ApplicationBuildResponse {
   finishedAt?: Date;
   imageBuilds: ApplicationBuildImageResult[];
 }
+
+/** A registered sandbox image (template) as returned by the platform API. */
+export interface SandboxTemplate {
+  id?: string;
+  name?: string;
+  snapshotId?: string;
+  snapshotSandboxId?: string;
+  snapshotUri?: string;
+  snapshotFormatVersion?: string;
+  snapshotSizeBytes?: number;
+  rootfsDiskBytes?: number;
+  rootfsNodeKind?: string;
+  public?: boolean;
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -10,6 +10,8 @@ export {
   createSandboxImage,
   importSandboxImage,
   deleteSandboxImage,
+  findSandboxImageByName,
+  listSandboxImages,
 } from "./sandbox-image.js";
 export { Image, dockerfileContent, ImageBuildOperationType } from "./image.js";
 export { sandboxUrlFromIngressEndpoint } from "./url.js";
@@ -85,6 +87,7 @@ export type {
   ApplicationBuildContext,
   ApplicationBuildImageResult,
   ApplicationBuildResponse,
+  SandboxTemplate,
 } from "./cloud-models.js";
 
 export type {

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { existsSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { CloudClient } from "./cloud-client.js";
+import type { SandboxTemplate } from "./cloud-models.js";
 import { Image, dockerfileContent } from "./image.js";
 
 /**
@@ -466,6 +467,84 @@ export async function deleteSandboxImage(imageName: string): Promise<void> {
   });
   try {
     await client.deleteSandboxImage(imageName);
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Look up a registered sandbox image by its registered name.
+ *
+ * Returns the registered sandbox template, or `null` if no image with that
+ * name exists. Uses the same environment-based Tensorlake auth as
+ * `createSandboxImage`, and requires organization/project context
+ * (`TENSORLAKE_ORGANIZATION_ID` and `TENSORLAKE_PROJECT_ID`) since the lookup
+ * is routed through the platform sandbox-templates API.
+ */
+export async function findSandboxImageByName(
+  imageName: string,
+): Promise<SandboxTemplate | null> {
+  if (typeof imageName !== "string" || imageName.length === 0) {
+    throw new TypeError("imageName must be a non-empty string");
+  }
+
+  const context = buildContextFromEnv();
+  const bearerToken = context.apiKey ?? context.personalAccessToken;
+  if (!bearerToken) {
+    throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.");
+  }
+  if (!context.organizationId || !context.projectId) {
+    throw new Error(
+      "Looking up a sandbox image by name requires organization and project " +
+        "context (TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID).",
+    );
+  }
+
+  const client = new CloudClient({
+    apiUrl: context.apiUrl,
+    apiKey: bearerToken,
+    organizationId: context.organizationId,
+    projectId: context.projectId,
+    namespace: context.namespace,
+  });
+  try {
+    return await client.findSandboxImageByName(imageName);
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * List all registered sandbox images for the current project.
+ *
+ * Returns the registered sandbox templates (each with `id`, `name`,
+ * `snapshotId`, `public`, etc.). Uses the same environment-based Tensorlake
+ * auth as `createSandboxImage`, and requires organization/project context
+ * (`TENSORLAKE_ORGANIZATION_ID` and `TENSORLAKE_PROJECT_ID`) since the listing
+ * is routed through the platform sandbox-templates API.
+ */
+export async function listSandboxImages(): Promise<SandboxTemplate[]> {
+  const context = buildContextFromEnv();
+  const bearerToken = context.apiKey ?? context.personalAccessToken;
+  if (!bearerToken) {
+    throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.");
+  }
+  if (!context.organizationId || !context.projectId) {
+    throw new Error(
+      "Listing sandbox images requires organization and project context " +
+        "(TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID).",
+    );
+  }
+
+  const client = new CloudClient({
+    apiUrl: context.apiUrl,
+    apiKey: bearerToken,
+    organizationId: context.organizationId,
+    projectId: context.projectId,
+    namespace: context.namespace,
+  });
+  try {
+    return await client.listSandboxImages();
   } finally {
     client.close();
   }

--- a/typescript/tests/cloud-client.test.ts
+++ b/typescript/tests/cloud-client.test.ts
@@ -113,6 +113,92 @@ describe("CloudClient", () => {
     client.close();
   });
 
+  it("finds a sandbox image by name through the platform templates route", async () => {
+    mockFetch((url, init) => {
+      expect(url).toBe(
+        "http://localhost:8900/platform/v1/organizations/org-1/projects/proj-1/sandbox-templates/by-name/tensorlake%2Ftest%3A1",
+      );
+      expect(init?.method).toBe("GET");
+      return new Response(
+        JSON.stringify({ id: "tpl-1", name: "tensorlake/test:1", snapshotId: "snap-1" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const client = new CloudClient({
+      apiUrl: "http://localhost:8900",
+      organizationId: "org-1",
+      projectId: "proj-1",
+    });
+    const template = await client.findSandboxImageByName("tensorlake/test:1");
+    expect(template).toEqual({
+      id: "tpl-1",
+      name: "tensorlake/test:1",
+      snapshotId: "snap-1",
+    });
+    client.close();
+  });
+
+  it("returns null when a sandbox image is not found", async () => {
+    mockFetch(
+      () => new Response(JSON.stringify({ message: "not found" }), { status: 404 }),
+    );
+
+    const client = new CloudClient({
+      apiUrl: "http://localhost:8900",
+      organizationId: "org-1",
+      projectId: "proj-1",
+    });
+    const template = await client.findSandboxImageByName("missing");
+    expect(template).toBeNull();
+    client.close();
+  });
+
+  it("lists sandbox images following pagination through the platform route", async () => {
+    const base =
+      "http://localhost:8900/platform/v1/organizations/org-1/projects/proj-1/sandbox-templates";
+    const requested: string[] = [];
+    mockFetch((url) => {
+      requested.push(url);
+      if (url === `${base}?pageSize=100`) {
+        return new Response(
+          JSON.stringify({
+            items: [
+              { id: "tpl-1", name: "image-a", snapshotId: "snap-a" },
+              { id: "tpl-2", name: "image-b", snapshotId: "snap-b" },
+            ],
+            pagination: { next: `${base}?pageSize=100&cursor=abc` },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          items: [{ id: "tpl-3", name: "image-c", snapshotId: "snap-c" }],
+          pagination: { next: null },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const client = new CloudClient({
+      apiUrl: "http://localhost:8900",
+      organizationId: "org-1",
+      projectId: "proj-1",
+    });
+    const images = await client.listSandboxImages();
+    expect(images.map((image) => image.name)).toEqual([
+      "image-a",
+      "image-b",
+      "image-c",
+    ]);
+    expect(requested).toEqual([
+      `${base}?pageSize=100`,
+      `${base}?pageSize=100&cursor=abc`,
+    ]);
+    client.close();
+  });
+
   it("streams build logs as camel-cased events", async () => {
     mockFetch(() =>
       new Response(

--- a/typescript/tests/cloud-client.test.ts
+++ b/typescript/tests/cloud-client.test.ts
@@ -119,8 +119,14 @@ describe("CloudClient", () => {
         "http://localhost:8900/platform/v1/organizations/org-1/projects/proj-1/sandbox-templates/by-name/tensorlake%2Ftest%3A1",
       );
       expect(init?.method).toBe("GET");
+      // The platform API emits snake_case keys; the client must convert them.
       return new Response(
-        JSON.stringify({ id: "tpl-1", name: "tensorlake/test:1", snapshotId: "snap-1" }),
+        JSON.stringify({
+          id: "tpl-1",
+          name: "tensorlake/test:1",
+          snapshot_id: "snap-1",
+          rootfs_disk_bytes: 1024,
+        }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     });
@@ -135,6 +141,7 @@ describe("CloudClient", () => {
       id: "tpl-1",
       name: "tensorlake/test:1",
       snapshotId: "snap-1",
+      rootfsDiskBytes: 1024,
     });
     client.close();
   });
@@ -160,12 +167,13 @@ describe("CloudClient", () => {
     const requested: string[] = [];
     mockFetch((url) => {
       requested.push(url);
+      // The platform API emits snake_case keys; the client must convert them.
       if (url === `${base}?pageSize=100`) {
         return new Response(
           JSON.stringify({
             items: [
-              { id: "tpl-1", name: "image-a", snapshotId: "snap-a" },
-              { id: "tpl-2", name: "image-b", snapshotId: "snap-b" },
+              { id: "tpl-1", name: "image-a", snapshot_id: "snap-a", rootfs_disk_bytes: 1 },
+              { id: "tpl-2", name: "image-b", snapshot_id: "snap-b", rootfs_disk_bytes: 2 },
             ],
             pagination: { next: `${base}?pageSize=100&cursor=abc` },
           }),
@@ -174,7 +182,7 @@ describe("CloudClient", () => {
       }
       return new Response(
         JSON.stringify({
-          items: [{ id: "tpl-3", name: "image-c", snapshotId: "snap-c" }],
+          items: [{ id: "tpl-3", name: "image-c", snapshot_id: "snap-c", rootfs_disk_bytes: 3 }],
           pagination: { next: null },
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
@@ -192,6 +200,13 @@ describe("CloudClient", () => {
       "image-b",
       "image-c",
     ]);
+    // Confirm snake_case keys from each page were converted to camelCase.
+    expect(images.map((image) => image.snapshotId)).toEqual([
+      "snap-a",
+      "snap-b",
+      "snap-c",
+    ]);
+    expect(images.map((image) => image.rootfsDiskBytes)).toEqual([1, 2, 3]);
     expect(requested).toEqual([
       `${base}?pageSize=100`,
       `${base}?pageSize=100&cursor=abc`,


### PR DESCRIPTION
Expose find_sandbox_image_by_name / list_sandbox_images (Python) and findSandboxImageByName / listSandboxImages (TypeScript), routed through the platform sandbox-templates API. Bump Python and TypeScript SDKs to 0.5.46.