### PR TITLE
Add docker compat flag for sandbox image builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,74 @@ cd tests && poetry run python path/to/test_file.py
 make build_proto
 ```
 
+## Manual Cloud Sandbox Validations
+
+For validations that must run inside the real Tensorlake builder image, use a throwaway Python virtualenv with the published `tensorlake` package. Do this for live environment checks, not normal repo tests.
+
+Key points:
+- Install from PyPI in a fresh venv: `python3 -m venv /tmp/tl-validate-venv && /tmp/tl-validate-venv/bin/python -m pip install -q --upgrade pip tensorlake`.
+- Read the token from `~/.config/tensorlake/credentials.toml`, but never print it. The published SDK reads `TENSORLAKE_API_KEY`; `TENSORLAKE_PAT` is not enough for sandbox creation.
+- Read `organization` and `project` from `.tensorlake/config.toml` and pass them explicitly to `SandboxClient.for_cloud(...)`. Relying only on environment variables can produce missing scope headers.
+- Create the throwaway sandbox from `tensorlake/rootfs-builder`, run validation commands, and always delete it with `client.delete(sandbox_id)` in a `finally` block.
+- Commands run as `tl-user` by default. Builder-image checks that start `dockerd` must run as root, e.g. `sudo -n <script>`.
+
+Minimal pattern:
+
+```python
+import os
+from pathlib import Path
+from tensorlake.sandbox import SandboxClient
+
+
+def token_for(endpoint: str) -> str:
+    current = None
+    for raw in (Path.home() / ".config/tensorlake/credentials.toml").read_text().splitlines():
+        line = raw.strip()
+        if line.startswith("["):
+            current = line.strip("[]").strip().strip('"')
+        elif current == endpoint and line.startswith("token"):
+            return line.split("=", 1)[1].strip().strip('"')
+    raise RuntimeError(f"no token for {endpoint}")
+
+
+def local_config() -> dict[str, str]:
+    out = {}
+    for raw in Path(".tensorlake/config.toml").read_text().splitlines():
+        line = raw.strip()
+        if "=" in line:
+            key, value = line.split("=", 1)
+            out[key.strip()] = value.strip().strip('"')
+    return out
+
+
+endpoint = "https://api.tensorlake.ai"
+token = token_for(endpoint)
+cfg = local_config()
+os.environ["TENSORLAKE_API_KEY"] = token
+
+client = SandboxClient.for_cloud(
+    api_key=token,
+    api_url=endpoint,
+    organization_id=cfg["organization"],
+    project_id=cfg["project"],
+)
+sandbox = None
+try:
+    sandbox = client.create_and_connect(image="tensorlake/rootfs-builder")
+    sandbox.write_file("/tmp/validate.sh", b"#!/usr/bin/env bash\nset -euo pipefail\nsudo -n id\n")
+    result = sandbox.run(
+        "sh",
+        ["-lc", "chmod +x /tmp/validate.sh && sudo -n /tmp/validate.sh"],
+        timeout=900,
+    )
+    print(result.stdout)
+    if getattr(result, "exit_code", 0) != 0:
+        raise RuntimeError(result.stderr)
+finally:
+    if sandbox is not None:
+        client.delete(sandbox.sandbox_id)
+```
+
 ## Architecture
 
 ### Three Public APIs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.46"
+version = "0.5.47"
 dependencies = [
  "base64",
  "bollard",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.46"
+version = "0.5.47"
 dependencies = [
  "anyhow",
  "base64",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.46"
+version = "0.5.47"
 dependencies = [
  "napi",
  "napi-build",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.46"
+version = "0.5.47"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.46"
+version = "0.5.47"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -4,11 +4,9 @@ use crate::commands::sbx::{
     sandbox_proxy_base, wait_for_sandbox_status,
 };
 use crate::error::{CliError, Result};
-use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 
 const DEFAULT_SANDBOX_CPUS: f64 = 1.0;
 const DEFAULT_SANDBOX_MEMORY_MB: i64 = 1024;
-const MAX_CLOUD_INIT_USER_DATA_BYTES: usize = 16 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpuRequest<'a> {
@@ -78,7 +76,6 @@ pub struct CreateArgs<'a> {
     pub entrypoint: &'a [String],
     pub snapshot_id: Option<&'a str>,
     pub image_name: Option<&'a str>,
-    pub cloud_init: Option<&'a str>,
     pub wait: bool,
     pub ports: &'a [u16],
     pub allow_unauthenticated_access: bool,
@@ -99,7 +96,6 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         entrypoint,
         snapshot_id,
         image_name,
-        cloud_init,
         wait,
         ports,
         allow_unauthenticated_access,
@@ -108,7 +104,6 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         network_deny,
     } = args;
 
-    let cloud_init_base64 = cloud_init.map(encode_cloud_init_source).transpose()?;
     let gpu = match gpu_count {
         Some(count) => Some(GpuRequest {
             count,
@@ -126,7 +121,6 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         entrypoint,
         snapshot_id,
         image_name,
-        cloud_init_base64.as_deref(),
     );
     if let Some(n) = name {
         body["name"] = serde_json::Value::String(n.to_string());
@@ -247,7 +241,6 @@ fn build_create_request_body(
     entrypoint: &[String],
     snapshot_id: Option<&str>,
     image_name: Option<&str>,
-    cloud_init_base64: Option<&str>,
 ) -> serde_json::Value {
     let mut body = serde_json::json!({});
 
@@ -295,74 +288,16 @@ fn build_create_request_body(
     if !entrypoint.is_empty() {
         body["entrypoint"] = serde_json::json!(entrypoint);
     }
-    if let Some(user_data) = cloud_init_base64 {
-        body["cloud_init_base64"] = serde_json::Value::String(user_data.to_string());
-    }
-
     body
-}
-
-fn cloud_init_include_data(source: &str) -> Result<Option<Vec<u8>>> {
-    if is_windows_absolute_path(source) {
-        return Ok(None);
-    }
-
-    match url::Url::parse(source) {
-        Ok(url) if matches!(url.scheme(), "http" | "https") && url.host_str().is_some() => {
-            Ok(Some(format!("#include\n{source}\n").into_bytes()))
-        }
-        Ok(_) => Err(CliError::usage(
-            "cloud-init URL must be an absolute HTTP(S) URL with a host",
-        )),
-        Err(_) if source.contains("://") => Err(CliError::usage(
-            "cloud-init URL must be an absolute HTTP(S) URL with a host",
-        )),
-        Err(_) => Ok(None),
-    }
-}
-
-fn is_windows_absolute_path(source: &str) -> bool {
-    let bytes = source.as_bytes();
-    bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && matches!(bytes[2], b'\\' | b'/')
-}
-
-fn encode_cloud_init_source(source: &str) -> Result<String> {
-    let data = if let Some(data) = cloud_init_include_data(source)? {
-        data
-    } else {
-        std::fs::read(source).map_err(|error| {
-            CliError::Other(anyhow::anyhow!(
-                "failed to read cloud-init file {}: {}",
-                source,
-                error
-            ))
-        })?
-    };
-
-    if data.is_empty() {
-        return Err(CliError::usage("cloud-init user data must not be empty"));
-    }
-    if data.len() > MAX_CLOUD_INIT_USER_DATA_BYTES {
-        return Err(CliError::usage(format!(
-            "cloud-init user data exceeds {} byte limit",
-            MAX_CLOUD_INIT_USER_DATA_BYTES
-        )));
-    }
-    Ok(BASE64_STANDARD.encode(data))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        GpuRequest, build_create_request_body, encode_cloud_init_source, format_ready_message,
-    };
+    use super::{GpuRequest, build_create_request_body, format_ready_message};
 
     #[test]
     fn create_body_uses_defaults_without_snapshot() {
-        let body = build_create_request_body(None, None, None, None, None, &[], None, None, None);
+        let body = build_create_request_body(None, None, None, None, None, &[], None, None);
 
         assert_eq!(body["resources"]["cpus"], 1.0);
         assert_eq!(body["resources"]["memory_mb"], 1024);
@@ -372,17 +307,8 @@ mod tests {
 
     #[test]
     fn create_body_omits_resources_for_snapshot_without_overrides() {
-        let body = build_create_request_body(
-            None,
-            None,
-            None,
-            None,
-            None,
-            &[],
-            Some("snap-1"),
-            None,
-            None,
-        );
+        let body =
+            build_create_request_body(None, None, None, None, None, &[], Some("snap-1"), None);
 
         assert_eq!(body["snapshot_id"], "snap-1");
         assert!(body.get("resources").is_none());
@@ -390,17 +316,8 @@ mod tests {
 
     #[test]
     fn create_body_includes_only_explicit_snapshot_overrides() {
-        let body = build_create_request_body(
-            Some(2.5),
-            None,
-            None,
-            None,
-            None,
-            &[],
-            Some("snap-1"),
-            None,
-            None,
-        );
+        let body =
+            build_create_request_body(Some(2.5), None, None, None, None, &[], Some("snap-1"), None);
 
         assert_eq!(body["snapshot_id"], "snap-1");
         assert_eq!(body["resources"]["cpus"], 2.5);
@@ -409,17 +326,8 @@ mod tests {
 
     #[test]
     fn create_body_includes_disk_override_without_snapshot() {
-        let body = build_create_request_body(
-            None,
-            None,
-            Some(25 * 1024),
-            None,
-            None,
-            &[],
-            None,
-            None,
-            None,
-        );
+        let body =
+            build_create_request_body(None, None, Some(25 * 1024), None, None, &[], None, None);
 
         assert_eq!(body["resources"]["cpus"], 1.0);
         assert_eq!(body["resources"]["memory_mb"], 1024);
@@ -436,7 +344,6 @@ mod tests {
             None,
             &[],
             Some("snap-1"),
-            None,
             None,
         );
 
@@ -457,7 +364,6 @@ mod tests {
             &[],
             None,
             Some("tensorlake/ubuntu-minimal"),
-            None,
         );
 
         assert_eq!(body["image"], "tensorlake/ubuntu-minimal");
@@ -479,7 +385,6 @@ mod tests {
             &[],
             None,
             Some("tensorlake/ubuntu-minimal"),
-            None,
         );
 
         assert_eq!(body["resources"]["gpus"][0]["count"], 1);
@@ -500,64 +405,12 @@ mod tests {
             &[],
             Some("snap-1"),
             None,
-            None,
         );
 
         assert_eq!(body["snapshot_id"], "snap-1");
         assert_eq!(body["resources"]["gpus"][0]["count"], 1);
         assert_eq!(body["resources"]["gpus"][0]["model"], "A10");
         assert!(body["resources"].get("cpus").is_none());
-    }
-
-    #[test]
-    fn create_body_includes_cloud_init_user_data_base64() {
-        let body = build_create_request_body(
-            None,
-            None,
-            None,
-            None,
-            None,
-            &[],
-            None,
-            Some("tensorlake/cloud-init"),
-            Some("I2Nsb3VkLWNvbmZpZwo="),
-        );
-
-        assert_eq!(body["cloud_init_base64"], "I2Nsb3VkLWNvbmZpZwo=");
-    }
-
-    #[test]
-    fn create_body_allows_snapshot_with_cloud_init_user_data_base64() {
-        let body = build_create_request_body(
-            None,
-            None,
-            None,
-            None,
-            None,
-            &[],
-            Some("snap-fs"),
-            None,
-            Some("I2Nsb3VkLWNvbmZpZwo="),
-        );
-
-        assert_eq!(body["snapshot_id"], "snap-fs");
-        assert_eq!(body["cloud_init_base64"], "I2Nsb3VkLWNvbmZpZwo=");
-    }
-
-    #[test]
-    fn cloud_init_rejects_invalid_url() {
-        let err = encode_cloud_init_source("ftp://example.com/cloud-init.yaml")
-            .expect_err("unsupported URL scheme should fail");
-
-        assert!(err.to_string().contains("HTTP(S) URL"));
-    }
-
-    #[test]
-    fn cloud_init_treats_windows_absolute_paths_as_files() {
-        let err = encode_cloud_init_source(r"C:\cloud-init.yaml")
-            .expect_err("missing Windows path should be treated as a file path");
-
-        assert!(err.to_string().contains("failed to read cloud-init file"));
     }
 
     #[test]

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -19,6 +19,7 @@ pub async fn run(
     cpus: Option<f64>,
     memory_mb: Option<i64>,
     is_public: bool,
+    docker_compat: bool,
     output_json: bool,
 ) -> Result<()> {
     let options = SandboxImageBuildOptions {
@@ -39,6 +40,7 @@ pub async fn run(
                 "Tensorlake CLI (rust/{})",
                 env!("CARGO_PKG_VERSION")
             )),
+            docker_compat,
         },
         dockerfile_path: PathBuf::from(dockerfile_path),
         dockerfile_text: None,

--- a/crates/cli/src/commands/sbx/image/import.rs
+++ b/crates/cli/src/commands/sbx/image/import.rs
@@ -20,6 +20,7 @@ pub async fn run(
     cpus: Option<f64>,
     memory_mb: Option<i64>,
     is_public: bool,
+    docker_compat: bool,
     output_json: bool,
 ) -> Result<()> {
     let options = SandboxImageImportOptions {
@@ -40,6 +41,7 @@ pub async fn run(
                 "Tensorlake CLI (rust/{})",
                 env!("CARGO_PKG_VERSION")
             )),
+            docker_compat,
         },
         image_reference: image_reference.to_string(),
     };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -452,10 +452,6 @@ enum SbxCommands {
         #[arg(short, long, conflicts_with = "snapshot")]
         image: Option<String>,
 
-        /// Local cloud-init file path or HTTP(S) URL for the sandbox
-        #[arg(long = "cloud-init", value_name = "PATH_OR_URL")]
-        cloud_init: Option<String>,
-
         /// Return immediately after creation instead of waiting for the sandbox to be running
         #[arg(short, long)]
         no_wait: bool,
@@ -798,7 +794,7 @@ enum ImageCommands {
         #[arg(short, long)]
         public: bool,
 
-        /// Use Docker/BuildKit export compatibility mode for rootfs materialization
+        /// Use Docker/BuildKit max compatibility mode
         #[arg(long = "docker_compat")]
         docker_compat: bool,
 
@@ -839,7 +835,7 @@ enum ImageCommands {
         #[arg(short, long)]
         public: bool,
 
-        /// Use Docker/BuildKit export compatibility mode for rootfs materialization
+        /// Use Docker/BuildKit max compatibility mode
         #[arg(long = "docker_compat")]
         docker_compat: bool,
 
@@ -1169,7 +1165,6 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         entrypoint,
                         snapshot,
                         image,
-                        cloud_init,
                         no_wait,
                         ports,
                         allow_unauthenticated_access,
@@ -1201,7 +1196,6 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 entrypoint: &entrypoint,
                                 snapshot_id: snapshot.as_deref(),
                                 image_name: image.as_deref(),
-                                cloud_init: cloud_init.as_deref(),
                                 wait: !no_wait,
                                 ports: &ports,
                                 allow_unauthenticated_access,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -798,6 +798,10 @@ enum ImageCommands {
         #[arg(short, long)]
         public: bool,
 
+        /// Use Docker/BuildKit export compatibility mode for rootfs materialization
+        #[arg(long = "docker_compat")]
+        docker_compat: bool,
+
         /// Print the registered sandbox image JSON response to stdout
         #[arg(long = "json", hide = true)]
         json: bool,
@@ -834,6 +838,10 @@ enum ImageCommands {
         /// Make this sandbox image publicly accessible
         #[arg(short, long)]
         public: bool,
+
+        /// Use Docker/BuildKit export compatibility mode for rootfs materialization
+        #[arg(long = "docker_compat")]
+        docker_compat: bool,
 
         /// Print the registered sandbox image JSON response to stdout
         #[arg(long = "json", hide = true)]
@@ -1414,6 +1422,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             cpus,
                             memory,
                             public,
+                            docker_compat,
                             json,
                         } => {
                             let disk_mb = if let Some(value) = disk_mb {
@@ -1436,6 +1445,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 cpus,
                                 memory,
                                 public,
+                                docker_compat,
                                 json,
                             )
                             .await
@@ -1448,6 +1458,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             cpus,
                             memory,
                             public,
+                            docker_compat,
                             json,
                         } => {
                             commands::sbx::image::import::run(
@@ -1459,6 +1470,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 cpus,
                                 memory,
                                 public,
+                                docker_compat,
                                 json,
                             )
                             .await
@@ -2013,6 +2025,40 @@ mod tests {
                 assert_eq!(builder_disk_mb, Some(65536));
             }
             _ => panic!("expected sbx image create command"),
+        }
+    }
+
+    #[test]
+    fn image_create_parses_docker_compat() {
+        match parse_command([
+            "tl",
+            "sbx",
+            "image",
+            "create",
+            "./Dockerfile",
+            "--docker_compat",
+        ]) {
+            Commands::Sbx(SbxCommands::Image(ImageCommands::Create { docker_compat, .. })) => {
+                assert!(docker_compat)
+            }
+            _ => panic!("expected sbx image create command"),
+        }
+    }
+
+    #[test]
+    fn image_import_parses_docker_compat() {
+        match parse_command([
+            "tl",
+            "sbx",
+            "image",
+            "import",
+            "ubuntu:24.04",
+            "--docker_compat",
+        ]) {
+            Commands::Sbx(SbxCommands::Image(ImageCommands::Import { docker_compat, .. })) => {
+                assert!(docker_compat)
+            }
+            _ => panic!("expected sbx image import command"),
         }
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -794,7 +794,7 @@ enum ImageCommands {
         #[arg(short, long)]
         public: bool,
 
-        /// Use Docker/BuildKit max compatibility mode
+        /// Use Docker/BuildKit max compatibility mode (build is slower and uses more memory and disk space on builder sandbox)
         #[arg(long = "docker_compat")]
         docker_compat: bool,
 
@@ -835,7 +835,7 @@ enum ImageCommands {
         #[arg(short, long)]
         public: bool,
 
-        /// Use Docker/BuildKit max compatibility mode
+        /// Use Docker/BuildKit max compatibility mode (import is slower and uses more memory and disk space on builder sandbox)
         #[arg(long = "docker_compat")]
         docker_compat: bool,
 

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -156,6 +156,7 @@ pub struct CommonBuildOptions {
     pub memory_mb: Option<i64>,
     pub is_public: bool,
     pub user_agent: Option<String>,
+    pub docker_compat: bool,
 }
 
 /// Options for building a sandbox image from a Dockerfile. This is the
@@ -406,6 +407,13 @@ where
             unresolvable.line_number, unresolvable.reference, detail, unresolvable.reference,
         )));
     }
+    if options.docker_compat {
+        emit(SandboxImageBuildEvent::Warning(
+            "Docker compatibility mode is enabled. This uses Docker/BuildKit export for rootfs \
+             materialization, which can be slower and may require a larger builder sandbox disk."
+                .to_string(),
+        ));
+    }
 
     let ctx = resolve_build_context(options.clone()).await?;
 
@@ -557,6 +565,7 @@ where
                 &prepared,
                 &prepared_spec,
                 options.disk_mb,
+                options.docker_compat,
                 &mut emit,
             )
             .await?;
@@ -1053,6 +1062,7 @@ async fn upload_build_inputs(
     prepared: &PreparedSandboxTemplateBuild,
     prepared_spec: &Value,
     disk_mb: Option<u64>,
+    docker_compat: bool,
     emit: &mut impl FnMut(SandboxImageBuildEvent),
 ) -> Result<()> {
     // Pre-create REMOTE_BUILD_DIR with permissive mode as root so the
@@ -1074,7 +1084,14 @@ async fn upload_build_inputs(
     }
 
     let docker_config_json = resolved_docker_config_json().await?;
-    let spec = build_rootfs_spec(prepared_spec, prepared, plan, disk_mb, docker_config_json)?;
+    let spec = build_rootfs_spec(
+        prepared_spec,
+        prepared,
+        plan,
+        disk_mb,
+        docker_config_json,
+        docker_compat,
+    )?;
     ensure_remote_parent_dir(proxy, REMOTE_SPEC_PATH).await?;
     proxy
         .write_file(REMOTE_SPEC_PATH, serde_json::to_vec_pretty(&spec)?)
@@ -1088,6 +1105,7 @@ fn build_rootfs_spec(
     plan: &DockerfileBuildPlan,
     disk_mb: Option<u64>,
     docker_config_json: Option<String>,
+    docker_compat: bool,
 ) -> Result<Value> {
     let mut spec = prepared_spec.clone();
     let object = spec.as_object_mut().ok_or_else(|| {
@@ -1123,6 +1141,9 @@ fn build_rootfs_spec(
             "dockerConfigJson".to_string(),
             Value::String(docker_config_json),
         );
+    }
+    if docker_compat {
+        object.insert("dockerCompat".to_string(), Value::Bool(true));
     }
 
     Ok(spec)
@@ -2705,10 +2726,12 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
         let plan = super::plan_image_import("ubuntu:24.04", None).unwrap();
 
         let spec =
-            super::build_rootfs_spec(&prepared_spec, &prepared, &plan, Some(10240), None).unwrap();
+            super::build_rootfs_spec(&prepared_spec, &prepared, &plan, Some(10240), None, false)
+                .unwrap();
         assert_eq!(spec["importImageReference"], "ubuntu:24.04");
         assert_eq!(spec["baseImage"], "ubuntu:24.04");
         assert_eq!(spec["dockerfile"], "FROM ubuntu:24.04\n");
+        assert!(spec.get("dockerCompat").is_none());
     }
 
     #[test]
@@ -3142,6 +3165,7 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
             &plan,
             Some(2048),
             Some("{}".to_string()),
+            true,
         )
         .unwrap();
         assert_eq!(spec["dockerfile"], "FROM alpine\nRUN echo hi\n");
@@ -3151,6 +3175,7 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
         );
         assert_eq!(spec["rootfsDiskBytes"], 2048_u64 * 1024 * 1024);
         assert_eq!(spec["dockerConfigJson"], "{}");
+        assert_eq!(spec["dockerCompat"], true);
     }
 
     #[test]
@@ -3169,8 +3194,9 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
             import_image_reference: None,
         };
 
-        let spec = build_rootfs_spec(&prepared_spec, &prepared, &plan, None, None).unwrap();
+        let spec = build_rootfs_spec(&prepared_spec, &prepared, &plan, None, None, false).unwrap();
         assert_eq!(spec["rootfsDiskBytes"], 20_u64 * 1024 * 1024 * 1024);
+        assert!(spec.get("dockerCompat").is_none());
     }
 
     #[test]

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -460,7 +460,6 @@ where
             network: None,
             snapshot_id: None,
             name: None,
-            cloud_init_base64: None,
         })
         .await?;
     let sandbox_id = created.sandbox_id.clone();

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -55,8 +55,6 @@ pub struct CreateSandboxRequest {
     /// When absent the sandbox is ephemeral.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cloud_init_base64: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/cloud-sdk/tests/sandbox_templates.rs
+++ b/crates/cloud-sdk/tests/sandbox_templates.rs
@@ -162,6 +162,7 @@ async fn test_create_then_delete_sandbox_image() {
                     memory_mb: Some(1024),
                     is_public: false,
                     user_agent: None,
+                    docker_compat: false,
                 },
                 dockerfile_path,
                 dockerfile_text: None,

--- a/crates/rust-cloud-sdk-node/src/lib.rs
+++ b/crates/rust-cloud-sdk-node/src/lib.rs
@@ -42,6 +42,7 @@ pub struct SandboxImageBuildOptionsJs {
     pub namespace: Option<String>,
     pub use_scope_headers: Option<bool>,
     pub user_agent: Option<String>,
+    pub docker_compat: Option<bool>,
     pub dockerfile_text: Option<String>,
     pub context_dir: Option<String>,
 }
@@ -67,6 +68,7 @@ pub struct SandboxImageImportOptionsJs {
     pub namespace: Option<String>,
     pub use_scope_headers: Option<bool>,
     pub user_agent: Option<String>,
+    pub docker_compat: Option<bool>,
 }
 
 #[napi(object)]
@@ -125,6 +127,7 @@ pub async fn build_sandbox_image(
             memory_mb: options.memory_mb,
             is_public: options.is_public.unwrap_or(false),
             user_agent: options.user_agent,
+            docker_compat: options.docker_compat.unwrap_or(false),
         },
         dockerfile_path: PathBuf::from(options.dockerfile_path),
         dockerfile_text: options.dockerfile_text,
@@ -169,6 +172,7 @@ pub async fn import_sandbox_image(
             memory_mb: options.memory_mb,
             is_public: options.is_public.unwrap_or(false),
             user_agent: options.user_agent,
+            docker_compat: options.docker_compat.unwrap_or(false),
         },
         image_reference: options.image_reference,
     };

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.46"
+version = "0.5.47"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -24,11 +24,11 @@ use tensorlake::document_ai::DocumentAiClient;
 use tensorlake::images::ImagesClient;
 use tensorlake::images::models::{ApplicationBuildContext, CreateApplicationBuildRequest};
 use tensorlake::sandbox_images::SandboxImageBuildEvent;
+use tensorlake::sandbox_templates::SandboxTemplatesClient;
 use tensorlake::sandboxes::models::{
     ArchivedSandboxesPaginationDirection, CreateSandboxRequest, ListArchivedSandboxesParams,
     SandboxPoolRequest, SnapshotType, UpdateSandboxRequest,
 };
-use tensorlake::sandbox_templates::SandboxTemplatesClient;
 use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
 };
@@ -170,8 +170,7 @@ impl CloudApiClient {
             let project_id = project_id.clone();
             let image_name = image_name.clone();
             async move {
-                let templates =
-                    SandboxTemplatesClient::new(client, organization_id, project_id);
+                let templates = SandboxTemplatesClient::new(client, organization_id, project_id);
                 match templates.find_by_name(&image_name).await? {
                     Some(traced) => {
                         let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
@@ -187,17 +186,12 @@ impl CloudApiClient {
     ///
     /// Returns a JSON array of templates. Routed through the platform
     /// sandbox-templates API, which requires the organization/project scope.
-    fn list_sandbox_images(
-        &self,
-        organization_id: String,
-        project_id: String,
-    ) -> PyResult<String> {
+    fn list_sandbox_images(&self, organization_id: String, project_id: String) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let organization_id = organization_id.clone();
             let project_id = project_id.clone();
             async move {
-                let templates =
-                    SandboxTemplatesClient::new(client, organization_id, project_id);
+                let templates = SandboxTemplatesClient::new(client, organization_id, project_id);
                 let traced = templates.list().await?;
                 serde_json::to_string(&*traced).map_err(SdkError::from)
             }
@@ -2862,6 +2856,7 @@ fn create_image_context_file(
     namespace=None,
     use_scope_headers=false,
     user_agent=None,
+    docker_compat=false,
     dockerfile_text=None,
     context_dir=None,
     emit=None,
@@ -2882,6 +2877,7 @@ fn build_sandbox_image(
     namespace: Option<String>,
     use_scope_headers: bool,
     user_agent: Option<String>,
+    docker_compat: bool,
     dockerfile_text: Option<String>,
     context_dir: Option<String>,
     emit: Option<Py<PyAny>>,
@@ -2901,6 +2897,7 @@ fn build_sandbox_image(
             memory_mb,
             is_public,
             user_agent,
+            docker_compat,
         ),
         dockerfile_path: PathBuf::from(dockerfile_path),
         dockerfile_text,
@@ -2951,6 +2948,7 @@ fn build_sandbox_image(
     namespace=None,
     use_scope_headers=false,
     user_agent=None,
+    docker_compat=false,
     emit=None,
 ))]
 fn import_sandbox_image(
@@ -2969,6 +2967,7 @@ fn import_sandbox_image(
     namespace: Option<String>,
     use_scope_headers: bool,
     user_agent: Option<String>,
+    docker_compat: bool,
     emit: Option<Py<PyAny>>,
 ) -> PyResult<String> {
     let options = tensorlake::sandbox_images::SandboxImageImportOptions {
@@ -2986,6 +2985,7 @@ fn import_sandbox_image(
             memory_mb,
             is_public,
             user_agent,
+            docker_compat,
         ),
         image_reference,
     };
@@ -3035,6 +3035,7 @@ fn common_build_options(
     memory_mb: Option<i64>,
     is_public: bool,
     user_agent: Option<String>,
+    docker_compat: bool,
 ) -> tensorlake::sandbox_images::CommonBuildOptions {
     tensorlake::sandbox_images::CommonBuildOptions {
         api_url,
@@ -3050,6 +3051,7 @@ fn common_build_options(
         memory_mb,
         is_public,
         user_agent,
+        docker_compat,
     }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.46"
+version = "0.5.47"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -104,6 +104,7 @@ class Image:
         disk_mb: int | None = None,
         builder_disk_mb: int | None = None,
         is_public: bool = False,
+        docker_compat: bool = False,
         context_dir: str | None = None,
         verbose: bool = False,
     ) -> dict:
@@ -119,6 +120,8 @@ class Image:
             disk_mb: Root disk size for the generated sandbox image in MB.
             builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
             is_public: Make the registered image publicly accessible.
+            docker_compat: Use Docker/BuildKit export compatibility mode for
+                rootfs materialization.
             context_dir: Directory used to resolve relative COPY/ADD paths.
                 Defaults to the current working directory.
             verbose: If True, print build progress to stderr.
@@ -136,6 +139,7 @@ class Image:
             disk_mb=disk_mb,
             builder_disk_mb=builder_disk_mb,
             is_public=is_public,
+            docker_compat=docker_compat,
             context_dir=context_dir,
             verbose=verbose,
         )

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -120,7 +120,9 @@ class Image:
             disk_mb: Root disk size for the generated sandbox image in MB.
             builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
             is_public: Make the registered image publicly accessible.
-            docker_compat: Use Docker/BuildKit max compatibility mode.
+            docker_compat: Use Docker/BuildKit max compatibility mode (build
+                is slower and uses more memory and disk space on builder
+                sandbox).
             context_dir: Directory used to resolve relative COPY/ADD paths.
                 Defaults to the current working directory.
             verbose: If True, print build progress to stderr.

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -120,8 +120,7 @@ class Image:
             disk_mb: Root disk size for the generated sandbox image in MB.
             builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
             is_public: Make the registered image publicly accessible.
-            docker_compat: Use Docker/BuildKit export compatibility mode for
-                rootfs materialization.
+            docker_compat: Use Docker/BuildKit max compatibility mode.
             context_dir: Directory used to resolve relative COPY/ADD paths.
                 Defaults to the current working directory.
             verbose: If True, print build progress to stderr.

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -522,8 +522,8 @@ def build_sandbox_image(
         disk_mb: Root disk size for the generated sandbox image in MB.
         builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
         is_public: Make the registered image publicly accessible.
-        docker_compat: Use Docker/BuildKit max compatibility mode. Slower and
-            may require a larger builder sandbox disk.
+        docker_compat: Use Docker/BuildKit max compatibility mode (build is
+            slower and uses more memory and disk space on builder sandbox).
         context_dir: Directory used to resolve relative COPY/ADD sources.
             Ignored when ``source`` is a Dockerfile path (the Dockerfile's
             parent directory is used instead).
@@ -633,8 +633,8 @@ def import_sandbox_image(
         disk_mb: Root disk size for the generated sandbox image in MB.
         builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
         is_public: Make the registered image publicly accessible.
-        docker_compat: Use Docker/BuildKit max compatibility mode. Slower and
-            may require a larger builder sandbox disk.
+        docker_compat: Use Docker/BuildKit max compatibility mode (import is
+            slower and uses more memory and disk space on builder sandbox).
         verbose: Print progress to stderr. Ignored if ``emit`` is provided.
         emit: Callback invoked for each build event. Takes precedence over
             ``verbose``.

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -522,9 +522,8 @@ def build_sandbox_image(
         disk_mb: Root disk size for the generated sandbox image in MB.
         builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
         is_public: Make the registered image publicly accessible.
-        docker_compat: Use Docker/BuildKit export compatibility mode for
-            rootfs materialization. Slower and may require a larger builder
-            sandbox disk.
+        docker_compat: Use Docker/BuildKit max compatibility mode. Slower and
+            may require a larger builder sandbox disk.
         context_dir: Directory used to resolve relative COPY/ADD sources.
             Ignored when ``source`` is a Dockerfile path (the Dockerfile's
             parent directory is used instead).
@@ -634,9 +633,8 @@ def import_sandbox_image(
         disk_mb: Root disk size for the generated sandbox image in MB.
         builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
         is_public: Make the registered image publicly accessible.
-        docker_compat: Use Docker/BuildKit export compatibility mode for
-            rootfs materialization. Slower and may require a larger builder
-            sandbox disk.
+        docker_compat: Use Docker/BuildKit max compatibility mode. Slower and
+            may require a larger builder sandbox disk.
         verbose: Print progress to stderr. Ignored if ``emit`` is provided.
         emit: Callback invoked for each build event. Takes precedence over
             ``verbose``.

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -219,6 +219,7 @@ def _run_rust_image_create(
     disk_mb: int | None,
     builder_disk_mb: int | None,
     is_public: bool,
+    docker_compat: bool,
     emit: EmitFn,
 ) -> dict:
     ctx, token = _resolve_build_credentials()
@@ -240,6 +241,7 @@ def _run_rust_image_create(
         ctx.namespace,
         ctx.personal_access_token is not None and ctx.api_key is None,
         USER_AGENT,
+        docker_compat,
         dockerfile_text,
         context_dir,
         _forwarder(emit),
@@ -256,6 +258,7 @@ def _run_rust_image_import(
     disk_mb: int | None,
     builder_disk_mb: int | None,
     is_public: bool,
+    docker_compat: bool,
     emit: EmitFn,
 ) -> dict:
     ctx, token = _resolve_build_credentials()
@@ -284,6 +287,7 @@ def _run_rust_image_import(
         ctx.namespace,
         ctx.personal_access_token is not None and ctx.api_key is None,
         USER_AGENT,
+        docker_compat,
         _forwarder(emit),
     )
     return _finish_image_registration(result_json, registered_name, emit)
@@ -497,6 +501,7 @@ def build_sandbox_image(
     disk_mb: int | None = None,
     builder_disk_mb: int | None = None,
     is_public: bool = False,
+    docker_compat: bool = False,
     context_dir: str | None = None,
     verbose: bool = False,
     emit: EmitFn | None = None,
@@ -517,6 +522,9 @@ def build_sandbox_image(
         disk_mb: Root disk size for the generated sandbox image in MB.
         builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
         is_public: Make the registered image publicly accessible.
+        docker_compat: Use Docker/BuildKit export compatibility mode for
+            rootfs materialization. Slower and may require a larger builder
+            sandbox disk.
         context_dir: Directory used to resolve relative COPY/ADD sources.
             Ignored when ``source`` is a Dockerfile path (the Dockerfile's
             parent directory is used instead).
@@ -582,6 +590,7 @@ def build_sandbox_image(
             disk_mb=disk_mb,
             builder_disk_mb=builder_disk_mb,
             is_public=is_public,
+            docker_compat=docker_compat,
             emit=emit,
         )
     except SandboxImageError:
@@ -599,6 +608,7 @@ def import_sandbox_image(
     disk_mb: int | None = None,
     builder_disk_mb: int | None = None,
     is_public: bool = False,
+    docker_compat: bool = False,
     verbose: bool = False,
     emit: EmitFn | None = None,
 ) -> dict:
@@ -624,6 +634,9 @@ def import_sandbox_image(
         disk_mb: Root disk size for the generated sandbox image in MB.
         builder_disk_mb: Root disk size for the temporary builder sandbox in MB.
         is_public: Make the registered image publicly accessible.
+        docker_compat: Use Docker/BuildKit export compatibility mode for
+            rootfs materialization. Slower and may require a larger builder
+            sandbox disk.
         verbose: Print progress to stderr. Ignored if ``emit`` is provided.
         emit: Callback invoked for each build event. Takes precedence over
             ``verbose``.
@@ -662,6 +675,7 @@ def import_sandbox_image(
             disk_mb=disk_mb,
             builder_disk_mb=builder_disk_mb,
             is_public=is_public,
+            docker_compat=docker_compat,
             emit=emit,
         )
     except SandboxImageError:
@@ -722,6 +736,7 @@ def build_sandbox_application_image(
             disk_mb=disk_mb,
             builder_disk_mb=builder_disk_mb,
             is_public=is_public,
+            docker_compat=False,
             emit=emit,
         )
     except SandboxImageError:

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -27,7 +27,6 @@ from .client import (
     _normalize_user_ports,
     _parse_rust_client_error_fields,
     _raise_as_sandbox_error,
-    _read_cloud_init_config,
     _resolve_sandbox_identifier,
     _rust_status_code,
     _startup_failure_message,
@@ -217,7 +216,6 @@ class AsyncSandboxClient:
         deny_out: list[str] | None = None,
         snapshot_id: str | None = None,
         name: str | None = None,
-        cloud_init: str | os.PathLike[str] | None = None,
     ) -> Traced[CreateSandboxResponse]:
         network = None
         if not allow_internet_access or allow_out is not None or deny_out is not None:
@@ -226,7 +224,6 @@ class AsyncSandboxClient:
                 allow_out=allow_out or [],
                 deny_out=deny_out or [],
             )
-        cloud_init_base64 = _read_cloud_init_config(cloud_init=cloud_init)
         request_model = CreateSandboxRequest(
             image=image,
             resources=CreateSandboxResources(
@@ -240,7 +237,6 @@ class AsyncSandboxClient:
             network=network,
             snapshot_id=snapshot_id,
             name=name,
-            cloud_init_base64=cloud_init_base64,
         )
         try:
             trace_id, response_json = await self._rust_client.create_sandbox_async(
@@ -746,7 +742,6 @@ class AsyncSandboxClient:
         request_timeout: float | None = None,
         startup_timeout: float | None = None,
         name: str | None = None,
-        cloud_init: str | os.PathLike[str] | None = None,
     ) -> "AsyncSandbox":
         wait_timeout = (
             request_timeout
@@ -760,8 +755,6 @@ class AsyncSandboxClient:
         request_client = self._with_request_timeout(wait_timeout)
 
         requested_name = None if pool_id is not None else name
-        if pool_id is not None and cloud_init is not None:
-            raise SandboxError("cloud-init cannot be used with `pool_id`.")
         if pool_id is not None:
             result = await request_client.claim(pool_id)
         else:
@@ -779,7 +772,6 @@ class AsyncSandboxClient:
                 deny_out=deny_out,
                 snapshot_id=snapshot_id,
                 name=name,
-                cloud_init=cloud_init,
             )
 
         if result.status == SandboxStatus.RUNNING:

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -159,7 +159,6 @@ class AsyncSandbox:
         request_timeout: float | None = None,
         startup_timeout: float | None = None,
         name: str | None = None,
-        cloud_init: str | os.PathLike[str] | None = None,
         api_key: str | None = _defaults.API_KEY,
         api_url: str = _defaults.API_URL,
         organization_id: str | None = None,
@@ -203,7 +202,6 @@ class AsyncSandbox:
             proxy_url=proxy_url,
             request_timeout=effective_request_timeout,
             name=name,
-            cloud_init=cloud_init,
         )
 
     @classmethod

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import os
-import re
 import time
 import warnings
 from typing import NoReturn
@@ -152,48 +150,6 @@ def _unsupported_request_timeout_kwarg(e: TypeError) -> bool:
 
 
 _RESERVED_SANDBOX_MANAGEMENT_PORT = 9501
-_MAX_CLOUD_INIT_USER_DATA_BYTES = 16 * 1024
-_URL_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
-
-
-def _cloud_init_include_data(source_str: str) -> bytes | None:
-    parsed = urlparse(source_str)
-    if parsed.scheme in {"http", "https"} and parsed.netloc:
-        return f"#include\n{source_str}\n".encode("utf-8")
-    if len(parsed.scheme) == 1 and source_str[1:3] in {":\\", ":/"}:
-        return None
-    if parsed.scheme:
-        raise SandboxError("cloud-init URL must be an absolute HTTP(S) URL with a host")
-    if _URL_SCHEME_RE.match(source_str):
-        raise SandboxError("cloud-init URL must be an absolute HTTP(S) URL with a host")
-    return None
-
-
-def _read_cloud_init_config(
-    cloud_init: str | os.PathLike[str] | None = None,
-) -> str | None:
-    if cloud_init is None:
-        return None
-
-    source_str = os.fspath(cloud_init)
-    data = _cloud_init_include_data(source_str)
-    if data is None:
-        try:
-            with open(source_str, "rb") as file:
-                data = file.read()
-        except OSError as e:
-            raise SandboxError(
-                f"failed to read cloud-init file {source_str!r}: {e}"
-            ) from None
-
-    if not data:
-        raise SandboxError("cloud-init user data must not be empty")
-    if len(data) > _MAX_CLOUD_INIT_USER_DATA_BYTES:
-        raise SandboxError(
-            "cloud-init user data exceeds "
-            f"{_MAX_CLOUD_INIT_USER_DATA_BYTES} byte limit"
-        )
-    return base64.b64encode(data).decode("ascii")
 
 
 def _normalize_user_ports(ports: list[int]) -> list[int]:
@@ -437,7 +393,6 @@ class SandboxClient:
         deny_out: list[str] | None = None,
         snapshot_id: str | None = None,
         name: str | None = None,
-        cloud_init: str | os.PathLike[str] | None = None,
     ) -> Traced[CreateSandboxResponse]:
         """Create a new standalone sandbox.
 
@@ -468,8 +423,6 @@ class SandboxClient:
                 overridden.
             name: Optional name for the sandbox. Named sandboxes support
                 suspend/resume. When absent the sandbox is ephemeral.
-            cloud_init: Local cloud-init file path or HTTP(S) URL for the sandbox.
-                Supported for fresh sandboxes and filesystem-only snapshot restores.
 
         Returns:
             Traced[CreateSandboxResponse] with sandbox_id, status, and trace_id
@@ -485,7 +438,6 @@ class SandboxClient:
                 allow_out=allow_out or [],
                 deny_out=deny_out or [],
             )
-        cloud_init_base64 = _read_cloud_init_config(cloud_init=cloud_init)
 
         request_model = CreateSandboxRequest(
             image=image,
@@ -500,7 +452,6 @@ class SandboxClient:
             network=network,
             snapshot_id=snapshot_id,
             name=name,
-            cloud_init_base64=cloud_init_base64,
         )
 
         try:
@@ -1304,7 +1255,6 @@ class SandboxClient:
         request_timeout: float | None = None,
         startup_timeout: float | None = None,
         name: str | None = None,
-        cloud_init: str | os.PathLike[str] | None = None,
     ) -> "Sandbox":
         """Create a sandbox, wait for it to start, and return a connected Sandbox.
 
@@ -1341,8 +1291,6 @@ class SandboxClient:
             startup_timeout: Deprecated alias for ``request_timeout``.
             name: Optional name for the sandbox. Named sandboxes support
                 suspend/resume. When absent the sandbox is ephemeral.
-            cloud_init: Local cloud-init file path or HTTP(S) URL for the sandbox.
-                Not supported with pools.
 
         Returns:
             Connected Sandbox instance (auto-terminates in context manager)
@@ -1365,8 +1313,6 @@ class SandboxClient:
         # claim() never sends `name` to the server, so only the create() path
         # may fall back to the requested name when caching info locally.
         requested_name = None if pool_id is not None else name
-        if pool_id is not None and cloud_init is not None:
-            raise SandboxError("cloud-init cannot be used with `pool_id`.")
         if pool_id is not None:
             result = request_client.claim(pool_id)
         else:
@@ -1384,7 +1330,6 @@ class SandboxClient:
                 deny_out=deny_out,
                 snapshot_id=snapshot_id,
                 name=name,
-                cloud_init=cloud_init,
             )
 
         # Fast path: the blocking create/claim response already carries Running status

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -214,7 +214,6 @@ class CreateSandboxRequest(BaseModel):
     network: NetworkConfig | None = None
     snapshot_id: str | None = None
     name: str | None = None
-    cloud_init_base64: str | None = None
 
 
 class UpdateSandboxRequest(BaseModel):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -223,7 +223,6 @@ class Sandbox:
         request_timeout: float | None = None,
         startup_timeout: float | None = None,
         name: str | None = None,
-        cloud_init: str | os.PathLike[str] | None = None,
         api_key: str | None = _defaults.API_KEY,
         api_url: str = _defaults.API_URL,
         organization_id: str | None = None,
@@ -256,8 +255,6 @@ class Sandbox:
             request_timeout: Max seconds to wait for HTTP operations.
             startup_timeout: Deprecated alias for ``request_timeout``.
             name: Optional name; named sandboxes support suspend/resume.
-            cloud_init: Local cloud-init file path or HTTP(S) URL for the sandbox.
-                Not supported with pools.
             api_key: Tensorlake API key (defaults to TENSORLAKE_API_KEY env var).
             api_url: API server URL (defaults to TENSORLAKE_API_URL env var).
             organization_id: Organization ID for multi-tenant access.
@@ -307,7 +304,6 @@ class Sandbox:
             proxy_url=proxy_url,
             request_timeout=effective_request_timeout,
             name=name,
-            cloud_init=cloud_init,
         )
 
     @classmethod

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -89,6 +89,7 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             "default",
             False,
             sbm.USER_AGENT,
+            False,
             None,
             None,
             ANY,
@@ -133,6 +134,7 @@ class TestBuildSandboxImageFromDockerfileOptions(unittest.TestCase):
             "default",
             False,
             sbm.USER_AGENT,
+            False,
             None,
             None,
             ANY,
@@ -141,6 +143,19 @@ class TestBuildSandboxImageFromDockerfileOptions(unittest.TestCase):
     def test_missing_dockerfile_raises_load_error(self):
         with self.assertRaises(sbm.SandboxImageLoadError):
             sbm.build_sandbox_image("/nonexistent/Dockerfile")
+
+    def test_docker_compat_is_forwarded(self):
+        ctx = _make_ctx()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dockerfile_path = Path(tmpdir) / "Dockerfile"
+            dockerfile_path.write_text("FROM python:3.12-slim\n", encoding="utf-8")
+
+            build_ctx, rust_builder = _make_build_patches(ctx)
+            with build_ctx, rust_builder as rust_builder_mock:
+                sbm.build_sandbox_image(str(dockerfile_path), docker_compat=True)
+
+        self.assertIs(rust_builder_mock.call_args.args[14], True)
 
     def test_rust_builder_events_are_forwarded_to_emit(self):
         ctx = _make_ctx()
@@ -166,6 +181,7 @@ class TestBuildSandboxImageFromDockerfileOptions(unittest.TestCase):
                 dockerfile_text=None,
                 context_dir=None,
                 is_public=False,
+                docker_compat=False,
                 emit=emitted.append,
             )
 
@@ -355,6 +371,7 @@ class TestImportSandboxImage(unittest.TestCase):
             "default",
             False,
             sbm.USER_AGENT,
+            False,
             ANY,
         )
 
@@ -382,6 +399,13 @@ class TestImportSandboxImage(unittest.TestCase):
             )
         self.assertEqual(rust_importer_mock.call_args.args[3], "override")
 
+    def test_docker_compat_is_forwarded(self):
+        ctx = _make_ctx()
+        build_ctx, rust_importer = _make_import_patches(ctx)
+        with build_ctx, rust_importer as rust_importer_mock:
+            sbm.import_sandbox_image("pytorch/pytorch:2.4.1", docker_compat=True)
+        self.assertIs(rust_importer_mock.call_args.args[14], True)
+
     def test_empty_reference_raises_build_error(self):
         with self.assertRaises(sbm.SandboxImageBuildError):
             sbm.import_sandbox_image("   ")
@@ -403,8 +427,8 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
             def fake_rust_builder(*args, **_kwargs):
                 captured["args"] = args
                 captured["dockerfile_path"] = args[2]
-                captured["dockerfile_text"] = args[14]
-                captured["context_dir"] = args[15]
+                captured["dockerfile_text"] = args[15]
+                captured["context_dir"] = args[16]
                 return '{"id":"tpl-1","snapshot_id":"snap-1"}'
 
             rust_builder_mock.side_effect = fake_rust_builder
@@ -488,7 +512,7 @@ class TestBuildSandboxApplicationImage(unittest.TestCase):
         with build_ctx, rust_builder as rust_builder_mock:
 
             def fake_rust_builder(*args, **_kwargs):
-                captured["dockerfile_text"] = args[14]
+                captured["dockerfile_text"] = args[15]
                 return '{"id":"tpl-1","snapshot_id":"snap-1"}'
 
             rust_builder_mock.side_effect = fake_rust_builder

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -1,6 +1,4 @@
-import base64
 import json
-import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -565,83 +563,6 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         request_json = json.loads(fake.create_request_json)
         self.assertEqual(request_json["resources"]["disk_mb"], 25 * 1024)
         self.assertNotIn("ephemeral_disk_mb", request_json["resources"])
-
-    def test_create_sends_cloud_init_base64_from_path(self):
-        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
-        fake = _FakeRustClient()
-        client._rust_client = fake
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as file:
-            file.write("#cloud-config\n")
-            file.flush()
-
-            client.create(cloud_init=file.name)
-
-        request_json = json.loads(fake.create_request_json)
-        self.assertEqual(
-            request_json["cloud_init_base64"],
-            base64.b64encode(b"#cloud-config\n").decode("ascii"),
-        )
-
-    def test_create_sends_cloud_init_url_as_include_base64(self):
-        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
-        fake = _FakeRustClient()
-        client._rust_client = fake
-
-        client.create(cloud_init="https://example.com/cloud-init.yaml")
-
-        request_json = json.loads(fake.create_request_json)
-        self.assertEqual(
-            request_json["cloud_init_base64"],
-            base64.b64encode(b"#include\nhttps://example.com/cloud-init.yaml\n").decode(
-                "ascii"
-            ),
-        )
-
-    def test_create_rejects_invalid_cloud_init_url(self):
-        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
-        fake = _FakeRustClient()
-        client._rust_client = fake
-
-        with self.assertRaisesRegex(SandboxError, "HTTP\\(S\\) URL"):
-            client.create(cloud_init="ftp://example.com/cloud-init.yaml")
-
-        self.assertIsNone(fake.create_request_json)
-
-    def test_create_sends_cloud_init_file_with_snapshot(self):
-        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
-        fake = _FakeRustClient()
-        client._rust_client = fake
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as file:
-            file.write("#cloud-config\n")
-            file.flush()
-
-            client.create(snapshot_id="snap-1", cloud_init=file.name)
-
-        request_json = json.loads(fake.create_request_json)
-        self.assertEqual(request_json["snapshot_id"], "snap-1")
-        self.assertEqual(
-            request_json["cloud_init_base64"],
-            base64.b64encode(b"#cloud-config\n").decode("ascii"),
-        )
-
-    def test_create_sends_cloud_init_url_with_snapshot(self):
-        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
-        fake = _FakeRustClient()
-        client._rust_client = fake
-
-        client.create(
-            snapshot_id="snap-1",
-            cloud_init="https://example.com/cloud-init.yaml",
-        )
-
-        request_json = json.loads(fake.create_request_json)
-        self.assertEqual(request_json["snapshot_id"], "snap-1")
-        self.assertEqual(
-            request_json["cloud_init_base64"],
-            base64.b64encode(b"#include\nhttps://example.com/cloud-init.yaml\n").decode(
-                "ascii"
-            ),
-        )
 
     def test_create_and_connect_raises_error_details_from_startup_failure(self):
         class _StartupFailureRustClient(_FakeRustClient):

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -248,34 +248,86 @@ class TestSandboxImages(BaseSandboxTest):
                 except Exception:
                     pass
 
-    def test_create_then_delete_sandbox_image(self):
-        registered_name = f"sdk-python-delete-test-{uuid4().hex[:8]}"
+    def test_create_run_then_delete_sandbox_images(self):
+        suffix = uuid4().hex[:8]
+        scenarios = [
+            (
+                "regular",
+                f"sdk-python-delete-test-{suffix}",
+                False,
+                "/tmp/python-delete-acceptance",
+                "python regular build acceptance",
+            ),
+            (
+                "docker-compat",
+                f"sdk-python-docker-compat-delete-test-{suffix}",
+                True,
+                "/tmp/python-docker-compat-delete-acceptance",
+                "python docker compat build acceptance",
+            ),
+        ]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            dockerfile_path = Path(tmpdir) / "Dockerfile"
-            dockerfile_path.write_text(
-                "FROM tensorlake/ubuntu-minimal\n"
-                "RUN printf 'python delete acceptance\\n' > /tmp/python-delete-acceptance\n",
-                encoding="utf-8",
-            )
-
-            created = False
-            try:
-                build_sandbox_image(
-                    str(dockerfile_path),
-                    registered_name=registered_name,
-                    cpus=1.0,
-                    memory_mb=1024,
-                )
-                created = True
-
-                delete_sandbox_image(registered_name)
-            finally:
-                if created:
+        created_images: list[str] = []
+        try:
+            for (
+                label,
+                registered_name,
+                docker_compat,
+                marker_path,
+                marker_text,
+            ) in scenarios:
+                with self.subTest(label=label):
                     try:
-                        delete_sandbox_image(registered_name)
-                    except Exception:
-                        pass
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            dockerfile_path = Path(tmpdir) / "Dockerfile"
+                            dockerfile_path.write_text(
+                                "FROM tensorlake/ubuntu-minimal\n"
+                                f"RUN printf '{marker_text}\\n' > {marker_path}\n",
+                                encoding="utf-8",
+                            )
+
+                            build_sandbox_image(
+                                str(dockerfile_path),
+                                registered_name=registered_name,
+                                cpus=1.0,
+                                memory_mb=1024,
+                                docker_compat=docker_compat,
+                            )
+                            created_images.append(registered_name)
+
+                            sandbox: Sandbox | None = None
+                            try:
+                                sandbox = self.client.create_and_connect(
+                                    image=registered_name,
+                                    cpus=1.0,
+                                    memory_mb=1024,
+                                    disk_mb=_SANDBOX_DISK_MB,
+                                    entrypoint=["sleep", "300"],
+                                    request_timeout=120,
+                                )
+                                result = sandbox.run("cat", args=[marker_path])
+                                self.assertEqual(result.exit_code, 0)
+                                self.assertEqual(result.stdout.strip(), marker_text)
+                            finally:
+                                if sandbox is not None:
+                                    sandbox_id = sandbox.sandbox_id
+                                    sandbox.terminate()
+                                    _poll_sandbox_status(
+                                        self.client,
+                                        sandbox_id,
+                                        SandboxStatus.TERMINATED,
+                                        timeout=30,
+                                    )
+                    finally:
+                        if registered_name in created_images:
+                            delete_sandbox_image(registered_name)
+                            created_images.remove(registered_name)
+        finally:
+            for registered_name in created_images:
+                try:
+                    delete_sandbox_image(registered_name)
+                except Exception:
+                    pass
 
     def test_build_failure_reports_builder_disk_space_advice(self):
         self._assert_failed_build_advice(

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.46",
+  "version": "0.5.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.46",
+      "version": "0.5.47",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.46",
+  "version": "0.5.47",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import * as defaults from "./defaults.js";
 import { SandboxError } from "./errors.js";
 import type { Traced } from "./http.js";
@@ -39,34 +38,6 @@ import { Sandbox } from "./sandbox.js";
 import { nowMs, logSdkTimingEvent, logSdkTiming } from "./sdk-timings.js";
 import { resolveProxyUrl } from "./url.js";
 
-const MAX_CLOUD_INIT_USER_DATA_BYTES = 16 * 1024;
-
-function cloudInitIncludeData(source: string): Buffer | undefined {
-  const isWindowsPath = /^[A-Za-z]:[\\/]/.test(source);
-  try {
-    const url = new URL(source);
-    if (
-      (url.protocol === "http:" || url.protocol === "https:") &&
-      url.hostname.length > 0
-    ) {
-      return Buffer.from(`#include\n${url.toString()}\n`, "utf8");
-    }
-    if (!isWindowsPath) {
-      throw new SandboxError(
-        "cloud-init URL must be an absolute HTTP(S) URL with a host",
-      );
-    }
-  } catch (error) {
-    if (error instanceof SandboxError) throw error;
-    if (!isWindowsPath && /^[A-Za-z][A-Za-z0-9+.-]*:/.test(source)) {
-      throw new SandboxError(
-        "cloud-init URL must be an absolute HTTP(S) URL with a host",
-      );
-    }
-  }
-  return undefined;
-}
-
 function gpuRequest(
   gpus: number | undefined,
   gpuModel: string | undefined,
@@ -80,33 +51,6 @@ function gpuRequest(
     throw new SandboxError("only A10 GPU sandboxes are supported for now");
   }
   return [{ count: gpus, model: gpuModel }];
-}
-
-async function readCloudInitBase64(
-  cloudInit: string | URL | undefined,
-): Promise<string | undefined> {
-  if (cloudInit == null) return undefined;
-
-  const sourceText = cloudInit instanceof URL ? cloudInit.toString() : cloudInit;
-  const includeData = cloudInitIncludeData(sourceText);
-  const data =
-    includeData ??
-    (await readFile(sourceText).catch((error) => {
-      throw new SandboxError(
-        `failed to read cloud-init file ${JSON.stringify(sourceText)}: ${error}`,
-      );
-    }));
-
-  if (data.length === 0) {
-    throw new SandboxError("cloud-init user data must not be empty");
-  }
-  if (data.length > MAX_CLOUD_INIT_USER_DATA_BYTES) {
-    throw new SandboxError(
-      `cloud-init user data exceeds ${MAX_CLOUD_INIT_USER_DATA_BYTES} byte limit`,
-    );
-  }
-
-  return data.toString("base64");
 }
 
 /**
@@ -236,7 +180,6 @@ export class SandboxClient {
 
   /** Create a new sandbox. Returns immediately; the sandbox may still be starting. Use `createAndConnect()` for a blocking, ready-to-use handle. */
   async create(options?: CreateSandboxOptions): Promise<Traced<CreateSandboxResponse>> {
-    const cloudInitBase64 = await readCloudInitBase64(options?.cloudInit);
     const gpuResources = gpuRequest(options?.gpus, options?.gpuModel);
     const body: Record<string, unknown> = {
       resources: {
@@ -252,7 +195,6 @@ export class SandboxClient {
     if (options?.entrypoint != null) body.entrypoint = options.entrypoint;
     if (options?.snapshotId != null) body.snapshot_id = options.snapshotId;
     if (options?.name != null) body.name = options.name;
-    if (cloudInitBase64 != null) body.cloud_init_base64 = cloudInitBase64;
 
     if (
       options?.allowInternetAccess === false ||
@@ -674,9 +616,6 @@ export class SandboxClient {
   async createAndConnect(
     options?: CreateAndConnectOptions,
   ): Promise<Sandbox> {
-    if (options?.poolId != null && options?.cloudInit != null) {
-      throw new SandboxError("cloud-init cannot be used with poolId");
-    }
     const opStart = nowMs();
     const requestTimeout =
       options?.requestTimeout ??

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -103,11 +103,6 @@ export interface CreateSandboxOptions {
   snapshotId?: string;
   /** Optional name for the sandbox. Named sandboxes support suspend/resume. When absent the sandbox is ephemeral. */
   name?: string;
-  /**
-   * Local cloud-init file path or HTTP(S) URL for the sandbox. Supported for
-   * fresh sandboxes and filesystem-only snapshot restores.
-   */
-  cloudInit?: string | URL;
 }
 
 export interface UpdateSandboxOptions {

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -25,6 +25,7 @@ export interface CreateSandboxImageOptions {
   builderDiskMb?: number;
   isPublic?: boolean;
   contextDir?: string;
+  dockerCompat?: boolean;
   /**
    * Print build progress to stderr. Ignored when an explicit `emit` is
    * passed via `deps`. Defaults to false — `createSandboxImage` is silent
@@ -45,6 +46,7 @@ export interface ImportSandboxImageOptions {
   diskMb?: number;
   builderDiskMb?: number;
   isPublic?: boolean;
+  dockerCompat?: boolean;
   /**
    * Print build progress to stderr. Ignored when an explicit `emit` is
    * passed via `deps`. Defaults to false.
@@ -75,6 +77,7 @@ interface NativeBindingCommonOptions {
   namespace?: string | undefined | null;
   useScopeHeaders?: boolean | undefined | null;
   userAgent?: string | undefined | null;
+  dockerCompat?: boolean | undefined | null;
 }
 
 interface NativeBindingOptions extends NativeBindingCommonOptions {
@@ -320,6 +323,7 @@ export async function createSandboxImage(
       useScopeHeaders:
         context.personalAccessToken != null && context.apiKey == null,
       userAgent: undefined,
+      dockerCompat: options.dockerCompat ?? false,
       dockerfileText,
       contextDir: nativeContextDir,
     },
@@ -417,6 +421,7 @@ export async function importSandboxImage(
       useScopeHeaders:
         context.personalAccessToken != null && context.apiKey == null,
       userAgent: undefined,
+      dockerCompat: options.dockerCompat ?? false,
     },
     (event) => {
       try {
@@ -560,6 +565,7 @@ export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {
       memory: { type: "string" },
       disk_mb: { type: "string" },
       builder_disk_mb: { type: "string" },
+      docker_compat: { type: "boolean", default: false },
       public: { type: "boolean", default: false },
     },
   });
@@ -567,7 +573,7 @@ export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {
   const dockerfilePath = parsed.positionals[0];
   if (!dockerfilePath) {
     throw new Error(
-      "Usage: tensorlake-create-sandbox-image <dockerfile_path> [--name NAME] [--cpus N] [--memory MB] [--disk_mb MB] [--builder_disk_mb MB] [--public]",
+      "Usage: tensorlake-create-sandbox-image <dockerfile_path> [--name NAME] [--cpus N] [--memory MB] [--disk_mb MB] [--builder_disk_mb MB] [--docker_compat] [--public]",
     );
   }
 
@@ -604,6 +610,7 @@ export async function runCreateSandboxImageCli(argv = process.argv.slice(2)) {
       memoryMb,
       diskMb,
       builderDiskMb,
+      dockerCompat: parsed.values.docker_compat,
       isPublic: parsed.values.public,
     },
     { emit: ndjsonStdoutEmit },
@@ -620,6 +627,7 @@ export async function runImportSandboxImageCli(argv = process.argv.slice(2)) {
       memory: { type: "string" },
       disk_mb: { type: "string" },
       builder_disk_mb: { type: "string" },
+      docker_compat: { type: "boolean", default: false },
       public: { type: "boolean", default: false },
     },
   });
@@ -627,7 +635,7 @@ export async function runImportSandboxImageCli(argv = process.argv.slice(2)) {
   const imageReference = parsed.positionals[0];
   if (!imageReference) {
     throw new Error(
-      "Usage: tensorlake-import-sandbox-image <image_reference> [--name NAME] [--cpus N] [--memory MB] [--disk_mb MB] [--builder_disk_mb MB] [--public]",
+      "Usage: tensorlake-import-sandbox-image <image_reference> [--name NAME] [--cpus N] [--memory MB] [--disk_mb MB] [--builder_disk_mb MB] [--docker_compat] [--public]",
     );
   }
 
@@ -664,6 +672,7 @@ export async function runImportSandboxImageCli(argv = process.argv.slice(2)) {
       memoryMb,
       diskMb,
       builderDiskMb,
+      dockerCompat: parsed.values.docker_compat,
       isPublic: parsed.values.public,
     },
     { emit: ndjsonStdoutEmit },

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -25,6 +25,10 @@ export interface CreateSandboxImageOptions {
   builderDiskMb?: number;
   isPublic?: boolean;
   contextDir?: string;
+  /**
+   * Use Docker/BuildKit max compatibility mode (build is slower and uses more
+   * memory and disk space on builder sandbox).
+   */
   dockerCompat?: boolean;
   /**
    * Print build progress to stderr. Ignored when an explicit `emit` is
@@ -46,6 +50,10 @@ export interface ImportSandboxImageOptions {
   diskMb?: number;
   builderDiskMb?: number;
   isPublic?: boolean;
+  /**
+   * Use Docker/BuildKit max compatibility mode (import is slower and uses more
+   * memory and disk space on builder sandbox).
+   */
   dockerCompat?: boolean;
   /**
    * Print build progress to stderr. Ignored when an explicit `emit` is

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1,7 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
 import { SandboxClient } from "../src/client.js";
 import { SandboxStatus, SnapshotStatus } from "../src/models.js";
 import { clearNativeStub, installNativeStub } from "./native-stub.js";
@@ -14,23 +11,10 @@ function nativeError(status: number, message: string): Error {
 }
 
 describe("SandboxClient", () => {
-  let tempDirs: string[] = [];
-
   afterEach(() => {
     clearNativeStub();
     vi.restoreAllMocks();
-    const dirs = tempDirs;
-    tempDirs = [];
-    return Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
   });
-
-  async function tempFile(contents: string | Uint8Array): Promise<string> {
-    const dir = await mkdtemp(join(tmpdir(), "tensorlake-sdk-test-"));
-    tempDirs.push(dir);
-    const path = join(dir, "cloud-init.yaml");
-    await writeFile(path, contents);
-    return path;
-  }
 
   describe("construction", () => {
     it("creates cloud client with defaults", () => {
@@ -230,120 +214,6 @@ describe("SandboxClient", () => {
       client.close();
     });
 
-    it("reads cloudInit file path and sends cloud_init_base64", async () => {
-      const path = await tempFile("#cloud-config\n");
-      installNativeStub({
-        client: {
-          createSandbox: vi.fn(async (json: string) => {
-            const body = JSON.parse(json);
-            expect(body.cloud_init_base64).toBe(
-              Buffer.from("#cloud-config\n").toString("base64"),
-            );
-            return {
-              traceId: "t",
-              json: JSON.stringify({ sandbox_id: "sbx-cloud-init", status: "pending" }),
-            };
-          }),
-        },
-      });
-
-      const client = SandboxClient.forLocalhost();
-      await client.create({ cloudInit: path });
-      client.close();
-    });
-
-    it("encodes cloudInit URL as include user-data", async () => {
-      installNativeStub({
-        client: {
-          createSandbox: vi.fn(async (json: string) => {
-            const body = JSON.parse(json);
-            expect(body.cloud_init_base64).toBe(
-              Buffer.from("#include\nhttps://example.com/cloud-init.yaml\n").toString(
-                "base64",
-              ),
-            );
-            return {
-              traceId: "t",
-              json: JSON.stringify({ sandbox_id: "sbx-cloud-init-url", status: "pending" }),
-            };
-          }),
-        },
-      });
-
-      const client = SandboxClient.forLocalhost();
-      await client.create({ cloudInit: "https://example.com/cloud-init.yaml" });
-      client.close();
-    });
-
-    it("rejects invalid cloudInit URLs before sending a request", async () => {
-      const createSandbox = vi.fn(async () => {
-        throw new Error("request should not be sent");
-      });
-      installNativeStub({ client: { createSandbox } });
-
-      const client = SandboxClient.forLocalhost();
-      await expect(
-        client.create({ cloudInit: "ftp://example.com/cloud-init.yaml" }),
-      ).rejects.toThrow("HTTP(S) URL");
-      expect(createSandbox).not.toHaveBeenCalled();
-      client.close();
-    });
-
-    it("sends cloudInit file with snapshotId", async () => {
-      const path = await tempFile("#cloud-config\n");
-      installNativeStub({
-        client: {
-          createSandbox: vi.fn(async (json: string) => {
-            const body = JSON.parse(json);
-            expect(body.snapshot_id).toBe("snap-1");
-            expect(body.cloud_init_base64).toBe(
-              Buffer.from("#cloud-config\n").toString("base64"),
-            );
-            return {
-              traceId: "t",
-              json: JSON.stringify({
-                sandbox_id: "sbx-cloud-init-snapshot",
-                status: "pending",
-              }),
-            };
-          }),
-        },
-      });
-
-      const client = SandboxClient.forLocalhost();
-      await client.create({ snapshotId: "snap-1", cloudInit: path });
-      client.close();
-    });
-
-    it("sends cloudInit URL with snapshotId", async () => {
-      installNativeStub({
-        client: {
-          createSandbox: vi.fn(async (json: string) => {
-            const body = JSON.parse(json);
-            expect(body.snapshot_id).toBe("snap-1");
-            expect(body.cloud_init_base64).toBe(
-              Buffer.from("#include\nhttps://example.com/cloud-init.yaml\n").toString(
-                "base64",
-              ),
-            );
-            return {
-              traceId: "t",
-              json: JSON.stringify({
-                sandbox_id: "sbx-cloud-init-url-snapshot",
-                status: "pending",
-              }),
-            };
-          }),
-        },
-      });
-
-      const client = SandboxClient.forLocalhost();
-      await client.create({
-        snapshotId: "snap-1",
-        cloudInit: "https://example.com/cloud-init.yaml",
-      });
-      client.close();
-    });
   });
 
   describe("get", () => {

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -38,6 +38,7 @@ const SANDBOX_LIFECYCLE_TIMEOUT_MS = 360_000;
 const SANDBOX_CREATE_TIMEOUT_MS = 180_000;
 const SANDBOX_SETUP_TIMEOUT_MS = 300_000;
 const SANDBOX_SUITE_TIMEOUT_MS = 420_000;
+const SANDBOX_IMAGE_SUITE_TIMEOUT_MS = 900_000;
 const STALE_RESOURCE_GRACE_MS =
   Number(process.env.TENSORLAKE_TEST_CLEANUP_GRACE_SECS ?? "60") * 1000;
 const CLEANUP_ALL_TEST_RESOURCES = ["1", "true", "yes"].includes(
@@ -243,39 +244,96 @@ beforeAll(async () => {
 
 describe("Sandbox Images", () => {
   it(
-    "creates and deletes a sandbox image",
+    "creates, runs, and deletes sandbox images",
     async () => {
-      const registeredName = `sdk-ts-delete-test-${randomSuffix()}`;
-      const tempDir = await mkdir(
-        path.join(os.tmpdir(), `tensorlake-image-${registeredName}`),
-        { recursive: true },
-      );
-      const dockerfilePath = path.join(tempDir, "Dockerfile");
-      await writeFile(
-        dockerfilePath,
-        "FROM tensorlake/ubuntu-minimal\nRUN printf 'ts delete acceptance\\n' > /tmp/ts-delete-acceptance\n",
-        "utf8",
-      );
-
-      let created = false;
+      const suffix = randomSuffix();
+      const scenarios = [
+        {
+          label: "regular",
+          registeredName: `sdk-ts-delete-test-${suffix}`,
+          dockerCompat: false,
+          markerPath: "/tmp/ts-delete-acceptance",
+          markerText: "ts regular build acceptance",
+        },
+        {
+          label: "docker-compat",
+          registeredName: `sdk-ts-docker-compat-delete-test-${suffix}`,
+          dockerCompat: true,
+          markerPath: "/tmp/ts-docker-compat-delete-acceptance",
+          markerText: "ts docker compat build acceptance",
+        },
+      ];
+      const client = createTestClient();
+      const createdImages: string[] = [];
       try {
-        await createSandboxImage(dockerfilePath, {
-          registeredName,
-          cpus: 1.0,
-          memoryMb: 1024,
-        });
-        created = true;
+        for (const scenario of scenarios) {
+          const tempDir = await mkdir(
+            path.join(os.tmpdir(), `tensorlake-image-${scenario.registeredName}`),
+            { recursive: true },
+          );
+          const dockerfilePath = path.join(tempDir, "Dockerfile");
+          await writeFile(
+            dockerfilePath,
+            `FROM tensorlake/ubuntu-minimal\nRUN printf '${scenario.markerText}\\n' > ${scenario.markerPath}\n`,
+            "utf8",
+          );
 
-        await deleteSandboxImage(registeredName);
+          await createSandboxImage(dockerfilePath, {
+            registeredName: scenario.registeredName,
+            cpus: 1.0,
+            memoryMb: 1024,
+            dockerCompat: scenario.dockerCompat,
+          });
+          createdImages.push(scenario.registeredName);
+
+          let sandbox: Sandbox | undefined;
+          try {
+            sandbox = await createAndConnectWithStartupRetry(client, {
+              image: scenario.registeredName,
+              cpus: 1.0,
+              memoryMb: 1024,
+              diskMb: SANDBOX_DISK_MB,
+              entrypoint: ["sleep", "300"],
+              requestTimeout: 120,
+            });
+            const result = await sandbox.run("cat", {
+              args: [scenario.markerPath],
+            });
+            expect(
+              result.exitCode,
+              `${scenario.label} sandbox ${sandbox.sandboxId}: exitCode`,
+            ).toBe(0);
+            expect(
+              result.stdout.trim(),
+              `${scenario.label} sandbox ${sandbox.sandboxId}: stdout`,
+            ).toBe(scenario.markerText);
+          } finally {
+            if (sandbox != null) {
+              const sandboxId = sandbox.sandboxId;
+              await sandbox.terminate();
+              await pollSandboxStatus(
+                client,
+                sandboxId,
+                SandboxStatus.TERMINATED,
+                30,
+              );
+            }
+          }
+
+          await deleteSandboxImage(scenario.registeredName);
+          const imageIndex = createdImages.indexOf(scenario.registeredName);
+          if (imageIndex >= 0) createdImages.splice(imageIndex, 1);
+        }
       } finally {
-        if (created) {
+        client.close();
+        for (const registeredName of createdImages) {
           await deleteSandboxImage(registeredName).catch(() => {});
         }
       }
 
-      expect(created).toBe(true);
+      expect(createdImages).toHaveLength(0);
     },
-    SANDBOX_SUITE_TIMEOUT_MS,
+    SANDBOX_IMAGE_SUITE_TIMEOUT_MS,
   );
 });
 

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -75,6 +75,7 @@ describe("createSandboxImage", () => {
       dockerfilePath: path.resolve(dockerfilePath),
       registeredName: "sandbox-image",
       isPublic: true,
+      dockerCompat: false,
       dockerfileText: undefined,
       contextDir: undefined,
     });
@@ -106,6 +107,20 @@ describe("createSandboxImage", () => {
     // is responsible for parsing/validating it).
     const expectedDockerfile = `${dockerfileContent(image)}\n`;
     expect(captured.options.dockerfileText).toBe(expectedDockerfile);
+  });
+
+  it("forwards dockerCompat to the native build binding", async () => {
+    const tempDir = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-compat`),
+      { recursive: true },
+    );
+    const dockerfilePath = path.join(tempDir, "Dockerfile");
+    await writeFile(dockerfilePath, "FROM python:3.12-slim\n", "utf8");
+
+    const { captured } = makeFakeBinding();
+    await createSandboxImage(dockerfilePath, { dockerCompat: true });
+
+    expect(captured.options.dockerCompat).toBe(true);
   });
 
   it("forwards native events back through the user emit callback", async () => {
@@ -342,6 +357,7 @@ describe("importSandboxImage", () => {
       imageReference: "pytorch/pytorch:2.4.1-cuda12.1-cudnn9-runtime",
       registeredName: "pytorch",
       isPublic: true,
+      dockerCompat: false,
     });
     // The import option shape carries no Dockerfile fields.
     expect(captured.options).not.toHaveProperty("dockerfilePath");
@@ -361,6 +377,14 @@ describe("importSandboxImage", () => {
       registeredName: "override",
     });
     expect(captured.options.registeredName).toBe("override");
+  });
+
+  it("forwards dockerCompat to the native import binding", async () => {
+    const { captured } = makeFakeBinding();
+    await importSandboxImage("pytorch/pytorch:2.4.1", {
+      dockerCompat: true,
+    });
+    expect(captured.options.dockerCompat).toBe(true);
   });
 
   it("forwards native events back through the user emit callback", async () => {


### PR DESCRIPTION
## Summary
- add sandbox image Docker compatibility mode across CLI, Python SDK, TypeScript SDK, and Rust/native bindings
- emit dockerCompat in the rootfs builder spec only when requested
- add a warning event for Docker compat builds/imports
- preserve existing parent resolution and diff rootfs behavior
- extend Python and TypeScript production sandbox image integration tests to build regular and Docker compat images, boot sandboxes from them, verify marker files, and delete the images
- remove sandbox cloud-init CLI/SDK support because we decided to drop this feature
- document the throwaway builder-sandbox validation workflow in CLAUDE.md
- bump Python/Rust/CLI/TypeScript package versions to 0.5.47

Companion provisioner PR: https://github.com/tensorlakeai/provisioner/pull/987

## Tests
- cargo test -p tensorlake build_rootfs_spec
- cargo test -p tensorlake-cli docker_compat
- cargo test -p tensorlake-cli create_body
- cargo check -p tensorlake -p tensorlake-cli -p tensorlake-rust-cloud-sdk-node -p tensorlake-rust-cloud-sdk-py
- poetry run pytest tests/image/test_sandbox_builder.py -q
- poetry run pytest tests/sandbox/test_client_rust_backend.py -q
- poetry run black --check src/tensorlake tests/sandbox/test_client_rust_backend.py --extend-exclude vendor
- poetry run isort --check src/tensorlake tests/sandbox/test_client_rust_backend.py --profile black --extend-skip vendor
- poetry run black --check tests/sandbox/test_lifecycle.py --extend-exclude vendor
- poetry run python -m py_compile tests/sandbox/test_lifecycle.py
- npm run typecheck
- npm test -- --run tests/sandbox-image.test.ts
- npm test -- --run tests/client.test.ts
- live validation in a temporary tensorlake/rootfs-builder sandbox: private dockerd, docker buildx, metadata-overlay tar export to tar-to-ext4, docker import-style pull/export, and oci-image-to-ext4 smoke all passed

Note: npm run lint is currently blocked by the package's existing ESLint 9 configuration issue: no eslint.config.js is present.
