### PR TITLE
Provision tl-user in sandbox images built from upstream bases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.50"
+version = "0.5.51"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.50"
+version = "0.5.51"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.50"
+version = "0.5.51"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/image/_dockerfile.py
+++ b/src/tensorlake/image/_dockerfile.py
@@ -11,6 +11,25 @@ import json
 
 from .image import Image, _ImageBuildOperation, _ImageBuildOperationType
 
+# Tensorlake's sandbox runtime runs commands as the ``tl-user`` account. Provision
+# it so images built from upstream bases (e.g. ``python:3.11-slim``) that lack the
+# account don't fail at runtime with ``user not found: tl-user``.
+#
+# Best-effort and portable by design:
+#   * no-op when ``tl-user`` already exists (Tensorlake base images);
+#   * ``useradd`` for glibc bases (Debian/Ubuntu/Fedora/...);
+#   * BusyBox ``adduser -D`` fallback for Alpine, which lacks ``useradd``;
+#   * trailing ``|| true`` so a base with a non-root default ``USER`` (no
+#     permission to edit ``/etc/passwd``) or any other failure never aborts a
+#     build that previously succeeded.
+# Must stay byte-identical to the TypeScript SDK's ``ENSURE_RUNTIME_USER_COMMAND``.
+ENSURE_RUNTIME_USER_COMMAND = (
+    "id -u tl-user >/dev/null 2>&1 "
+    "|| useradd -m tl-user >/dev/null 2>&1 "
+    "|| adduser -D tl-user >/dev/null 2>&1 "
+    "|| true"
+)
+
 
 def render_op_line(op: _ImageBuildOperation) -> str:
     """Format a single build op as a Dockerfile instruction line."""
@@ -31,6 +50,7 @@ def image_to_dockerfile(image: Image) -> str:
     lines: list[str] = []
     if image._base_image:
         lines.append(f"FROM {image._base_image}")
+        lines.append(f"RUN {ENSURE_RUNTIME_USER_COMMAND}")
     for op in image._build_operations:
         lines.append(render_op_line(op))
     return "\n".join(lines)

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -23,6 +23,13 @@ class _ImageBuildOperation:
 
 
 class Image:
+    """A custom sandbox/function image.
+
+    Sandbox commands run as the ``tl-user`` account. When an image is built as a
+    sandbox image, ``tl-user`` is provisioned automatically, so any base image
+    (e.g. ``python:3.11-slim``) works without extra setup.
+    """
+
     def __init__(
         self,
         name: str = "default",

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -775,8 +775,8 @@ class Sandbox:
     ) -> str | dict[str, Any] | None:
         if user is None:
             # Caller did not request a specific user: omit the field so the
-            # sandbox resolves the image's configured user (e.g. the image
-            # ``USER`` directive, falling back to root).
+            # sandbox resolves the image's configured user (``tl-user`` on
+            # Tensorlake base images).
             return None
         if isinstance(user, str):
             value = user
@@ -868,9 +868,9 @@ class Sandbox:
             working_dir: Working directory
             timeout: Maximum seconds to wait (enforced server-side; None = no limit)
             user: Process user. Defaults to ``None``, which runs as the image's
-                configured user (the image ``USER`` directive, falling back to
-                root). Pass a username such as ``"root"``, a Docker-style id
-                string like ``"1000:1000"``, or ``ProcessUserSpec(uid=1000, gid=1000)``.
+                configured user — ``tl-user`` on Tensorlake base images. Pass a
+                username such as ``"root"``, a Docker-style id string like
+                ``"1000:1000"``, or ``ProcessUserSpec(uid=1000, gid=1000)``.
 
         Returns:
             Traced[CommandResult] — access ``.trace_id`` for the W3C trace ID
@@ -952,9 +952,9 @@ class Sandbox:
             stdout_mode: OutputMode.CAPTURE or OutputMode.DISCARD
             stderr_mode: OutputMode.CAPTURE or OutputMode.DISCARD
             user: Process user. Defaults to ``None``, which runs as the image's
-                configured user (the image ``USER`` directive, falling back to
-                root). Pass a username such as ``"root"``, a Docker-style id
-                string like ``"1000:1000"``, or ``ProcessUserSpec(uid=1000, gid=1000)``.
+                configured user — ``tl-user`` on Tensorlake base images. Pass a
+                username such as ``"root"``, a Docker-style id string like
+                ``"1000:1000"``, or ``ProcessUserSpec(uid=1000, gid=1000)``.
             name: Optional managed-process name. Supplying this opts the process
                 into daemon management.
             restart: Optional restart policy. Supplying this opts the process

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -448,10 +448,15 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
         _, _, rust_builder, captured = self._run_build(image)
 
         # The registered Dockerfile must match exactly what the TS SDK would
-        # generate — no WORKDIR /app or pip install tensorlake injection.
+        # generate — no WORKDIR /app or pip install tensorlake injection, but
+        # the tl-user runtime account is provisioned right after FROM.
         expected_dockerfile = "\n".join(
             [
                 "FROM python:3.12-slim",
+                "RUN id -u tl-user >/dev/null 2>&1 "
+                "|| useradd -m tl-user >/dev/null 2>&1 "
+                "|| adduser -D tl-user >/dev/null 2>&1 "
+                "|| true",
                 "RUN apt-get update",
                 "WORKDIR /app",
                 'ENV APP_ENV="prod"',

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.49",
+  "version": "0.5.50",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/image.ts
+++ b/typescript/src/image.ts
@@ -169,8 +169,29 @@ function renderBuildOp(op: ImageBuildOperation): string {
   return `${op.type}${options} ${op.args.join(" ")}`;
 }
 
+// Tensorlake's sandbox runtime runs commands as the `tl-user` account. Provision
+// it so images built from upstream bases (e.g. `python:3.11-slim`) that lack the
+// account don't fail at runtime with `user not found: tl-user`.
+//
+// Best-effort and portable by design:
+//   * no-op when `tl-user` already exists (Tensorlake base images);
+//   * `useradd` for glibc bases (Debian/Ubuntu/Fedora/...);
+//   * BusyBox `adduser -D` fallback for Alpine, which lacks `useradd`;
+//   * trailing `|| true` so a base with a non-root default `USER` (no
+//     permission to edit `/etc/passwd`) or any other failure never aborts a
+//     build that previously succeeded.
+// Must stay byte-identical to the Python SDK's `ENSURE_RUNTIME_USER_COMMAND`.
+const ENSURE_RUNTIME_USER_COMMAND =
+  "id -u tl-user >/dev/null 2>&1 " +
+  "|| useradd -m tl-user >/dev/null 2>&1 " +
+  "|| adduser -D tl-user >/dev/null 2>&1 " +
+  "|| true";
+
 export function dockerfileContent(image: Image): string {
-  const lines = image.baseImage == null ? [] : [`FROM ${image.baseImage}`];
+  const lines =
+    image.baseImage == null
+      ? []
+      : [`FROM ${image.baseImage}`, `RUN ${ENSURE_RUNTIME_USER_COMMAND}`];
   lines.push(...image.buildOperations.map((op) => renderBuildOp(op)));
   return lines.join("\n");
 }

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -446,6 +446,10 @@ describe("dockerfileContent", () => {
     expect(dockerfileContent(image)).toBe(
       [
         "FROM python:3.12-slim",
+        "RUN id -u tl-user >/dev/null 2>&1 " +
+          "|| useradd -m tl-user >/dev/null 2>&1 " +
+          "|| adduser -D tl-user >/dev/null 2>&1 " +
+          "|| true",
         "RUN apt-get update",
         "WORKDIR /app",
         'ENV APP_ENV="prod"',


### PR DESCRIPTION
## Changes

Inject a best-effort `RUN` into generated sandbox Dockerfiles that provision the `tl-user` account when it's missing from the base image.

## Why

Sandbox commands run as `tl-user`. Images built from upstream bases (e.g. `python:3.11-slim`) don't ship that account, so commands failed at runtime with `user not found: tl-user`. Tensorlake's own bases already include it, which is why this only surfaced with custom bases.

## How

`ENSURE_RUNTIME_USER_COMMAND` runs after `FROM`:

- no-op if `tl-user` already exists (Tensorlake bases)
- `useradd` for glibc bases (Debian/Ubuntu/…)
- `adduser -D` fallback for Alpine/BusyBox
- trailing `|| true` so the build never aborts

Kept byte-identical between the Python and TypeScript SDKs.

## Notes

- Bumps Python SDK to 0.5.51 and TypeScript SDK to 0.5.50.