### PR TITLE
Sw/fix template app

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.49"
+version = "0.5.50"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/project/templates.rs
+++ b/crates/cli/src/project/templates.rs
@@ -39,9 +39,9 @@ Once deployed, call it using curl or the Python SDK:
 
 **Using curl:**
 ```bash
-curl -X POST https://api.tensorlake.ai/applications/{function_name} \
+curl https://api.tensorlake.ai/applications/{function_name} \
   -H "Authorization: Bearer $TENSORLAKE_API_KEY" \
-  -d 'World'
+  --json '"World"'
 ```
 
 **Using Python SDK:**

--- a/crates/cli/src/project/templates.rs
+++ b/crates/cli/src/project/templates.rs
@@ -16,7 +16,7 @@ def {function_name}(name: str) -> str:
     Returns:
         A greeting message
     """
-    return f"Hello, {{name}}!"
+    return f"Hello, {name}!"
 "#;
 
 pub const README_TEMPLATE: &str = r#"# {app_name}

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.49"
+version = "0.5.50"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.49"
+version = "0.5.50"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]


### PR DESCRIPTION
### Changes 

 - Scaffolded app code now emits f"Hello, {name}!" instead of the escaped {{name}} (Rust template double-brace was leaking into generated Python).
 - README curl example now uses --json '"World"' to match the SDK-generated command — correct JSON content type and a valid JSON-encoded body (the old -d 'World' sent form-encoded, invalid JSON; -X POST was redundant).