### PR TITLE
[codex] Unify CLI login scope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.54"
+version = "0.5.55"
 dependencies = [
  "base64",
  "bollard",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.54"
+version = "0.5.55"
 dependencies = [
  "anyhow",
  "base64",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.54"
+version = "0.5.55"
 dependencies = [
  "napi",
  "napi-build",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.54"
+version = "0.5.55"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.54"
+version = "0.5.55"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/auth/context.rs
+++ b/crates/cli/src/auth/context.rs
@@ -120,8 +120,10 @@ impl CliContext {
         let use_scope_headers = self.personal_access_token.is_some() && self.api_key.is_none();
 
         if use_scope_headers
-            && let (Some(organization_id), Some(project_id)) =
-                (self.effective_organization_id(), self.effective_project_id())
+            && let (Some(organization_id), Some(project_id)) = (
+                self.effective_organization_id(),
+                self.effective_project_id(),
+            )
         {
             builder = builder.scope(&organization_id, &project_id);
         }

--- a/crates/cli/src/auth/login.rs
+++ b/crates/cli/src/auth/login.rs
@@ -187,12 +187,25 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
         .and_then(|v| v.as_str())
         .ok_or_else(|| CliError::auth("unexpected response during token exchange"))?
         .to_string();
+    let exchange_org_id = exchange_body
+        .get("organization_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let exchange_project_id = exchange_body
+        .get("project_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
 
-    save_credentials(&ctx.api_url, &access_token)?;
+    save_credentials(
+        &ctx.api_url,
+        &access_token,
+        exchange_org_id.as_deref(),
+        exchange_project_id.as_deref(),
+    )?;
     eprintln!("login successful!");
 
-    let mut org_id = None;
-    let mut proj_id = None;
+    let mut org_id = exchange_org_id;
+    let mut proj_id = exchange_project_id;
 
     if auto_init {
         // Recreate context with new PAT
@@ -202,13 +215,15 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
             None,
             Some(&access_token),
             Some(&ctx.namespace),
-            ctx.organization_id.as_deref(),
-            ctx.project_id.as_deref(),
+            org_id.as_deref().or(ctx.organization_id.as_deref()),
+            proj_id.as_deref().or(ctx.project_id.as_deref()),
             ctx.debug,
         );
         let updated_ctx = CliContext::from_resolved(resolved);
 
-        if updated_ctx.has_org_and_project() {
+        if org_id.is_some() && proj_id.is_some() {
+            eprintln!("configured selected organization and project.");
+        } else if updated_ctx.has_org_and_project() {
             org_id = updated_ctx.effective_organization_id();
             proj_id = updated_ctx.effective_project_id();
         } else {

--- a/crates/cli/src/auth/login.rs
+++ b/crates/cli/src/auth/login.rs
@@ -61,6 +61,36 @@ async fn countdown_before_open(seconds: u64) {
     }
 }
 
+fn update_status_line(interactive: bool, message: &str) {
+    if interactive {
+        eprint!("\r\x1b[2K{message}");
+        let _ = std::io::stderr().flush();
+    } else {
+        eprintln!("{message}");
+    }
+}
+
+fn finish_status_line(interactive: bool, message: &str) {
+    if interactive {
+        eprintln!("\r\x1b[2K{message}");
+    } else {
+        eprintln!("{message}");
+    }
+}
+
+async fn wait_before_next_login_poll(attempt: u64, seconds: u64, interactive: bool) {
+    for remaining in (1..=seconds).rev() {
+        let unit = if remaining == 1 { "second" } else { "seconds" };
+        update_status_line(
+            interactive,
+            &format!(
+                "Waiting for browser approval. Check #{attempt}; checking again in {remaining} {unit}..."
+            ),
+        );
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
 /// Run the interactive device code login flow.
 pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginResult> {
     let login_start_url = format!("{}/platform/cli/login/start", ctx.api_url);
@@ -121,14 +151,17 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
         );
     }
 
-    eprintln!("Waiting for browser approval. Complete the flow in your browser.");
-
     let poll_url = format!(
         "{}/platform/cli/login/poll?device_code={}",
         ctx.api_url, device_code
     );
 
     let mut poll_attempt = 1;
+    let interactive_stderr = std::io::stderr().is_terminal();
+    update_status_line(
+        interactive_stderr,
+        "Waiting for browser approval. Complete the flow in your browser.",
+    );
     loop {
         let poll_resp = http
             .get(&poll_url)
@@ -157,22 +190,26 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
 
         match status {
             "pending" => {
-                eprintln!("Still waiting for approval... checking again in 5 seconds.");
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 poll_attempt += 1;
+                wait_before_next_login_poll(poll_attempt, 5, interactive_stderr).await;
             }
             "expired" => {
+                finish_status_line(interactive_stderr, "Login request expired.");
                 return Err(CliError::auth(
                     "login request has expired. run 'tl login' to start a new one.",
                 ));
             }
             "failed" => {
+                finish_status_line(interactive_stderr, "Login request denied.");
                 return Err(CliError::auth(
                     "login request was denied. run 'tl login' to try again.",
                 ));
             }
             "approved" => {
-                eprintln!("Browser approval received. Requesting your PAT...");
+                finish_status_line(
+                    interactive_stderr,
+                    "Browser approval received. Requesting your PAT...",
+                );
                 break;
             }
             other => {
@@ -184,7 +221,10 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
         }
 
         if poll_attempt % 6 == 0 {
-            eprintln!("Still waiting. If the browser did not open, use the URL above.");
+            update_status_line(
+                interactive_stderr,
+                "Still waiting. If the browser did not open, use the URL above.",
+            );
         }
     }
 

--- a/crates/cli/src/auth/login.rs
+++ b/crates/cli/src/auth/login.rs
@@ -41,6 +41,14 @@ fn device_fingerprint() -> serde_json::Value {
     serde_json::Value::Object(body)
 }
 
+async fn countdown_before_open(seconds: u64) {
+    for remaining in (1..=seconds).rev() {
+        let unit = if remaining == 1 { "second" } else { "seconds" };
+        eprintln!("Opening the browser in {remaining} {unit}...");
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
 /// Run the interactive device code login flow.
 pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginResult> {
     let login_start_url = format!("{}/platform/cli/login/start", ctx.api_url);
@@ -91,10 +99,9 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
         urlencoding::encode(&user_code),
     );
     eprintln!("URL: {}", verification_uri);
-    eprintln!("opening web browser...");
 
     // Give user time to read
-    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    countdown_before_open(5).await;
 
     if open::that(&verification_uri).is_err() {
         eprintln!(
@@ -102,13 +109,14 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
         );
     }
 
-    eprintln!("waiting for the code to be processed...");
+    eprintln!("Waiting for browser approval. Complete the flow in your browser.");
 
     let poll_url = format!(
         "{}/platform/cli/login/poll?device_code={}",
         ctx.api_url, device_code
     );
 
+    let mut poll_attempt = 1;
     loop {
         let poll_resp = http
             .get(&poll_url)
@@ -137,7 +145,9 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
 
         match status {
             "pending" => {
+                eprintln!("Still waiting for approval... checking again in 5 seconds.");
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                poll_attempt += 1;
             }
             "expired" => {
                 return Err(CliError::auth(
@@ -149,13 +159,20 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
                     "login request was denied. run 'tl login' to try again.",
                 ));
             }
-            "approved" => break,
+            "approved" => {
+                eprintln!("Browser approval received. Requesting your PAT...");
+                break;
+            }
             other => {
                 return Err(CliError::auth(format!(
                     "got unexpected login status '{}'. run 'tl login' again.",
                     other
                 )));
             }
+        }
+
+        if poll_attempt % 6 == 0 {
+            eprintln!("Still waiting. If the browser did not open, use the URL above.");
         }
     }
 

--- a/crates/cli/src/auth/login.rs
+++ b/crates/cli/src/auth/login.rs
@@ -5,6 +5,7 @@ use crate::config::resolver;
 use crate::error::{CliError, Result};
 use crate::http;
 use crate::project::detection::find_project_root;
+use std::io::{IsTerminal, Write};
 
 /// Result of a successful login flow.
 pub struct LoginResult {
@@ -42,10 +43,21 @@ fn device_fingerprint() -> serde_json::Value {
 }
 
 async fn countdown_before_open(seconds: u64) {
+    let interactive = std::io::stderr().is_terminal();
+
     for remaining in (1..=seconds).rev() {
         let unit = if remaining == 1 { "second" } else { "seconds" };
-        eprintln!("Opening the browser in {remaining} {unit}...");
+        if interactive {
+            eprint!("\r\x1b[2KOpening the browser in {remaining} {unit}...");
+            let _ = std::io::stderr().flush();
+        } else {
+            eprintln!("Opening the browser in {remaining} {unit}...");
+        }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
+    if interactive {
+        eprintln!("\r\x1b[2KOpening browser...");
     }
 }
 

--- a/crates/cli/src/auth/login.rs
+++ b/crates/cli/src/auth/login.rs
@@ -290,9 +290,7 @@ pub async fn run_login_flow(ctx: &CliContext, auto_init: bool) -> Result<LoginRe
         );
         let updated_ctx = CliContext::from_resolved(resolved);
 
-        if org_id.is_some() && proj_id.is_some() {
-            eprintln!("configured selected organization and project.");
-        } else if updated_ctx.has_org_and_project() {
+        if updated_ctx.has_org_and_project() {
             org_id = updated_ctx.effective_organization_id();
             proj_id = updated_ctx.effective_project_id();
         } else {

--- a/crates/cli/src/commands/whoami.rs
+++ b/crates/cli/src/commands/whoami.rs
@@ -2,9 +2,55 @@ use crate::auth::context::CliContext;
 use crate::commands::sbx::resolve_sandbox_lifecycle_url;
 use crate::error::Result;
 
+#[derive(Debug, Clone)]
+struct ProjectScopeInfo {
+    organization_name: Option<String>,
+    project_name: Option<String>,
+}
+
 fn mask_credential(value: &str) -> String {
     let visible = 20.min(value.len());
     format!("{}****", &value[..visible])
+}
+
+fn display_scope_value(id: &str, name: Option<&str>) -> String {
+    match name.map(str::trim).filter(|name| !name.is_empty()) {
+        Some(name) => format!("{name} ({id})"),
+        None => id.to_string(),
+    }
+}
+
+async fn fetch_project_scope_info(
+    ctx: &CliContext,
+    organization_id: Option<&str>,
+    project_id: Option<&str>,
+) -> Option<ProjectScopeInfo> {
+    let organization_id = organization_id?;
+    let project_id = project_id?;
+    let client = ctx.client().ok()?;
+    let url = format!(
+        "{}/platform/v1/organizations/{}/projects/{}",
+        ctx.api_url,
+        urlencoding::encode(organization_id),
+        urlencoding::encode(project_id),
+    );
+
+    let resp = client.get(url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+
+    let body: serde_json::Value = resp.json().await.ok()?;
+    Some(ProjectScopeInfo {
+        organization_name: body
+            .get("organizationName")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        project_name: body
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+    })
 }
 
 pub async fn run(ctx: &mut CliContext, output_json: bool) -> Result<()> {
@@ -35,6 +81,22 @@ pub async fn run(ctx: &mut CliContext, output_json: bool) -> Result<()> {
     let has_api_key = ctx.api_key.is_some();
     let has_pat = ctx.personal_access_token.is_some();
 
+    let api_key_scope_info = if has_api_key {
+        fetch_project_scope_info(
+            ctx,
+            ctx.introspect_org_id().as_deref(),
+            ctx.introspect_project_id().as_deref(),
+        )
+        .await
+    } else {
+        None
+    };
+    let pat_scope_info = if has_pat && !has_api_key {
+        fetch_project_scope_info(ctx, pat_org.as_deref(), pat_project.as_deref()).await
+    } else {
+        None
+    };
+
     if output_json {
         let mut root = serde_json::Map::new();
 
@@ -61,8 +123,26 @@ pub async fn run(ctx: &mut CliContext, output_json: bool) -> Result<()> {
             if let Some(org) = ctx.introspect_org_id() {
                 obj.insert("organizationId".to_string(), serde_json::Value::String(org));
             }
+            if let Some(name) = api_key_scope_info
+                .as_ref()
+                .and_then(|scope| scope.organization_name.as_ref())
+            {
+                obj.insert(
+                    "organizationName".to_string(),
+                    serde_json::Value::String(name.clone()),
+                );
+            }
             if let Some(proj) = ctx.introspect_project_id() {
                 obj.insert("projectId".to_string(), serde_json::Value::String(proj));
+            }
+            if let Some(name) = api_key_scope_info
+                .as_ref()
+                .and_then(|scope| scope.project_name.as_ref())
+            {
+                obj.insert(
+                    "projectName".to_string(),
+                    serde_json::Value::String(name.clone()),
+                );
             }
             root.insert("apiKey".to_string(), serde_json::Value::Object(obj));
         }
@@ -75,11 +155,35 @@ pub async fn run(ctx: &mut CliContext, output_json: bool) -> Result<()> {
                     serde_json::Value::String(mask_credential(pat)),
                 );
             }
-            if let Some(org) = pat_org {
-                obj.insert("organizationId".to_string(), serde_json::Value::String(org));
+            if let Some(org) = &pat_org {
+                obj.insert(
+                    "organizationId".to_string(),
+                    serde_json::Value::String(org.clone()),
+                );
             }
-            if let Some(proj) = pat_project {
-                obj.insert("projectId".to_string(), serde_json::Value::String(proj));
+            if let Some(name) = pat_scope_info
+                .as_ref()
+                .and_then(|scope| scope.organization_name.as_ref())
+            {
+                obj.insert(
+                    "organizationName".to_string(),
+                    serde_json::Value::String(name.clone()),
+                );
+            }
+            if let Some(proj) = &pat_project {
+                obj.insert(
+                    "projectId".to_string(),
+                    serde_json::Value::String(proj.clone()),
+                );
+            }
+            if let Some(name) = pat_scope_info
+                .as_ref()
+                .and_then(|scope| scope.project_name.as_ref())
+            {
+                obj.insert(
+                    "projectName".to_string(),
+                    serde_json::Value::String(name.clone()),
+                );
             }
             root.insert(
                 "personalAccessToken".to_string(),
@@ -120,10 +224,26 @@ pub async fn run(ctx: &mut CliContext, output_json: bool) -> Result<()> {
                 println!("    Key ID       : {}", key_id);
             }
             if let Some(org) = ctx.introspect_org_id() {
-                println!("    Organization : {}", org);
+                println!(
+                    "    Organization : {}",
+                    display_scope_value(
+                        &org,
+                        api_key_scope_info
+                            .as_ref()
+                            .and_then(|scope| scope.organization_name.as_deref())
+                    )
+                );
             }
             if let Some(proj) = ctx.introspect_project_id() {
-                println!("    Project      : {}", proj);
+                println!(
+                    "    Project      : {}",
+                    display_scope_value(
+                        &proj,
+                        api_key_scope_info
+                            .as_ref()
+                            .and_then(|scope| scope.project_name.as_deref())
+                    )
+                );
             }
         }
 
@@ -133,11 +253,27 @@ pub async fn run(ctx: &mut CliContext, output_json: bool) -> Result<()> {
             if let Some(pat) = &ctx.personal_access_token {
                 println!("    Token        : {}", mask_credential(pat));
             }
-            if let Some(org) = pat_org {
-                println!("    Organization : {}", org);
+            if let Some(org) = &pat_org {
+                println!(
+                    "    Organization : {}",
+                    display_scope_value(
+                        org,
+                        pat_scope_info
+                            .as_ref()
+                            .and_then(|scope| scope.organization_name.as_deref())
+                    )
+                );
             }
-            if let Some(proj) = pat_project {
-                println!("    Project      : {}", proj);
+            if let Some(proj) = &pat_project {
+                println!(
+                    "    Project      : {}",
+                    display_scope_value(
+                        proj,
+                        pat_scope_info
+                            .as_ref()
+                            .and_then(|scope| scope.project_name.as_deref())
+                    )
+                );
             }
         }
     }

--- a/crates/cli/src/config/files.rs
+++ b/crates/cli/src/config/files.rs
@@ -6,6 +6,13 @@ use crate::error::{CliError, Result};
 /// Type alias for TOML table (matches what toml crate uses internally).
 pub type TomlTable = toml::map::Map<String, toml::Value>;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StoredCredentials {
+    pub token: String,
+    pub organization_id: Option<String>,
+    pub project_id: Option<String>,
+}
+
 /// Global config directory: ~/.config/tensorlake/
 pub fn config_dir() -> PathBuf {
     dirs::home_dir()
@@ -132,17 +139,27 @@ pub fn save_local_config(config: &TomlTable, project_root: &Path) -> Result<()> 
 
 /// Load PAT from credentials file for the given API URL.
 pub fn load_credentials(api_url: &str) -> Option<String> {
+    load_stored_credentials(api_url).map(|credentials| credentials.token)
+}
+
+/// Load PAT and selected scope from credentials file for the given API URL.
+pub fn load_stored_credentials(api_url: &str) -> Option<StoredCredentials> {
     let path = credentials_path();
     if !path.exists() {
         return None;
     }
     let content = fs::read_to_string(&path).ok()?;
     let table = parse_toml_table(&content)?;
-    extract_scoped_token(&table, api_url)
+    extract_scoped_credentials(&table, api_url)
 }
 
 /// Save PAT to credentials file scoped by API URL.
-pub fn save_credentials(api_url: &str, token: &str) -> Result<()> {
+pub fn save_credentials(
+    api_url: &str,
+    token: &str,
+    organization_id: Option<&str>,
+    project_id: Option<&str>,
+) -> Result<()> {
     let dir = config_dir();
     fs::create_dir_all(&dir)?;
 
@@ -168,6 +185,18 @@ pub fn save_credentials(api_url: &str, token: &str) -> Result<()> {
 
     let mut section = TomlTable::new();
     section.insert("token".to_string(), toml::Value::String(token.to_string()));
+    if let Some(organization_id) = organization_id {
+        section.insert(
+            "organization".to_string(),
+            toml::Value::String(organization_id.to_string()),
+        );
+    }
+    if let Some(project_id) = project_id {
+        section.insert(
+            "project".to_string(),
+            toml::Value::String(project_id.to_string()),
+        );
+    }
     table.insert(normalized_url, toml::Value::Table(section));
 
     let content = toml::to_string_pretty(&toml::Value::Table(table))?;
@@ -182,33 +211,54 @@ pub fn save_credentials(api_url: &str, token: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn extract_scoped_token(credentials: &TomlTable, api_url: &str) -> Option<String> {
+    extract_scoped_credentials(credentials, api_url).map(|credentials| credentials.token)
+}
+
+fn credentials_from_value(value: &toml::Value) -> Option<StoredCredentials> {
+    let token = value.get("token").and_then(|v| v.as_str())?.to_string();
+    let organization_id = value
+        .get("organization")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let project_id = value
+        .get("project")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Some(StoredCredentials {
+        token,
+        organization_id,
+        project_id,
+    })
+}
+
+fn extract_scoped_credentials(credentials: &TomlTable, api_url: &str) -> Option<StoredCredentials> {
     let normalized_api_url = normalize_api_url(api_url);
 
     // 1) exact key match
-    if let Some(token) = credentials
+    if let Some(credentials) = credentials
         .get(api_url.trim())
-        .and_then(|scoped| scoped.get("token"))
-        .and_then(|v| v.as_str())
+        .and_then(credentials_from_value)
     {
-        return Some(token.to_string());
+        return Some(credentials);
     }
 
     // 2) canonical key match
-    if let Some(token) = credentials
+    if let Some(credentials) = credentials
         .get(&normalized_api_url)
-        .and_then(|scoped| scoped.get("token"))
-        .and_then(|v| v.as_str())
+        .and_then(credentials_from_value)
     {
-        return Some(token.to_string());
+        return Some(credentials);
     }
 
     // 3) compatible lookup across previously stored URL variants
     for (key, value) in credentials {
         if normalize_api_url(key) == normalized_api_url
-            && let Some(token) = value.get("token").and_then(|v| v.as_str())
+            && let Some(credentials) = credentials_from_value(value)
         {
-            return Some(token.to_string());
+            return Some(credentials);
         }
     }
 
@@ -216,7 +266,11 @@ fn extract_scoped_token(credentials: &TomlTable, api_url: &str) -> Option<String
     credentials
         .get("token")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+        .map(|s| StoredCredentials {
+            token: s.to_string(),
+            organization_id: None,
+            project_id: None,
+        })
 }
 
 /// Get a nested value from a TOML table using dot notation (e.g. "tensorlake.api_url").
@@ -268,7 +322,7 @@ fn add_to_gitignore(path: &Path, entry: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_scoped_token, normalize_api_url};
+    use super::{extract_scoped_credentials, extract_scoped_token, normalize_api_url};
 
     #[test]
     fn normalize_api_url_collapses_common_equivalents() {
@@ -301,6 +355,24 @@ token = "abc123"
                 .expect("token for default-port key"),
             "abc123"
         );
+    }
+
+    #[test]
+    fn extract_scoped_credentials_includes_selected_scope() {
+        let content = r#"
+["https://api.tensorlake.ai"]
+token = "abc123"
+organization = "org_123"
+project = "project_456"
+"#;
+        let table: super::TomlTable = toml::from_str(content).expect("valid toml");
+
+        let credentials = extract_scoped_credentials(&table, "https://api.tensorlake.ai/")
+            .expect("stored credentials");
+
+        assert_eq!(credentials.token, "abc123");
+        assert_eq!(credentials.organization_id.as_deref(), Some("org_123"));
+        assert_eq!(credentials.project_id.as_deref(), Some("project_456"));
     }
 
     #[test]

--- a/crates/cli/src/config/resolver.rs
+++ b/crates/cli/src/config/resolver.rs
@@ -1,5 +1,5 @@
 use crate::config::files::{
-    TomlTable, get_nested_value, load_credentials, load_global_config, load_local_config,
+    TomlTable, get_nested_value, load_global_config, load_local_config, load_stored_credentials,
     normalize_api_url,
 };
 
@@ -16,7 +16,7 @@ pub struct ResolvedConfig {
     pub debug: bool,
 }
 
-/// Resolve all configuration from CLI args > env vars > local config > global config > defaults.
+/// Resolve all configuration from CLI args/env vars > stored login scope > local config > global config > defaults.
 /// CLI args and env vars are already merged by clap (via `env` attribute).
 #[allow(clippy::too_many_arguments)]
 pub fn resolve(
@@ -35,10 +35,37 @@ pub fn resolve(
     let final_api_url = resolve_api_url(api_url, &local_config, &global_config);
     let final_cloud_url =
         resolve_cloud_url(cloud_url, &final_api_url, &local_config, &global_config);
-    let (final_api_key, final_pat) =
-        resolve_auth(api_key, pat, &local_config, &global_config, &final_api_url);
+    let stored_credentials = load_stored_credentials(&final_api_url);
+    let use_stored_scope = pat.is_none();
+    let (final_api_key, final_pat) = resolve_auth(
+        api_key,
+        pat,
+        &local_config,
+        &global_config,
+        stored_credentials
+            .as_ref()
+            .map(|credentials| credentials.token.as_str()),
+    );
     let final_namespace = resolve_namespace(namespace, &local_config, &global_config);
-    let (org_id, proj_id) = resolve_project_config(organization_id, project_id, &local_config);
+    let (org_id, proj_id) = resolve_project_config(
+        organization_id,
+        project_id,
+        &local_config,
+        if use_stored_scope {
+            stored_credentials
+                .as_ref()
+                .and_then(|credentials| credentials.organization_id.as_deref())
+        } else {
+            None
+        },
+        if use_stored_scope {
+            stored_credentials
+                .as_ref()
+                .and_then(|credentials| credentials.project_id.as_deref())
+        } else {
+            None
+        },
+    );
 
     ResolvedConfig {
         api_url: final_api_url,
@@ -86,15 +113,16 @@ fn resolve_auth(
     pat: Option<&str>,
     local: &TomlTable,
     global: &TomlTable,
-    api_url: &str,
+    stored_pat: Option<&str>,
 ) -> (Option<String>, Option<String>) {
     let final_api_key = api_key
         .map(|s| s.to_string())
         .or_else(|| get_nested_value(local, "tensorlake.apikey"))
         .or_else(|| get_nested_value(global, "tensorlake.apikey"));
 
-    let file_pat = load_credentials(api_url);
-    let final_pat = pat.map(|s| s.to_string()).or(file_pat);
+    let final_pat = pat
+        .map(|s| s.to_string())
+        .or_else(|| stored_pat.map(str::to_string));
 
     (final_api_key, final_pat)
 }
@@ -110,13 +138,17 @@ fn resolve_project_config(
     org_id: Option<&str>,
     proj_id: Option<&str>,
     local: &TomlTable,
+    stored_org_id: Option<&str>,
+    stored_proj_id: Option<&str>,
 ) -> (Option<String>, Option<String>) {
     let final_org_id = org_id
         .map(|s| s.to_string())
+        .or_else(|| stored_org_id.map(str::to_string))
         .or_else(|| get_nested_value(local, "organization"));
 
     let final_proj_id = proj_id
         .map(|s| s.to_string())
+        .or_else(|| stored_proj_id.map(str::to_string))
         .or_else(|| get_nested_value(local, "project"));
 
     (final_org_id, final_proj_id)

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.54"
+version = "0.5.55"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.54"
+version = "0.5.55"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]


### PR DESCRIPTION
## Summary
- store the PAT returned by `tl login` together with the browser-selected organization and project
- resolve `tl info` and PAT-scoped CLI requests from the saved login scope
- keep explicit `--organization` / `--project` and explicit PAT overrides from silently borrowing stale saved scope

## Validation
- `cargo check -p tensorlake-cli`
- `cargo test -p tensorlake-cli config::files::tests`
