### PR TITLE
Match docker build-context UX for sandbox Image builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.49"
+version = "0.5.50"
 dependencies = [
  "base64",
  "bollard",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.49"
+version = "0.5.50"
 dependencies = [
  "napi",
  "napi-build",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.49"
+version = "0.5.50"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.50"
+version = "0.5.51"
 dependencies = [
  "base64",
  "bollard",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.50"
+version = "0.5.51"
 dependencies = [
  "napi",
  "napi-build",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.50"
+version = "0.5.51"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.50"
+version = "0.5.51"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.50"
+version = "0.5.51"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.50"
+version = "0.5.51"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -124,7 +124,10 @@ class Image:
                 is slower and uses more memory and disk space on builder
                 sandbox).
             context_dir: Directory used to resolve relative COPY/ADD paths.
-                Defaults to the current working directory.
+                When omitted, an empty build context is used (the generated
+                Dockerfile needs no host files), so the current working
+                directory is not uploaded. Pass this explicitly only when the
+                image copies local files.
             verbose: If True, print build progress to stderr.
 
         Returns:

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -123,11 +123,12 @@ class Image:
             docker_compat: Use Docker/BuildKit max compatibility mode (build
                 is slower and uses more memory and disk space on builder
                 sandbox).
-            context_dir: Directory used to resolve relative COPY/ADD paths.
-                When omitted, an empty build context is used (the generated
-                Dockerfile needs no host files), so the current working
-                directory is not uploaded. Pass this explicitly only when the
-                image copies local files.
+            context_dir: Directory uploaded as the build context. When omitted,
+                a minimal context is assembled automatically containing only
+                the files referenced by this image's COPY/ADD ops (resolved
+                relative to the current working directory), so the cwd is not
+                uploaded wholesale. Pass this to upload a specific directory
+                as-is instead.
             verbose: If True, print build progress to stderr.
 
         Returns:

--- a/src/tensorlake/image/image.py
+++ b/src/tensorlake/image/image.py
@@ -123,12 +123,13 @@ class Image:
             docker_compat: Use Docker/BuildKit max compatibility mode (build
                 is slower and uses more memory and disk space on builder
                 sandbox).
-            context_dir: Directory uploaded as the build context. When omitted,
-                a minimal context is assembled automatically containing only
-                the files referenced by this image's COPY/ADD ops (resolved
-                relative to the current working directory), so the cwd is not
-                uploaded wholesale. Pass this to upload a specific directory
-                as-is instead.
+            context_dir: Build context directory, used exactly like
+                ``docker build <context_dir>``: it is uploaded as-is and
+                ``copy()``/``add()`` sources resolve relative to it. Required
+                when this image has ``copy()``/``add()`` ops that read host
+                files — building without it then raises. When the image has no
+                such ops it may be omitted, and an empty context (just the
+                generated Dockerfile) is uploaded so the cwd is not archived.
             verbose: If True, print build progress to stderr.
 
         Returns:

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -16,9 +16,11 @@ sandbox runs from the image (``ONBUILD``/``SHELL``/``EXPOSE``/``HEALTHCHECK``/
 from __future__ import annotations
 
 import contextlib
+import glob as globlib
 import json
 import os
 import re
+import shutil
 import tempfile
 import warnings
 from pathlib import Path
@@ -28,7 +30,7 @@ from tensorlake._tracing import USER_AGENT
 from tensorlake.cli._common import Context
 
 from ._dockerfile import image_to_dockerfile
-from .image import Image
+from .image import Image, _ImageBuildOperation, _ImageBuildOperationType
 from .utils import dockerfile_content
 
 EmitFn = Callable[[dict], None]
@@ -494,19 +496,110 @@ def list_sandbox_images() -> list[dict]:
         ) from exc
 
 
-def _image_context_dir(context_dir: str | None, stack: contextlib.ExitStack) -> str:
+_GLOB_CHARS = ("*", "?", "[")
+
+
+def _is_remote_src(src: str) -> bool:
+    """True for ADD sources that are remote URLs rather than host files."""
+    return src.startswith(("http://", "https://"))
+
+
+def _op_references_host_files(op: _ImageBuildOperation) -> bool:
+    """True when a build op copies files from the host into the image.
+
+    ``COPY --from=<stage>`` and remote ``ADD <url>`` sources don't read host
+    files, so they don't need anything staged into the build context.
+    """
+    if op.type not in (_ImageBuildOperationType.COPY, _ImageBuildOperationType.ADD):
+        return False
+    if "from" in (op.options or {}):
+        return False
+    if op.type == _ImageBuildOperationType.ADD and _is_remote_src(op.args[0]):
+        return False
+    return True
+
+
+def _stage_source(src: str, base: Path, dest: Path) -> None:
+    """Copy a single COPY/ADD source from ``base`` into the minimal context.
+
+    The source is preserved at the same path (relative to the context root)
+    that the rendered Dockerfile instruction expects, so the staged context is
+    a faithful subset of ``base`` containing only the referenced files.
+    """
+    # Docker resolves COPY/ADD sources relative to the context root; a leading
+    # "./" or "/" is equivalent to a context-relative path.
+    pattern = src.lstrip("/")
+    if pattern.startswith("./"):
+        pattern = pattern[2:]
+
+    if any(ch in pattern for ch in _GLOB_CHARS):
+        matches = [Path(p) for p in globlib.glob(str(base / pattern), recursive=True)]
+        if not matches:
+            raise SandboxImageBuildError(
+                f"COPY/ADD source {src!r} matched no files under {base}. "
+                "Pass `context_dir=...` if the sources live elsewhere."
+            )
+    else:
+        candidate = base / pattern
+        if not candidate.exists():
+            raise SandboxImageBuildError(
+                f"COPY/ADD source {src!r} not found under {base}. "
+                "Pass `context_dir=...` if the sources live elsewhere."
+            )
+        matches = [candidate]
+
+    for match in matches:
+        # Path (relative to the context root) that the rendered Dockerfile
+        # instruction refers to. Collapse ".." lexically but DO NOT follow
+        # symlinks: the Dockerfile names the source path, so the staged file
+        # must live at that same path even when the source is a symlink
+        # (resolving it would stage the link target's path instead).
+        normalized = Path(os.path.normpath(match))
+        try:
+            rel = normalized.relative_to(base)
+        except ValueError as exc:
+            raise SandboxImageBuildError(
+                f"COPY/ADD source {src!r} resolves outside the build context "
+                f"base {base}. Pass an explicit `context_dir`."
+            ) from exc
+        target = dest / rel
+        if match.is_dir():
+            shutil.copytree(match, target, dirs_exist_ok=True)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(match, target)
+
+
+def _image_context_dir(
+    image: Image,
+    context_dir: str | None,
+    stack: contextlib.ExitStack,
+) -> str:
     """Resolve the build-context directory for an :class:`Image` build.
 
-    Image objects render their Dockerfile from text and (by design) don't copy
-    host files, so there is no build context to upload. When the caller doesn't
-    pass an explicit ``context_dir`` we use a throwaway empty temp dir rather
-    than the current working directory — otherwise the whole cwd (which has no
-    Dockerfile in it) gets archived and uploaded. The temp dir is cleaned up
-    when ``stack`` closes.
+    When the caller passes an explicit ``context_dir`` we upload that directory
+    as-is (an escape hatch for complex layouts). Otherwise we assemble a
+    *minimal* throwaway context that contains only the files referenced by the
+    image's COPY/ADD ops — resolved relative to the current working directory —
+    so those copies succeed without archiving and uploading the whole cwd. An
+    image with no host-file copies yields an empty context. The temp dir is
+    cleaned up when ``stack`` closes.
     """
     if context_dir is not None:
         return str(Path(context_dir).resolve())
-    return stack.enter_context(tempfile.TemporaryDirectory(prefix="tl-build-context-"))
+    temp = stack.enter_context(tempfile.TemporaryDirectory(prefix="tl-build-context-"))
+    base = Path(os.getcwd()).resolve()
+    dest = Path(temp)
+    for op in image._build_operations:
+        if _op_references_host_files(op):
+            _stage_source(op.args[0], base, dest)
+    # Carry over the context root's .dockerignore so the Rust archiver applies
+    # the same exclusions it would for a full-cwd context. Staged files keep
+    # their cwd-relative paths, so the patterns still match.
+    dockerignore = base / ".dockerignore"
+    if dockerignore.is_file():
+        shutil.copy2(dockerignore, dest / ".dockerignore")
+    return temp
 
 
 def build_sandbox_image(
@@ -541,11 +634,13 @@ def build_sandbox_image(
         is_public: Make the registered image publicly accessible.
         docker_compat: Use Docker/BuildKit max compatibility mode (build is
             slower and uses more memory and disk space on builder sandbox).
-        context_dir: Directory used to resolve relative COPY/ADD sources for
-            an :class:`Image` source. When omitted, an empty build context is
-            used rather than the current working directory, so cwd is not
-            archived and uploaded. Ignored when ``source`` is a Dockerfile path
-            (the Dockerfile's parent directory is used instead).
+        context_dir: Directory uploaded as the build context for an
+            :class:`Image` source. When omitted, a minimal context is assembled
+            automatically containing only the files referenced by the image's
+            COPY/ADD ops (resolved relative to the current working directory),
+            so cwd is not archived and uploaded wholesale. Pass this to upload a
+            specific directory as-is instead. Ignored when ``source`` is a
+            Dockerfile path (the Dockerfile's parent directory is used instead).
         verbose: Print progress to stderr. Ignored if ``emit`` is provided.
         emit: Callback invoked for each build event. Takes precedence over
             ``verbose``. Use this to integrate the builder into custom UIs.
@@ -567,7 +662,7 @@ def build_sandbox_image(
         if isinstance(source, Image):
             if not source._base_image:
                 raise SandboxImageLoadError("Image must have a base_image to build")
-            rust_context_dir = _image_context_dir(context_dir, stack)
+            rust_context_dir = _image_context_dir(source, context_dir, stack)
             rust_dockerfile_path = str(Path(rust_context_dir) / "Dockerfile")
             dockerfile_text = image_to_dockerfile(source)
             if not dockerfile_text.endswith("\n"):
@@ -738,7 +833,7 @@ def build_sandbox_application_image(
         )
 
     with contextlib.ExitStack() as stack:
-        rust_context_dir = _image_context_dir(context_dir, stack)
+        rust_context_dir = _image_context_dir(image, context_dir, stack)
         rust_dockerfile_path = str(Path(rust_context_dir) / "Dockerfile")
         dockerfile_text = dockerfile_content(image, extra_env_vars=build_env_vars)
         if not dockerfile_text.endswith("\n"):

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -16,11 +16,9 @@ sandbox runs from the image (``ONBUILD``/``SHELL``/``EXPOSE``/``HEALTHCHECK``/
 from __future__ import annotations
 
 import contextlib
-import glob as globlib
 import json
 import os
 import re
-import shutil
 import tempfile
 import warnings
 from pathlib import Path
@@ -496,110 +494,30 @@ def list_sandbox_images() -> list[dict]:
         ) from exc
 
 
-_GLOB_CHARS = ("*", "?", "[")
-
-
-def _is_remote_src(src: str) -> bool:
-    """True for ADD sources that are remote URLs rather than host files."""
-    return src.startswith(("http://", "https://"))
-
-
 def _op_references_host_files(op: _ImageBuildOperation) -> bool:
     """True when a build op copies files from the host into the image.
 
     ``COPY --from=<stage>`` and remote ``ADD <url>`` sources don't read host
-    files, so they don't need anything staged into the build context.
+    files, so they don't need a build context.
     """
     if op.type not in (_ImageBuildOperationType.COPY, _ImageBuildOperationType.ADD):
         return False
     if "from" in (op.options or {}):
         return False
-    if op.type == _ImageBuildOperationType.ADD and _is_remote_src(op.args[0]):
+    if op.type == _ImageBuildOperationType.ADD and op.args[0].startswith(
+        ("http://", "https://")
+    ):
         return False
     return True
 
 
-def _stage_source(src: str, base: Path, dest: Path) -> None:
-    """Copy a single COPY/ADD source from ``base`` into the minimal context.
+def _image_requires_context(image: Image) -> bool:
+    """True if the image has COPY/ADD ops that read files from the host.
 
-    The source is preserved at the same path (relative to the context root)
-    that the rendered Dockerfile instruction expects, so the staged context is
-    a faithful subset of ``base`` containing only the referenced files.
+    Such builds need a build context to resolve those sources, so the caller
+    must pass ``context_dir`` (mirroring ``docker build <context>``).
     """
-    # Docker resolves COPY/ADD sources relative to the context root; a leading
-    # "./" or "/" is equivalent to a context-relative path.
-    pattern = src.lstrip("/")
-    if pattern.startswith("./"):
-        pattern = pattern[2:]
-
-    if any(ch in pattern for ch in _GLOB_CHARS):
-        matches = [Path(p) for p in globlib.glob(str(base / pattern), recursive=True)]
-        if not matches:
-            raise SandboxImageBuildError(
-                f"COPY/ADD source {src!r} matched no files under {base}. "
-                "Pass `context_dir=...` if the sources live elsewhere."
-            )
-    else:
-        candidate = base / pattern
-        if not candidate.exists():
-            raise SandboxImageBuildError(
-                f"COPY/ADD source {src!r} not found under {base}. "
-                "Pass `context_dir=...` if the sources live elsewhere."
-            )
-        matches = [candidate]
-
-    for match in matches:
-        # Path (relative to the context root) that the rendered Dockerfile
-        # instruction refers to. Collapse ".." lexically but DO NOT follow
-        # symlinks: the Dockerfile names the source path, so the staged file
-        # must live at that same path even when the source is a symlink
-        # (resolving it would stage the link target's path instead).
-        normalized = Path(os.path.normpath(match))
-        try:
-            rel = normalized.relative_to(base)
-        except ValueError as exc:
-            raise SandboxImageBuildError(
-                f"COPY/ADD source {src!r} resolves outside the build context "
-                f"base {base}. Pass an explicit `context_dir`."
-            ) from exc
-        target = dest / rel
-        if match.is_dir():
-            shutil.copytree(match, target, dirs_exist_ok=True)
-        else:
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(match, target)
-
-
-def _image_context_dir(
-    image: Image,
-    context_dir: str | None,
-    stack: contextlib.ExitStack,
-) -> str:
-    """Resolve the build-context directory for an :class:`Image` build.
-
-    When the caller passes an explicit ``context_dir`` we upload that directory
-    as-is (an escape hatch for complex layouts). Otherwise we assemble a
-    *minimal* throwaway context that contains only the files referenced by the
-    image's COPY/ADD ops — resolved relative to the current working directory —
-    so those copies succeed without archiving and uploading the whole cwd. An
-    image with no host-file copies yields an empty context. The temp dir is
-    cleaned up when ``stack`` closes.
-    """
-    if context_dir is not None:
-        return str(Path(context_dir).resolve())
-    temp = stack.enter_context(tempfile.TemporaryDirectory(prefix="tl-build-context-"))
-    base = Path(os.getcwd()).resolve()
-    dest = Path(temp)
-    for op in image._build_operations:
-        if _op_references_host_files(op):
-            _stage_source(op.args[0], base, dest)
-    # Carry over the context root's .dockerignore so the Rust archiver applies
-    # the same exclusions it would for a full-cwd context. Staged files keep
-    # their cwd-relative paths, so the patterns still match.
-    dockerignore = base / ".dockerignore"
-    if dockerignore.is_file():
-        shutil.copy2(dockerignore, dest / ".dockerignore")
-    return temp
+    return any(_op_references_host_files(op) for op in image._build_operations)
 
 
 def build_sandbox_image(
@@ -634,13 +552,14 @@ def build_sandbox_image(
         is_public: Make the registered image publicly accessible.
         docker_compat: Use Docker/BuildKit max compatibility mode (build is
             slower and uses more memory and disk space on builder sandbox).
-        context_dir: Directory uploaded as the build context for an
-            :class:`Image` source. When omitted, a minimal context is assembled
-            automatically containing only the files referenced by the image's
-            COPY/ADD ops (resolved relative to the current working directory),
-            so cwd is not archived and uploaded wholesale. Pass this to upload a
-            specific directory as-is instead. Ignored when ``source`` is a
-            Dockerfile path (the Dockerfile's parent directory is used instead).
+        context_dir: Build context directory for an :class:`Image` source,
+            used exactly like ``docker build <context_dir>``: it is uploaded
+            as-is and COPY/ADD sources resolve relative to it. Required when
+            the image has COPY/ADD ops that read host files — building without
+            it then raises. When the image has no such ops it may be omitted,
+            and an empty context (just the generated Dockerfile) is uploaded so
+            cwd is not archived. Ignored when ``source`` is a Dockerfile path
+            (the Dockerfile's parent directory is used instead).
         verbose: Print progress to stderr. Ignored if ``emit`` is provided.
         emit: Callback invoked for each build event. Takes precedence over
             ``verbose``. Use this to integrate the builder into custom UIs.
@@ -662,7 +581,23 @@ def build_sandbox_image(
         if isinstance(source, Image):
             if not source._base_image:
                 raise SandboxImageLoadError("Image must have a base_image to build")
-            rust_context_dir = _image_context_dir(source, context_dir, stack)
+            if context_dir is not None:
+                # Upload the given directory as-is, like `docker build <dir>`.
+                rust_context_dir = str(Path(context_dir).resolve())
+            elif _image_requires_context(source):
+                raise SandboxImageBuildError(
+                    "This image uses COPY/ADD to read files from the host, so "
+                    "it needs a build context. Pass `context_dir=...` pointing "
+                    "at the directory that contains those sources; COPY/ADD "
+                    "paths resolve relative to it, like `docker build "
+                    "<context_dir>`."
+                )
+            else:
+                # No host-file copies: upload an empty context (just the
+                # generated Dockerfile) instead of archiving the whole cwd.
+                rust_context_dir = stack.enter_context(
+                    tempfile.TemporaryDirectory(prefix="tl-build-context-")
+                )
             rust_dockerfile_path = str(Path(rust_context_dir) / "Dockerfile")
             dockerfile_text = image_to_dockerfile(source)
             if not dockerfile_text.endswith("\n"):
@@ -832,31 +767,30 @@ def build_sandbox_application_image(
             stacklevel=2,
         )
 
-    with contextlib.ExitStack() as stack:
-        rust_context_dir = _image_context_dir(image, context_dir, stack)
-        rust_dockerfile_path = str(Path(rust_context_dir) / "Dockerfile")
-        dockerfile_text = dockerfile_content(image, extra_env_vars=build_env_vars)
-        if not dockerfile_text.endswith("\n"):
-            dockerfile_text += "\n"
+    rust_context_dir = str(Path(context_dir or os.getcwd()).resolve())
+    rust_dockerfile_path = str(Path(rust_context_dir) / "Dockerfile")
+    dockerfile_text = dockerfile_content(image, extra_env_vars=build_env_vars)
+    if not dockerfile_text.endswith("\n"):
+        dockerfile_text += "\n"
 
-        try:
-            return _run_rust_image_create(
-                rust_dockerfile_path,
-                effective_registered_name,
-                dockerfile_text=dockerfile_text,
-                context_dir=rust_context_dir,
-                cpus=cpus,
-                memory_mb=memory_mb,
-                disk_mb=disk_mb,
-                builder_disk_mb=builder_disk_mb,
-                is_public=is_public,
-                docker_compat=False,
-                emit=emit,
-            )
-        except SandboxImageError:
-            raise
-        except Exception as e:
-            raise SandboxImageBuildError(f"{type(e).__name__}: {e}") from e
+    try:
+        return _run_rust_image_create(
+            rust_dockerfile_path,
+            effective_registered_name,
+            dockerfile_text=dockerfile_text,
+            context_dir=rust_context_dir,
+            cpus=cpus,
+            memory_mb=memory_mb,
+            disk_mb=disk_mb,
+            builder_disk_mb=builder_disk_mb,
+            is_public=is_public,
+            docker_compat=False,
+            emit=emit,
+        )
+    except SandboxImageError:
+        raise
+    except Exception as e:
+        raise SandboxImageBuildError(f"{type(e).__name__}: {e}") from e
 
 
 def _default_registered_name(dockerfile_path: str) -> str:

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -494,12 +494,37 @@ def list_sandbox_images() -> list[dict]:
         ) from exc
 
 
-def _op_references_host_files(op: _ImageBuildOperation) -> bool:
-    """True when a build op copies files from the host into the image.
+def _run_op_mounts_context(op: _ImageBuildOperation) -> bool:
+    """True when a ``RUN`` op bind-mounts the build context (reads host files).
 
-    ``COPY --from=<stage>`` and remote ``ADD <url>`` sources don't read host
-    files, so they don't need a build context.
+    A BuildKit ``RUN --mount=type=bind`` reads from the build context unless it
+    mounts ``from=<stage/image>``. ``bind`` is the default mount type, so a
+    mount with no explicit ``type`` counts too. Other mount types
+    (``cache``/``tmpfs``/``secret``/``ssh``) don't read the build context.
     """
+    if op.type is not _ImageBuildOperationType.RUN:
+        return False
+    mount = (op.options or {}).get("mount")
+    if not mount:
+        return False
+    fields: dict[str, str] = {}
+    for token in mount.split(","):
+        key, _, value = token.partition("=")
+        fields[key.strip()] = value.strip()
+    if fields.get("type", "bind") != "bind":
+        return False
+    return "from" not in fields
+
+
+def _op_references_host_files(op: _ImageBuildOperation) -> bool:
+    """True when a build op reads files from the host build context.
+
+    ``COPY``/``ADD`` with host sources need a context; a ``RUN`` with a
+    ``--mount=type=bind`` (the default type) reads it too. ``COPY --from=<stage>``,
+    remote ``ADD <url>``, ``from=`` bind mounts, and non-bind mounts don't.
+    """
+    if op.type is _ImageBuildOperationType.RUN:
+        return _run_op_mounts_context(op)
     if op.type not in (_ImageBuildOperationType.COPY, _ImageBuildOperationType.ADD):
         return False
     if "from" in (op.options or {}):
@@ -512,10 +537,11 @@ def _op_references_host_files(op: _ImageBuildOperation) -> bool:
 
 
 def _image_requires_context(image: Image) -> bool:
-    """True if the image has COPY/ADD ops that read files from the host.
+    """True if the image has ops that read files from the host.
 
-    Such builds need a build context to resolve those sources, so the caller
-    must pass ``context_dir`` (mirroring ``docker build <context>``).
+    Such builds need a build context to resolve those sources (COPY/ADD host
+    sources, or a RUN bind mount), so the caller must pass ``context_dir``
+    (mirroring ``docker build <context>``).
     """
     return any(_op_references_host_files(op) for op in image._build_operations)
 
@@ -586,11 +612,11 @@ def build_sandbox_image(
                 rust_context_dir = str(Path(context_dir).resolve())
             elif _image_requires_context(source):
                 raise SandboxImageBuildError(
-                    "This image uses COPY/ADD to read files from the host, so "
-                    "it needs a build context. Pass `context_dir=...` pointing "
-                    "at the directory that contains those sources; COPY/ADD "
-                    "paths resolve relative to it, like `docker build "
-                    "<context_dir>`."
+                    "This image reads files from the host (via COPY/ADD or a "
+                    "RUN bind mount), so it needs a build context. Pass "
+                    "`context_dir=...` pointing at the directory that contains "
+                    "those sources; they resolve relative to it, like "
+                    "`docker build <context_dir>`."
                 )
             else:
                 # No host-file copies: upload an empty context (just the

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -15,9 +15,11 @@ sandbox runs from the image (``ONBUILD``/``SHELL``/``EXPOSE``/``HEALTHCHECK``/
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
+import tempfile
 import warnings
 from pathlib import Path
 from typing import Any, Callable
@@ -492,6 +494,21 @@ def list_sandbox_images() -> list[dict]:
         ) from exc
 
 
+def _image_context_dir(context_dir: str | None, stack: contextlib.ExitStack) -> str:
+    """Resolve the build-context directory for an :class:`Image` build.
+
+    Image objects render their Dockerfile from text and (by design) don't copy
+    host files, so there is no build context to upload. When the caller doesn't
+    pass an explicit ``context_dir`` we use a throwaway empty temp dir rather
+    than the current working directory — otherwise the whole cwd (which has no
+    Dockerfile in it) gets archived and uploaded. The temp dir is cleaned up
+    when ``stack`` closes.
+    """
+    if context_dir is not None:
+        return str(Path(context_dir).resolve())
+    return stack.enter_context(tempfile.TemporaryDirectory(prefix="tl-build-context-"))
+
+
 def build_sandbox_image(
     source: Image | str,
     *,
@@ -524,9 +541,11 @@ def build_sandbox_image(
         is_public: Make the registered image publicly accessible.
         docker_compat: Use Docker/BuildKit max compatibility mode (build is
             slower and uses more memory and disk space on builder sandbox).
-        context_dir: Directory used to resolve relative COPY/ADD sources.
-            Ignored when ``source`` is a Dockerfile path (the Dockerfile's
-            parent directory is used instead).
+        context_dir: Directory used to resolve relative COPY/ADD sources for
+            an :class:`Image` source. When omitted, an empty build context is
+            used rather than the current working directory, so cwd is not
+            archived and uploaded. Ignored when ``source`` is a Dockerfile path
+            (the Dockerfile's parent directory is used instead).
         verbose: Print progress to stderr. Ignored if ``emit`` is provided.
         emit: Callback invoked for each build event. Takes precedence over
             ``verbose``. Use this to integrate the builder into custom UIs.
@@ -544,58 +563,59 @@ def build_sandbox_image(
     if emit is None:
         emit = _stderr_emit if verbose else _noop_emit
 
-    if isinstance(source, Image):
-        if not source._base_image:
-            raise SandboxImageLoadError("Image must have a base_image to build")
-        rust_context_dir = str(Path(context_dir or os.getcwd()).resolve())
-        rust_dockerfile_path = str(Path(rust_context_dir) / "Dockerfile")
-        dockerfile_text = image_to_dockerfile(source)
-        if not dockerfile_text.endswith("\n"):
-            dockerfile_text += "\n"
-        effective_registered_name = registered_name or source.name
-    elif isinstance(source, (str, os.PathLike)):
-        path = Path(os.fspath(source)).resolve()
-        if not path.is_file():
-            raise SandboxImageLoadError(f"Dockerfile not found: {source}")
-        rust_dockerfile_path = str(path)
-        rust_context_dir = None
-        dockerfile_text = None
-        effective_registered_name = registered_name or _default_registered_name(
-            str(path)
-        )
-    else:
-        # Programmer error — propagate directly rather than wrapping.
-        raise TypeError(
-            "source must be an Image or a Dockerfile path, got "
-            f"{type(source).__name__}"
-        )
+    with contextlib.ExitStack() as stack:
+        if isinstance(source, Image):
+            if not source._base_image:
+                raise SandboxImageLoadError("Image must have a base_image to build")
+            rust_context_dir = _image_context_dir(context_dir, stack)
+            rust_dockerfile_path = str(Path(rust_context_dir) / "Dockerfile")
+            dockerfile_text = image_to_dockerfile(source)
+            if not dockerfile_text.endswith("\n"):
+                dockerfile_text += "\n"
+            effective_registered_name = registered_name or source.name
+        elif isinstance(source, (str, os.PathLike)):
+            path = Path(os.fspath(source)).resolve()
+            if not path.is_file():
+                raise SandboxImageLoadError(f"Dockerfile not found: {source}")
+            rust_dockerfile_path = str(path)
+            rust_context_dir = None
+            dockerfile_text = None
+            effective_registered_name = registered_name or _default_registered_name(
+                str(path)
+            )
+        else:
+            # Programmer error — propagate directly rather than wrapping.
+            raise TypeError(
+                "source must be an Image or a Dockerfile path, got "
+                f"{type(source).__name__}"
+            )
 
-    if effective_registered_name == _DEFAULT_IMAGE_NAME:
-        warnings.warn(
-            f"Building sandbox image with the default name {_DEFAULT_IMAGE_NAME!r}. "
-            "Pass `registered_name=...` or `Image(name=...)` to avoid collisions "
-            "with other default-named images in this project.",
-            stacklevel=2,
-        )
+        if effective_registered_name == _DEFAULT_IMAGE_NAME:
+            warnings.warn(
+                f"Building sandbox image with the default name {_DEFAULT_IMAGE_NAME!r}. "
+                "Pass `registered_name=...` or `Image(name=...)` to avoid collisions "
+                "with other default-named images in this project.",
+                stacklevel=2,
+            )
 
-    try:
-        return _run_rust_image_create(
-            rust_dockerfile_path,
-            effective_registered_name,
-            dockerfile_text=dockerfile_text,
-            context_dir=rust_context_dir,
-            cpus=cpus,
-            memory_mb=memory_mb,
-            disk_mb=disk_mb,
-            builder_disk_mb=builder_disk_mb,
-            is_public=is_public,
-            docker_compat=docker_compat,
-            emit=emit,
-        )
-    except SandboxImageError:
-        raise
-    except Exception as e:
-        raise SandboxImageBuildError(f"{type(e).__name__}: {e}") from e
+        try:
+            return _run_rust_image_create(
+                rust_dockerfile_path,
+                effective_registered_name,
+                dockerfile_text=dockerfile_text,
+                context_dir=rust_context_dir,
+                cpus=cpus,
+                memory_mb=memory_mb,
+                disk_mb=disk_mb,
+                builder_disk_mb=builder_disk_mb,
+                is_public=is_public,
+                docker_compat=docker_compat,
+                emit=emit,
+            )
+        except SandboxImageError:
+            raise
+        except Exception as e:
+            raise SandboxImageBuildError(f"{type(e).__name__}: {e}") from e
 
 
 def import_sandbox_image(
@@ -717,30 +737,31 @@ def build_sandbox_application_image(
             stacklevel=2,
         )
 
-    rust_context_dir = str(Path(context_dir or os.getcwd()).resolve())
-    rust_dockerfile_path = str(Path(rust_context_dir) / "Dockerfile")
-    dockerfile_text = dockerfile_content(image, extra_env_vars=build_env_vars)
-    if not dockerfile_text.endswith("\n"):
-        dockerfile_text += "\n"
+    with contextlib.ExitStack() as stack:
+        rust_context_dir = _image_context_dir(context_dir, stack)
+        rust_dockerfile_path = str(Path(rust_context_dir) / "Dockerfile")
+        dockerfile_text = dockerfile_content(image, extra_env_vars=build_env_vars)
+        if not dockerfile_text.endswith("\n"):
+            dockerfile_text += "\n"
 
-    try:
-        return _run_rust_image_create(
-            rust_dockerfile_path,
-            effective_registered_name,
-            dockerfile_text=dockerfile_text,
-            context_dir=rust_context_dir,
-            cpus=cpus,
-            memory_mb=memory_mb,
-            disk_mb=disk_mb,
-            builder_disk_mb=builder_disk_mb,
-            is_public=is_public,
-            docker_compat=False,
-            emit=emit,
-        )
-    except SandboxImageError:
-        raise
-    except Exception as e:
-        raise SandboxImageBuildError(f"{type(e).__name__}: {e}") from e
+        try:
+            return _run_rust_image_create(
+                rust_dockerfile_path,
+                effective_registered_name,
+                dockerfile_text=dockerfile_text,
+                context_dir=rust_context_dir,
+                cpus=cpus,
+                memory_mb=memory_mb,
+                disk_mb=disk_mb,
+                builder_disk_mb=builder_disk_mb,
+                is_public=is_public,
+                docker_compat=False,
+                emit=emit,
+            )
+        except SandboxImageError:
+            raise
+        except Exception as e:
+            raise SandboxImageBuildError(f"{type(e).__name__}: {e}") from e
 
 
 def _default_registered_name(dockerfile_path: str) -> str:

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import tempfile
 import unittest
@@ -432,15 +431,14 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
                 captured["dockerfile_text"] = args[15]
                 context_dir = args[16]
                 captured["context_dir"] = context_dir
-                # Snapshot the staged context now — the temp dir is removed once
-                # build_sandbox_image returns.
+                # Snapshot the context contents now — a temp dir built for an
+                # Image without context_dir is removed once the build returns.
                 captured["context_files"] = (
                     sorted(
                         str(p.relative_to(context_dir))
-                        for p in Path(context_dir).rglob("*")
-                        if p.is_file()
+                        for p in Path(context_dir).iterdir()
                     )
-                    if context_dir is not None
+                    if context_dir is not None and Path(context_dir).is_dir()
                     else None
                 )
                 return '{"id":"tpl-1","snapshot_id":"snap-1"}'
@@ -517,105 +515,61 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
         # The temp dir is cleaned up once the build returns.
         self.assertFalse(Path(str(context_dir)).exists())
 
-    @contextlib.contextmanager
-    def _cwd(self, path: str):
-        old = os.getcwd()
-        os.chdir(path)
-        try:
-            yield
-        finally:
-            os.chdir(old)
+    def test_default_empty_context_has_no_files(self):
+        # An image with no COPY/ADD host-file ops gets an empty context — just
+        # the (separately passed) Dockerfile text, nothing archived from disk.
+        image = Image(name="no-copy-image", base_image="python:3.12-slim").run(
+            "pip install numpy"
+        )
+        _, _, _, captured = self._run_build(image)
+        self.assertEqual(captured["context_files"], [])
 
-    def test_minimal_context_stages_only_referenced_files(self):
-        # Without context_dir, the build context is assembled from just the
-        # COPY/ADD sources (resolved against cwd) — unrelated files in cwd must
-        # NOT be uploaded.
+    def test_copy_without_context_dir_raises(self):
+        # COPY/ADD that reads host files needs a context. Without context_dir
+        # the build must fail fast with a clear, actionable message rather than
+        # guessing or uploading the whole cwd.
+        image = Image(name="copy-image", base_image="python:3.12-slim").copy(
+            "requirements.txt", "/tmp/requirements.txt"
+        )
+        with self.assertRaises(sbm.SandboxImageBuildError) as ctx:
+            self._run_build(image)
+        self.assertIn("context_dir", str(ctx.exception))
+
+    def test_add_without_context_dir_raises(self):
+        image = Image(name="add-image", base_image="python:3.12-slim").add(
+            "./data", "/app/data"
+        )
+        with self.assertRaises(sbm.SandboxImageBuildError) as ctx:
+            self._run_build(image)
+        self.assertIn("context_dir", str(ctx.exception))
+
+    def test_remote_add_does_not_require_context(self):
+        # A remote ADD <url> reads nothing from the host, so it needs no
+        # context and builds with an empty one.
+        image = Image(name="url-image", base_image="python:3.12-slim").add(
+            "https://example.com/data.tar.gz", "/app/data.tar.gz"
+        )
+        _, _, _, captured = self._run_build(image)
+        self.assertEqual(captured["context_files"], [])
+
+    def test_copy_from_stage_does_not_require_context(self):
+        # COPY --from=<stage> reads from another build stage, not the host.
+        image = Image(name="stage-image", base_image="python:3.12-slim").copy(
+            "/build/app", "/app", options={"from": "builder"}
+        )
+        _, _, _, captured = self._run_build(image)
+        self.assertEqual(captured["context_files"], [])
+
+    def test_copy_with_context_dir_uploads_dir_as_is(self):
+        # With an explicit context_dir, COPY ops are allowed and the directory
+        # is uploaded as-is (resolved), like `docker build <dir>`.
         image = Image(name="copy-image", base_image="python:3.12-slim").copy(
             "requirements.txt", "/tmp/requirements.txt"
         )
         with tempfile.TemporaryDirectory() as tmp:
             Path(tmp, "requirements.txt").write_text("flask\n", encoding="utf-8")
-            Path(tmp, "secret.env").write_text("nope", encoding="utf-8")
-            os.mkdir(Path(tmp, "big"))
-            Path(tmp, "big", "data.bin").write_text("x" * 100, encoding="utf-8")
-            with self._cwd(tmp):
-                _, _, _, captured = self._run_build(image)
-
-        self.assertEqual(captured["context_files"], ["requirements.txt"])
-
-    def test_minimal_context_expands_globs(self):
-        image = Image(name="glob-image", base_image="python:3.12-slim").copy(
-            "*.txt", "/app/"
-        )
-        with tempfile.TemporaryDirectory() as tmp:
-            Path(tmp, "a.txt").write_text("a", encoding="utf-8")
-            Path(tmp, "b.txt").write_text("b", encoding="utf-8")
-            Path(tmp, "skip.md").write_text("m", encoding="utf-8")
-            with self._cwd(tmp):
-                _, _, _, captured = self._run_build(image)
-
-        self.assertEqual(captured["context_files"], ["a.txt", "b.txt"])
-
-    def test_minimal_context_copies_directories(self):
-        image = Image(name="dir-image", base_image="python:3.12-slim").copy(
-            "./src", "/app/src"
-        )
-        with tempfile.TemporaryDirectory() as tmp:
-            os.makedirs(Path(tmp, "src", "pkg"))
-            Path(tmp, "src", "main.py").write_text("print()", encoding="utf-8")
-            Path(tmp, "src", "pkg", "util.py").write_text("x=1", encoding="utf-8")
-            Path(tmp, "ignored.py").write_text("nope", encoding="utf-8")
-            with self._cwd(tmp):
-                _, _, _, captured = self._run_build(image)
-
-        self.assertEqual(
-            captured["context_files"],
-            [str(Path("src", "main.py")), str(Path("src", "pkg", "util.py"))],
-        )
-
-    def test_minimal_context_stages_symlink_at_source_path(self):
-        # A COPY source that is a symlink must be staged at the path the
-        # Dockerfile references (the link name), not the resolved target path,
-        # otherwise the build can't find it.
-        image = Image(name="link-image", base_image="python:3.12-slim").copy(
-            "link.txt", "/app/link.txt"
-        )
-        with tempfile.TemporaryDirectory() as tmp:
-            Path(tmp, "target.txt").write_text("payload", encoding="utf-8")
-            os.symlink(Path(tmp, "target.txt"), Path(tmp, "link.txt"))
-            with self._cwd(tmp):
-                _, _, _, captured = self._run_build(image)
-
-        self.assertEqual(captured["context_files"], ["link.txt"])
-
-    def test_minimal_context_carries_dockerignore(self):
-        # Without context_dir the staged context must include cwd's
-        # .dockerignore so the Rust archiver applies the same exclusions it
-        # would for a full-cwd context.
-        image = Image(name="ignore-image", base_image="python:3.12-slim").copy(
-            "./src", "/app/src"
-        )
-        with tempfile.TemporaryDirectory() as tmp:
-            os.makedirs(Path(tmp, "src"))
-            Path(tmp, "src", "main.py").write_text("print()", encoding="utf-8")
-            Path(tmp, "src", "secret.env").write_text("nope", encoding="utf-8")
-            Path(tmp, ".dockerignore").write_text("src/secret.env\n", encoding="utf-8")
-            with self._cwd(tmp):
-                _, _, _, captured = self._run_build(image)
-
-        # The .dockerignore is staged at the context root; the actual exclusion
-        # is enforced by the Rust archiver, which reads it from there.
-        self.assertIn(".dockerignore", captured["context_files"])
-
-    def test_missing_copy_source_raises(self):
-        image = Image(name="missing-image", base_image="python:3.12-slim").copy(
-            "does-not-exist.txt", "/tmp/x"
-        )
-        with tempfile.TemporaryDirectory() as tmp:
-            with self._cwd(tmp):
-                with self.assertRaises(sbm.SandboxImageBuildError) as ctx:
-                    self._run_build(image)
-        self.assertIn("does-not-exist.txt", str(ctx.exception))
+            _, _, _, captured = self._run_build(image, context_dir=tmp)
+            self.assertEqual(captured["context_dir"], str(Path(tmp).resolve()))
 
     def test_warns_on_default_name(self):
         image = Image(base_image="python:3.12-slim")

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import unittest
 import warnings
@@ -481,6 +482,26 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
             self.assertEqual(captured["context_dir"], str(Path(tmpdir).resolve()))
 
         self.assertEqual(generated, [])
+
+    def test_default_context_is_empty_not_cwd(self):
+        # Without an explicit context_dir, an Image build must NOT upload the
+        # current working directory (which has no Dockerfile in it). It uses a
+        # throwaway empty temp dir instead, so only the generated Dockerfile
+        # text is built — nothing from cwd is archived.
+        image = Image(name="no-context-image", base_image="python:3.12-slim").run(
+            "pip install numpy"
+        )
+        _, _, _, captured = self._run_build(image)
+
+        context_dir = captured["context_dir"]
+        self.assertIsInstance(context_dir, str)
+        self.assertNotEqual(
+            Path(str(context_dir)).resolve(),
+            Path(os.getcwd()).resolve(),
+            "Image build must not default its build context to cwd",
+        )
+        # The temp dir is cleaned up once the build returns.
+        self.assertFalse(Path(str(context_dir)).exists())
 
     def test_warns_on_default_name(self):
         image = Image(base_image="python:3.12-slim")

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -560,6 +560,37 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
         _, _, _, captured = self._run_build(image)
         self.assertEqual(captured["context_files"], [])
 
+    def test_run_bind_mount_without_context_dir_raises(self):
+        # A RUN bind mount reads the build context, so it needs a context.
+        # `type=bind` is the default, so omitting it must also be detected.
+        for mount in (
+            "type=bind,source=.,target=/src",
+            "target=/src",
+        ):
+            image = Image(name="mount-image", base_image="python:3.12-slim").run(
+                "make -C /src", options={"mount": mount}
+            )
+            with self.assertRaises(sbm.SandboxImageBuildError) as ctx:
+                self._run_build(image)
+            self.assertIn("context_dir", str(ctx.exception))
+
+    def test_run_mount_from_stage_does_not_require_context(self):
+        # A `from=` bind mount reads another stage/image, not the host.
+        image = Image(name="mount-stage", base_image="python:3.12-slim").run(
+            "make", options={"mount": "type=bind,from=builder,target=/src"}
+        )
+        _, _, _, captured = self._run_build(image)
+        self.assertEqual(captured["context_files"], [])
+
+    def test_run_cache_mount_does_not_require_context(self):
+        # Non-bind mounts (cache/tmpfs/secret/ssh) don't read the build context.
+        image = Image(name="mount-cache", base_image="python:3.12-slim").run(
+            "pip install -r req.txt",
+            options={"mount": "type=cache,target=/root/.cache"},
+        )
+        _, _, _, captured = self._run_build(image)
+        self.assertEqual(captured["context_files"], [])
+
     def test_copy_with_context_dir_uploads_dir_as_is(self):
         # With an explicit context_dir, COPY ops are allowed and the directory
         # is uploaded as-is (resolved), like `docker build <dir>`.

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import tempfile
 import unittest
@@ -429,7 +430,19 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
                 captured["args"] = args
                 captured["dockerfile_path"] = args[2]
                 captured["dockerfile_text"] = args[15]
-                captured["context_dir"] = args[16]
+                context_dir = args[16]
+                captured["context_dir"] = context_dir
+                # Snapshot the staged context now — the temp dir is removed once
+                # build_sandbox_image returns.
+                captured["context_files"] = (
+                    sorted(
+                        str(p.relative_to(context_dir))
+                        for p in Path(context_dir).rglob("*")
+                        if p.is_file()
+                    )
+                    if context_dir is not None
+                    else None
+                )
                 return '{"id":"tpl-1","snapshot_id":"snap-1"}'
 
             rust_builder_mock.side_effect = fake_rust_builder
@@ -446,7 +459,8 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
             .copy("./src", "/app/src")
         )
 
-        _, _, rust_builder, captured = self._run_build(image)
+        # COPY ops require an explicit context_dir.
+        _, _, rust_builder, captured = self._run_build(image, context_dir=".")
 
         # The registered Dockerfile must match exactly what the TS SDK would
         # generate — no WORKDIR /app or pip install tensorlake injection.
@@ -502,6 +516,106 @@ class TestBuildSandboxImageFromImage(unittest.TestCase):
         )
         # The temp dir is cleaned up once the build returns.
         self.assertFalse(Path(str(context_dir)).exists())
+
+    @contextlib.contextmanager
+    def _cwd(self, path: str):
+        old = os.getcwd()
+        os.chdir(path)
+        try:
+            yield
+        finally:
+            os.chdir(old)
+
+    def test_minimal_context_stages_only_referenced_files(self):
+        # Without context_dir, the build context is assembled from just the
+        # COPY/ADD sources (resolved against cwd) — unrelated files in cwd must
+        # NOT be uploaded.
+        image = Image(name="copy-image", base_image="python:3.12-slim").copy(
+            "requirements.txt", "/tmp/requirements.txt"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "requirements.txt").write_text("flask\n", encoding="utf-8")
+            Path(tmp, "secret.env").write_text("nope", encoding="utf-8")
+            os.mkdir(Path(tmp, "big"))
+            Path(tmp, "big", "data.bin").write_text("x" * 100, encoding="utf-8")
+            with self._cwd(tmp):
+                _, _, _, captured = self._run_build(image)
+
+        self.assertEqual(captured["context_files"], ["requirements.txt"])
+
+    def test_minimal_context_expands_globs(self):
+        image = Image(name="glob-image", base_image="python:3.12-slim").copy(
+            "*.txt", "/app/"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_text("a", encoding="utf-8")
+            Path(tmp, "b.txt").write_text("b", encoding="utf-8")
+            Path(tmp, "skip.md").write_text("m", encoding="utf-8")
+            with self._cwd(tmp):
+                _, _, _, captured = self._run_build(image)
+
+        self.assertEqual(captured["context_files"], ["a.txt", "b.txt"])
+
+    def test_minimal_context_copies_directories(self):
+        image = Image(name="dir-image", base_image="python:3.12-slim").copy(
+            "./src", "/app/src"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(Path(tmp, "src", "pkg"))
+            Path(tmp, "src", "main.py").write_text("print()", encoding="utf-8")
+            Path(tmp, "src", "pkg", "util.py").write_text("x=1", encoding="utf-8")
+            Path(tmp, "ignored.py").write_text("nope", encoding="utf-8")
+            with self._cwd(tmp):
+                _, _, _, captured = self._run_build(image)
+
+        self.assertEqual(
+            captured["context_files"],
+            [str(Path("src", "main.py")), str(Path("src", "pkg", "util.py"))],
+        )
+
+    def test_minimal_context_stages_symlink_at_source_path(self):
+        # A COPY source that is a symlink must be staged at the path the
+        # Dockerfile references (the link name), not the resolved target path,
+        # otherwise the build can't find it.
+        image = Image(name="link-image", base_image="python:3.12-slim").copy(
+            "link.txt", "/app/link.txt"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "target.txt").write_text("payload", encoding="utf-8")
+            os.symlink(Path(tmp, "target.txt"), Path(tmp, "link.txt"))
+            with self._cwd(tmp):
+                _, _, _, captured = self._run_build(image)
+
+        self.assertEqual(captured["context_files"], ["link.txt"])
+
+    def test_minimal_context_carries_dockerignore(self):
+        # Without context_dir the staged context must include cwd's
+        # .dockerignore so the Rust archiver applies the same exclusions it
+        # would for a full-cwd context.
+        image = Image(name="ignore-image", base_image="python:3.12-slim").copy(
+            "./src", "/app/src"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(Path(tmp, "src"))
+            Path(tmp, "src", "main.py").write_text("print()", encoding="utf-8")
+            Path(tmp, "src", "secret.env").write_text("nope", encoding="utf-8")
+            Path(tmp, ".dockerignore").write_text("src/secret.env\n", encoding="utf-8")
+            with self._cwd(tmp):
+                _, _, _, captured = self._run_build(image)
+
+        # The .dockerignore is staged at the context root; the actual exclusion
+        # is enforced by the Rust archiver, which reads it from there.
+        self.assertIn(".dockerignore", captured["context_files"])
+
+    def test_missing_copy_source_raises(self):
+        image = Image(name="missing-image", base_image="python:3.12-slim").copy(
+            "does-not-exist.txt", "/tmp/x"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with self._cwd(tmp):
+                with self.assertRaises(sbm.SandboxImageBuildError) as ctx:
+                    self._run_build(image)
+        self.assertIn("does-not-exist.txt", str(ctx.exception))
 
     def test_warns_on_default_name(self):
         image = Image(base_image="python:3.12-slim")

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.47",
+  "version": "0.5.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.47",
+      "version": "0.5.49",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",
@@ -21,7 +21,7 @@
         "tl": "bin/tl.cjs"
       },
       "devDependencies": {
-        "@types/node": "^20.11.0",
+        "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
         "eslint": "^9.0.0",
         "tsup": "^8.0.0",
@@ -1074,9 +1074,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.49",
+  "version": "0.5.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.49",
+      "version": "0.5.50",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.49",
+  "version": "0.5.50",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -61,7 +61,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/node": "^20.11.0",
+    "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
     "eslint": "^9.0.0",
     "tsup": "^8.0.0",

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -1,10 +1,23 @@
 import { createRequire } from "node:module";
 import path from "node:path";
-import { existsSync } from "node:fs";
+import os from "node:os";
+import {
+  cpSync,
+  existsSync,
+  globSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
 import { parseArgs } from "node:util";
 import { CloudClient } from "./cloud-client.js";
 import type { SandboxTemplate } from "./cloud-models.js";
-import { Image, dockerfileContent } from "./image.js";
+import {
+  Image,
+  ImageBuildOperationType,
+  dockerfileContent,
+} from "./image.js";
+import type { ImageBuildOperation } from "./image.js";
 
 /**
  * Sandbox-image build engine.
@@ -24,6 +37,13 @@ export interface CreateSandboxImageOptions {
   diskMb?: number;
   builderDiskMb?: number;
   isPublic?: boolean;
+  /**
+   * Directory used to resolve relative COPY/ADD sources for an `Image` source.
+   * Required when the image has COPY/ADD ops; omitting it then throws. For
+   * images without COPY/ADD ops it may be omitted and an empty build context
+   * is used so cwd is not archived and uploaded. Ignored when the source is a
+   * Dockerfile path (the Dockerfile's parent directory is used instead).
+   */
   contextDir?: string;
   /**
    * Use Docker/BuildKit max compatibility mode (build is slower and uses more
@@ -254,6 +274,102 @@ function eventToEmitDict(event: NativeBindingEvent): Record<string, unknown> {
   return out;
 }
 
+const GLOB_CHARS = /[*?[]/;
+
+/** True for ADD sources that are remote URLs rather than host files. */
+function isRemoteSrc(src: string): boolean {
+  return src.startsWith("http://") || src.startsWith("https://");
+}
+
+/**
+ * True when a build op copies files from the host into the image.
+ * `COPY --from=<stage>` and remote `ADD <url>` sources don't read host files.
+ */
+function opReferencesHostFiles(op: ImageBuildOperation): boolean {
+  if (
+    op.type !== ImageBuildOperationType.COPY &&
+    op.type !== ImageBuildOperationType.ADD
+  ) {
+    return false;
+  }
+  if (op.options.from != null) {
+    return false;
+  }
+  if (op.type === ImageBuildOperationType.ADD && isRemoteSrc(op.args[0])) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Copy a single COPY/ADD source from `base` into the minimal context at the
+ * same path the rendered Dockerfile instruction expects.
+ */
+function stageSource(src: string, base: string, dest: string): void {
+  // Docker resolves COPY/ADD sources relative to the context root; a leading
+  // "./" or "/" is equivalent to a context-relative path.
+  let pattern = src.replace(/^\/+/, "");
+  if (pattern.startsWith("./")) pattern = pattern.slice(2);
+
+  let matches: string[];
+  if (GLOB_CHARS.test(pattern)) {
+    matches = Array.from(globSync(pattern, { cwd: base })).map((m) =>
+      path.resolve(base, m),
+    );
+    if (matches.length === 0) {
+      throw new Error(
+        `COPY/ADD source "${src}" matched no files under ${base}. ` +
+          "Pass `contextDir` if the sources live elsewhere.",
+      );
+    }
+  } else {
+    const candidate = path.resolve(base, pattern);
+    if (!existsSync(candidate)) {
+      throw new Error(
+        `COPY/ADD source "${src}" not found under ${base}. ` +
+          "Pass `contextDir` if the sources live elsewhere.",
+      );
+    }
+    matches = [candidate];
+  }
+
+  const resolvedBase = path.resolve(base);
+  for (const match of matches) {
+    const rel = path.relative(resolvedBase, match);
+    if (rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new Error(
+        `COPY/ADD source "${src}" resolves outside the build context base ` +
+          `${base}. Pass an explicit contextDir.`,
+      );
+    }
+    const target = path.join(dest, rel);
+    mkdirSync(path.dirname(target), { recursive: true });
+    // `dereference` so a symlinked source is staged as the file it points to,
+    // at the path the Dockerfile names (a bare symlink would dangle in the
+    // throwaway context).
+    cpSync(match, target, { recursive: true, dereference: true });
+  }
+}
+
+/**
+ * Assemble a minimal build context under `dest` containing only the files
+ * referenced by the image's COPY/ADD ops, resolved relative to `base`.
+ */
+function populateMinimalContext(image: Image, base: string, dest: string): void {
+  for (const op of image.buildOperations) {
+    if (opReferencesHostFiles(op)) {
+      stageSource(op.args[0], base, dest);
+    }
+  }
+  // Carry over the context root's .dockerignore so the native archiver applies
+  // the same exclusions it would for a full-cwd context. Staged files keep
+  // their cwd-relative paths, so the patterns still match.
+  const dockerignore = path.join(base, ".dockerignore");
+  if (existsSync(dockerignore)) {
+    cpSync(dockerignore, path.join(dest, ".dockerignore"));
+  }
+}
+
 // --- Public API ------------------------------------------------------------
 
 export async function createSandboxImage(
@@ -268,12 +384,28 @@ export async function createSandboxImage(
   let dockerfileText: string | undefined;
   let nativeContextDir: string | undefined;
   let effectiveName: string;
+  // Throwaway empty build context created when an Image build has no explicit
+  // contextDir. Removed in the finally below.
+  let tempContextDir: string | undefined;
 
   if (source instanceof Image) {
     if (!source.baseImage) {
       throw new Error("Image must have a baseImage to build");
     }
-    const resolvedContext = path.resolve(options.contextDir ?? process.cwd());
+    // When the caller passes an explicit contextDir we upload that directory
+    // as-is (an escape hatch for complex layouts). Otherwise we assemble a
+    // minimal throwaway context that contains only the files referenced by the
+    // image's COPY/ADD ops (resolved relative to cwd), so those copies succeed
+    // without archiving and uploading the whole cwd. An image with no host-file
+    // copies yields an empty context.
+    let resolvedContext: string;
+    if (options.contextDir != null) {
+      resolvedContext = path.resolve(options.contextDir);
+    } else {
+      tempContextDir = mkdtempSync(path.join(os.tmpdir(), "tl-build-context-"));
+      populateMinimalContext(source, process.cwd(), tempContextDir);
+      resolvedContext = tempContextDir;
+    }
     dockerfilePath = path.join(resolvedContext, "Dockerfile");
     let text = dockerfileContent(source);
     if (!text.endsWith("\n")) text += "\n";
@@ -296,72 +428,80 @@ export async function createSandboxImage(
     );
   }
 
-  if (effectiveName === DEFAULT_IMAGE_NAME) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Building sandbox image with the default name "${DEFAULT_IMAGE_NAME}". ` +
-        "Pass `registeredName` or `Image({ name })` to avoid collisions " +
-        "with other default-named images in this project.",
+  try {
+    if (effectiveName === DEFAULT_IMAGE_NAME) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Building sandbox image with the default name "${DEFAULT_IMAGE_NAME}". ` +
+          "Pass `registeredName` or `Image({ name })` to avoid collisions " +
+          "with other default-named images in this project.",
+      );
+    }
+
+    const bearerToken = context.apiKey ?? context.personalAccessToken;
+    if (!bearerToken) {
+      throw new Error(
+        "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.",
+      );
+    }
+
+    emit({ type: "status", message: `Building image '${effectiveName}'...` });
+
+    const binding = loadNativeBinding();
+    let emitError: unknown;
+    const resultJson = await binding.buildSandboxImage(
+      {
+        apiUrl: context.apiUrl,
+        bearerToken,
+        dockerfilePath,
+        registeredName: effectiveName,
+        diskMb: options.diskMb,
+        builderDiskMb: options.builderDiskMb,
+        cpus: options.cpus,
+        memoryMb: options.memoryMb,
+        isPublic: options.isPublic ?? false,
+        organizationId: context.organizationId,
+        projectId: context.projectId,
+        namespace: context.namespace,
+        useScopeHeaders:
+          context.personalAccessToken != null && context.apiKey == null,
+        userAgent: undefined,
+        dockerCompat: options.dockerCompat ?? false,
+        dockerfileText,
+        contextDir: nativeContextDir,
+      },
+      (event) => {
+        try {
+          emit(eventToEmitDict(event));
+        } catch (error) {
+          emitError ??= error;
+        }
+      },
     );
+
+    if (emitError != null) {
+      throw emitError;
+    }
+
+    let result: Record<string, unknown> = {};
+    if (resultJson.trim().length > 0) {
+      result = JSON.parse(resultJson) as Record<string, unknown>;
+    }
+    emit({
+      type: "image_registered",
+      name: effectiveName,
+      image_id:
+        (typeof result.id === "string" && result.id) ||
+        (typeof result.templateId === "string" && result.templateId) ||
+        "",
+    });
+    emit({ type: "done" });
+    return result;
+  } finally {
+    if (tempContextDir != null) {
+      rmSync(tempContextDir, { recursive: true, force: true });
+    }
   }
-
-  const bearerToken = context.apiKey ?? context.personalAccessToken;
-  if (!bearerToken) {
-    throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.");
-  }
-
-  emit({ type: "status", message: `Building image '${effectiveName}'...` });
-
-  const binding = loadNativeBinding();
-  let emitError: unknown;
-  const resultJson = await binding.buildSandboxImage(
-    {
-      apiUrl: context.apiUrl,
-      bearerToken,
-      dockerfilePath,
-      registeredName: effectiveName,
-      diskMb: options.diskMb,
-      builderDiskMb: options.builderDiskMb,
-      cpus: options.cpus,
-      memoryMb: options.memoryMb,
-      isPublic: options.isPublic ?? false,
-      organizationId: context.organizationId,
-      projectId: context.projectId,
-      namespace: context.namespace,
-      useScopeHeaders:
-        context.personalAccessToken != null && context.apiKey == null,
-      userAgent: undefined,
-      dockerCompat: options.dockerCompat ?? false,
-      dockerfileText,
-      contextDir: nativeContextDir,
-    },
-    (event) => {
-      try {
-        emit(eventToEmitDict(event));
-      } catch (error) {
-        emitError ??= error;
-      }
-    },
-  );
-
-  if (emitError != null) {
-    throw emitError;
-  }
-
-  let result: Record<string, unknown> = {};
-  if (resultJson.trim().length > 0) {
-    result = JSON.parse(resultJson) as Record<string, unknown>;
-  }
-  emit({
-    type: "image_registered",
-    name: effectiveName,
-    image_id:
-      (typeof result.id === "string" && result.id) ||
-      (typeof result.templateId === "string" && result.templateId) ||
-      "",
-  });
-  emit({ type: "done" });
-  return result;
 }
 
 /**

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -38,11 +38,13 @@ export interface CreateSandboxImageOptions {
   builderDiskMb?: number;
   isPublic?: boolean;
   /**
-   * Directory used to resolve relative COPY/ADD sources for an `Image` source.
-   * Required when the image has COPY/ADD ops; omitting it then throws. For
-   * images without COPY/ADD ops it may be omitted and an empty build context
-   * is used so cwd is not archived and uploaded. Ignored when the source is a
-   * Dockerfile path (the Dockerfile's parent directory is used instead).
+   * Directory uploaded as the build context for an `Image` source. When
+   * omitted, a minimal context is assembled automatically containing only the
+   * files referenced by the image's COPY/ADD ops (resolved relative to cwd),
+   * so cwd is not archived and uploaded wholesale. An image with no host-file
+   * copies yields an empty context. Pass this to upload a specific directory
+   * as-is instead. Ignored when the source is a Dockerfile path (the
+   * Dockerfile's parent directory is used instead).
    */
   contextDir?: string;
   /**

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -266,11 +266,43 @@ function eventToEmitDict(event: NativeBindingEvent): Record<string, unknown> {
 }
 
 /**
- * True when a build op copies files from the host into the image.
- * `COPY --from=<stage>` and remote `ADD <url>` sources don't read host files,
- * so they don't need a build context.
+ * True when a `RUN` op bind-mounts the build context (reads host files).
+ * A BuildKit `RUN --mount=type=bind` reads from the build context unless it
+ * mounts `from=<stage/image>`. `bind` is the default mount type, so a mount
+ * with no explicit `type` counts too. Other mount types
+ * (`cache`/`tmpfs`/`secret`/`ssh`) don't read the build context.
+ */
+function runOpMountsContext(op: ImageBuildOperation): boolean {
+  if (op.type !== ImageBuildOperationType.RUN) {
+    return false;
+  }
+  const mount = op.options.mount;
+  if (mount == null || mount === "") {
+    return false;
+  }
+  const fields: Record<string, string> = {};
+  for (const token of mount.split(",")) {
+    const eq = token.indexOf("=");
+    const key = (eq === -1 ? token : token.slice(0, eq)).trim();
+    const value = eq === -1 ? "" : token.slice(eq + 1).trim();
+    fields[key] = value;
+  }
+  if ((fields.type ?? "bind") !== "bind") {
+    return false;
+  }
+  return !("from" in fields);
+}
+
+/**
+ * True when a build op reads files from the host build context.
+ * `COPY`/`ADD` with host sources need a context; a `RUN` with a
+ * `--mount=type=bind` (the default type) reads it too. `COPY --from=<stage>`,
+ * remote `ADD <url>`, `from=` bind mounts, and non-bind mounts don't.
  */
 function opReferencesHostFiles(op: ImageBuildOperation): boolean {
+  if (op.type === ImageBuildOperationType.RUN) {
+    return runOpMountsContext(op);
+  }
   if (
     op.type !== ImageBuildOperationType.COPY &&
     op.type !== ImageBuildOperationType.ADD
@@ -290,9 +322,10 @@ function opReferencesHostFiles(op: ImageBuildOperation): boolean {
 }
 
 /**
- * True if the image has COPY/ADD ops that read files from the host. Such
- * builds need a build context to resolve those sources, so the caller must
- * pass `contextDir` (mirroring `docker build <context>`).
+ * True if the image has ops that read files from the host (COPY/ADD host
+ * sources, or a RUN bind mount). Such builds need a build context to resolve
+ * those sources, so the caller must pass `contextDir` (mirroring
+ * `docker build <context>`).
  */
 function imageRequiresContext(image: Image): boolean {
   return image.buildOperations.some(opReferencesHostFiles);
@@ -330,10 +363,10 @@ export async function createSandboxImage(
       resolvedContext = path.resolve(options.contextDir);
     } else if (imageRequiresContext(source)) {
       throw new Error(
-        "This image uses COPY/ADD to read files from the host, so it needs a " +
-          "build context. Pass `contextDir` pointing at the directory that " +
-          "contains those sources; COPY/ADD paths resolve relative to it, " +
-          "like `docker build <contextDir>`.",
+        "This image reads files from the host (via COPY/ADD or a RUN bind " +
+          "mount), so it needs a build context. Pass `contextDir` pointing at " +
+          "the directory that contains those sources; they resolve relative " +
+          "to it, like `docker build <contextDir>`.",
       );
     } else {
       tempContextDir = mkdtempSync(path.join(os.tmpdir(), "tl-build-context-"));

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -1,22 +1,11 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import os from "node:os";
-import {
-  cpSync,
-  existsSync,
-  globSync,
-  mkdirSync,
-  mkdtempSync,
-  rmSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { CloudClient } from "./cloud-client.js";
 import type { SandboxTemplate } from "./cloud-models.js";
-import {
-  Image,
-  ImageBuildOperationType,
-  dockerfileContent,
-} from "./image.js";
+import { Image, ImageBuildOperationType, dockerfileContent } from "./image.js";
 import type { ImageBuildOperation } from "./image.js";
 
 /**
@@ -38,13 +27,13 @@ export interface CreateSandboxImageOptions {
   builderDiskMb?: number;
   isPublic?: boolean;
   /**
-   * Directory uploaded as the build context for an `Image` source. When
-   * omitted, a minimal context is assembled automatically containing only the
-   * files referenced by the image's COPY/ADD ops (resolved relative to cwd),
-   * so cwd is not archived and uploaded wholesale. An image with no host-file
-   * copies yields an empty context. Pass this to upload a specific directory
-   * as-is instead. Ignored when the source is a Dockerfile path (the
-   * Dockerfile's parent directory is used instead).
+   * Build context directory for an `Image` source, used exactly like
+   * `docker build <contextDir>`: it is uploaded as-is and COPY/ADD sources
+   * resolve relative to it. Required when the image has COPY/ADD ops that read
+   * host files — building without it then throws. When the image has no such
+   * ops it may be omitted, and an empty context (just the generated Dockerfile)
+   * is uploaded so cwd is not archived. Ignored when the source is a Dockerfile
+   * path (the Dockerfile's parent directory is used instead).
    */
   contextDir?: string;
   /**
@@ -276,16 +265,10 @@ function eventToEmitDict(event: NativeBindingEvent): Record<string, unknown> {
   return out;
 }
 
-const GLOB_CHARS = /[*?[]/;
-
-/** True for ADD sources that are remote URLs rather than host files. */
-function isRemoteSrc(src: string): boolean {
-  return src.startsWith("http://") || src.startsWith("https://");
-}
-
 /**
  * True when a build op copies files from the host into the image.
- * `COPY --from=<stage>` and remote `ADD <url>` sources don't read host files.
+ * `COPY --from=<stage>` and remote `ADD <url>` sources don't read host files,
+ * so they don't need a build context.
  */
 function opReferencesHostFiles(op: ImageBuildOperation): boolean {
   if (
@@ -297,79 +280,22 @@ function opReferencesHostFiles(op: ImageBuildOperation): boolean {
   if (op.options.from != null) {
     return false;
   }
-  if (op.type === ImageBuildOperationType.ADD && isRemoteSrc(op.args[0])) {
+  if (
+    op.type === ImageBuildOperationType.ADD &&
+    (op.args[0].startsWith("http://") || op.args[0].startsWith("https://"))
+  ) {
     return false;
   }
   return true;
 }
 
 /**
- * Copy a single COPY/ADD source from `base` into the minimal context at the
- * same path the rendered Dockerfile instruction expects.
+ * True if the image has COPY/ADD ops that read files from the host. Such
+ * builds need a build context to resolve those sources, so the caller must
+ * pass `contextDir` (mirroring `docker build <context>`).
  */
-function stageSource(src: string, base: string, dest: string): void {
-  // Docker resolves COPY/ADD sources relative to the context root; a leading
-  // "./" or "/" is equivalent to a context-relative path.
-  let pattern = src.replace(/^\/+/, "");
-  if (pattern.startsWith("./")) pattern = pattern.slice(2);
-
-  let matches: string[];
-  if (GLOB_CHARS.test(pattern)) {
-    matches = Array.from(globSync(pattern, { cwd: base })).map((m) =>
-      path.resolve(base, m),
-    );
-    if (matches.length === 0) {
-      throw new Error(
-        `COPY/ADD source "${src}" matched no files under ${base}. ` +
-          "Pass `contextDir` if the sources live elsewhere.",
-      );
-    }
-  } else {
-    const candidate = path.resolve(base, pattern);
-    if (!existsSync(candidate)) {
-      throw new Error(
-        `COPY/ADD source "${src}" not found under ${base}. ` +
-          "Pass `contextDir` if the sources live elsewhere.",
-      );
-    }
-    matches = [candidate];
-  }
-
-  const resolvedBase = path.resolve(base);
-  for (const match of matches) {
-    const rel = path.relative(resolvedBase, match);
-    if (rel.startsWith("..") || path.isAbsolute(rel)) {
-      throw new Error(
-        `COPY/ADD source "${src}" resolves outside the build context base ` +
-          `${base}. Pass an explicit contextDir.`,
-      );
-    }
-    const target = path.join(dest, rel);
-    mkdirSync(path.dirname(target), { recursive: true });
-    // `dereference` so a symlinked source is staged as the file it points to,
-    // at the path the Dockerfile names (a bare symlink would dangle in the
-    // throwaway context).
-    cpSync(match, target, { recursive: true, dereference: true });
-  }
-}
-
-/**
- * Assemble a minimal build context under `dest` containing only the files
- * referenced by the image's COPY/ADD ops, resolved relative to `base`.
- */
-function populateMinimalContext(image: Image, base: string, dest: string): void {
-  for (const op of image.buildOperations) {
-    if (opReferencesHostFiles(op)) {
-      stageSource(op.args[0], base, dest);
-    }
-  }
-  // Carry over the context root's .dockerignore so the native archiver applies
-  // the same exclusions it would for a full-cwd context. Staged files keep
-  // their cwd-relative paths, so the patterns still match.
-  const dockerignore = path.join(base, ".dockerignore");
-  if (existsSync(dockerignore)) {
-    cpSync(dockerignore, path.join(dest, ".dockerignore"));
-  }
+function imageRequiresContext(image: Image): boolean {
+  return image.buildOperations.some(opReferencesHostFiles);
 }
 
 // --- Public API ------------------------------------------------------------
@@ -394,18 +320,23 @@ export async function createSandboxImage(
     if (!source.baseImage) {
       throw new Error("Image must have a baseImage to build");
     }
-    // When the caller passes an explicit contextDir we upload that directory
-    // as-is (an escape hatch for complex layouts). Otherwise we assemble a
-    // minimal throwaway context that contains only the files referenced by the
-    // image's COPY/ADD ops (resolved relative to cwd), so those copies succeed
-    // without archiving and uploading the whole cwd. An image with no host-file
-    // copies yields an empty context.
+    // With an explicit contextDir we upload that directory as-is, like
+    // `docker build <dir>`. Without one, an image that reads host files via
+    // COPY/ADD can't be built (there is no context to resolve them against);
+    // images without such ops get an empty context (just the Dockerfile) so
+    // the whole cwd is not archived.
     let resolvedContext: string;
     if (options.contextDir != null) {
       resolvedContext = path.resolve(options.contextDir);
+    } else if (imageRequiresContext(source)) {
+      throw new Error(
+        "This image uses COPY/ADD to read files from the host, so it needs a " +
+          "build context. Pass `contextDir` pointing at the directory that " +
+          "contains those sources; COPY/ADD paths resolve relative to it, " +
+          "like `docker build <contextDir>`.",
+      );
     } else {
       tempContextDir = mkdtempSync(path.join(os.tmpdir(), "tl-build-context-"));
-      populateMinimalContext(source, process.cwd(), tempContextDir);
       resolvedContext = tempContextDir;
     }
     dockerfilePath = path.join(resolvedContext, "Dockerfile");

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -209,6 +209,44 @@ describe("createSandboxImage", () => {
     expect(captured.contextFiles).toEqual([]);
   });
 
+  it("throws when a RUN bind mount reads the context without a contextDir", async () => {
+    // A RUN bind mount reads the build context, so it needs a context.
+    // `type=bind` is the default, so omitting it must also be detected.
+    for (const mount of ["type=bind,source=.,target=/src", "target=/src"]) {
+      const image = new Image({
+        name: "mount-image",
+        baseImage: "python:3.12-slim",
+      }).run("make -C /src", { mount });
+
+      makeFakeBinding();
+      await expect(createSandboxImage(image)).rejects.toThrow(/contextDir/);
+    }
+  });
+
+  it("does not require a context for a RUN mount with from=<stage>", async () => {
+    const image = new Image({
+      name: "mount-stage",
+      baseImage: "python:3.12-slim",
+    }).run("make", { mount: "type=bind,from=builder,target=/src" });
+
+    const { captured } = makeFakeBinding();
+    await createSandboxImage(image);
+
+    expect(captured.contextFiles).toEqual([]);
+  });
+
+  it("does not require a context for a RUN cache mount", async () => {
+    const image = new Image({
+      name: "mount-cache",
+      baseImage: "python:3.12-slim",
+    }).run("pip install -r req.txt", { mount: "type=cache,target=/root/.cache" });
+
+    const { captured } = makeFakeBinding();
+    await createSandboxImage(image);
+
+    expect(captured.contextFiles).toEqual([]);
+  });
+
   it("uploads the given directory as-is when contextDir is set with COPY ops", async () => {
     const tempDir = await mkdir(
       path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-ctxcopy`),

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync } from "node:fs";
-import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -147,16 +147,74 @@ describe("createSandboxImage", () => {
     expect(existsSync(contextDir)).toBe(false);
   });
 
-  it("stages only referenced files into the minimal context (no contextDir)", async () => {
-    // Without contextDir, the build context is assembled from just the
-    // COPY/ADD sources (resolved against cwd) — unrelated files in cwd must
-    // NOT be uploaded.
-    const tempCwd = await mkdir(
-      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-mincopy`),
+  it("uses an empty context for an image with no COPY/ADD ops", async () => {
+    const image = new Image({
+      name: "no-copy-image",
+      baseImage: "python:3.12-slim",
+    }).run("pip install numpy");
+
+    const { captured } = makeFakeBinding();
+    await createSandboxImage(image);
+
+    expect(captured.contextFiles).toEqual([]);
+  });
+
+  it("throws when COPY reads host files without a contextDir", async () => {
+    // COPY/ADD that reads host files needs a context. Without contextDir the
+    // build must fail fast with a clear, actionable message rather than
+    // guessing or uploading the whole cwd.
+    const image = new Image({
+      name: "copy-image",
+      baseImage: "python:3.12-slim",
+    }).copy("requirements.txt", "/tmp/requirements.txt");
+
+    makeFakeBinding();
+    await expect(createSandboxImage(image)).rejects.toThrow(/contextDir/);
+  });
+
+  it("throws when ADD reads host files without a contextDir", async () => {
+    const image = new Image({
+      name: "add-image",
+      baseImage: "python:3.12-slim",
+    }).add("./data", "/app/data");
+
+    makeFakeBinding();
+    await expect(createSandboxImage(image)).rejects.toThrow(/contextDir/);
+  });
+
+  it("does not require a context for a remote ADD <url>", async () => {
+    // A remote ADD <url> reads nothing from the host, so it builds with an
+    // empty context.
+    const image = new Image({
+      name: "url-image",
+      baseImage: "python:3.12-slim",
+    }).add("https://example.com/data.tar.gz", "/app/data.tar.gz");
+
+    const { captured } = makeFakeBinding();
+    await createSandboxImage(image);
+
+    expect(captured.contextFiles).toEqual([]);
+  });
+
+  it("does not require a context for COPY --from=<stage>", async () => {
+    // COPY --from reads from another build stage, not the host.
+    const image = new Image({
+      name: "stage-image",
+      baseImage: "python:3.12-slim",
+    }).copy("/build/app", "/app", { from: "builder" });
+
+    const { captured } = makeFakeBinding();
+    await createSandboxImage(image);
+
+    expect(captured.contextFiles).toEqual([]);
+  });
+
+  it("uploads the given directory as-is when contextDir is set with COPY ops", async () => {
+    const tempDir = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-ctxcopy`),
       { recursive: true },
     );
-    await writeFile(path.join(tempCwd, "requirements.txt"), "flask\n", "utf8");
-    await writeFile(path.join(tempCwd, "secret.env"), "nope", "utf8");
+    await writeFile(path.join(tempDir, "requirements.txt"), "flask\n", "utf8");
 
     const image = new Image({
       name: "copy-image",
@@ -164,132 +222,9 @@ describe("createSandboxImage", () => {
     }).copy("requirements.txt", "/tmp/requirements.txt");
 
     const { captured } = makeFakeBinding();
-    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
-    try {
-      await createSandboxImage(image);
-    } finally {
-      spy.mockRestore();
-    }
+    await createSandboxImage(image, { contextDir: tempDir as string });
 
-    expect(captured.contextFiles).toEqual(["requirements.txt"]);
-  });
-
-  it("expands globs and copies directories into the minimal context", async () => {
-    const tempCwd = await mkdir(
-      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-globdir`),
-      { recursive: true },
-    );
-    await writeFile(path.join(tempCwd, "a.txt"), "a", "utf8");
-    await writeFile(path.join(tempCwd, "b.txt"), "b", "utf8");
-    await writeFile(path.join(tempCwd, "skip.md"), "m", "utf8");
-    await mkdir(path.join(tempCwd, "src", "pkg"), { recursive: true });
-    await writeFile(path.join(tempCwd, "src", "main.py"), "print()", "utf8");
-    await writeFile(path.join(tempCwd, "src", "pkg", "util.py"), "x=1", "utf8");
-    await writeFile(path.join(tempCwd, "ignored.py"), "nope", "utf8");
-
-    const image = new Image({
-      name: "glob-image",
-      baseImage: "python:3.12-slim",
-    })
-      .copy("*.txt", "/app/")
-      .copy("./src", "/app/src");
-
-    const { captured } = makeFakeBinding();
-    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
-    try {
-      await createSandboxImage(image);
-    } finally {
-      spy.mockRestore();
-    }
-
-    expect(captured.contextFiles).toEqual([
-      "a.txt",
-      "b.txt",
-      "src/main.py",
-      "src/pkg/util.py",
-    ]);
-  });
-
-  it("stages a symlinked source at the path the Dockerfile names", async () => {
-    // A COPY source that is a symlink must be staged at the link path the
-    // Dockerfile references (with the target's contents), not left as a
-    // dangling link in the throwaway context.
-    const tempCwd = await mkdir(
-      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-symlink`),
-      { recursive: true },
-    );
-    await writeFile(path.join(tempCwd, "target.txt"), "payload", "utf8");
-    await symlink(
-      path.join(tempCwd, "target.txt"),
-      path.join(tempCwd, "link.txt"),
-    );
-
-    const image = new Image({
-      name: "link-image",
-      baseImage: "python:3.12-slim",
-    }).copy("link.txt", "/app/link.txt");
-
-    const { captured } = makeFakeBinding();
-    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
-    try {
-      await createSandboxImage(image);
-    } finally {
-      spy.mockRestore();
-    }
-
-    expect(captured.contextFiles).toEqual(["link.txt"]);
-  });
-
-  it("carries cwd's .dockerignore into the minimal context", async () => {
-    // Without contextDir the staged context must include cwd's .dockerignore
-    // so the native archiver applies the same exclusions it would for a
-    // full-cwd context.
-    const tempCwd = await mkdir(
-      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-dockerignore`),
-      { recursive: true },
-    );
-    await mkdir(path.join(tempCwd, "src"), { recursive: true });
-    await writeFile(path.join(tempCwd, "src", "main.py"), "print()", "utf8");
-    await writeFile(path.join(tempCwd, "src", "secret.env"), "nope", "utf8");
-    await writeFile(path.join(tempCwd, ".dockerignore"), "src/secret.env\n", "utf8");
-
-    const image = new Image({
-      name: "ignore-image",
-      baseImage: "python:3.12-slim",
-    }).copy("./src", "/app/src");
-
-    const { captured } = makeFakeBinding();
-    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
-    try {
-      await createSandboxImage(image);
-    } finally {
-      spy.mockRestore();
-    }
-
-    // The .dockerignore is staged at the context root; the actual exclusion is
-    // enforced by the native archiver, which reads it from there.
-    expect(captured.contextFiles).toContain(".dockerignore");
-  });
-
-  it("throws when a COPY source does not exist", async () => {
-    const tempCwd = await mkdir(
-      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-missing`),
-      { recursive: true },
-    );
-    const image = new Image({
-      name: "missing-image",
-      baseImage: "python:3.12-slim",
-    }).copy("does-not-exist.txt", "/tmp/x");
-
-    makeFakeBinding();
-    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
-    try {
-      await expect(createSandboxImage(image)).rejects.toThrow(
-        /does-not-exist\.txt/,
-      );
-    } finally {
-      spy.mockRestore();
-    }
+    expect(captured.options.contextDir).toBe(path.resolve(tempDir as string));
   });
 
   it("forwards dockerCompat to the native build binding", async () => {

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync, readdirSync } from "node:fs";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,6 +13,9 @@ import { Image, dockerfileContent } from "../src/image.js";
 interface CapturedCall {
   options: Record<string, unknown>;
   emit?: ((event: { eventType: string; stream?: string | null; message: string }) => void) | null;
+  // Files staged into the build context, relative + posix-normalized, sorted.
+  // Snapshotted at call time since the temp context is removed once build returns.
+  contextFiles?: string[] | null;
 }
 
 function makeFakeBinding(opts: {
@@ -27,6 +31,19 @@ function makeFakeBinding(opts: {
   ) => {
     captured.options = options;
     captured.emit = emit;
+    const contextDir = options.contextDir as string | undefined;
+    captured.contextFiles =
+      contextDir != null
+        ? readdirSync(contextDir, { recursive: true, withFileTypes: true })
+            .filter((d) => d.isFile())
+            .map((d) =>
+              path
+                .relative(contextDir, path.join(d.parentPath, d.name))
+                .split(path.sep)
+                .join("/"),
+            )
+            .sort()
+        : null;
     if (emit && opts.events) {
       for (const event of opts.events) emit(event);
     }
@@ -107,6 +124,172 @@ describe("createSandboxImage", () => {
     // is responsible for parsing/validating it).
     const expectedDockerfile = `${dockerfileContent(image)}\n`;
     expect(captured.options.dockerfileText).toBe(expectedDockerfile);
+  });
+
+  it("uses an empty build context (not cwd) when contextDir is omitted", async () => {
+    // Without an explicit contextDir, an Image build must NOT upload the
+    // current working directory (which has no Dockerfile in it). It uses a
+    // throwaway empty temp dir instead, so only the generated Dockerfile text
+    // is built — nothing from cwd is archived — and that temp dir is cleaned
+    // up once the build returns.
+    const image = new Image({
+      name: "no-context-image",
+      baseImage: "python:3.12-slim",
+    }).run("pip install numpy");
+
+    const { captured } = makeFakeBinding();
+    await createSandboxImage(image);
+
+    const contextDir = captured.options.contextDir as string;
+    expect(typeof contextDir).toBe("string");
+    expect(path.resolve(contextDir)).not.toBe(path.resolve(process.cwd()));
+    // The temp dir is removed once the build returns.
+    expect(existsSync(contextDir)).toBe(false);
+  });
+
+  it("stages only referenced files into the minimal context (no contextDir)", async () => {
+    // Without contextDir, the build context is assembled from just the
+    // COPY/ADD sources (resolved against cwd) — unrelated files in cwd must
+    // NOT be uploaded.
+    const tempCwd = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-mincopy`),
+      { recursive: true },
+    );
+    await writeFile(path.join(tempCwd, "requirements.txt"), "flask\n", "utf8");
+    await writeFile(path.join(tempCwd, "secret.env"), "nope", "utf8");
+
+    const image = new Image({
+      name: "copy-image",
+      baseImage: "python:3.12-slim",
+    }).copy("requirements.txt", "/tmp/requirements.txt");
+
+    const { captured } = makeFakeBinding();
+    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
+    try {
+      await createSandboxImage(image);
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(captured.contextFiles).toEqual(["requirements.txt"]);
+  });
+
+  it("expands globs and copies directories into the minimal context", async () => {
+    const tempCwd = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-globdir`),
+      { recursive: true },
+    );
+    await writeFile(path.join(tempCwd, "a.txt"), "a", "utf8");
+    await writeFile(path.join(tempCwd, "b.txt"), "b", "utf8");
+    await writeFile(path.join(tempCwd, "skip.md"), "m", "utf8");
+    await mkdir(path.join(tempCwd, "src", "pkg"), { recursive: true });
+    await writeFile(path.join(tempCwd, "src", "main.py"), "print()", "utf8");
+    await writeFile(path.join(tempCwd, "src", "pkg", "util.py"), "x=1", "utf8");
+    await writeFile(path.join(tempCwd, "ignored.py"), "nope", "utf8");
+
+    const image = new Image({
+      name: "glob-image",
+      baseImage: "python:3.12-slim",
+    })
+      .copy("*.txt", "/app/")
+      .copy("./src", "/app/src");
+
+    const { captured } = makeFakeBinding();
+    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
+    try {
+      await createSandboxImage(image);
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(captured.contextFiles).toEqual([
+      "a.txt",
+      "b.txt",
+      "src/main.py",
+      "src/pkg/util.py",
+    ]);
+  });
+
+  it("stages a symlinked source at the path the Dockerfile names", async () => {
+    // A COPY source that is a symlink must be staged at the link path the
+    // Dockerfile references (with the target's contents), not left as a
+    // dangling link in the throwaway context.
+    const tempCwd = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-symlink`),
+      { recursive: true },
+    );
+    await writeFile(path.join(tempCwd, "target.txt"), "payload", "utf8");
+    await symlink(
+      path.join(tempCwd, "target.txt"),
+      path.join(tempCwd, "link.txt"),
+    );
+
+    const image = new Image({
+      name: "link-image",
+      baseImage: "python:3.12-slim",
+    }).copy("link.txt", "/app/link.txt");
+
+    const { captured } = makeFakeBinding();
+    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
+    try {
+      await createSandboxImage(image);
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(captured.contextFiles).toEqual(["link.txt"]);
+  });
+
+  it("carries cwd's .dockerignore into the minimal context", async () => {
+    // Without contextDir the staged context must include cwd's .dockerignore
+    // so the native archiver applies the same exclusions it would for a
+    // full-cwd context.
+    const tempCwd = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-dockerignore`),
+      { recursive: true },
+    );
+    await mkdir(path.join(tempCwd, "src"), { recursive: true });
+    await writeFile(path.join(tempCwd, "src", "main.py"), "print()", "utf8");
+    await writeFile(path.join(tempCwd, "src", "secret.env"), "nope", "utf8");
+    await writeFile(path.join(tempCwd, ".dockerignore"), "src/secret.env\n", "utf8");
+
+    const image = new Image({
+      name: "ignore-image",
+      baseImage: "python:3.12-slim",
+    }).copy("./src", "/app/src");
+
+    const { captured } = makeFakeBinding();
+    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
+    try {
+      await createSandboxImage(image);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // The .dockerignore is staged at the context root; the actual exclusion is
+    // enforced by the native archiver, which reads it from there.
+    expect(captured.contextFiles).toContain(".dockerignore");
+  });
+
+  it("throws when a COPY source does not exist", async () => {
+    const tempCwd = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-missing`),
+      { recursive: true },
+    );
+    const image = new Image({
+      name: "missing-image",
+      baseImage: "python:3.12-slim",
+    }).copy("does-not-exist.txt", "/tmp/x");
+
+    makeFakeBinding();
+    const spy = vi.spyOn(process, "cwd").mockReturnValue(tempCwd as string);
+    try {
+      await expect(createSandboxImage(image)).rejects.toThrow(
+        /does-not-exist\.txt/,
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("forwards dockerCompat to the native build binding", async () => {


### PR DESCRIPTION
## Summary

Align `Image.build()` / `createSandboxImage()` with `docker build <context>`:

- When `context_dir` is given, upload that directory as-is.
- When omitted and the image reads host files (COPY/ADD host sources, or a`RUN --mount=type=bind` reading the context), fail fast asking for`context_dir` instead of silently archiving the cwd.
- When omitted and the image reads no host files, upload an empty context (just the generated Dockerfile).

Bind-mount detection covers the BuildKit default (`type=bind`, no `from=`); `from=` mounts and cache/tmpfs/secret/ssh mounts don't require a context.

## Why

The old path always uploaded the cwd, leaking unrelated files into the build context and surprising users. The new behavior is explicit and matches Docker.

## Changes

- Python + TypeScript SDK kept in sync (`sandbox_builder.py`, `sandbox-image.ts`).
- Tests added for COPY/ADD, remote ADD, `--from` stage, and RUN bind/cache mounts.

## Versions

Python SDK → 0.5.51, TypeScript SDK → 0.5.50.