### PR TITLE
Fix running sandbox CLI listing

### DIFF
--- a/crates/cli/src/commands/sbx/ls.rs
+++ b/crates/cli/src/commands/sbx/ls.rs
@@ -19,7 +19,10 @@ pub async fn run(
     }
 
     let client = ctx.client()?;
-    let url = sandbox_endpoint(ctx, "sandboxes");
+    let mut url = sandbox_endpoint(ctx, "sandboxes");
+    if running_only {
+        url = url_with_query_param(&url, "status", "running");
+    }
 
     let mut count = 0usize;
     let mut terminated_hidden = 0usize;
@@ -518,6 +521,22 @@ mod tests {
             Some(
                 "https://sandbox.tensorlake.ai/archived-sandboxes?limit=100&cursor=abc".to_string()
             )
+        );
+    }
+
+    #[test]
+    fn top_level_next_cursor_preserves_running_status_filter() {
+        let body = json!({
+            "sandboxes": [],
+            "next_cursor": "abc"
+        });
+
+        assert_eq!(
+            next_sandbox_list_url(
+                "https://sandbox.tensorlake.ai/sandboxes?status=running",
+                &body
+            ),
+            Some("https://sandbox.tensorlake.ai/sandboxes?status=running&cursor=abc".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary
- Make `tl sbx ls --running` request the backend `status=running` sandbox list instead of filtering the unfiltered list locally
- Preserve `status=running` across cursor pagination
- Add a regression test for top-level `next_cursor` pagination preserving the running filter

## Root Cause
`tl sbx ls --running` fetched `/sandboxes` and then filtered each returned page client-side. The backend exposes `?status=running` as a separate live running-sandbox view, so client-side filtering over the generic paginated list can undercount or miss running sandboxes.

## Verification
- `cargo test -p tensorlake-cli commands::sbx::ls::tests`
- `rustfmt --edition 2024 --check crates/cli/src/commands/sbx/ls.rs`

Note: full `cargo fmt --check` reports pre-existing formatting differences in unrelated crates (`sandbox_templates`, `rust-cloud-sdk-node`), so I checked the touched file directly.
