### PR TITLE
Add sandbox builder upload diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.47"
+version = "0.5.48"
 dependencies = [
  "base64",
  "bollard",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.47"
+version = "0.5.48"
 dependencies = [
  "anyhow",
  "base64",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.47"
+version = "0.5.48"
 dependencies = [
  "napi",
  "napi-build",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.47"
+version = "0.5.48"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.48"
+version = "0.5.49"
 dependencies = [
  "base64",
  "bollard",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.48"
+version = "0.5.49"
 dependencies = [
  "anyhow",
  "base64",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.48"
+version = "0.5.49"
 dependencies = [
  "napi",
  "napi-build",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.48"
+version = "0.5.49"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.48"
+version = "0.5.49"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -1,13 +1,15 @@
 use std::path::PathBuf;
 
 use tensorlake::sandbox_images::{
-    CommonBuildOptions, SandboxImageBuildEvent, SandboxImageBuildOptions, build_sandbox_image,
+    CommonBuildOptions, SandboxImageBuildOptions, build_sandbox_image,
 };
 
 use crate::{
     auth::context::CliContext,
     error::{CliError, Result},
 };
+
+use super::ImageBuildEventRenderer;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
@@ -47,13 +49,10 @@ pub async fn run(
         context_dir: None,
     };
 
-    let registered = build_sandbox_image(options, |event| match event {
-        SandboxImageBuildEvent::Status(message) => eprintln!("⚙️  {message}"),
-        SandboxImageBuildEvent::BuildLog { message, .. } => eprintln!("{message}"),
-        SandboxImageBuildEvent::Warning(message) => eprintln!("⚠️  {message}"),
-    })
-    .await
-    .map_err(|error| CliError::Other(error.into()))?;
+    let mut renderer = ImageBuildEventRenderer::new();
+    let registered = build_sandbox_image(options, |event| renderer.render(event))
+        .await
+        .map_err(|error| CliError::Other(error.into()))?;
 
     if output_json {
         println!("{}", serde_json::to_string_pretty(&registered)?);

--- a/crates/cli/src/commands/sbx/image/import.rs
+++ b/crates/cli/src/commands/sbx/image/import.rs
@@ -1,11 +1,13 @@
 use tensorlake::sandbox_images::{
-    CommonBuildOptions, SandboxImageBuildEvent, SandboxImageImportOptions, import_sandbox_image,
+    CommonBuildOptions, SandboxImageImportOptions, import_sandbox_image,
 };
 
 use crate::{
     auth::context::CliContext,
     error::{CliError, Result},
 };
+
+use super::ImageBuildEventRenderer;
 
 /// Import a registry image directly into a Tensorlake sandbox image, with no
 /// Dockerfile and no Docker daemon: the builder pulls the image's layers and
@@ -46,13 +48,10 @@ pub async fn run(
         image_reference: image_reference.to_string(),
     };
 
-    let registered = import_sandbox_image(options, |event| match event {
-        SandboxImageBuildEvent::Status(message) => eprintln!("⚙️  {message}"),
-        SandboxImageBuildEvent::BuildLog { message, .. } => eprintln!("{message}"),
-        SandboxImageBuildEvent::Warning(message) => eprintln!("⚠️  {message}"),
-    })
-    .await
-    .map_err(|error| CliError::Other(error.into()))?;
+    let mut renderer = ImageBuildEventRenderer::new();
+    let registered = import_sandbox_image(options, |event| renderer.render(event))
+        .await
+        .map_err(|error| CliError::Other(error.into()))?;
 
     if output_json {
         println!("{}", serde_json::to_string_pretty(&registered)?);

--- a/crates/cli/src/commands/sbx/image/mod.rs
+++ b/crates/cli/src/commands/sbx/image/mod.rs
@@ -7,7 +7,71 @@ pub mod rm;
 
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
-use tensorlake::{Client, ClientBuilder, sandbox_templates::SandboxTemplatesClient};
+use indicatif::{ProgressBar, ProgressStyle};
+use tensorlake::{
+    Client, ClientBuilder, sandbox_images::SandboxImageBuildEvent,
+    sandbox_templates::SandboxTemplatesClient,
+};
+
+const BUILD_CONTEXT_PROGRESS_PREFIX: &str = "Creating build context archive:";
+const UPLOAD_CONTEXT_PROGRESS_PREFIX: &str = "Uploading build context archive:";
+
+pub struct ImageBuildEventRenderer {
+    progress: Option<ProgressBar>,
+}
+
+impl ImageBuildEventRenderer {
+    pub fn new() -> Self {
+        Self { progress: None }
+    }
+
+    pub fn render(&mut self, event: SandboxImageBuildEvent) {
+        match event {
+            SandboxImageBuildEvent::Status(message) if is_progress_status(&message) => {
+                self.render_progress(&message);
+            }
+            SandboxImageBuildEvent::Status(message) => {
+                self.finish_progress_line();
+                eprintln!("⚙️  {message}");
+            }
+            SandboxImageBuildEvent::BuildLog { message, .. } => {
+                self.finish_progress_line();
+                eprintln!("{message}");
+            }
+            SandboxImageBuildEvent::Warning(message) => {
+                self.finish_progress_line();
+                eprintln!("⚠️  {message}");
+            }
+        }
+    }
+
+    fn render_progress(&mut self, message: &str) {
+        let progress = self.progress.get_or_insert_with(|| {
+            let progress = ProgressBar::new_spinner();
+            progress.set_style(ProgressStyle::with_template("{msg}").unwrap());
+            progress
+        });
+        progress.set_message(format!("⚙️  {message}"));
+        progress.tick();
+    }
+
+    fn finish_progress_line(&mut self) {
+        if let Some(progress) = self.progress.take() {
+            progress.finish_and_clear();
+        }
+    }
+}
+
+impl Drop for ImageBuildEventRenderer {
+    fn drop(&mut self) {
+        self.finish_progress_line();
+    }
+}
+
+fn is_progress_status(message: &str) -> bool {
+    message.starts_with(BUILD_CONTEXT_PROGRESS_PREFIX)
+        || message.starts_with(UPLOAD_CONTEXT_PROGRESS_PREFIX)
+}
 
 /// Build the sandbox-templates API base URL for the current org/project.
 pub fn templates_base_url(ctx: &CliContext) -> Result<(String, String, String)> {

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -98,6 +98,10 @@ impl<R, F> ProgressReader<R, F> {
             on_progress,
         }
     }
+
+    fn bytes_read(&self) -> u64 {
+        self.bytes_read
+    }
 }
 
 impl<R, F> Read for ProgressReader<R, F>
@@ -1950,14 +1954,15 @@ fn create_context_archive(
     let mut last_percent = upload_percent(0, uncompressed_bytes);
     for file in &files {
         let input = File::open(&file.full_path)?;
-        let metadata = std::fs::metadata(&file.full_path)?;
+        let metadata = input.metadata()?;
+        let file_bytes = metadata.len();
         let mut header = tar::Header::new_gnu();
         header.set_metadata(&metadata);
-        header.set_size(file.bytes);
+        header.set_size(file_bytes);
         header.set_cksum();
 
-        {
-            let mut reader = ProgressReader::new(input, |file_archived_bytes| {
+        let bytes_read = {
+            let mut reader = ProgressReader::new(input.take(file_bytes), |file_archived_bytes| {
                 let current_bytes = archived_bytes
                     .saturating_add(file_archived_bytes)
                     .min(uncompressed_bytes);
@@ -1973,9 +1978,18 @@ fn create_context_archive(
                 }
             });
             tar.append_data(&mut header, &file.relative_path, &mut reader)?;
+            reader.bytes_read()
+        };
+        if bytes_read != file_bytes {
+            return Err(SandboxImageBuildError::other(format!(
+                "Build context file changed while archiving: {} (expected {}, read {})",
+                file.full_path.display(),
+                format_bytes(file_bytes),
+                format_bytes(bytes_read),
+            )));
         }
 
-        archived_bytes = archived_bytes.saturating_add(file.bytes);
+        archived_bytes = archived_bytes.saturating_add(file_bytes);
     }
     if last_percent < 100 {
         emit_archive_progress(uncompressed_bytes, uncompressed_bytes, emit);

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -1936,7 +1936,7 @@ fn create_context_archive(
     emit: &mut impl FnMut(SandboxImageBuildEvent),
 ) -> Result<ContextArchiveStats> {
     let file = File::create(archive_path)?;
-    let gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    let gz = flate2::write::GzEncoder::new(file, flate2::Compression::fast());
     let mut tar = tar::Builder::new(gz);
 
     let files = collect_context_archive_files(context_dir)?;

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -463,10 +463,13 @@ where
         gpu_configs: None,
     };
     emit(SandboxImageBuildEvent::Status(format!(
-        "Builder resources: {:.2} CPU, {}, {} disk (target rootfs {})",
+        "Builder resources: {:.2} CPU, {}, {} disk",
         resources.cpus,
         format_bytes(resources.memory_mb.max(0) as u64 * 1024 * 1024),
         format_bytes(builder_disk_mb * 1024 * 1024),
+    )));
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Target rootfs size: {}",
         format_bytes(rootfs_disk_bytes),
     )));
 

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     fs::File,
+    io::Read,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -61,6 +62,7 @@ const ROOTFS_BUILDER_COMMAND: &str = "tl-rootfs-build";
 const ROOTFS_BUILDER_PROCESS_USER: &str = "root";
 const DIAGNOSTIC_COMMAND_TIMEOUT_SECS: i64 = 5;
 const BUILDER_DISK_USAGE_DIAGNOSTIC_THRESHOLD_PERCENT: u8 = 95;
+const ARCHIVE_PROGRESS_BYTE_INTERVAL_BYTES: u64 = 64 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ProcessTerminalStatus {
@@ -80,6 +82,37 @@ struct ContextArchiveFile {
     full_path: PathBuf,
     relative_path: String,
     bytes: u64,
+}
+
+struct ProgressReader<R, F> {
+    inner: R,
+    bytes_read: u64,
+    on_progress: F,
+}
+
+impl<R, F> ProgressReader<R, F> {
+    fn new(inner: R, on_progress: F) -> Self {
+        Self {
+            inner,
+            bytes_read: 0,
+            on_progress,
+        }
+    }
+}
+
+impl<R, F> Read for ProgressReader<R, F>
+where
+    R: Read,
+    F: FnMut(u64),
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let read = self.inner.read(buf)?;
+        if read > 0 {
+            self.bytes_read = self.bytes_read.saturating_add(read as u64);
+            (self.on_progress)(self.bytes_read);
+        }
+        Ok(read)
+    }
 }
 
 /// Dockerfile instructions that run as usual during the rootfs builder's
@@ -1913,15 +1946,36 @@ fn create_context_archive(
     emit_archive_progress(0, uncompressed_bytes, emit);
 
     let mut archived_bytes = 0_u64;
+    let mut last_emitted_bytes = 0_u64;
     let mut last_percent = upload_percent(0, uncompressed_bytes);
     for file in &files {
-        tar.append_path_with_name(&file.full_path, &file.relative_path)?;
-        archived_bytes = archived_bytes.saturating_add(file.bytes);
-        let percent = upload_percent(archived_bytes, uncompressed_bytes);
-        if percent == 100 || percent >= last_percent.saturating_add(10) {
-            last_percent = percent;
-            emit_archive_progress(archived_bytes, uncompressed_bytes, emit);
+        let input = File::open(&file.full_path)?;
+        let metadata = std::fs::metadata(&file.full_path)?;
+        let mut header = tar::Header::new_gnu();
+        header.set_metadata(&metadata);
+        header.set_size(file.bytes);
+        header.set_cksum();
+
+        {
+            let mut reader = ProgressReader::new(input, |file_archived_bytes| {
+                let current_bytes = archived_bytes
+                    .saturating_add(file_archived_bytes)
+                    .min(uncompressed_bytes);
+                let percent = upload_percent(current_bytes, uncompressed_bytes);
+                if percent == 100
+                    || percent > last_percent
+                    || current_bytes.saturating_sub(last_emitted_bytes)
+                        >= ARCHIVE_PROGRESS_BYTE_INTERVAL_BYTES
+                {
+                    last_percent = percent;
+                    last_emitted_bytes = current_bytes;
+                    emit_archive_progress(current_bytes, uncompressed_bytes, emit);
+                }
+            });
+            tar.append_data(&mut header, &file.relative_path, &mut reader)?;
         }
+
+        archived_bytes = archived_bytes.saturating_add(file.bytes);
     }
     if last_percent < 100 {
         emit_archive_progress(uncompressed_bytes, uncompressed_bytes, emit);

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -75,6 +75,13 @@ struct ContextArchiveStats {
     compressed_bytes: u64,
 }
 
+#[derive(Debug, Clone)]
+struct ContextArchiveFile {
+    full_path: PathBuf,
+    relative_path: String,
+    bytes: u64,
+}
+
 /// Dockerfile instructions that run as usual during the rootfs builder's
 /// `docker build`, but have no effect when a sandbox is later run from the
 /// image. The builder preserves the built image's OCI config, yet the
@@ -1867,7 +1874,7 @@ async fn upload_context_archive(
         .prefix("tensorlake-build-context-")
         .suffix(".tar.gz")
         .tempfile()?;
-    let stats = create_context_archive(context_dir, archive.path())?;
+    let stats = create_context_archive(context_dir, archive.path(), emit)?;
     emit(SandboxImageBuildEvent::Status(format!(
         "Build context: {} files, {} uncompressed, {} compressed",
         stats.file_count,
@@ -1887,17 +1894,36 @@ async fn upload_context_archive(
     extract_context_archive(proxy, emit).await
 }
 
-fn create_context_archive(context_dir: &Path, archive_path: &Path) -> Result<ContextArchiveStats> {
+fn create_context_archive(
+    context_dir: &Path,
+    archive_path: &Path,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) -> Result<ContextArchiveStats> {
     let file = File::create(archive_path)?;
     let gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
     let mut tar = tar::Builder::new(gz);
 
-    let files = collect_dir_files(context_dir, context_dir)?;
-    let mut uncompressed_bytes = 0_u64;
-    for (full_path, relative_path) in &files {
-        uncompressed_bytes = uncompressed_bytes.saturating_add(std::fs::metadata(full_path)?.len());
-        tar.append_path_with_name(full_path, relative_path)?;
+    let files = collect_context_archive_files(context_dir)?;
+    let uncompressed_bytes = files
+        .iter()
+        .fold(0_u64, |total, file| total.saturating_add(file.bytes));
+    emit_archive_progress(0, uncompressed_bytes, emit);
+
+    let mut archived_bytes = 0_u64;
+    let mut last_percent = upload_percent(0, uncompressed_bytes);
+    for file in &files {
+        tar.append_path_with_name(&file.full_path, &file.relative_path)?;
+        archived_bytes = archived_bytes.saturating_add(file.bytes);
+        let percent = upload_percent(archived_bytes, uncompressed_bytes);
+        if percent == 100 || percent >= last_percent.saturating_add(10) {
+            last_percent = percent;
+            emit_archive_progress(archived_bytes, uncompressed_bytes, emit);
+        }
     }
+    if last_percent < 100 {
+        emit_archive_progress(uncompressed_bytes, uncompressed_bytes, emit);
+    }
+
     tar.finish()?;
     tar.into_inner()?.finish()?;
     let compressed_bytes = std::fs::metadata(archive_path)?.len();
@@ -1906,6 +1932,32 @@ fn create_context_archive(context_dir: &Path, archive_path: &Path) -> Result<Con
         uncompressed_bytes,
         compressed_bytes,
     })
+}
+
+fn collect_context_archive_files(context_dir: &Path) -> Result<Vec<ContextArchiveFile>> {
+    let mut files = Vec::new();
+    for (full_path, relative_path) in collect_dir_files(context_dir, context_dir)? {
+        let bytes = std::fs::metadata(&full_path)?.len();
+        files.push(ContextArchiveFile {
+            full_path,
+            relative_path,
+            bytes,
+        });
+    }
+    Ok(files)
+}
+
+fn emit_archive_progress(
+    archived_bytes: u64,
+    total_bytes: u64,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) {
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Creating build context archive: {}% ({} / {})",
+        upload_percent(archived_bytes, total_bytes),
+        format_bytes(archived_bytes.min(total_bytes)),
+        format_bytes(total_bytes),
+    )));
 }
 
 async fn upload_archive_with_progress(
@@ -3629,7 +3681,17 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
         std::fs::write(root.join("cache/keep.txt"), "keep").unwrap();
 
         let archive_file = tempfile::NamedTempFile::new().unwrap();
-        create_context_archive(root, archive_file.path()).unwrap();
+        let mut events = Vec::new();
+        let stats =
+            create_context_archive(root, archive_file.path(), &mut |event| events.push(event))
+                .unwrap();
+
+        assert_eq!(stats.file_count, 3);
+        assert!(events.iter().any(|event| matches!(
+            event,
+            SandboxImageBuildEvent::Status(message)
+                if message.starts_with("Creating build context archive:")
+        )));
 
         let file = std::fs::File::open(archive_file.path()).unwrap();
         let decoder = flate2::read::GzDecoder::new(file);

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -68,6 +68,13 @@ struct ProcessTerminalStatus {
     oom_killed: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ContextArchiveStats {
+    file_count: usize,
+    uncompressed_bytes: u64,
+    compressed_bytes: u64,
+}
+
 /// Dockerfile instructions that run as usual during the rootfs builder's
 /// `docker build`, but have no effect when a sandbox is later run from the
 /// image. The builder preserves the built image's OCI config, yet the
@@ -448,6 +455,13 @@ where
         disk_mb: Some(builder_disk_mb),
         gpu_configs: None,
     };
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Builder resources: {:.2} CPU, {}, {} disk (target rootfs {})",
+        resources.cpus,
+        format_bytes(resources.memory_mb.max(0) as u64 * 1024 * 1024),
+        format_bytes(builder_disk_mb * 1024 * 1024),
+        format_bytes(rootfs_disk_bytes),
+    )));
 
     emit(SandboxImageBuildEvent::Status(format!(
         "Creating rootfs builder sandbox from {}...",
@@ -1077,7 +1091,7 @@ async fn upload_build_inputs(
         emit(SandboxImageBuildEvent::Status(
             "Uploading build context...".to_string(),
         ));
-        upload_context_archive(proxy, &plan.context_dir).await?;
+        upload_context_archive(proxy, &plan.context_dir, emit).await?;
     }
 
     let docker_config_json = resolved_docker_config_json().await?;
@@ -1833,7 +1847,11 @@ fn streaming_process_payload(
     Value::Object(payload)
 }
 
-async fn upload_context_archive(proxy: &SandboxProxyClient, context_dir: &Path) -> Result<()> {
+async fn upload_context_archive(
+    proxy: &SandboxProxyClient,
+    context_dir: &Path,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) -> Result<()> {
     if !context_dir.is_dir() {
         return Err(SandboxImageBuildError::other(format!(
             "Local build context not found: {}",
@@ -1841,36 +1859,143 @@ async fn upload_context_archive(proxy: &SandboxProxyClient, context_dir: &Path) 
         )));
     }
 
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Creating build context archive from {}...",
+        context_dir.display()
+    )));
     let archive = tempfile::Builder::new()
         .prefix("tensorlake-build-context-")
         .suffix(".tar.gz")
         .tempfile()?;
-    create_context_archive(context_dir, archive.path())?;
+    let stats = create_context_archive(context_dir, archive.path())?;
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Build context: {} files, {} uncompressed, {} compressed",
+        stats.file_count,
+        format_bytes(stats.uncompressed_bytes),
+        format_bytes(stats.compressed_bytes),
+    )));
 
     ensure_remote_parent_dir(proxy, REMOTE_CONTEXT_ARCHIVE_PATH).await?;
-    proxy
-        .upload_file(REMOTE_CONTEXT_ARCHIVE_PATH, archive.path())
-        .await?;
-    extract_context_archive(proxy).await
+    upload_archive_with_progress(
+        proxy,
+        REMOTE_CONTEXT_ARCHIVE_PATH,
+        archive.path(),
+        stats.compressed_bytes,
+        emit,
+    )
+    .await?;
+    extract_context_archive(proxy, emit).await
 }
 
-fn create_context_archive(context_dir: &Path, archive_path: &Path) -> Result<()> {
+fn create_context_archive(context_dir: &Path, archive_path: &Path) -> Result<ContextArchiveStats> {
     let file = File::create(archive_path)?;
     let gz = flate2::write::GzEncoder::new(file, flate2::Compression::default());
     let mut tar = tar::Builder::new(gz);
 
-    for (full_path, relative_path) in collect_dir_files(context_dir, context_dir)? {
+    let files = collect_dir_files(context_dir, context_dir)?;
+    let mut uncompressed_bytes = 0_u64;
+    for (full_path, relative_path) in &files {
+        uncompressed_bytes = uncompressed_bytes.saturating_add(std::fs::metadata(full_path)?.len());
         tar.append_path_with_name(full_path, relative_path)?;
     }
     tar.finish()?;
     tar.into_inner()?.finish()?;
-    Ok(())
+    let compressed_bytes = std::fs::metadata(archive_path)?.len();
+    Ok(ContextArchiveStats {
+        file_count: files.len(),
+        uncompressed_bytes,
+        compressed_bytes,
+    })
 }
 
-async fn extract_context_archive(proxy: &SandboxProxyClient) -> Result<()> {
+async fn upload_archive_with_progress(
+    proxy: &SandboxProxyClient,
+    remote_path: &str,
+    local_path: &Path,
+    total_bytes: u64,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) -> Result<()> {
+    emit_upload_progress(0, total_bytes, emit);
+    let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel();
+    let upload = proxy.upload_file_with_progress(remote_path, local_path, progress_tx);
+    tokio::pin!(upload);
+
+    let mut last_percent = 0_u64;
+    loop {
+        tokio::select! {
+            progress = progress_rx.recv() => {
+                if let Some(uploaded) = progress {
+                    let percent = upload_percent(uploaded, total_bytes);
+                    if percent == 100 || percent >= last_percent.saturating_add(10) {
+                        last_percent = percent;
+                        emit_upload_progress(uploaded, total_bytes, emit);
+                    }
+                }
+            }
+            result = &mut upload => {
+                result?;
+                emit_upload_progress(total_bytes, total_bytes, emit);
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn emit_upload_progress(
+    uploaded_bytes: u64,
+    total_bytes: u64,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) {
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Uploading build context archive: {}% ({} / {})",
+        upload_percent(uploaded_bytes, total_bytes),
+        format_bytes(uploaded_bytes.min(total_bytes)),
+        format_bytes(total_bytes),
+    )));
+}
+
+fn upload_percent(uploaded_bytes: u64, total_bytes: u64) -> u64 {
+    if total_bytes == 0 {
+        return 100;
+    }
+    uploaded_bytes
+        .saturating_mul(100)
+        .saturating_div(total_bytes)
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = UNITS[0];
+    for next_unit in &UNITS[1..] {
+        if value < 1024.0 {
+            break;
+        }
+        value /= 1024.0;
+        unit = next_unit;
+    }
+
+    if unit == "B" {
+        format!("{bytes} B")
+    } else if value < 10.0 {
+        format!("{value:.2} {unit}")
+    } else if value < 100.0 {
+        format!("{value:.1} {unit}")
+    } else {
+        format!("{value:.0} {unit}")
+    }
+}
+
+async fn extract_context_archive(
+    proxy: &SandboxProxyClient,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) -> Result<()> {
     ensure_remote_parent_dir(proxy, &join_posix(REMOTE_CONTEXT_DIR, ".keep")).await?;
 
-    let mut emit = |_| {};
+    emit(SandboxImageBuildEvent::Status(
+        "Untarring build context archive in builder sandbox...".to_string(),
+    ));
+    let mut process_emit = |event| emit(event);
     run_streaming_process(
         proxy,
         "tar",
@@ -1883,10 +2008,13 @@ async fn extract_context_archive(proxy: &SandboxProxyClient) -> Result<()> {
         None,
         None,
         false,
-        &mut emit,
+        &mut process_emit,
     )
     .await?;
     proxy.delete_file(REMOTE_CONTEXT_ARCHIVE_PATH).await?;
+    emit(SandboxImageBuildEvent::Status(
+        "Build context extracted; removed remote archive".to_string(),
+    ));
     Ok(())
 }
 
@@ -2544,7 +2672,7 @@ mod tests {
         load_dockerfile_text_plan, logical_dockerfile_lines, normalize_posix,
         parse_df_line_usage_percent, parse_df_max_usage_percent, process_terminal_status,
         rootfs_builder_env, rootfs_builder_executable, rootfs_disk_bytes, rootfs_disk_bytes_to_mb,
-        splice_signed_upload, streaming_process_payload,
+        splice_signed_upload, streaming_process_payload, upload_percent,
     };
     use crate::sandboxes::models::ProcessInfo;
     use serde_json::{Value, json};
@@ -3524,6 +3652,13 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
             entries,
             vec![".dockerignore", "cache/keep.txt", "included.txt"]
         );
+    }
+
+    #[test]
+    fn upload_percent_handles_empty_and_partial_totals() {
+        assert_eq!(upload_percent(0, 0), 100);
+        assert_eq!(upload_percent(25, 100), 25);
+        assert_eq!(upload_percent(100, 100), 100);
     }
 
     #[test]

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -2,7 +2,7 @@ pub mod desktop;
 pub mod models;
 
 use eventsource_stream::Eventsource;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use reqwest::Method;
 use reqwest::StatusCode;
 use reqwest::header::{ACCEPT, CONTENT_LENGTH};
@@ -613,6 +613,29 @@ impl SandboxProxyClient {
         let file = File::open(local_path.as_ref()).await?;
         let size = file.metadata().await?.len();
         let stream = ReaderStream::new(file);
+        let req = self
+            .request(Method::PUT, "/api/v1/files")
+            .query(&[("path", path)])
+            .header(CONTENT_LENGTH, size)
+            .body(reqwest::Body::wrap_stream(stream))
+            .build()?;
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
+    }
+
+    pub async fn upload_file_with_progress(
+        &self,
+        path: &str,
+        local_path: impl AsRef<Path>,
+        progress_tx: tokio::sync::mpsc::UnboundedSender<u64>,
+    ) -> Result<Traced<()>, SdkError> {
+        let file = File::open(local_path.as_ref()).await?;
+        let size = file.metadata().await?.len();
+        let mut uploaded = 0_u64;
+        let stream = ReaderStream::new(file).map_ok(move |chunk| {
+            uploaded = uploaded.saturating_add(chunk.len() as u64);
+            let _ = progress_tx.send(uploaded);
+            chunk
+        });
         let req = self
             .request(Method::PUT, "/api/v1/files")
             .query(&[("path", path)])

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.48"
+version = "0.5.49"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.48"
+version = "0.5.49"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.48",
+  "version": "0.5.49",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Print builder sandbox CPU, memory, disk, and target rootfs disk before provisioning
- Print build context file count plus uncompressed and compressed archive sizes
- Report build context archive upload percentage while streaming the upload
- Print explicit untar and remote archive cleanup status messages

## Tests
- cargo fmt --package tensorlake --check
- cargo check -p tensorlake
- cargo test -p tensorlake sandbox_images::tests::