### PR TITLE
Bump all packages to 0.5.53 in lockstep and prevent version drift

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -8,14 +8,21 @@ DEFAULT_FILES = (
     "pyproject.toml",
     "Cargo.toml",
     "crates/rust-cloud-sdk-py/pyproject.toml",
+    "typescript/package.json",
 )
 
 
 def bump_version(path: Path, version: str) -> None:
     content = path.read_text()
+    if path.suffix == ".json":
+        pattern = r'"version":\s*"[^"]*"'
+        replacement = f'"version": "{version}"'
+    else:
+        pattern = r'^version = "[^"]*"'
+        replacement = f'version = "{version}"'
     updated = re.sub(
-        r'^version = "[^"]*"',
-        f'version = "{version}"',
+        pattern,
+        replacement,
         content,
         count=1,
         flags=re.MULTILINE,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,15 +142,15 @@ Two execution modes:
 
 ## Releasing / version bumps
 
-**IMPORTANT: After finishing code changes on a branch, before handing back to the user, remind them to bump the version for whatever they touched.** Look at the diff: if Python/Rust files changed, prompt for a Python-SDK bump; if `typescript/` changed, prompt for a TypeScript bump; if both, prompt for both. Don't bump untouched packages — the Python and TypeScript SDKs version independently.
+**IMPORTANT: After finishing code changes on a branch, before handing back to the user, remind them to bump the version.** All packages (Python, Rust, CLI, TypeScript) are released in lockstep at a single shared version, so a release bumps everything together.
 
 How to bump:
 
-- **Python SDK / CLI release** (Rust workspace + Python wheels): run `python .github/scripts/bump_version.py <new-version>`. It updates the three files used by the PyPI / crates.io / CLI release workflows:
+- Run `python .github/scripts/bump_version.py <new-version>`. A single command updates every version-bearing file used by the PyPI / crates.io / CLI / npm release workflows:
   - `pyproject.toml` (root, `tensorlake` PyPI package)
-  - `Cargo.toml` (root, workspace version — all crates inherit via `version.workspace = true`)
+  - `Cargo.toml` (root, workspace version — all crates inherit via `version.workspace = true`, including `crates/cli`)
   - `crates/rust-cloud-sdk-py/pyproject.toml`
-- **TypeScript SDK release** (npm): manually bump `typescript/package.json`. The `publish_npm.yaml` workflow reads the version from this file. The bump script does NOT touch it.
+  - `typescript/package.json` (npm package; `publish_npm.yaml` reads the version from here)
 - `Cargo.lock` and `typescript/package-lock.json` regenerate on build/install — commit them after they refresh, don't hand-edit.
 
 ## Running Applications tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.52"
+version = "0.5.53"
 dependencies = [
  "base64",
  "bollard",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.52"
+version = "0.5.53"
 dependencies = [
  "anyhow",
  "base64",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.52"
+version = "0.5.53"
 dependencies = [
  "napi",
  "napi-build",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.52"
+version = "0.5.53"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.52"
+version = "0.5.53"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensorlake-cli"
-version = "0.5.52"
+version.workspace = true
 edition = "2024"
 license = "Apache-2.0"
 description = "TensorLake CLI"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.52"
+version = "0.5.53"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.52"
+version = "0.5.53"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.52",
+  "version": "0.5.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.52",
+      "version": "0.5.53",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",
@@ -1226,6 +1226,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1532,6 +1533,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1586,6 +1588,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2306,6 +2309,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2355,6 +2359,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2792,6 +2797,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2839,6 +2845,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.52",
+  "version": "0.5.53",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Context

The four release workflows were all dispatched at **0.5.52** (~1h ago) and three of four failed because 0.5.52 was already taken:

- **PyPI** (`tensorlake`): failed — 0.5.52 already published.
- **crates.io** (`tensorlake`, from `crates/cloud-sdk`): failed — `crate tensorlake@0.5.52 already exists on crates.io index`.
- **CLI Binaries**: failed at `gh release create` — tag `cli-v0.5.52` already exists.
- **npm** (`tensorlake`): succeeded — it published 0.5.52.

Net result: registries are out of sync. The underlying cause of recurring drift is that the bump script only updated 3 of the 5 files that carry a version.

**Target version `0.5.53`** — verified free on PyPI, npm, crates.io, and CLI git tags (all max out at 0.5.52).

## Changes

1. **`crates/cli/Cargo.toml`** → `version.workspace = true` (was explicit `version = "0.5.52"`), matching every other crate so the workspace bump covers the CLI binary version. Safe: `crates/cli` is not published to crates.io and the CLI release tag is derived from root `Cargo.toml`.
2. **`.github/scripts/bump_version.py`** → added `typescript/package.json` to `DEFAULT_FILES` and made `bump_version()` JSON-aware. One command now bumps Python + Rust + CLI + TS in lockstep.
3. **Bumped to 0.5.53** across all version-bearing files (root `pyproject.toml`, root `Cargo.toml`, `crates/rust-cloud-sdk-py/pyproject.toml`, `typescript/package.json`; `crates/cli` follows via inheritance).
4. **Lockfiles refreshed** — `Cargo.lock` and `typescript/package-lock.json` regenerated via `cargo update` / `npm install`.
5. **`CLAUDE.md`** — release section now documents single-command lockstep versioning.

## Verification

- `cargo metadata` reports `tensorlake`, `tensorlake-cli`, `tensorlake-rust-cloud-sdk-node`, `tensorlake-rust-cloud-sdk-py` all at **0.5.53**.
- No remaining `0.5.52` references in any source `.toml`/`.json`/`.py` file.

After merge, re-dispatch the four release workflows — all four should publish 0.5.53 cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)