### PR TITLE
sandbox: address managed processes by PID or name across SDK + CLI

### DIFF
--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -132,9 +132,9 @@ fn build_process_payload(
         body["user"] = Value::String(user.to_string());
     }
     if let Some(name) = options.name {
-        if name.trim().is_empty() {
-            return Err(CliError::usage("--name must not be empty"));
-        }
+        // Single source-of-truth rule shared with the SDK + daemon (URL-safe, not a number).
+        tensorlake::sandboxes::validate_managed_name(name)
+            .map_err(|e| CliError::usage(e.to_string()))?;
         body["name"] = Value::String(name.to_string());
     }
     if let Some(restart) = build_restart_config(options) {

--- a/crates/cli/src/commands/sbx/process.rs
+++ b/crates/cli/src/commands/sbx/process.rs
@@ -6,11 +6,16 @@ use crate::commands::sbx::{
 };
 use crate::error::{CliError, Result};
 
-pub async fn ps(ctx: &CliContext, sandbox_id: &str, pid: Option<i64>, json: bool) -> Result<()> {
+pub async fn ps(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    process: Option<&str>,
+    json: bool,
+) -> Result<()> {
     let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
     let client = ctx.client()?;
-    let path = match pid {
-        Some(pid) => format!("/api/v1/processes/{pid}"),
+    let path = match process {
+        Some(process) => format!("/api/v1/processes/{process}"),
         None => "/api/v1/processes".to_string(),
     };
     let body = send_process_request(
@@ -24,7 +29,7 @@ pub async fn ps(ctx: &CliContext, sandbox_id: &str, pid: Option<i64>, json: bool
         return Ok(());
     }
 
-    if pid.is_some() {
+    if process.is_some() {
         print_process_table(std::slice::from_ref(&body));
     } else {
         let processes = body
@@ -41,31 +46,33 @@ pub async fn ps(ctx: &CliContext, sandbox_id: &str, pid: Option<i64>, json: bool
     Ok(())
 }
 
-pub async fn restart(ctx: &CliContext, sandbox_id: &str, pid: i64) -> Result<()> {
+pub async fn restart(ctx: &CliContext, sandbox_id: &str, process: &str) -> Result<()> {
     let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
     let client = ctx.client()?;
     let body = send_process_request(
         &target,
         client.post(format!(
-            "{}/api/v1/processes/{pid}/restart",
+            "{}/api/v1/processes/{process}/restart",
             target.proxy_base
         )),
     )
     .await?;
-    let next_pid = body.get("pid").and_then(Value::as_i64).unwrap_or(pid);
-    println!("{next_pid}");
+    match body.get("pid").and_then(Value::as_i64) {
+        Some(next_pid) => println!("{next_pid}"),
+        None => println!("{process}"),
+    }
     Ok(())
 }
 
-pub async fn kill(ctx: &CliContext, sandbox_id: &str, pid: i64) -> Result<()> {
+pub async fn kill(ctx: &CliContext, sandbox_id: &str, process: &str) -> Result<()> {
     let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
     let client = ctx.client()?;
     send_process_request(
         &target,
-        client.delete(format!("{}/api/v1/processes/{pid}", target.proxy_base)),
+        client.delete(format!("{}/api/v1/processes/{process}", target.proxy_base)),
     )
     .await?;
-    println!("Killed process {pid}.");
+    println!("Killed process {process}.");
     Ok(())
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -698,30 +698,30 @@ enum SbxCommands {
         /// Sandbox ID or name
         sandbox_id: String,
 
-        /// Optional process PID to inspect
-        pid: Option<i64>,
+        /// Optional process to inspect: PID or process name given on creation
+        process: Option<String>,
 
         /// Print JSON
         #[arg(long)]
         json: bool,
     },
 
-    /// Restart a managed sandbox process by PID
+    /// Restart a managed sandbox process
     Restart {
         /// Sandbox ID or name
         sandbox_id: String,
 
-        /// Process PID
-        pid: i64,
+        /// PID or process name given on creation
+        process: String,
     },
 
-    /// Kill a sandbox process by PID
+    /// Kill a sandbox process (or stop a managed process)
     Kill {
         /// Sandbox ID or name
         sandbox_id: String,
 
-        /// Process PID
-        pid: i64,
+        /// PID or process name given on creation
+        process: String,
     },
 
     /// Copy files between local and sandbox
@@ -1391,15 +1391,17 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     }
                     SbxCommands::Ps {
                         sandbox_id,
-                        pid,
+                        process,
                         json,
-                    } => commands::sbx::process::ps(ctx, &sandbox_id, pid, json).await,
-                    SbxCommands::Restart { sandbox_id, pid } => {
-                        commands::sbx::process::restart(ctx, &sandbox_id, pid).await
-                    }
-                    SbxCommands::Kill { sandbox_id, pid } => {
-                        commands::sbx::process::kill(ctx, &sandbox_id, pid).await
-                    }
+                    } => commands::sbx::process::ps(ctx, &sandbox_id, process.as_deref(), json).await,
+                    SbxCommands::Restart {
+                        sandbox_id,
+                        process,
+                    } => commands::sbx::process::restart(ctx, &sandbox_id, &process).await,
+                    SbxCommands::Kill {
+                        sandbox_id,
+                        process,
+                    } => commands::sbx::process::kill(ctx, &sandbox_id, &process).await,
                     SbxCommands::Cp { src, dest } => commands::sbx::cp::run(ctx, &src, &dest).await,
                     SbxCommands::Copy {
                         sandbox_id,
@@ -2069,29 +2071,35 @@ mod tests {
 
     #[test]
     fn sbx_process_lifecycle_commands_parse() {
-        match parse_command(["tl", "sbx", "ps", "sbx-123", "42", "--json"]) {
+        match parse_command(["tl", "sbx", "ps", "sbx-123", "web", "--json"]) {
             Commands::Sbx(SbxCommands::Ps {
                 sandbox_id,
-                pid,
+                process,
                 json,
             }) => {
                 assert_eq!(sandbox_id, "sbx-123");
-                assert_eq!(pid, Some(42));
+                assert_eq!(process.as_deref(), Some("web"));
                 assert!(json);
             }
             _ => panic!("expected sbx ps command"),
         }
         match parse_command(["tl", "sbx", "restart", "sbx-123", "42"]) {
-            Commands::Sbx(SbxCommands::Restart { sandbox_id, pid }) => {
+            Commands::Sbx(SbxCommands::Restart {
+                sandbox_id,
+                process,
+            }) => {
                 assert_eq!(sandbox_id, "sbx-123");
-                assert_eq!(pid, 42);
+                assert_eq!(process, "42");
             }
             _ => panic!("expected sbx restart command"),
         }
-        match parse_command(["tl", "sbx", "kill", "sbx-123", "42"]) {
-            Commands::Sbx(SbxCommands::Kill { sandbox_id, pid }) => {
+        match parse_command(["tl", "sbx", "kill", "sbx-123", "web"]) {
+            Commands::Sbx(SbxCommands::Kill {
+                sandbox_id,
+                process,
+            }) => {
                 assert_eq!(sandbox_id, "sbx-123");
-                assert_eq!(pid, 42);
+                assert_eq!(process, "web");
             }
             _ => panic!("expected sbx kill command"),
         }

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -27,6 +27,95 @@ use models::{
     SendSignalResponse, SignBlobRequest, SnapshotInfo, SnapshotType, UpdateSandboxRequest,
 };
 
+/// A reference to a sandbox process: either its OS **pid** or a managed-process **name**
+/// given at creation. This is the single place the pid/name path segment is built, reused by
+/// the Rust SDK, the Python/Node bindings, and the CLI.
+#[derive(Debug, Clone)]
+pub enum ProcessRef {
+    Pid(u64),
+    Name(String),
+}
+
+impl ProcessRef {
+    /// The `{pid_or_name}` path segment. A pid is a bare decimal; a name is **percent-encoded**
+    /// so arbitrary characters (spaces, punctuation) survive as a single path segment. `/`
+    /// can't appear in a valid name (see [`validate_managed_name`]), so encoded slashes never
+    /// arise. The daemon's `Path<String>` extractor percent-decodes before matching the name.
+    pub fn to_path_segment(&self) -> String {
+        match self {
+            ProcessRef::Pid(pid) => pid.to_string(),
+            ProcessRef::Name(name) => urlencoding::encode(name).into_owned(),
+        }
+    }
+}
+
+impl From<u64> for ProcessRef {
+    fn from(pid: u64) -> Self {
+        ProcessRef::Pid(pid)
+    }
+}
+impl From<u32> for ProcessRef {
+    fn from(pid: u32) -> Self {
+        ProcessRef::Pid(pid as u64)
+    }
+}
+impl From<i64> for ProcessRef {
+    fn from(pid: i64) -> Self {
+        ProcessRef::Pid(pid as u64)
+    }
+}
+impl From<&str> for ProcessRef {
+    fn from(s: &str) -> Self {
+        // An all-ASCII-digit string is a pid; anything else is a managed name. This mirrors
+        // the daemon's route disambiguation, so a stringified pid still hits the pid branch.
+        if !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()) {
+            if let Ok(pid) = s.parse::<u64>() {
+                return ProcessRef::Pid(pid);
+            }
+        }
+        ProcessRef::Name(s.to_string())
+    }
+}
+impl From<String> for ProcessRef {
+    fn from(s: String) -> Self {
+        ProcessRef::from(s.as_str())
+    }
+}
+impl From<&String> for ProcessRef {
+    fn from(s: &String) -> Self {
+        ProcessRef::from(s.as_str())
+    }
+}
+
+/// Validate a user-supplied managed-process name. **Single source of truth** for the rule
+/// across the Rust SDK, the Python/Node bindings, and the CLI (the daemon keeps a
+/// byte-identical copy in its own repo). Permissive on purpose -- a name may contain any
+/// characters (spaces, punctuation, unicode; clients percent-encode the path segment) with
+/// only three rejections:
+///   1. empty (no path segment),
+///   2. contains `/` (an encoded slash is unreliable across the proxy/router chain), and
+///   3. all ASCII digits (reserved for PID addressing on the shared `/processes/{pid_or_name}`
+///      route -- this is the one residual backward-incompatibility; see release notes).
+pub fn validate_managed_name(name: &str) -> Result<(), SdkError> {
+    if name.is_empty() {
+        return Err(SdkError::ClientError(
+            "managed process name must not be empty".to_string(),
+        ));
+    }
+    if name.contains('/') {
+        return Err(SdkError::ClientError(
+            "managed process name must not contain '/'".to_string(),
+        ));
+    }
+    if name.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(SdkError::ClientError(
+            "managed process name must not be all digits; numeric strings are reserved for PID addressing"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// A client for managing sandbox lifecycle, pool, and snapshot APIs.
 #[derive(Clone)]
 pub struct SandboxesClient {
@@ -332,6 +421,11 @@ impl SandboxProxyClient {
     }
 
     pub async fn start_process(&self, payload: &Value) -> Result<Traced<ProcessInfo>, SdkError> {
+        // Validate a managed name up front (clear client-side error before the round-trip).
+        // The daemon re-validates as the final authority for any path that bypasses this.
+        if let Some(name) = payload.get("name").and_then(Value::as_str) {
+            validate_managed_name(name)?;
+        }
         let req = self
             .request(Method::POST, "/api/v1/processes")
             .json(payload)
@@ -348,98 +442,141 @@ impl SandboxProxyClient {
             .map(|r| r.processes))
     }
 
-    pub async fn get_process(&self, pid: i64) -> Result<Traced<ProcessInfo>, SdkError> {
+    pub async fn get_process(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<ProcessInfo>, SdkError> {
+        let seg = process.into().to_path_segment();
         let req = self
-            .request(Method::GET, &format!("/api/v1/processes/{pid}"))
+            .request(Method::GET, &format!("/api/v1/processes/{seg}"))
             .build()?;
         self.client.execute_json(req).await
     }
 
-    pub async fn kill_process(&self, pid: i64) -> Result<Traced<()>, SdkError> {
+    pub async fn kill_process(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<()>, SdkError> {
+        let seg = process.into().to_path_segment();
         let req = self
-            .request(Method::DELETE, &format!("/api/v1/processes/{pid}"))
+            .request(Method::DELETE, &format!("/api/v1/processes/{seg}"))
             .build()?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn restart_process(&self, pid: i64) -> Result<Traced<ProcessInfo>, SdkError> {
+    pub async fn restart_process(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<ProcessInfo>, SdkError> {
+        let seg = process.into().to_path_segment();
         let req = self
-            .request(Method::POST, &format!("/api/v1/processes/{pid}/restart"))
+            .request(Method::POST, &format!("/api/v1/processes/{seg}/restart"))
             .build()?;
         self.client.execute_json(req).await
     }
 
     pub async fn send_signal(
         &self,
-        pid: i64,
+        process: impl Into<ProcessRef>,
         signal: i64,
     ) -> Result<Traced<SendSignalResponse>, SdkError> {
+        let seg = process.into().to_path_segment();
         let req = self
-            .request(Method::POST, &format!("/api/v1/processes/{pid}/signal"))
+            .request(Method::POST, &format!("/api/v1/processes/{seg}/signal"))
             .json(&serde_json::json!({ "signal": signal }))
             .build()?;
         self.client.execute_json(req).await
     }
 
-    pub async fn write_stdin(&self, pid: i64, data: Vec<u8>) -> Result<Traced<()>, SdkError> {
+    pub async fn write_stdin(
+        &self,
+        process: impl Into<ProcessRef>,
+        data: Vec<u8>,
+    ) -> Result<Traced<()>, SdkError> {
+        let seg = process.into().to_path_segment();
         let req = self
-            .request(Method::POST, &format!("/api/v1/processes/{pid}/stdin"))
+            .request(Method::POST, &format!("/api/v1/processes/{seg}/stdin"))
             .body(data)
             .build()?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn close_stdin(&self, pid: i64) -> Result<Traced<()>, SdkError> {
+    pub async fn close_stdin(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<()>, SdkError> {
+        let seg = process.into().to_path_segment();
         let req = self
             .request(
                 Method::POST,
-                &format!("/api/v1/processes/{pid}/stdin/close"),
+                &format!("/api/v1/processes/{seg}/stdin/close"),
             )
             .build()?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
-    pub async fn get_stdout(&self, pid: i64) -> Result<Traced<OutputResponse>, SdkError> {
+    pub async fn get_stdout(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<OutputResponse>, SdkError> {
+        let seg = process.into().to_path_segment();
         let req = self
-            .request(Method::GET, &format!("/api/v1/processes/{pid}/stdout"))
+            .request(Method::GET, &format!("/api/v1/processes/{seg}/stdout"))
             .build()?;
         self.client.execute_json(req).await
     }
 
-    pub async fn get_stderr(&self, pid: i64) -> Result<Traced<OutputResponse>, SdkError> {
+    pub async fn get_stderr(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<OutputResponse>, SdkError> {
+        let seg = process.into().to_path_segment();
         let req = self
-            .request(Method::GET, &format!("/api/v1/processes/{pid}/stderr"))
+            .request(Method::GET, &format!("/api/v1/processes/{seg}/stderr"))
             .build()?;
         self.client.execute_json(req).await
     }
 
-    pub async fn get_output(&self, pid: i64) -> Result<Traced<OutputResponse>, SdkError> {
+    pub async fn get_output(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<OutputResponse>, SdkError> {
+        let seg = process.into().to_path_segment();
         let req = self
-            .request(Method::GET, &format!("/api/v1/processes/{pid}/output"))
+            .request(Method::GET, &format!("/api/v1/processes/{seg}/output"))
             .build()?;
         self.client.execute_json(req).await
     }
 
-    pub async fn follow_stdout(&self, pid: i64) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
+    pub async fn follow_stdout(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
         let mut events = Vec::new();
         let trace_id = self
-            .follow_stdout_streaming(pid, |event| events.push(event))
+            .follow_stdout_streaming(process, |event| events.push(event))
             .await?;
         Ok(Traced::new(trace_id, events))
     }
 
-    pub async fn follow_stderr(&self, pid: i64) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
+    pub async fn follow_stderr(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
         let mut events = Vec::new();
         let trace_id = self
-            .follow_stderr_streaming(pid, |event| events.push(event))
+            .follow_stderr_streaming(process, |event| events.push(event))
             .await?;
         Ok(Traced::new(trace_id, events))
     }
 
-    pub async fn follow_output(&self, pid: i64) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
+    pub async fn follow_output(
+        &self,
+        process: impl Into<ProcessRef>,
+    ) -> Result<Traced<Vec<OutputEvent>>, SdkError> {
         let mut events = Vec::new();
         let trace_id = self
-            .follow_output_streaming(pid, |event| events.push(event))
+            .follow_output_streaming(process, |event| events.push(event))
             .await?;
         Ok(Traced::new(trace_id, events))
     }
@@ -450,28 +587,31 @@ impl SandboxProxyClient {
     /// language bindings that surface a live event stream to the caller.
     pub async fn follow_stdout_streaming(
         &self,
-        pid: i64,
+        process: impl Into<ProcessRef>,
         on_event: impl FnMut(OutputEvent),
     ) -> Result<String, SdkError> {
-        self.follow_stream_cb(&format!("/api/v1/processes/{pid}/stdout/follow"), on_event)
+        let seg = process.into().to_path_segment();
+        self.follow_stream_cb(&format!("/api/v1/processes/{seg}/stdout/follow"), on_event)
             .await
     }
 
     pub async fn follow_stderr_streaming(
         &self,
-        pid: i64,
+        process: impl Into<ProcessRef>,
         on_event: impl FnMut(OutputEvent),
     ) -> Result<String, SdkError> {
-        self.follow_stream_cb(&format!("/api/v1/processes/{pid}/stderr/follow"), on_event)
+        let seg = process.into().to_path_segment();
+        self.follow_stream_cb(&format!("/api/v1/processes/{seg}/stderr/follow"), on_event)
             .await
     }
 
     pub async fn follow_output_streaming(
         &self,
-        pid: i64,
+        process: impl Into<ProcessRef>,
         on_event: impl FnMut(OutputEvent),
     ) -> Result<String, SdkError> {
-        self.follow_stream_cb(&format!("/api/v1/processes/{pid}/output/follow"), on_event)
+        let seg = process.into().to_path_segment();
+        self.follow_stream_cb(&format!("/api/v1/processes/{seg}/output/follow"), on_event)
             .await
     }
 
@@ -704,5 +844,40 @@ impl SandboxProxyClient {
             .json(request)
             .build()?;
         self.client.execute_json(req).await
+    }
+}
+
+#[cfg(test)]
+mod process_ref_tests {
+    use super::{validate_managed_name, ProcessRef};
+
+    #[test]
+    fn validate_managed_name_rules() {
+        // Only three rejections: empty, contains '/', and all-digits (reserved for PID).
+        let long_digits = "9".repeat(100);
+        for bad in ["", "123", "0", "a/b", "worker/api", &long_digits] {
+            assert!(validate_managed_name(bad).is_err(), "expected {bad:?} rejected");
+        }
+        // Permissive: spaces, punctuation, leading/trailing whitespace, and unicode are all
+        // allowed now (clients percent-encode the path segment).
+        for ok in [
+            "web", "web1", "1web", "my-app_v.2", "web 1", " web ", "a?b", "a%b", "a#b", "café",
+        ] {
+            assert!(validate_managed_name(ok).is_ok(), "expected {ok:?} accepted");
+        }
+    }
+
+    #[test]
+    fn process_ref_path_segments() {
+        assert_eq!(ProcessRef::from(1234u64).to_path_segment(), "1234");
+        assert_eq!(ProcessRef::from(42i64).to_path_segment(), "42");
+        // A numeric string is treated as a pid; a name is percent-encoded.
+        assert_eq!(ProcessRef::from("1234").to_path_segment(), "1234");
+        assert!(matches!(ProcessRef::from("1234"), ProcessRef::Pid(1234)));
+        assert_eq!(ProcessRef::from("web").to_path_segment(), "web");
+        assert!(matches!(ProcessRef::from("web"), ProcessRef::Name(_)));
+        // Spaces and reserved characters in a name are percent-encoded into one segment.
+        assert_eq!(ProcessRef::from("web 1").to_path_segment(), "web%201");
+        assert_eq!(ProcessRef::from("a?b").to_path_segment(), "a%3Fb");
     }
 }

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -714,94 +714,117 @@ impl NativeSandboxProxyClient {
         .await
     }
 
+    // `process` is the pid-or-name path segment (the TS layer stringifies). Cloned per retry
+    // attempt because `with_retry` may invoke the closure more than once.
     #[napi]
-    pub async fn get_process(&self, pid: i32) -> napi::Result<TracedJson> {
-        with_retry(self.client.clone(), 5, move |c| async move {
-            let traced = c.get_process(pid as i64).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced)?;
-            Ok(TracedJson { trace_id, json })
+    pub async fn get_process(&self, process: String) -> napi::Result<TracedJson> {
+        with_retry(self.client.clone(), 5, move |c| {
+            let process = process.clone();
+            async move {
+                let traced = c.get_process(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
         })
         .await
     }
 
     #[napi]
-    pub async fn kill_process(&self, pid: i32) -> napi::Result<String> {
-        with_retry(self.client.clone(), 5, move |c| async move {
-            c.kill_process(pid as i64).await.map(|t| t.trace_id)
+    pub async fn kill_process(&self, process: String) -> napi::Result<String> {
+        with_retry(self.client.clone(), 5, move |c| {
+            let process = process.clone();
+            async move { c.kill_process(process).await.map(|t| t.trace_id) }
         })
         .await
     }
 
     #[napi]
-    pub async fn restart_process(&self, pid: i32) -> napi::Result<TracedJson> {
-        with_retry(self.client.clone(), 5, move |c| async move {
-            let traced = c.restart_process(pid as i64).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced)?;
-            Ok(TracedJson { trace_id, json })
+    pub async fn restart_process(&self, process: String) -> napi::Result<TracedJson> {
+        with_retry(self.client.clone(), 5, move |c| {
+            let process = process.clone();
+            async move {
+                let traced = c.restart_process(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
         })
         .await
     }
 
     #[napi]
-    pub async fn send_signal(&self, pid: i32, signal: i32) -> napi::Result<TracedJson> {
-        with_retry(self.client.clone(), 5, move |c| async move {
-            let traced = c.send_signal(pid as i64, signal as i64).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced)?;
-            Ok(TracedJson { trace_id, json })
+    pub async fn send_signal(&self, process: String, signal: i32) -> napi::Result<TracedJson> {
+        with_retry(self.client.clone(), 5, move |c| {
+            let process = process.clone();
+            async move {
+                let traced = c.send_signal(process, signal as i64).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
         })
         .await
     }
 
     #[napi]
-    pub async fn write_stdin(&self, pid: i32, data: Buffer) -> napi::Result<String> {
+    pub async fn write_stdin(&self, process: String, data: Buffer) -> napi::Result<String> {
         let bytes = data.to_vec();
         with_retry(self.client.clone(), 5, move |c| {
+            let process = process.clone();
             let bytes = bytes.clone();
-            async move { c.write_stdin(pid as i64, bytes).await.map(|t| t.trace_id) }
+            async move { c.write_stdin(process, bytes).await.map(|t| t.trace_id) }
         })
         .await
     }
 
     #[napi]
-    pub async fn close_stdin(&self, pid: i32) -> napi::Result<String> {
-        with_retry(self.client.clone(), 5, move |c| async move {
-            c.close_stdin(pid as i64).await.map(|t| t.trace_id)
+    pub async fn close_stdin(&self, process: String) -> napi::Result<String> {
+        with_retry(self.client.clone(), 5, move |c| {
+            let process = process.clone();
+            async move { c.close_stdin(process).await.map(|t| t.trace_id) }
         })
         .await
     }
 
     #[napi]
-    pub async fn get_stdout(&self, pid: i32) -> napi::Result<TracedJson> {
-        with_retry(self.client.clone(), 5, move |c| async move {
-            let traced = c.get_stdout(pid as i64).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced)?;
-            Ok(TracedJson { trace_id, json })
+    pub async fn get_stdout(&self, process: String) -> napi::Result<TracedJson> {
+        with_retry(self.client.clone(), 5, move |c| {
+            let process = process.clone();
+            async move {
+                let traced = c.get_stdout(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
         })
         .await
     }
 
     #[napi]
-    pub async fn get_stderr(&self, pid: i32) -> napi::Result<TracedJson> {
-        with_retry(self.client.clone(), 5, move |c| async move {
-            let traced = c.get_stderr(pid as i64).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced)?;
-            Ok(TracedJson { trace_id, json })
+    pub async fn get_stderr(&self, process: String) -> napi::Result<TracedJson> {
+        with_retry(self.client.clone(), 5, move |c| {
+            let process = process.clone();
+            async move {
+                let traced = c.get_stderr(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
         })
         .await
     }
 
     #[napi]
-    pub async fn get_output(&self, pid: i32) -> napi::Result<TracedJson> {
-        with_retry(self.client.clone(), 5, move |c| async move {
-            let traced = c.get_output(pid as i64).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced)?;
-            Ok(TracedJson { trace_id, json })
+    pub async fn get_output(&self, process: String) -> napi::Result<TracedJson> {
+        with_retry(self.client.clone(), 5, move |c| {
+            let process = process.clone();
+            async move {
+                let traced = c.get_output(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
         })
         .await
     }
@@ -811,12 +834,12 @@ impl NativeSandboxProxyClient {
     #[napi]
     pub async fn follow_stdout(
         &self,
-        pid: i32,
+        process: String,
         emit: ThreadsafeFunction<String, ErrorStrategy::Fatal>,
     ) -> napi::Result<String> {
         self.client
             .clone()
-            .follow_stdout_streaming(pid as i64, move |event| emit_event(&emit, event))
+            .follow_stdout_streaming(process, move |event| emit_event(&emit, event))
             .await
             .map_err(into_napi_error)
     }
@@ -824,12 +847,12 @@ impl NativeSandboxProxyClient {
     #[napi]
     pub async fn follow_stderr(
         &self,
-        pid: i32,
+        process: String,
         emit: ThreadsafeFunction<String, ErrorStrategy::Fatal>,
     ) -> napi::Result<String> {
         self.client
             .clone()
-            .follow_stderr_streaming(pid as i64, move |event| emit_event(&emit, event))
+            .follow_stderr_streaming(process, move |event| emit_event(&emit, event))
             .await
             .map_err(into_napi_error)
     }
@@ -837,12 +860,12 @@ impl NativeSandboxProxyClient {
     #[napi]
     pub async fn follow_output(
         &self,
-        pid: i32,
+        process: String,
         emit: ThreadsafeFunction<String, ErrorStrategy::Fatal>,
     ) -> napi::Result<String> {
         self.client
             .clone()
-            .follow_output_streaming(pid as i64, move |event| emit_event(&emit, event))
+            .follow_output_streaming(process, move |event| emit_event(&emit, event))
             .await
             .map_err(into_napi_error)
     }
@@ -999,6 +1022,13 @@ impl NativeSandboxProxyClient {
         })
         .await
     }
+}
+
+/// Validate a managed-process name client-side; throws on failure. Wraps the single
+/// source-of-truth rule in the Rust cloud SDK so the TS layer need not reimplement it.
+#[napi]
+pub fn validate_managed_name(name: String) -> napi::Result<()> {
+    tensorlake::sandboxes::validate_managed_name(&name).map_err(into_napi_error)
 }
 
 /// Serialize one streaming event and push it across the napi threadsafe

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -1402,120 +1402,156 @@ impl CloudSandboxProxyClient {
         })
     }
 
-    fn get_process_json(&self, pid: i64) -> PyResult<(String, String)> {
-        self.run_with_retry(5, move |client| async move {
-            let traced = client.get_process(pid).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
-            Ok((trace_id, json))
-        })
-    }
-
-    fn kill_process(&self, pid: i64) -> PyResult<String> {
-        self.run_with_retry(5, move |client| async move {
-            let traced = client.kill_process(pid).await?;
-            Ok(traced.trace_id)
-        })
-    }
-
-    fn restart_process_json(&self, pid: i64) -> PyResult<(String, String)> {
-        self.run_with_retry(5, move |client| async move {
-            let traced = client.restart_process(pid).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
-            Ok((trace_id, json))
-        })
-    }
-
-    fn send_signal_json(&self, pid: i64, signal: i64) -> PyResult<(String, String)> {
-        self.run_with_retry(5, move |client| async move {
-            let traced = client.send_signal(pid, signal).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
-            Ok((trace_id, json))
-        })
-    }
-
-    fn write_stdin(&self, pid: i64, data: Vec<u8>) -> PyResult<String> {
+    // `process` is the pid-or-name path segment (the Python layer stringifies). It is cloned
+    // per retry attempt because `run_with_retry` may invoke the closure more than once.
+    fn get_process_json(&self, process: String) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| {
-            let data = data.clone();
+            let process = process.clone();
             async move {
-                let traced = client.write_stdin(pid, data).await?;
+                let traced = client.get_process(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
+            }
+        })
+    }
+
+    fn kill_process(&self, process: String) -> PyResult<String> {
+        self.run_with_retry(5, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.kill_process(process).await?;
                 Ok(traced.trace_id)
             }
         })
     }
 
-    fn close_stdin(&self, pid: i64) -> PyResult<String> {
-        self.run_with_retry(5, move |client| async move {
-            let traced = client.close_stdin(pid).await?;
-            Ok(traced.trace_id)
+    fn restart_process_json(&self, process: String) -> PyResult<(String, String)> {
+        self.run_with_retry(5, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.restart_process(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
+            }
         })
     }
 
-    fn get_stdout_json(&self, pid: i64) -> PyResult<(String, String)> {
-        self.run_with_retry(5, move |client| async move {
-            let traced = client.get_stdout(pid).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
-            Ok((trace_id, json))
+    fn send_signal_json(&self, process: String, signal: i64) -> PyResult<(String, String)> {
+        self.run_with_retry(5, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.send_signal(process, signal).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
+            }
         })
     }
 
-    fn get_stderr_json(&self, pid: i64) -> PyResult<(String, String)> {
-        self.run_with_retry(5, move |client| async move {
-            let traced = client.get_stderr(pid).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
-            Ok((trace_id, json))
+    fn write_stdin(&self, process: String, data: Vec<u8>) -> PyResult<String> {
+        self.run_with_retry(5, move |client| {
+            let process = process.clone();
+            let data = data.clone();
+            async move {
+                let traced = client.write_stdin(process, data).await?;
+                Ok(traced.trace_id)
+            }
         })
     }
 
-    fn get_output_json(&self, pid: i64) -> PyResult<(String, String)> {
-        self.run_with_retry(5, move |client| async move {
-            let traced = client.get_output(pid).await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
-            Ok((trace_id, json))
+    fn close_stdin(&self, process: String) -> PyResult<String> {
+        self.run_with_retry(5, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.close_stdin(process).await?;
+                Ok(traced.trace_id)
+            }
         })
     }
 
-    fn follow_stdout_json(&self, pid: i64) -> PyResult<(String, Vec<String>)> {
-        self.run_with_retry(10, move |client| async move {
-            let traced = client.follow_stdout(pid).await?;
-            let trace_id = traced.trace_id.clone();
-            let events = traced
-                .into_inner()
-                .into_iter()
-                .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
-                .collect::<Result<Vec<String>, SdkError>>()?;
-            Ok((trace_id, events))
+    fn get_stdout_json(&self, process: String) -> PyResult<(String, String)> {
+        self.run_with_retry(5, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.get_stdout(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
+            }
         })
     }
 
-    fn follow_stderr_json(&self, pid: i64) -> PyResult<(String, Vec<String>)> {
-        self.run_with_retry(10, move |client| async move {
-            let traced = client.follow_stderr(pid).await?;
-            let trace_id = traced.trace_id.clone();
-            let events = traced
-                .into_inner()
-                .into_iter()
-                .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
-                .collect::<Result<Vec<String>, SdkError>>()?;
-            Ok((trace_id, events))
+    fn get_stderr_json(&self, process: String) -> PyResult<(String, String)> {
+        self.run_with_retry(5, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.get_stderr(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
+            }
         })
     }
 
-    fn follow_output_json(&self, pid: i64) -> PyResult<(String, Vec<String>)> {
-        self.run_with_retry(10, move |client| async move {
-            let traced = client.follow_output(pid).await?;
-            let trace_id = traced.trace_id.clone();
-            let events = traced
-                .into_inner()
-                .into_iter()
-                .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
-                .collect::<Result<Vec<String>, SdkError>>()?;
-            Ok((trace_id, events))
+    fn get_output_json(&self, process: String) -> PyResult<(String, String)> {
+        self.run_with_retry(5, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.get_output(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
+                Ok((trace_id, json))
+            }
+        })
+    }
+
+    fn follow_stdout_json(&self, process: String) -> PyResult<(String, Vec<String>)> {
+        self.run_with_retry(10, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.follow_stdout(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let events = traced
+                    .into_inner()
+                    .into_iter()
+                    .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
+                    .collect::<Result<Vec<String>, SdkError>>()?;
+                Ok((trace_id, events))
+            }
+        })
+    }
+
+    fn follow_stderr_json(&self, process: String) -> PyResult<(String, Vec<String>)> {
+        self.run_with_retry(10, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.follow_stderr(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let events = traced
+                    .into_inner()
+                    .into_iter()
+                    .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
+                    .collect::<Result<Vec<String>, SdkError>>()?;
+                Ok((trace_id, events))
+            }
+        })
+    }
+
+    fn follow_output_json(&self, process: String) -> PyResult<(String, Vec<String>)> {
+        self.run_with_retry(10, move |client| {
+            let process = process.clone();
+            async move {
+                let traced = client.follow_output(process).await?;
+                let trace_id = traced.trace_id.clone();
+                let events = traced
+                    .into_inner()
+                    .into_iter()
+                    .map(|event| serde_json::to_string(&event).map_err(SdkError::from))
+                    .collect::<Result<Vec<String>, SdkError>>()?;
+                Ok((trace_id, events))
+            }
         })
     }
 
@@ -1666,25 +1702,32 @@ impl CloudSandboxProxyClient {
     fn get_process_json_async<'py>(
         &self,
         py: Python<'py>,
-        pid: i64,
+        process: String,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced =
-                retry_async_op(client, 5, move |c| async move { c.get_process(pid).await })
-                    .await
-                    .map_err(into_sandbox_py_error)?;
+            let traced = retry_async_op(client, 5, move |c| {
+                let process = process.clone();
+                async move { c.get_process(process).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
         })
     }
 
-    fn kill_process_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
+    fn kill_process_async<'py>(
+        &self,
+        py: Python<'py>,
+        process: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let trace_id = retry_async_op(client, 5, move |c| async move {
-                c.kill_process(pid).await.map(|t| t.trace_id)
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let process = process.clone();
+                async move { c.kill_process(process).await.map(|t| t.trace_id) }
             })
             .await
             .map_err(into_sandbox_py_error)?;
@@ -1695,15 +1738,14 @@ impl CloudSandboxProxyClient {
     fn restart_process_json_async<'py>(
         &self,
         py: Python<'py>,
-        pid: i64,
+        process: String,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(
-                client,
-                5,
-                move |c| async move { c.restart_process(pid).await },
-            )
+            let traced = retry_async_op(client, 5, move |c| {
+                let process = process.clone();
+                async move { c.restart_process(process).await }
+            })
             .await
             .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
@@ -1715,13 +1757,14 @@ impl CloudSandboxProxyClient {
     fn send_signal_json_async<'py>(
         &self,
         py: Python<'py>,
-        pid: i64,
+        process: String,
         signal: i64,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move {
-                c.send_signal(pid, signal).await
+            let traced = retry_async_op(client, 5, move |c| {
+                let process = process.clone();
+                async move { c.send_signal(process, signal).await }
             })
             .await
             .map_err(into_sandbox_py_error)?;
@@ -1734,14 +1777,15 @@ impl CloudSandboxProxyClient {
     fn write_stdin_async<'py>(
         &self,
         py: Python<'py>,
-        pid: i64,
+        process: String,
         data: Vec<u8>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
             let trace_id = retry_async_op(client, 5, move |c| {
+                let process = process.clone();
                 let data = data.clone();
-                async move { c.write_stdin(pid, data).await.map(|t| t.trace_id) }
+                async move { c.write_stdin(process, data).await.map(|t| t.trace_id) }
             })
             .await
             .map_err(into_sandbox_py_error)?;
@@ -1749,11 +1793,16 @@ impl CloudSandboxProxyClient {
         })
     }
 
-    fn close_stdin_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
+    fn close_stdin_async<'py>(
+        &self,
+        py: Python<'py>,
+        process: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let trace_id = retry_async_op(client, 5, move |c| async move {
-                c.close_stdin(pid).await.map(|t| t.trace_id)
+            let trace_id = retry_async_op(client, 5, move |c| {
+                let process = process.clone();
+                async move { c.close_stdin(process).await.map(|t| t.trace_id) }
             })
             .await
             .map_err(into_sandbox_py_error)?;
@@ -1761,36 +1810,57 @@ impl CloudSandboxProxyClient {
         })
     }
 
-    fn get_stdout_json_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
+    fn get_stdout_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        process: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move { c.get_stdout(pid).await })
-                .await
-                .map_err(into_sandbox_py_error)?;
+            let traced = retry_async_op(client, 5, move |c| {
+                let process = process.clone();
+                async move { c.get_stdout(process).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
         })
     }
 
-    fn get_stderr_json_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
+    fn get_stderr_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        process: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move { c.get_stderr(pid).await })
-                .await
-                .map_err(into_sandbox_py_error)?;
+            let traced = retry_async_op(client, 5, move |c| {
+                let process = process.clone();
+                async move { c.get_stderr(process).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
         })
     }
 
-    fn get_output_json_async<'py>(&self, py: Python<'py>, pid: i64) -> PyResult<Bound<'py, PyAny>> {
+    fn get_output_json_async<'py>(
+        &self,
+        py: Python<'py>,
+        process: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| async move { c.get_output(pid).await })
-                .await
-                .map_err(into_sandbox_py_error)?;
+            let traced = retry_async_op(client, 5, move |c| {
+                let process = process.clone();
+                async move { c.get_output(process).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
@@ -1800,15 +1870,14 @@ impl CloudSandboxProxyClient {
     fn follow_stdout_json_async<'py>(
         &self,
         py: Python<'py>,
-        pid: i64,
+        process: String,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(
-                client,
-                10,
-                move |c| async move { c.follow_stdout(pid).await },
-            )
+            let traced = retry_async_op(client, 10, move |c| {
+                let process = process.clone();
+                async move { c.follow_stdout(process).await }
+            })
             .await
             .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
@@ -1824,15 +1893,14 @@ impl CloudSandboxProxyClient {
     fn follow_stderr_json_async<'py>(
         &self,
         py: Python<'py>,
-        pid: i64,
+        process: String,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(
-                client,
-                10,
-                move |c| async move { c.follow_stderr(pid).await },
-            )
+            let traced = retry_async_op(client, 10, move |c| {
+                let process = process.clone();
+                async move { c.follow_stderr(process).await }
+            })
             .await
             .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
@@ -1848,15 +1916,14 @@ impl CloudSandboxProxyClient {
     fn follow_output_json_async<'py>(
         &self,
         py: Python<'py>,
-        pid: i64,
+        process: String,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(
-                client,
-                10,
-                move |c| async move { c.follow_output(pid).await },
-            )
+            let traced = retry_async_op(client, 10, move |c| {
+                let process = process.clone();
+                async move { c.follow_output(process).await }
+            })
             .await
             .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
@@ -3078,6 +3145,14 @@ fn emit_sandbox_image_event(callback: &Py<PyAny>, event: SandboxImageBuildEvent)
     });
 }
 
+/// Validate a managed-process name client-side, raising `ValueError` on failure. Wraps the
+/// single source-of-truth rule in the Rust cloud SDK so Python need not reimplement it.
+#[pyfunction]
+fn validate_managed_name(name: &str) -> PyResult<()> {
+    tensorlake::sandboxes::validate_managed_name(name)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}
+
 #[pymodule]
 fn _cloud_sdk(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     // Eager-init the shared tokio runtime at import time so the first sync
@@ -3102,5 +3177,6 @@ fn _cloud_sdk(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(create_image_context_file, module)?)?;
     module.add_function(wrap_pyfunction!(build_sandbox_image, module)?)?;
     module.add_function(wrap_pyfunction!(import_sandbox_image, module)?)?;
+    module.add_function(wrap_pyfunction!(validate_managed_name, module)?)?;
     Ok(())
 }

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -43,10 +43,13 @@ from .models import (
     StdinMode,
 )
 from .sandbox import (
+    _PROCESS_ARG_UNSET,
     _RUST_SANDBOX_PROXY_CLIENT_AVAILABLE,
     RustCloudSandboxProxyClient,
     Sandbox,
     _raise_as_sandbox_error,
+    _resolve_process_arg,
+    _validate_managed_name_client_side,
 )
 
 if TYPE_CHECKING:
@@ -477,6 +480,8 @@ class AsyncSandbox:
         restart: RestartPolicyConfig | Mapping[str, object] | None = None,
         health_check: ProcessHealthCheck | Mapping[str, object] | None = None,
     ) -> Traced[ProcessInfo]:
+        if name is not None:
+            _validate_managed_name_client_side(name)
         process_user = Sandbox._normalize_process_user(user)
         restart_payload = Sandbox._normalize_restart_config(restart)
         health_check_payload = Sandbox._normalize_health_check(health_check)
@@ -511,35 +516,66 @@ class AsyncSandbox:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def get_process(self, pid: int) -> Traced[ProcessInfo]:
+    async def get_process(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[ProcessInfo]:
+        """Get information about a process by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
             trace_id, response_json = await self._rust_client.get_process_json_async(
-                pid=pid
+                seg
             )
             return Traced(trace_id, ProcessInfo.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def kill_process(self, pid: int) -> Traced[None]:
+    async def kill_process(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[None]:
+        """Kill a process by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id = await self._rust_client.kill_process_async(pid=pid)
+            trace_id = await self._rust_client.kill_process_async(seg)
             return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def restart_process(self, pid: int) -> Traced[ProcessInfo]:
+    async def restart_process(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[ProcessInfo]:
+        """Restart a managed process by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
             trace_id, response_json = (
-                await self._rust_client.restart_process_json_async(pid=pid)
+                await self._rust_client.restart_process_json_async(seg)
             )
             return Traced(trace_id, ProcessInfo.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def send_signal(self, pid: int, signal: int) -> Traced[SendSignalResponse]:
+    async def send_signal(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        signal: int = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[SendSignalResponse]:
+        """Send a signal to a process by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
+        if signal is _PROCESS_ARG_UNSET:
+            raise TypeError("missing required argument: `signal`")
         try:
             trace_id, response_json = await self._rust_client.send_signal_json_async(
-                pid=pid, signal=signal
+                seg, signal
             )
             return Traced(
                 trace_id, SendSignalResponse.model_validate_json(response_json)
@@ -549,51 +585,90 @@ class AsyncSandbox:
 
     # --- Process I/O ---
 
-    async def write_stdin(self, pid: int, data: bytes) -> Traced[None]:
+    async def write_stdin(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        data: bytes = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[None]:
+        """Write data to a process's stdin by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
+        if data is _PROCESS_ARG_UNSET:
+            raise TypeError("missing required argument: `data`")
         try:
-            trace_id = await self._rust_client.write_stdin_async(pid=pid, data=data)
+            trace_id = await self._rust_client.write_stdin_async(seg, data)
             return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def close_stdin(self, pid: int) -> Traced[None]:
+    async def close_stdin(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[None]:
+        """Close a process's stdin by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id = await self._rust_client.close_stdin_async(pid=pid)
+            trace_id = await self._rust_client.close_stdin_async(seg)
             return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def get_stdout(self, pid: int) -> Traced[OutputResponse]:
+    async def get_stdout(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[OutputResponse]:
+        """Get all stdout output from a process by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, response_json = await self._rust_client.get_stdout_json_async(
-                pid=pid
-            )
+            trace_id, response_json = await self._rust_client.get_stdout_json_async(seg)
             return Traced(trace_id, OutputResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def get_stderr(self, pid: int) -> Traced[OutputResponse]:
+    async def get_stderr(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[OutputResponse]:
+        """Get all stderr output from a process by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, response_json = await self._rust_client.get_stderr_json_async(
-                pid=pid
-            )
+            trace_id, response_json = await self._rust_client.get_stderr_json_async(seg)
             return Traced(trace_id, OutputResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def get_output(self, pid: int) -> Traced[OutputResponse]:
+    async def get_output(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[OutputResponse]:
+        """Get all combined output from a process by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, response_json = await self._rust_client.get_output_json_async(
-                pid=pid
-            )
+            trace_id, response_json = await self._rust_client.get_output_json_async(seg)
             return Traced(trace_id, OutputResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def follow_stdout(self, pid: int) -> TracedIterator[OutputEvent]:
+    async def follow_stdout(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> TracedIterator[OutputEvent]:
+        """Follow stdout output events by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
             trace_id, events_json = await self._rust_client.follow_stdout_json_async(
-                pid=pid
+                seg
             )
             return TracedIterator(
                 trace_id, [OutputEvent.model_validate_json(ej) for ej in events_json]
@@ -601,10 +676,17 @@ class AsyncSandbox:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def follow_stderr(self, pid: int) -> TracedIterator[OutputEvent]:
+    async def follow_stderr(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> TracedIterator[OutputEvent]:
+        """Follow stderr output events by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
             trace_id, events_json = await self._rust_client.follow_stderr_json_async(
-                pid=pid
+                seg
             )
             return TracedIterator(
                 trace_id, [OutputEvent.model_validate_json(ej) for ej in events_json]
@@ -612,10 +694,17 @@ class AsyncSandbox:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def follow_output(self, pid: int) -> TracedIterator[OutputEvent]:
+    async def follow_output(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> TracedIterator[OutputEvent]:
+        """Follow combined output events by PID or process name given on creation."""
+        seg = _resolve_process_arg(process, pid)
         try:
             trace_id, events_json = await self._rust_client.follow_output_json_async(
-                pid=pid
+                seg
             )
             return TracedIterator(
                 trace_id, [OutputEvent.model_validate_json(ej) for ej in events_json]

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -538,7 +538,13 @@ class ManagedProcessExit(BaseModel):
 
 
 class ManagedProcessInfo(BaseModel):
-    """Managed-process metadata embedded into ProcessInfo."""
+    """Managed-process metadata embedded into ProcessInfo.
+
+    A managed process is addressable by either its current PID or, if a ``name`` was given
+    at creation, that name (process APIs accept a PID or process name). ``id`` is a stable
+    daemon-local identifier: it equals ``name`` when one was set, otherwise a daemon-assigned
+    opaque id (the process is then addressable only by PID, not by ``id``).
+    """
 
     id: str
     name: str | None = None

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -113,6 +113,49 @@ def _raise_as_sandbox_error(e: Exception) -> None:
     raise SandboxError(str(e)) from e
 
 
+# Sentinel distinguishing "argument omitted" from an explicit value, so the deprecated `pid`
+# keyword can coexist with the new `process` parameter (and with the required second arg of
+# send_signal/write_stdin).
+_PROCESS_ARG_UNSET = object()
+
+
+def _validate_managed_name_client_side(name: str) -> None:
+    """Validate a managed-process name via the Rust core (raises ValueError on failure).
+
+    Degrades gracefully if the installed native module predates this validator (version
+    skew between the Python package and the compiled extension) -- the cloud SDK's
+    ``start_process`` and the daemon both re-validate authoritatively.
+    """
+    try:
+        from _cloud_sdk import validate_managed_name as _vmn
+    except ImportError:
+        return
+    _vmn(name)
+
+
+def _resolve_process_arg(process: object, pid: object) -> str:
+    """Resolve the process selector from the new ``process`` arg and the deprecated ``pid``.
+
+    Accepts a pid (int) or a managed-process name (str) and returns the path segment string.
+    Emits a ``DeprecationWarning`` when the old ``pid`` keyword is used; errors if both or
+    neither are given.
+    """
+    if pid is not _PROCESS_ARG_UNSET:
+        if process is not _PROCESS_ARG_UNSET:
+            raise TypeError("pass either `process` or `pid`, not both")
+        import warnings
+
+        warnings.warn(
+            "`pid` is deprecated; use `process` (accepts a PID or a managed-process name)",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        process = pid
+    if process is _PROCESS_ARG_UNSET:
+        raise TypeError("missing required argument: `process`")
+    return str(process)
+
+
 class Sandbox:
     """Client for interacting with a running sandbox.
 
@@ -956,7 +999,13 @@ class Sandbox:
                 root). Pass a username such as ``"root"``, a Docker-style id
                 string like ``"1000:1000"``, or ``ProcessUserSpec(uid=1000, gid=1000)``.
             name: Optional managed-process name. Supplying this opts the process
-                into daemon management.
+                into daemon management. Once named, the process can be addressed by this
+                name (in addition to its PID) in ``get_process``/``kill_process``/
+                ``send_signal``/etc. -- useful because a managed process's PID changes when
+                it restarts. The name may contain any characters except ``/`` and must not
+                be all digits (numeric strings are reserved for PID addressing). If omitted,
+                the daemon assigns an opaque id (exposed as ``ProcessInfo.managed.id``) and
+                the process is addressable only by its current PID.
             restart: Optional restart policy. Supplying this opts the process
                 into daemon management.
             health_check: Optional HTTP or TCP health check. Supplying this opts
@@ -966,6 +1015,8 @@ class Sandbox:
             Traced[ProcessInfo] — access ``.trace_id`` for the W3C trace ID
             and ``.pid`` / ``.status`` directly (or via ``.value``).
         """
+        if name is not None:
+            _validate_managed_name_client_side(name)
         process_user = self._normalize_process_user(user)
         restart_payload = self._normalize_restart_config(restart)
         health_check_payload = self._normalize_health_check(health_check)
@@ -1000,41 +1051,79 @@ class Sandbox:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get_process(self, pid: int) -> Traced[ProcessInfo]:
-        """Get information about a specific process."""
+    def get_process(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[ProcessInfo]:
+        """Get information about a specific process.
+
+        Args:
+            process: PID or process name given on creation.
+        """
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, response_json = self._rust_client.get_process_json(pid=pid)
+            trace_id, response_json = self._rust_client.get_process_json(seg)
             return Traced(trace_id, ProcessInfo.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def kill_process(self, pid: int) -> Traced[None]:
-        """Kill a process."""
+    def kill_process(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[None]:
+        """Kill a process.
+
+        Args:
+            process: PID or process name given on creation. For a managed process this stops
+                the whole supervisor (it will not be restarted).
+        """
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id = self._rust_client.kill_process(pid=pid)
+            trace_id = self._rust_client.kill_process(seg)
             return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def restart_process(self, pid: int) -> Traced[ProcessInfo]:
-        """Restart a managed process by PID."""
+    def restart_process(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[ProcessInfo]:
+        """Restart a managed process.
+
+        Args:
+            process: PID or process name given on creation.
+        """
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, response_json = self._rust_client.restart_process_json(pid=pid)
+            trace_id, response_json = self._rust_client.restart_process_json(seg)
             return Traced(trace_id, ProcessInfo.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def send_signal(self, pid: int, signal: int) -> Traced[SendSignalResponse]:
+    def send_signal(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        signal: int = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[SendSignalResponse]:
         """Send a signal to a process.
 
         Args:
-            pid: Process ID
+            process: PID or process name given on creation.
             signal: Signal number (e.g. 15 for SIGTERM, 9 for SIGKILL)
         """
+        seg = _resolve_process_arg(process, pid)
+        if signal is _PROCESS_ARG_UNSET:
+            raise TypeError("missing required argument: `signal`")
         try:
-            trace_id, response_json = self._rust_client.send_signal_json(
-                pid=pid, signal=signal
-            )
+            trace_id, response_json = self._rust_client.send_signal_json(seg, signal)
             return Traced(
                 trace_id, SendSignalResponse.model_validate_json(response_json)
             )
@@ -1043,52 +1132,115 @@ class Sandbox:
 
     # --- Process I/O ---
 
-    def write_stdin(self, pid: int, data: bytes) -> Traced[None]:
-        """Write data to a process's stdin."""
+    def write_stdin(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        data: bytes = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[None]:
+        """Write data to a process's stdin.
+
+        Args:
+            process: PID or process name given on creation.
+            data: Bytes to write to stdin.
+        """
+        seg = _resolve_process_arg(process, pid)
+        if data is _PROCESS_ARG_UNSET:
+            raise TypeError("missing required argument: `data`")
         try:
-            trace_id = self._rust_client.write_stdin(pid=pid, data=data)
+            trace_id = self._rust_client.write_stdin(seg, data)
             return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def close_stdin(self, pid: int) -> Traced[None]:
-        """Close a process's stdin."""
+    def close_stdin(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[None]:
+        """Close a process's stdin.
+
+        Args:
+            process: PID or process name given on creation.
+        """
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id = self._rust_client.close_stdin(pid=pid)
+            trace_id = self._rust_client.close_stdin(seg)
             return Traced(trace_id, None)
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get_stdout(self, pid: int) -> Traced[OutputResponse]:
-        """Get all stdout output from a process."""
+    def get_stdout(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[OutputResponse]:
+        """Get all stdout output from a process.
+
+        Args:
+            process: PID or process name given on creation.
+        """
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, response_json = self._rust_client.get_stdout_json(pid=pid)
+            trace_id, response_json = self._rust_client.get_stdout_json(seg)
             return Traced(trace_id, OutputResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get_stderr(self, pid: int) -> Traced[OutputResponse]:
-        """Get all stderr output from a process."""
+    def get_stderr(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[OutputResponse]:
+        """Get all stderr output from a process.
+
+        Args:
+            process: PID or process name given on creation.
+        """
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, response_json = self._rust_client.get_stderr_json(pid=pid)
+            trace_id, response_json = self._rust_client.get_stderr_json(seg)
             return Traced(trace_id, OutputResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def get_output(self, pid: int) -> Traced[OutputResponse]:
-        """Get all combined output from a process."""
+    def get_output(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> Traced[OutputResponse]:
+        """Get all combined output from a process.
+
+        Args:
+            process: PID or process name given on creation.
+        """
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, response_json = self._rust_client.get_output_json(pid=pid)
+            trace_id, response_json = self._rust_client.get_output_json(seg)
             return Traced(trace_id, OutputResponse.model_validate_json(response_json))
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def follow_stdout(self, pid: int) -> TracedIterator[OutputEvent]:
+    def follow_stdout(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> TracedIterator[OutputEvent]:
         """Collect all stdout output events from a process and return them as an iterable.
 
+        Args:
+            process: PID or process name given on creation.
+
         Blocks until the process exits and all output has been received."""
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, events_json = self._rust_client.follow_stdout_json(pid=pid)
+            trace_id, events_json = self._rust_client.follow_stdout_json(seg)
             return TracedIterator(
                 trace_id,
                 [OutputEvent.model_validate_json(ej) for ej in events_json],
@@ -1096,12 +1248,21 @@ class Sandbox:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def follow_stderr(self, pid: int) -> TracedIterator[OutputEvent]:
+    def follow_stderr(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> TracedIterator[OutputEvent]:
         """Collect all stderr output events from a process and return them as an iterable.
 
+        Args:
+            process: PID or process name given on creation.
+
         Blocks until the process exits and all output has been received."""
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, events_json = self._rust_client.follow_stderr_json(pid=pid)
+            trace_id, events_json = self._rust_client.follow_stderr_json(seg)
             return TracedIterator(
                 trace_id,
                 [OutputEvent.model_validate_json(ej) for ej in events_json],
@@ -1109,12 +1270,21 @@ class Sandbox:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def follow_output(self, pid: int) -> TracedIterator[OutputEvent]:
+    def follow_output(
+        self,
+        process: int | str = _PROCESS_ARG_UNSET,
+        *,
+        pid: int | str = _PROCESS_ARG_UNSET,
+    ) -> TracedIterator[OutputEvent]:
         """Collect all combined output events from a process and return them as an iterable.
 
+        Args:
+            process: PID or process name given on creation.
+
         Blocks until the process exits and all output has been received."""
+        seg = _resolve_process_arg(process, pid)
         try:
-            trace_id, events_json = self._rust_client.follow_output_json(pid=pid)
+            trace_id, events_json = self._rust_client.follow_output_json(seg)
             return TracedIterator(
                 trace_id,
                 [OutputEvent.model_validate_json(ej) for ej in events_json],

--- a/tests/sandbox/test_process_arg.py
+++ b/tests/sandbox/test_process_arg.py
@@ -1,0 +1,29 @@
+"""Unit tests for the process-selector back-compat shim (`pid` -> `process`)."""
+
+import warnings
+
+import pytest
+
+from tensorlake.sandbox.sandbox import _PROCESS_ARG_UNSET, _resolve_process_arg
+
+
+def test_process_arg_accepts_pid_and_name():
+    assert _resolve_process_arg(1234, _PROCESS_ARG_UNSET) == "1234"
+    assert _resolve_process_arg("web", _PROCESS_ARG_UNSET) == "web"
+
+
+def test_deprecated_pid_keyword_still_works_with_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert _resolve_process_arg(_PROCESS_ARG_UNSET, 42) == "42"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_both_process_and_pid_is_error():
+    with pytest.raises(TypeError):
+        _resolve_process_arg(1, 2)
+
+
+def test_missing_selector_is_error():
+    with pytest.raises(TypeError):
+        _resolve_process_arg(_PROCESS_ARG_UNSET, _PROCESS_ARG_UNSET)

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -57,8 +57,8 @@ class _FakeRustProxyClient:
             }
         return _TRACE_ID, json.dumps(response)
 
-    def restart_process_json(self, pid):
-        assert pid == 101
+    def restart_process_json(self, process):
+        assert process == "101"
         return _TRACE_ID, json.dumps(
             {
                 "handle": 8,
@@ -100,8 +100,8 @@ class _FakeRustProxyClient:
             }
         )
 
-    def follow_output_json(self, pid):
-        assert pid == 101
+    def follow_output_json(self, process):
+        assert process == "101"
         return _TRACE_ID, [
             json.dumps(
                 {

--- a/tests/sandbox/test_sandbox_rust_backend_async.py
+++ b/tests/sandbox/test_sandbox_rust_backend_async.py
@@ -61,47 +61,47 @@ class _FakeAsyncRustProxyClient:
     async def list_processes_json_async(self):
         return _TRACE_ID, json.dumps({"processes": [_process_info_dict()]})
 
-    async def get_process_json_async(self, *, pid):
-        return _TRACE_ID, json.dumps(_process_info_dict(pid))
+    async def get_process_json_async(self, process):
+        return _TRACE_ID, json.dumps(_process_info_dict())
 
-    async def kill_process_async(self, *, pid):
-        self.kill_calls.append(pid)
+    async def kill_process_async(self, process):
+        self.kill_calls.append(process)
         return _TRACE_ID
 
-    async def send_signal_json_async(self, *, pid, signal):
-        self.signal_calls.append((pid, signal))
+    async def send_signal_json_async(self, process, signal):
+        self.signal_calls.append((process, signal))
         return _TRACE_ID, json.dumps({"success": True})
 
-    async def write_stdin_async(self, *, pid, data):
-        self.write_stdin_calls.append((pid, data))
+    async def write_stdin_async(self, process, data):
+        self.write_stdin_calls.append((process, data))
         return _TRACE_ID
 
-    async def close_stdin_async(self, *, pid):
-        self.close_stdin_calls.append(pid)
+    async def close_stdin_async(self, process):
+        self.close_stdin_calls.append(process)
         return _TRACE_ID
 
-    async def get_stdout_json_async(self, *, pid):
-        return _TRACE_ID, json.dumps({"pid": pid, "lines": ["a", "b"], "line_count": 2})
+    async def get_stdout_json_async(self, process):
+        return _TRACE_ID, json.dumps({"pid": 101, "lines": ["a", "b"], "line_count": 2})
 
-    async def get_stderr_json_async(self, *, pid):
-        return _TRACE_ID, json.dumps({"pid": pid, "lines": ["err"], "line_count": 1})
+    async def get_stderr_json_async(self, process):
+        return _TRACE_ID, json.dumps({"pid": 101, "lines": ["err"], "line_count": 1})
 
-    async def get_output_json_async(self, *, pid):
+    async def get_output_json_async(self, process):
         return _TRACE_ID, json.dumps(
-            {"pid": pid, "lines": ["a", "b", "err"], "line_count": 3}
+            {"pid": 101, "lines": ["a", "b", "err"], "line_count": 3}
         )
 
-    async def follow_stdout_json_async(self, *, pid):
+    async def follow_stdout_json_async(self, process):
         return _TRACE_ID, [
             json.dumps({"line": "out", "timestamp": 1_700_000_000, "stream": "stdout"})
         ]
 
-    async def follow_stderr_json_async(self, *, pid):
+    async def follow_stderr_json_async(self, process):
         return _TRACE_ID, [
             json.dumps({"line": "err", "timestamp": 1_700_000_001, "stream": "stderr"})
         ]
 
-    async def follow_output_json_async(self, *, pid):
+    async def follow_output_json_async(self, process):
         return _TRACE_ID, [
             json.dumps(
                 {"line": "hello", "timestamp": 1_700_000_000, "stream": "stdout"}
@@ -368,7 +368,7 @@ class TestAsyncSandboxRustBackend(unittest.IsolatedAsyncioTestCase):
 
         traced = await sandbox.write_stdin(101, b"hello")
 
-        self.assertEqual(fake.write_stdin_calls, [(101, b"hello")])
+        self.assertEqual(fake.write_stdin_calls, [("101", b"hello")])
         self.assertEqual(traced.trace_id, _TRACE_ID)
 
     async def test_close_stdin_forwards_pid(self):
@@ -376,21 +376,21 @@ class TestAsyncSandboxRustBackend(unittest.IsolatedAsyncioTestCase):
 
         await sandbox.close_stdin(101)
 
-        self.assertEqual(fake.close_stdin_calls, [101])
+        self.assertEqual(fake.close_stdin_calls, ["101"])
 
     async def test_kill_process_forwards_pid(self):
         sandbox, fake = _make_async_sandbox()
 
         await sandbox.kill_process(101)
 
-        self.assertEqual(fake.kill_calls, [101])
+        self.assertEqual(fake.kill_calls, ["101"])
 
     async def test_send_signal_forwards_pid_and_signal(self):
         sandbox, fake = _make_async_sandbox()
 
         traced = await sandbox.send_signal(101, 15)
 
-        self.assertEqual(fake.signal_calls, [(101, 15)])
+        self.assertEqual(fake.signal_calls, [("101", 15)])
         self.assertTrue(traced.success)
 
     async def test_get_stdout_returns_traced_response(self):

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -341,6 +341,14 @@ export interface ManagedProcessExit {
   endedAt: Date;
 }
 
+/**
+ * Managed-process metadata embedded into {@link ProcessInfo}.
+ *
+ * A managed process is addressable by either its current PID or, if a `name` was given at
+ * creation, that name (process APIs accept a PID or process name). `id` is a stable
+ * daemon-local identifier: it equals `name` when one was set, otherwise a daemon-assigned
+ * opaque id (the process is then addressable only by PID, not by `id`).
+ */
 export interface ManagedProcessInfo {
   id: string;
   name?: string;
@@ -363,7 +371,14 @@ export interface StartProcessOptions {
   stdoutMode?: OutputMode;
   stderrMode?: OutputMode;
   user?: ProcessUser;
-  /** Optional managed-process name. Supplying this opts into managed process behavior. */
+  /**
+   * Optional managed-process name. Supplying this opts into managed process behavior, and
+   * lets the process be addressed by this name (in addition to its PID) in
+   * `getProcess`/`killProcess`/`sendSignal`/etc. — useful because a managed process's PID
+   * changes when it restarts. May contain any characters except `/` and must not be all
+   * digits (numeric strings are reserved for PID addressing). If omitted, the daemon assigns
+   * an opaque id (`ManagedProcessInfo.id`) and the process is addressable only by its current PID.
+   */
   name?: string;
   /** Optional restart behavior. Supplying this opts into managed process behavior. */
   restart?: RestartPolicyConfig;

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -48,19 +48,20 @@ export interface NativeSandboxProxyClient {
 
   startProcess(payloadJson: string): Promise<TracedJson>;
   listProcesses(): Promise<TracedJson>;
-  getProcess(pid: number): Promise<TracedJson>;
-  killProcess(pid: number): Promise<string>;
-  restartProcess(pid: number): Promise<TracedJson>;
-  sendSignal(pid: number, signal: number): Promise<TracedJson>;
-  writeStdin(pid: number, data: Buffer): Promise<string>;
-  closeStdin(pid: number): Promise<string>;
-  getStdout(pid: number): Promise<TracedJson>;
-  getStderr(pid: number): Promise<TracedJson>;
-  getOutput(pid: number): Promise<TracedJson>;
+  // `process` is the pid-or-name path segment (the TS layer stringifies the number|string arg).
+  getProcess(process: string): Promise<TracedJson>;
+  killProcess(process: string): Promise<string>;
+  restartProcess(process: string): Promise<TracedJson>;
+  sendSignal(process: string, signal: number): Promise<TracedJson>;
+  writeStdin(process: string, data: Buffer): Promise<string>;
+  closeStdin(process: string): Promise<string>;
+  getStdout(process: string): Promise<TracedJson>;
+  getStderr(process: string): Promise<TracedJson>;
+  getOutput(process: string): Promise<TracedJson>;
 
-  followStdout(pid: number, emit: NativeEmit): Promise<string>;
-  followStderr(pid: number, emit: NativeEmit): Promise<string>;
-  followOutput(pid: number, emit: NativeEmit): Promise<string>;
+  followStdout(process: string, emit: NativeEmit): Promise<string>;
+  followStderr(process: string, emit: NativeEmit): Promise<string>;
+  followOutput(process: string, emit: NativeEmit): Promise<string>;
   runProcess(payloadJson: string): Promise<TracedEvents>;
   runProcessStreaming(payloadJson: string, emit: NativeEmit): Promise<string>;
 
@@ -141,6 +142,8 @@ interface NativeSandboxProxyClientCtor {
 export interface NativeSandboxBinding {
   NativeSandboxClient: NativeSandboxClientCtor;
   NativeSandboxProxyClient: NativeSandboxProxyClientCtor;
+  /** Validate a managed-process name; throws on failure. Single source-of-truth rule in Rust. */
+  validateManagedName: (name: string) => void;
 }
 
 // ---- Binding loader -------------------------------------------------------

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -775,7 +775,12 @@ export class Sandbox {
     if (options?.stderrMode != null && options.stderrMode !== OutputMode.CAPTURE) {
       payload.stderr_mode = options.stderrMode;
     }
-    if (options?.name != null) payload.name = options.name;
+    if (options?.name != null) {
+      // Validate the managed name client-side (throws) via the single source-of-truth rule
+      // in the Rust core. The daemon re-validates as the authority.
+      loadNativeSandboxBinding().validateManagedName(options.name);
+      payload.name = options.name;
+    }
     if (options?.restart != null) payload.restart = toSnakeKeys(options.restart);
     if (options?.healthCheck != null) {
       payload.health_check = toSnakeKeys(options.healthCheck);
@@ -802,35 +807,42 @@ export class Sandbox {
     return Object.assign(processes, { traceId });
   }
 
-  /** Get current status and metadata for a process by PID. */
-  async getProcess(pid: number): Promise<Traced<ProcessInfo>> {
-    const proxy = await this.proxy.client();
-    const { traceId, json } = await callNative(() => proxy.getProcess(pid), {
-      sandboxId: this.sandboxId,
-    });
-    return Object.assign(fromSnakeKeys(JSON.parse(json)) as ProcessInfo, { traceId });
-  }
-
-  /** Send SIGKILL to a process. */
-  async killProcess(pid: number): Promise<void> {
-    const proxy = await this.proxy.client();
-    await callNative(() => proxy.killProcess(pid), { sandboxId: this.sandboxId });
-  }
-
-  /** Restart a managed process by PID. */
-  async restartProcess(pid: number): Promise<Traced<ProcessInfo>> {
-    const proxy = await this.proxy.client();
-    const { traceId, json } = await callNative(() => proxy.restartProcess(pid), {
-      sandboxId: this.sandboxId,
-    });
-    return Object.assign(fromSnakeKeys(JSON.parse(json)) as ProcessInfo, { traceId });
-  }
-
-  /** Send an arbitrary signal to a process (e.g. `15` for SIGTERM, `9` for SIGKILL). */
-  async sendSignal(pid: number, signal: number): Promise<Traced<SendSignalResponse>> {
+  /** Get current status and metadata for a process. `process` is a PID or process name given on creation. */
+  async getProcess(process: number | string): Promise<Traced<ProcessInfo>> {
     const proxy = await this.proxy.client();
     const { traceId, json } = await callNative(
-      () => proxy.sendSignal(pid, signal),
+      () => proxy.getProcess(String(process)),
+      { sandboxId: this.sandboxId },
+    );
+    return Object.assign(fromSnakeKeys(JSON.parse(json)) as ProcessInfo, { traceId });
+  }
+
+  /** Send SIGKILL to a process (or stop a managed process). `process` is a PID or process name given on creation. */
+  async killProcess(process: number | string): Promise<void> {
+    const proxy = await this.proxy.client();
+    await callNative(() => proxy.killProcess(String(process)), {
+      sandboxId: this.sandboxId,
+    });
+  }
+
+  /** Restart a managed process. `process` is a PID or process name given on creation. */
+  async restartProcess(process: number | string): Promise<Traced<ProcessInfo>> {
+    const proxy = await this.proxy.client();
+    const { traceId, json } = await callNative(
+      () => proxy.restartProcess(String(process)),
+      { sandboxId: this.sandboxId },
+    );
+    return Object.assign(fromSnakeKeys(JSON.parse(json)) as ProcessInfo, { traceId });
+  }
+
+  /** Send an arbitrary signal (e.g. `15` for SIGTERM, `9` for SIGKILL). `process` is a PID or process name given on creation. */
+  async sendSignal(
+    process: number | string,
+    signal: number,
+  ): Promise<Traced<SendSignalResponse>> {
+    const proxy = await this.proxy.client();
+    const { traceId, json } = await callNative(
+      () => proxy.sendSignal(String(process), signal),
       { sandboxId: this.sandboxId },
     );
     return Object.assign(fromSnakeKeys(JSON.parse(json)) as SendSignalResponse, {
@@ -840,57 +852,62 @@ export class Sandbox {
 
   // --- Process I/O ---
 
-  /** Write bytes to a process's stdin. The process must have been started with `stdinMode: StdinMode.PIPE`. */
-  async writeStdin(pid: number, data: Uint8Array): Promise<void> {
+  /** Write bytes to a process's stdin (must be started with `stdinMode: StdinMode.PIPE`). `process` is a PID or process name given on creation. */
+  async writeStdin(process: number | string, data: Uint8Array): Promise<void> {
     const proxy = await this.proxy.client();
-    await callNative(() => proxy.writeStdin(pid, Buffer.from(data)), {
+    await callNative(() => proxy.writeStdin(String(process), Buffer.from(data)), {
       sandboxId: this.sandboxId,
     });
   }
 
-  /** Close a process's stdin pipe, signalling EOF to the process. */
-  async closeStdin(pid: number): Promise<void> {
+  /** Close a process's stdin pipe, signalling EOF. `process` is a PID or process name given on creation. */
+  async closeStdin(process: number | string): Promise<void> {
     const proxy = await this.proxy.client();
-    await callNative(() => proxy.closeStdin(pid), { sandboxId: this.sandboxId });
-  }
-
-  /** Return all captured stdout lines produced so far by a process. */
-  async getStdout(pid: number): Promise<Traced<OutputResponse>> {
-    const proxy = await this.proxy.client();
-    const { traceId, json } = await callNative(() => proxy.getStdout(pid), {
+    await callNative(() => proxy.closeStdin(String(process)), {
       sandboxId: this.sandboxId,
     });
+  }
+
+  /** Return all captured stdout lines produced so far. `process` is a PID or process name given on creation. */
+  async getStdout(process: number | string): Promise<Traced<OutputResponse>> {
+    const proxy = await this.proxy.client();
+    const { traceId, json } = await callNative(
+      () => proxy.getStdout(String(process)),
+      { sandboxId: this.sandboxId },
+    );
     return Object.assign(fromSnakeKeys(JSON.parse(json)) as OutputResponse, { traceId });
   }
 
-  /** Return all captured stderr lines produced so far by a process. */
-  async getStderr(pid: number): Promise<Traced<OutputResponse>> {
+  /** Return all captured stderr lines produced so far. `process` is a PID or process name given on creation. */
+  async getStderr(process: number | string): Promise<Traced<OutputResponse>> {
     const proxy = await this.proxy.client();
-    const { traceId, json } = await callNative(() => proxy.getStderr(pid), {
-      sandboxId: this.sandboxId,
-    });
+    const { traceId, json } = await callNative(
+      () => proxy.getStderr(String(process)),
+      { sandboxId: this.sandboxId },
+    );
     return Object.assign(fromSnakeKeys(JSON.parse(json)) as OutputResponse, { traceId });
   }
 
-  /** Return all captured stdout+stderr lines produced so far by a process. */
-  async getOutput(pid: number): Promise<Traced<OutputResponse>> {
+  /** Return all captured stdout+stderr lines produced so far. `process` is a PID or process name given on creation. */
+  async getOutput(process: number | string): Promise<Traced<OutputResponse>> {
     const proxy = await this.proxy.client();
-    const { traceId, json } = await callNative(() => proxy.getOutput(pid), {
-      sandboxId: this.sandboxId,
-    });
+    const { traceId, json } = await callNative(
+      () => proxy.getOutput(String(process)),
+      { sandboxId: this.sandboxId },
+    );
     return Object.assign(fromSnakeKeys(JSON.parse(json)) as OutputResponse, { traceId });
   }
 
   // --- Streaming (SSE) ---
 
-  /** Stream stdout events from a process until it exits. Yields one `OutputEvent` per line. */
+  /** Stream stdout events until the process exits. `process` is a PID or process name given on creation. */
   async *followStdout(
-    pid: number,
+    process: number | string,
     options?: { signal?: AbortSignal },
   ): AsyncIterable<OutputEvent> {
     const proxy = await this.proxy.client();
     for await (const raw of nativeEventStream(
-      (emit) => proxy.followStdout(pid, emit),
+      (emit) => proxy.followStdout(String(process), emit),
       { sandboxId: this.sandboxId },
       options?.signal,
     )) {
@@ -898,14 +915,14 @@ export class Sandbox {
     }
   }
 
-  /** Stream stderr events from a process until it exits. Yields one `OutputEvent` per line. */
+  /** Stream stderr events until the process exits. `process` is a PID or process name given on creation. */
   async *followStderr(
-    pid: number,
+    process: number | string,
     options?: { signal?: AbortSignal },
   ): AsyncIterable<OutputEvent> {
     const proxy = await this.proxy.client();
     for await (const raw of nativeEventStream(
-      (emit) => proxy.followStderr(pid, emit),
+      (emit) => proxy.followStderr(String(process), emit),
       { sandboxId: this.sandboxId },
       options?.signal,
     )) {
@@ -913,14 +930,14 @@ export class Sandbox {
     }
   }
 
-  /** Stream combined stdout+stderr events from a process until it exits. Yields one `OutputEvent` per line. */
+  /** Stream combined stdout+stderr events until the process exits. `process` is a PID or process name given on creation. */
   async *followOutput(
-    pid: number,
+    process: number | string,
     options?: { signal?: AbortSignal },
   ): AsyncIterable<OutputEvent> {
     const proxy = await this.proxy.client();
     for await (const raw of nativeEventStream(
-      (emit) => proxy.followOutput(pid, emit),
+      (emit) => proxy.followOutput(String(process), emit),
       { sandboxId: this.sandboxId },
       options?.signal,
     )) {

--- a/typescript/tests/native-sandbox.test.ts
+++ b/typescript/tests/native-sandbox.test.ts
@@ -49,6 +49,7 @@ function installFakeBinding(overrides: ProxyOverrides = {}): {
   Object.assign(proxy, overrides);
 
   const binding: NativeSandboxBinding = {
+    validateManagedName: vi.fn(),
     NativeSandboxClient: class {
       connectProxy() {
         return proxy as unknown as NativeSandboxProxyClient;
@@ -101,11 +102,11 @@ describe("Sandbox native proxy path", () => {
   });
 
   it("parses getProcess JSON from snake_case into camelCase", async () => {
-    installFakeBinding({
-      getProcess: vi.fn(async (pid: number) => ({
+    const { proxy } = installFakeBinding({
+      getProcess: vi.fn(async (process: string) => ({
         traceId: "tr-proc",
         json: JSON.stringify({
-          pid,
+          pid: Number(process),
           status: "running",
           command: "sleep",
           args: ["1"],
@@ -116,6 +117,7 @@ describe("Sandbox native proxy path", () => {
     });
     const sbx = makeSandbox();
     const proc = await sbx.getProcess(42);
+    expect(proxy.getProcess).toHaveBeenCalledWith("42");
     expect(proc.pid).toBe(42);
     // fromSnakeKeys maps started_at -> startedAt (and coerces the timestamp,
     // same as the previous undici path).
@@ -147,8 +149,8 @@ describe("Sandbox native proxy path", () => {
   });
 
   it("streams followStdout events live via the emit bridge", async () => {
-    installFakeBinding({
-      followStdout: vi.fn(async (_pid: number, emit: (e: string) => void) => {
+    const { proxy } = installFakeBinding({
+      followStdout: vi.fn(async (_process: string, emit: (e: string) => void) => {
         emit(JSON.stringify({ line: "a", timestamp: 1 }));
         emit(JSON.stringify({ line: "b", timestamp: 2 }));
         return "tr-follow";
@@ -159,6 +161,7 @@ describe("Sandbox native proxy path", () => {
     for await (const event of sbx.followStdout(7)) {
       lines.push(event.line);
     }
+    expect(proxy.followStdout).toHaveBeenCalledWith("7", expect.any(Function));
     expect(lines).toEqual(["a", "b"]);
     sbx.close();
   });

--- a/typescript/tests/native-stub.ts
+++ b/typescript/tests/native-stub.ts
@@ -121,6 +121,15 @@ export function installNativeStub(overrides?: {
   };
 
   const binding: NativeSandboxBinding = {
+    // Mirrors the Rust `validate_managed_name` rule so tests drive accept/reject: reject
+    // only empty, names containing '/', and all-digit names (reserved for PID).
+    validateManagedName: (name: string) => {
+      if (name === "" || name.includes("/") || /^[0-9]+$/.test(name)) {
+        throw new Error(
+          `managed process name must not be empty, contain '/', or be all digits: ${name}`,
+        );
+      }
+    },
     NativeSandboxClient: class {
       constructor(...args: unknown[]) {
         stub.clientCtorArgs = args;

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -385,14 +385,31 @@ describe("Sandbox", () => {
       expect(proc.managed?.healthCheck?.intervalMs).toBe(5000);
       sbx.close();
     });
+
+    it("rejects a numeric managed-process name client-side", async () => {
+      installNativeStub();
+      const sbx = makeSandbox();
+      await expect(sbx.startProcess("bash", { name: "123" })).rejects.toThrow();
+      sbx.close();
+    });
+
+    it("addresses a process by name or pid (segment is stringified)", async () => {
+      const stub = installNativeStub();
+      const sbx = makeSandbox();
+      await sbx.killProcess("web");
+      await sbx.killProcess(1234);
+      expect(stub.proxy.killProcess).toHaveBeenNthCalledWith(1, "web");
+      expect(stub.proxy.killProcess).toHaveBeenNthCalledWith(2, "1234");
+      sbx.close();
+    });
   });
 
   describe("restartProcess", () => {
     it("restarts the process by PID", async () => {
       const stub = installNativeStub({
         proxy: {
-          restartProcess: vi.fn(async (pid: number) => {
-            expect(pid).toBe(42);
+          restartProcess: vi.fn(async (process: string) => {
+            expect(process).toBe("42");
             return {
               traceId: "t",
               json: JSON.stringify({
@@ -426,7 +443,7 @@ describe("Sandbox", () => {
       const proc = await sbx.restartProcess(42);
       expect(proc.pid).toBe(43);
       expect(proc.managed?.restartCount).toBe(1);
-      expect(stub.proxy.restartProcess).toHaveBeenCalledWith(42);
+      expect(stub.proxy.restartProcess).toHaveBeenCalledWith("42");
       sbx.close();
     });
   });


### PR DESCRIPTION
## Problem

A managed sandbox process's PID changes when it restarts, so addressing it by the PID returned at creation is unstable. The SDKs and CLI only accepted a numeric PID.

## Change

Let every process API accept a **PID or the managed-process name** given at creation, with a **single shared implementation** in the Rust core.

- **`cloud-sdk` (core):** add `ProcessRef { Pid | Name }` + `to_path_segment`, and one `validate_managed_name` rule (non-empty, URL-safe `[A-Za-z0-9_.-]`, not all-digits, validated on the raw value — no trimming, so the validated name is exactly what's stored/addressed). Process methods take `process: impl Into<ProcessRef>`; `start_process` validates the name.
- **PyO3 + napi bindings:** accept a string `process` segment and re-export `validate_managed_name` (mapping to `ValueError` / a thrown `Error`) so Python/TS surface the rule without reimplementing it.
- **Python / TypeScript SDKs:** rename `pid` → `process` (`int | str` / `number | string`), keeping the old `pid` as a **deprecated keyword** (Python, with `DeprecationWarning`) / positional back-compat (TS, Rust, CLI). Client-side name validation degrades gracefully across native/Python version skew (the daemon re-validates authoritatively).
- **CLI:** `tl sbx ps/restart/kill` and `exec --name` accept a PID or name and reuse the shared validator.
- **Docs:** a managed process is addressable by PID or name; an unnamed process gets an opaque `managed.id` (addressable only by PID).

> Depends on the daemon change (tensorlakeai/compute-engine-internal#1286) for name addressing to function end-to-end — the rename/validation are backward compatible, so land/release **after** the daemon reaches the target environment. Native artifacts (`_cloud_sdk`, napi addon) must be rebuilt for the new `process` parameter + `validate_managed_name` export.

## Tests

- cloud-sdk: `process_ref_tests` (path segments + name-rule incl. whitespace/charset/all-digit).
- Python: `_resolve_process_arg` back-compat (deprecated `pid`, both/neither errors) + rust-backend fakes updated to the string-segment contract.
- TypeScript: numeric-name rejection + PID/name stringify; full `sandbox.test.ts` (30) green.
- CLI: `tl sbx ps/restart/kill` parse test updated to `process`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — relaxed name validation + migration notes

Initial revisions of this PR restricted managed-process names to `[A-Za-z0-9_.-]`, which was an unnecessary behavior break for existing users. The shared validator (`cloud_sdk::sandboxes::validate_managed_name`, reused by Rust/Python/TS/CLI — the daemon keeps a byte-identical copy) is now **permissive**: a name may contain **any characters except `/`**. Clients percent-encode the name into a single path segment (`ProcessRef::to_path_segment`); the daemon percent-decodes before matching. Only three rejections remain:

1. empty,
2. contains `/` (an encoded slash is unreliable across the sandbox-proxy/dataplane/router chain), and
3. **all ASCII digits** (reserved for PID addressing on the shared `/processes/{pid_or_name}` route).

### Migration / release notes (breaking)
- ✅ Names with spaces or punctuation (`web 1`, `worker.api`, `my-app_v.2`) are now **allowed** — no action needed.
- ⚠️ **All-numeric names (e.g. `"123"`) are no longer valid** and must be renamed. Numeric strings are reserved for PID addressing; this is the one residual incompatibility.
- ⚠️ Names containing `/` (e.g. `"worker/api"`) are rejected — rename to e.g. `worker-api`.
- The `pid → process` parameter rename keeps `pid` as a deprecated alias, so existing call sites keep working.
