### PR TITLE
Fix Content-Length on empty and raw POSTs

### DIFF
--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -3,7 +3,7 @@ use eventsource_stream::Eventsource;
 use futures::{Stream, StreamExt};
 use reqwest::{
     Method, Request, Response, StatusCode,
-    header::{ACCEPT, HeaderMap, HeaderValue, InvalidHeaderValue},
+    header::{ACCEPT, CONTENT_LENGTH, HeaderMap, HeaderValue, InvalidHeaderValue},
 };
 use reqwest_middleware::{ClientBuilder as ReqwestClientBuilder, ClientWithMiddleware, Middleware};
 use serde::de::DeserializeOwned;
@@ -422,6 +422,18 @@ impl Client {
             .map_err(Into::into)
     }
 
+    pub fn build_empty_post_request(&self, path: &str) -> Result<reqwest::Request, SdkError> {
+        build_empty_post_request_from_builder(self.request(Method::POST, path))
+    }
+
+    pub fn build_bytes_post_request(
+        &self,
+        path: &str,
+        body: Vec<u8>,
+    ) -> Result<reqwest::Request, SdkError> {
+        build_bytes_post_request_from_builder(self.request(Method::POST, path), body)
+    }
+
     /// Helper function to build POST, PUT or PATCH requests with JSON body
     pub fn build_post_json_request(
         &self,
@@ -472,6 +484,27 @@ impl Client {
             _ => Ok(response),
         }
     }
+}
+
+pub(crate) fn build_empty_post_request_from_builder(
+    builder: reqwest_middleware::RequestBuilder,
+) -> Result<reqwest::Request, SdkError> {
+    builder
+        .header(CONTENT_LENGTH, "0")
+        .build()
+        .map_err(Into::into)
+}
+
+pub(crate) fn build_bytes_post_request_from_builder(
+    builder: reqwest_middleware::RequestBuilder,
+    body: Vec<u8>,
+) -> Result<reqwest::Request, SdkError> {
+    let len = body.len().to_string();
+    builder
+        .header(CONTENT_LENGTH, len)
+        .body(body)
+        .build()
+        .map_err(Into::into)
 }
 
 fn generate_traceparent() -> (String, String) {

--- a/crates/cloud-sdk/src/images/mod.rs
+++ b/crates/cloud-sdk/src/images/mod.rs
@@ -104,7 +104,7 @@ impl ImagesClient {
             build_service_path.trim_end_matches('/'),
             application_build_id
         );
-        let req = self.client.request(Method::POST, &path).build()?;
+        let req = self.client.build_empty_post_request(&path)?;
         self.client.execute_json(req).await
     }
 
@@ -220,7 +220,7 @@ impl ImagesClient {
         request: &models::CancelBuildRequest,
     ) -> Result<Traced<()>, SdkError> {
         let uri_str = format!("/images/v2/builds/{}/cancel", request.build_id);
-        let req = self.client.request(Method::POST, &uri_str).build()?;
+        let req = self.client.build_empty_post_request(&uri_str)?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -736,9 +736,7 @@ struct IntrospectScope {
 }
 
 async fn introspect_scope(client: &Client) -> Result<IntrospectScope> {
-    let request = client
-        .request(Method::POST, "/platform/v1/keys/introspect")
-        .build()?;
+    let request = client.build_empty_post_request("/platform/v1/keys/introspect")?;
     let response = client.execute_raw(request).await?;
     if !response.status().is_success() {
         let status = response.status();

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -12,7 +12,10 @@ use tokio::fs::File;
 use tokio_util::io::ReaderStream;
 
 use crate::{
-    client::{Client, Traced},
+    client::{
+        Client, Traced, build_bytes_post_request_from_builder,
+        build_empty_post_request_from_builder,
+    },
     error::SdkError,
 };
 pub use desktop::SandboxDesktopClient;
@@ -182,7 +185,7 @@ impl SandboxesClient {
 
     pub async fn claim(&self, pool_id: &str) -> Result<Traced<CreateSandboxResponse>, SdkError> {
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}/sandboxes"));
-        let req = self.client.request(Method::POST, &uri).build()?;
+        let req = self.client.build_empty_post_request(&uri)?;
         self.client
             .execute_json_allow_status(req, &[StatusCode::GATEWAY_TIMEOUT])
             .await
@@ -194,11 +197,11 @@ impl SandboxesClient {
         times: usize,
     ) -> Result<Traced<CopySandboxResponse>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/copy"));
-        let req = self
-            .client
-            .request(Method::POST, &uri)
-            .query(&[("times", times)])
-            .build()?;
+        let req = build_empty_post_request_from_builder(
+            self.client
+                .request(Method::POST, &uri)
+                .query(&[("times", times)]),
+        )?;
         self.client
             .execute_json_allow_status(
                 req,
@@ -323,13 +326,13 @@ impl SandboxesClient {
 
     pub async fn suspend(&self, sandbox_id: &str) -> Result<Traced<()>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/suspend"));
-        let req = self.client.request(Method::POST, &uri).build()?;
+        let req = self.client.build_empty_post_request(&uri)?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
     pub async fn resume(&self, sandbox_id: &str) -> Result<Traced<()>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/resume"));
-        let req = self.client.request(Method::POST, &uri).build()?;
+        let req = self.client.build_empty_post_request(&uri)?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
@@ -385,7 +388,7 @@ impl SandboxesClient {
                 .build_post_json_request(Method::POST, &uri, &body)?
         } else {
             // Preserve today's wire shape (no body) for callers that don't set a snapshot type.
-            self.client.request(Method::POST, &uri).build()?
+            self.client.build_empty_post_request(&uri)?
         };
         self.client.execute_json(req).await
     }
@@ -562,9 +565,9 @@ impl SandboxProxyClient {
         process: impl Into<ProcessRef>,
     ) -> Result<Traced<ProcessInfo>, SdkError> {
         let seg = process.into().to_path_segment();
-        let req = self
-            .request(Method::POST, &format!("/api/v1/processes/{seg}/restart"))
-            .build()?;
+        let req = build_empty_post_request_from_builder(
+            self.request(Method::POST, &format!("/api/v1/processes/{seg}/restart")),
+        )?;
         self.client.execute_json(req).await
     }
 
@@ -587,10 +590,10 @@ impl SandboxProxyClient {
         data: Vec<u8>,
     ) -> Result<Traced<()>, SdkError> {
         let seg = process.into().to_path_segment();
-        let req = self
-            .request(Method::POST, &format!("/api/v1/processes/{seg}/stdin"))
-            .body(data)
-            .build()?;
+        let req = build_bytes_post_request_from_builder(
+            self.request(Method::POST, &format!("/api/v1/processes/{seg}/stdin")),
+            data,
+        )?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
@@ -599,12 +602,10 @@ impl SandboxProxyClient {
         process: impl Into<ProcessRef>,
     ) -> Result<Traced<()>, SdkError> {
         let seg = process.into().to_path_segment();
-        let req = self
-            .request(
-                Method::POST,
-                &format!("/api/v1/processes/{seg}/stdin/close"),
-            )
-            .build()?;
+        let req = build_empty_post_request_from_builder(self.request(
+            Method::POST,
+            &format!("/api/v1/processes/{seg}/stdin/close"),
+        ))?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -1,0 +1,149 @@
+use tensorlake::{
+    ClientBuilder,
+    sandboxes::{SandboxProxyClient, SandboxesClient},
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+#[tokio::test]
+async fn sandbox_proxy_raw_and_empty_posts_send_content_length_and_routing_headers() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept write_stdin");
+        let write_stdin = read_http_request(&mut socket).await;
+        write_empty_response(&mut socket).await;
+
+        let (mut socket, _) = listener.accept().await.expect("accept close_stdin");
+        let close_stdin = read_http_request(&mut socket).await;
+        write_empty_response(&mut socket).await;
+
+        let (mut socket, _) = listener.accept().await.expect("accept restart");
+        let restart = read_http_request(&mut socket).await;
+        let body = r#"{"pid":101,"status":"running","command":"bash","args":[],"started_at":0}"#;
+        write_json_response(&mut socket, body).await;
+
+        (write_stdin, close_stdin, restart)
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .build()
+        .expect("build client");
+    let sandbox = SandboxProxyClient::new(client, Some("sandbox-host.test".to_string()))
+        .with_sandbox_id(Some("sbx-1".to_string()))
+        .with_routing_hint(Some("route-a".to_string()));
+
+    sandbox
+        .write_stdin(101_i64, b"hello".to_vec())
+        .await
+        .expect("write stdin");
+    sandbox.close_stdin(101_i64).await.expect("close stdin");
+    sandbox
+        .restart_process(101_i64)
+        .await
+        .expect("restart process");
+
+    let (write_stdin, close_stdin, restart) = server.await.expect("server join");
+    let write_text = String::from_utf8_lossy(&write_stdin);
+    let close_text = String::from_utf8_lossy(&close_stdin);
+    let restart_text = String::from_utf8_lossy(&restart);
+
+    assert!(write_text.starts_with("POST /api/v1/processes/101/stdin HTTP/1.1\r\n"));
+    assert!(write_text.contains("\r\nhost: sandbox-host.test\r\n"));
+    assert!(write_text.contains("\r\nx-tensorlake-sandbox-id: sbx-1\r\n"));
+    assert!(write_text.contains("\r\nx-tensorlake-route-hint: route-a\r\n"));
+    assert!(write_text.contains("\r\ncontent-length: 5\r\n"));
+    assert!(write_stdin.ends_with(b"\r\n\r\nhello"));
+
+    assert!(close_text.starts_with("POST /api/v1/processes/101/stdin/close HTTP/1.1\r\n"));
+    assert!(close_text.contains("\r\ncontent-length: 0\r\n"));
+    assert!(close_text.contains("\r\nx-tensorlake-sandbox-id: sbx-1\r\n"));
+
+    assert!(restart_text.starts_with("POST /api/v1/processes/101/restart HTTP/1.1\r\n"));
+    assert!(restart_text.contains("\r\ncontent-length: 0\r\n"));
+    assert!(restart_text.contains("\r\nx-tensorlake-route-hint: route-a\r\n"));
+}
+
+#[tokio::test]
+async fn direct_empty_post_helper_sends_content_length_zero() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept request");
+        let request = read_http_request(&mut socket).await;
+        let body = r#"{"sandbox_id":"sbx-1","status":"running"}"#;
+        write_json_response(&mut socket, body).await;
+        request
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .build()
+        .expect("build client");
+    let sandboxes = SandboxesClient::new(client, "default", false);
+
+    sandboxes.claim("pool-1").await.expect("claim sandbox");
+
+    let request = server.await.expect("server join");
+    let request_text = String::from_utf8_lossy(&request);
+    assert!(request_text.starts_with("POST /sandbox-pools/pool-1/sandboxes HTTP/1.1\r\n"));
+    assert!(request_text.contains("\r\ncontent-length: 0\r\n"));
+}
+
+async fn read_http_request(socket: &mut TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut buf = [0_u8; 4096];
+
+    loop {
+        let read = socket.read(&mut buf).await.expect("read request");
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&buf[..read]);
+
+        if let Some(headers_end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+            let headers = String::from_utf8_lossy(&request[..headers_end + 4]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    if name.eq_ignore_ascii_case("content-length") {
+                        value.trim().parse::<usize>().ok()
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or(0);
+
+            if request.len() >= headers_end + 4 + content_length {
+                break;
+            }
+        }
+    }
+
+    request
+}
+
+async fn write_empty_response(socket: &mut TcpStream) {
+    socket
+        .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        .await
+        .expect("write response");
+}
+
+async fn write_json_response(socket: &mut TcpStream, body: &str) {
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    socket
+        .write_all(response.as_bytes())
+        .await
+        .expect("write response");
+}

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.53",
+  "version": "0.5.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.53",
+      "version": "0.5.54",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",


### PR DESCRIPTION
## Summary
- add shared Rust SDK helpers for empty-body and raw-byte POST request builders
- send explicit `Content-Length: 0` for empty POSTs and `Content-Length: data.len()` for raw-byte POSTs
- update sandbox stdin/restart and selected lifecycle/image/key POSTs while preserving sandbox routing headers
- bump SDK package metadata from `0.5.53` to `0.5.54` for release

## Root cause
`writeStdin()` routes through the Rust cloud SDK and builds `POST /api/v1/processes/{id}/stdin` with a raw byte body. The SDK did not explicitly set `Content-Length`, which can trigger server/gateway `411 Length Required` responses when the endpoint requires the header.

## Notes
The shared helpers compose with an existing `RequestBuilder`, so sandbox proxy calls still go through `SandboxProxyClient::request(...)` and keep `Host`, `X-Tensorlake-Sandbox-Id`, and `X-Tensorlake-Route-Hint` routing headers. JSON and multipart paths are intentionally unchanged.

## Tests
- `cargo test -p tensorlake --test sandboxes -- --nocapture`
- `cargo test -p tensorlake`
- `git diff --check`