### PR TITLE
Add tl git clone: fast-clone client vendored from artifact_storage

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -80,9 +80,19 @@ jobs:
               set -e
 
               echo "--- Installing tensorlake from TestPyPI ---"
-              pip install --index-url https://test.pypi.org/simple/ \
-                          --extra-index-url https://pypi.org/simple/ \
-                          tensorlake==${PYPI_VERSION}
+              for attempt in $(seq 1 8); do
+                if pip install --index-url https://test.pypi.org/simple/ \
+                                --extra-index-url https://pypi.org/simple/ \
+                                tensorlake==${PYPI_VERSION}; then
+                  break
+                fi
+                if [ "$attempt" -eq 8 ]; then
+                  echo "tensorlake==${PYPI_VERSION} still not resolvable on TestPyPI after 8 attempts"
+                  exit 1
+                fi
+                echo "TestPyPI index propagation not caught up yet (attempt ${attempt}/8), retrying in 30s..."
+                sleep 30
+              done
 
               echo "--- 1. Build images ---"
               tl build-images /tmp/test_app.py \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4605,6 +4606,12 @@ dependencies = [
  "time",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -186,6 +186,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bollard"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,7 +323,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -398,6 +407,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +457,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -521,6 +545,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -725,9 +758,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1141,6 +1185,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gsvc-codec"
+version = "0.5.55"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "flate2",
+ "futures",
+ "hex",
+ "parking_lot",
+ "rayon",
+ "serde",
+ "sha1 0.11.0",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,7 +1257,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1241,6 +1304,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2130,7 +2202,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
  "password-hash",
  "sha2",
@@ -2426,6 +2498,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2977,8 +3069,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2988,8 +3091,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3254,8 +3357,10 @@ dependencies = [
  "docker-credentials-config",
  "env-file-reader",
  "eventsource-stream",
+ "flate2",
  "futures",
  "gethostname",
+ "gsvc-codec",
  "hex",
  "http-body-util",
  "indicatif",
@@ -3267,6 +3372,7 @@ dependencies = [
  "rustpython-parser",
  "serde",
  "serde_json",
+ "sha1 0.11.0",
  "sha2",
  "shlex",
  "tempfile",
@@ -3568,7 +3674,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3600,7 +3718,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -4483,7 +4601,7 @@ dependencies = [
  "flate2",
  "hmac",
  "pbkdf2",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/cloud-sdk",
     "crates/cli",
+    "crates/gsvc-codec",
     "crates/rust-cloud-sdk-node",
     "crates/rust-cloud-sdk-py",
 ]
@@ -18,6 +19,9 @@ async-trait = "0.1"
 
 # Internal crates
 tensorlake = { path = "crates/cloud-sdk" }
+# Vendored from artifact_storage (crates/gsvc-codec) to back `tl git clone`.
+# See AGENTS.md in that repo: open a companion PR there if this crate's wire format changes upstream.
+gsvc-codec = { path = "crates/gsvc-codec" }
 
 # Async runtime
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "time", "process", "io-std", "io-util", "signal"] }
@@ -43,10 +47,12 @@ url = "2.5.8"
 urlencoding = "2.1"
 
 # Crypto & encoding
+sha1 = "0.11"
 sha2 = "0.10"
 hex = "0.4"
 base64 = "0.22"
 shlex = "1.3"
+crc32fast = "1"
 
 # Docker
 bollard = "0.20"
@@ -69,6 +75,10 @@ anyhow = "1.0.102"
 derive_builder = "0.20"
 pin-project-lite = "0.2.17"
 ignore = "0.4"
+parking_lot = "0.12"
+rayon = "1"
+tempfile = "3"
+tracing = "0.1"
 
 # Compression & archives
 flate2 = "1.1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,9 @@ tempfile = "3"
 tracing = "0.1"
 
 # Compression & archives
-flate2 = "1.1.9"
+# zlib-rs matches artifact_storage's flate2 feature choice, which gsvc-codec (vendored from there)
+# is tested against; the default miniz_oxide backend has produced a divergent test result.
+flate2 = { version = "1.1.9", features = ["zlib-rs"] }
 tar = "0.4"
 
 # OpenAPI

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -51,6 +51,9 @@ hex = { workspace = true }
 rand = { workspace = true }
 shlex = { workspace = true }
 rustpython-parser = "0.3"
+gsvc-codec = { workspace = true }
+flate2 = { workspace = true }
+sha1 = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -149,6 +149,25 @@ pub async fn restore_repo(ctx: &CliContext, repo: &str) -> Result<()> {
     Ok(())
 }
 
+/// Accept either a bare repo name or a full clone URL (as printed by `tl git url`), matching how
+/// `git clone` itself treats its argument. A URL's last non-empty path segment (with any `.git`
+/// suffix stripped) is used as the repo name.
+fn normalize_repo_arg(repo: &str) -> String {
+    let Ok(url) = reqwest::Url::parse(repo) else {
+        return repo.to_string();
+    };
+    if !matches!(url.scheme(), "http" | "https") {
+        return repo.to_string();
+    }
+    url.path_segments()
+        .into_iter()
+        .flatten()
+        .filter(|s| !s.is_empty())
+        .next_back()
+        .map(|s| s.strip_suffix(".git").unwrap_or(s).to_string())
+        .unwrap_or_else(|| repo.to_string())
+}
+
 pub async fn clone_repo(
     ctx: &CliContext,
     repo: &str,
@@ -157,6 +176,7 @@ pub async fn clone_repo(
     cache_max_bytes: Option<u64>,
     no_checkout: bool,
 ) -> Result<()> {
+    let repo = &normalize_repo_arg(repo);
     let project_id = project_id(ctx)?;
     let client = artifact_storage_client(ctx)?;
     let repo_url = client.git_repo_url(&project_id, repo);
@@ -403,4 +423,38 @@ fn parse_remote_message(raw: &str) -> String {
                 .map(|s| s.to_string())
         })
         .unwrap_or_else(|| raw.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_repo_arg_passes_through_bare_names() {
+        assert_eq!(normalize_repo_arg("linux1"), "linux1");
+    }
+
+    #[test]
+    fn normalize_repo_arg_extracts_repo_from_full_url() {
+        assert_eq!(
+            normalize_repo_arg("https://git.tensorlake.ai/project_abc/linux1"),
+            "linux1"
+        );
+        assert_eq!(
+            normalize_repo_arg("https://git.tensorlake.ai/project_abc/linux1.git"),
+            "linux1"
+        );
+        assert_eq!(
+            normalize_repo_arg("http://localhost:8080/demo/myrepo/"),
+            "myrepo"
+        );
+    }
+
+    #[test]
+    fn normalize_repo_arg_ignores_non_http_schemes() {
+        assert_eq!(
+            normalize_repo_arg("git@github.com:org/repo.git"),
+            "git@github.com:org/repo.git"
+        );
+    }
 }

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -180,11 +180,17 @@ pub async fn clone_repo(
     let project_id = project_id(ctx)?;
     let client = artifact_storage_client(ctx)?;
     let repo_url = client.git_repo_url(&project_id, repo);
+
+    let spinner = fastclone::new_spinner(&format!("minting git credential for {repo}"));
     let credential = client
         .mint_token_for_repo(&project_id, Some(repo))
         .await
         .map_err(map_sdk_error)?
         .into_inner();
+    if let Some(pb) = &spinner {
+        pb.set_message("fetching clone manifest");
+    }
+
     let dest = dest.unwrap_or_else(|| fastclone::default_dest_from_url(&repo_url));
     let opts = fastclone::FastCloneOptions {
         repo_url: repo_url.clone(),
@@ -196,6 +202,7 @@ pub async fn clone_repo(
             password: Some(credential.token),
         }),
         checkout: !no_checkout,
+        progress: spinner,
     };
     let stats = fastclone::fast_clone(opts).await?;
     println!(

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use comfy_table::Cell;
 use console::style;
 use tensorlake::artifact_storage::ArtifactStorageClient;
@@ -9,6 +11,10 @@ use tensorlake::{ClientBuilder, Sdk};
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
 use crate::output::table::new_table;
+
+mod fastclone;
+
+pub use fastclone::parse_cache_max_bytes;
 
 pub fn repo_url(ctx: &CliContext, repo: &str) -> Result<String> {
     let client = artifact_storage_client(ctx)?;
@@ -140,6 +146,42 @@ pub async fn restore_repo(ctx: &CliContext, repo: &str) -> Result<()> {
         .await
         .map_err(map_sdk_error)?;
     println!("restored {repo}");
+    Ok(())
+}
+
+pub async fn clone_repo(
+    ctx: &CliContext,
+    repo: &str,
+    dest: Option<PathBuf>,
+    cache_dir: Option<PathBuf>,
+    cache_max_bytes: Option<u64>,
+    no_checkout: bool,
+) -> Result<()> {
+    let project_id = project_id(ctx)?;
+    let client = artifact_storage_client(ctx)?;
+    let repo_url = client.git_repo_url(&project_id, repo);
+    let credential = client
+        .mint_token_for_repo(&project_id, Some(repo))
+        .await
+        .map_err(map_sdk_error)?
+        .into_inner();
+    let dest = dest.unwrap_or_else(|| fastclone::default_dest_from_url(&repo_url));
+    let opts = fastclone::FastCloneOptions {
+        repo_url: repo_url.clone(),
+        dest,
+        cache_dir,
+        cache_max_bytes,
+        credential: Some(fastclone::BasicAuth {
+            username: credential.git_username,
+            password: Some(credential.token),
+        }),
+        checkout: !no_checkout,
+    };
+    let stats = fastclone::fast_clone(opts).await?;
+    println!(
+        "{}",
+        fastclone::format_fast_clone_stats(&format!("cloned {repo}"), &stats)
+    );
     Ok(())
 }
 

--- a/crates/cli/src/commands/git/fastclone.rs
+++ b/crates/cli/src/commands/git/fastclone.rs
@@ -96,6 +96,27 @@ pub struct FastCloneOptions {
     /// Basic-auth credential for the gsvc origin, e.g. from a minted git token.
     pub credential: Option<BasicAuth>,
     pub checkout: bool,
+    /// Spinner already shown by the caller (e.g. while minting a credential); reused and
+    /// switched to a byte progress bar once the manifest's artifact sizes are known.
+    pub progress: Option<ProgressBar>,
+}
+
+/// A spinner for indeterminate-length work (auth, manifest fetch), or `None` when stderr isn't a
+/// TTY. `fast_clone` converts it into a byte progress bar once download sizes are known.
+pub fn new_spinner(message: &str) -> Option<ProgressBar> {
+    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        return None;
+    }
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"])
+            .template("{spinner} {msg}")
+            .unwrap(),
+    );
+    pb.set_message(message.to_string());
+    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+    Some(pb)
 }
 
 #[derive(Clone, Debug, Default)]
@@ -126,23 +147,16 @@ struct HttpCtx {
     progress: Option<ProgressBar>,
 }
 
-fn new_progress_bar(total_bytes: u64) -> Option<ProgressBar> {
-    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
-        return None;
-    }
-    let pb = ProgressBar::new(total_bytes);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "{spinner} {bytes}/{total_bytes} ({bytes_per_sec}, eta {eta}) {msg}",
-        )
-        .unwrap()
-        .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
-    );
-    pb.enable_steady_tick(std::time::Duration::from_millis(80));
-    Some(pb)
+fn byte_progress_style() -> ProgressStyle {
+    ProgressStyle::with_template(
+        "{spinner} {bytes}/{total_bytes} ({bytes_per_sec}, eta {eta}) {msg}",
+    )
+    .unwrap()
+    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"])
 }
 
-/// Run a fast clone into `opts.dest`.
+/// Run a fast clone into `opts.dest`. `opts.progress`, if set, is shown while resolving the
+/// manifest and then converted into a byte progress bar once download sizes are known.
 pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
     ensure_clone_target_available(&opts.dest)?;
     let mut clean_base = Url::parse(&opts.repo_url)
@@ -158,7 +172,7 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         client: reqwest::Client::builder().build()?,
         origin: clean_base.clone(),
         auth: opts.credential.clone(),
-        progress: None,
+        progress: opts.progress,
     };
     let manifest_url = clean_base.join("fast/clone-manifest")?;
     let manifest: FastCloneManifest = get_json(&ctx, manifest_url).await?;
@@ -179,9 +193,17 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         .map(|p| p.pack_bytes + p.idx_bytes)
         .sum::<u64>()
         + manifest.large_blobs.iter().map(|b| b.bytes).sum::<u64>();
-    ctx.progress = new_progress_bar(total_bytes);
     if let Some(pb) = &ctx.progress {
+        pb.set_style(byte_progress_style());
+        pb.set_length(total_bytes);
+        pb.set_position(0);
         pb.set_message("fetching pack artifacts");
+    } else if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        let pb = ProgressBar::new(total_bytes);
+        pb.set_style(byte_progress_style());
+        pb.set_message("fetching pack artifacts");
+        pb.enable_steady_tick(std::time::Duration::from_millis(80));
+        ctx.progress = Some(pb);
     }
 
     let mut stats = FastCloneStats {

--- a/crates/cli/src/commands/git/fastclone.rs
+++ b/crates/cli/src/commands/git/fastclone.rs
@@ -21,6 +21,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, bail};
 use flate2::Compression;
 use gsvc_codec::{BlobOidHasher, IdxV2, Oid};
+use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
@@ -122,6 +123,23 @@ struct HttpCtx {
     client: reqwest::Client,
     origin: Url,
     auth: Option<BasicAuth>,
+    progress: Option<ProgressBar>,
+}
+
+fn new_progress_bar(total_bytes: u64) -> Option<ProgressBar> {
+    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        return None;
+    }
+    let pb = ProgressBar::new(total_bytes);
+    pb.set_style(
+        ProgressStyle::with_template(
+            "{spinner} {bytes}/{total_bytes} ({bytes_per_sec}, eta {eta}) {msg}",
+        )
+        .unwrap()
+        .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+    );
+    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+    Some(pb)
 }
 
 /// Run a fast clone into `opts.dest`.
@@ -136,10 +154,11 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         let path = format!("{}/", clean_base.path());
         clean_base.set_path(&path);
     }
-    let ctx = HttpCtx {
+    let mut ctx = HttpCtx {
         client: reqwest::Client::builder().build()?,
         origin: clean_base.clone(),
         auth: opts.credential.clone(),
+        progress: None,
     };
     let manifest_url = clean_base.join("fast/clone-manifest")?;
     let manifest: FastCloneManifest = get_json(&ctx, manifest_url).await?;
@@ -153,6 +172,17 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
     let cache_dir = opts.cache_dir.clone().unwrap_or_else(default_cache_dir);
     std::fs::create_dir_all(&cache_dir)
         .with_context(|| format!("create cache dir {}", cache_dir.display()))?;
+
+    let total_bytes: u64 = manifest
+        .packs
+        .iter()
+        .map(|p| p.pack_bytes + p.idx_bytes)
+        .sum::<u64>()
+        + manifest.large_blobs.iter().map(|b| b.bytes).sum::<u64>();
+    ctx.progress = new_progress_bar(total_bytes);
+    if let Some(pb) = &ctx.progress {
+        pb.set_message("fetching pack artifacts");
+    }
 
     let mut stats = FastCloneStats {
         packs: manifest.packs.len(),
@@ -202,6 +232,11 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
             stats.reused_bytes += blob.bytes;
         }
     }
+
+    if let Some(pb) = ctx.progress.take() {
+        pb.finish_and_clear();
+    }
+    eprintln!("installing objects into {}", opts.dest.display());
 
     run_git_outside(&mut stats, &["init", "-q", opts.dest.to_str().unwrap()])?;
     let git_dir = opts.dest.join(".git");
@@ -334,7 +369,12 @@ where
     if path.exists() {
         match file_size(path)? {
             Some(size) if size == expected_bytes => match validate(path) {
-                Ok(()) => return Ok(false),
+                Ok(()) => {
+                    if let Some(pb) = &ctx.progress {
+                        pb.inc(expected_bytes);
+                    }
+                    return Ok(false);
+                }
                 Err(_) => {
                     let _ = fs::remove_file(path);
                 }
@@ -369,6 +409,9 @@ where
     let mut written = 0u64;
     while let Some(chunk) = resp.chunk().await? {
         written += chunk.len() as u64;
+        if let Some(pb) = &ctx.progress {
+            pb.inc(chunk.len() as u64);
+        }
         out.write_all(&chunk).await?;
     }
     out.flush().await?;
@@ -400,7 +443,12 @@ async fn ensure_loose_blob_cached(
 ) -> Result<bool> {
     if path.exists() {
         match validate_loose_blob_cache(path, oid, expected_bytes) {
-            Ok(()) => return Ok(false),
+            Ok(()) => {
+                if let Some(pb) = &ctx.progress {
+                    pb.inc(expected_bytes);
+                }
+                return Ok(false);
+            }
             Err(_) => {
                 let _ = fs::remove_file(path);
             }
@@ -432,6 +480,9 @@ async fn ensure_loose_blob_cached(
     let mut written = 0u64;
     while let Some(chunk) = resp.chunk().await? {
         written += chunk.len() as u64;
+        if let Some(pb) = &ctx.progress {
+            pb.inc(chunk.len() as u64);
+        }
         hasher.update(&chunk);
         enc.write_all(&chunk)?;
     }

--- a/crates/cli/src/commands/git/fastclone.rs
+++ b/crates/cli/src/commands/git/fastclone.rs
@@ -1,0 +1,999 @@
+//! Fast clone client: install trusted pack artifacts directly, then leave a normal Git repo.
+//!
+//! This is not a new Git protocol. The gsvc server exposes a read-only manifest and immutable
+//! pack/idx artifacts; this client downloads them into a content-addressed local cache,
+//! hardlinks/copies self-contained packs into `.git/objects/pack`, fixes any advertised thin packs
+//! after their bases are installed, writes refs, and checks out the requested HEAD. After that, the
+//! checkout uses ordinary `git fetch` / `git push` against the original remote.
+//!
+//! Vendored from `artifact_storage` (`crates/gsvc-server/src/fastclone.rs` and the
+//! `FastCloneManifest` wire types in `crates/gsvc-server/src/service.rs`). If the manifest format or
+//! client behavior changes upstream, open a companion PR here to keep this copy in sync — see the
+//! note in that repo's `AGENTS.md`.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
+use std::path::{Component, Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use flate2::Compression;
+use gsvc_codec::{BlobOidHasher, IdxV2, Oid};
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
+use tokio::io::AsyncWriteExt;
+
+/// Read-only manifest served by gsvc at `<repo>/fast/clone-manifest`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FastCloneManifest {
+    pub version: u32,
+    #[serde(default)]
+    pub source: FastCloneManifestSource,
+    pub repo: String,
+    pub head: Option<String>,
+    pub refs: Vec<FastCloneRef>,
+    pub packs: Vec<FastClonePack>,
+    pub large_blobs: Vec<FastCloneBlob>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FastCloneManifestSource {
+    Empty,
+    #[default]
+    Verbatim,
+    Optimized,
+    Mixed,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FastCloneRef {
+    pub name: String,
+    pub oid: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FastClonePack {
+    pub pack_id: String,
+    pub pack_hash: String,
+    #[serde(default)]
+    pub source: FastClonePackSource,
+    #[serde(default)]
+    pub requires_fix_thin: bool,
+    pub pack_bytes: u64,
+    pub idx_bytes: u64,
+    pub object_count: u32,
+    pub pack_path: String,
+    pub idx_path: String,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FastClonePackSource {
+    #[default]
+    Verbatim,
+    Optimized,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FastCloneBlob {
+    pub oid: String,
+    pub bytes: u64,
+    pub path: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct FastCloneOptions {
+    /// Clean https(s) repo URL, no embedded credentials (e.g. from `repo_url()`).
+    pub repo_url: String,
+    pub dest: PathBuf,
+    pub cache_dir: Option<PathBuf>,
+    pub cache_max_bytes: Option<u64>,
+    /// Basic-auth credential for the gsvc origin, e.g. from a minted git token.
+    pub credential: Option<BasicAuth>,
+    pub checkout: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FastCloneStats {
+    pub packs: usize,
+    pub pack_bytes: u64,
+    pub idx_bytes: u64,
+    pub downloaded_bytes: u64,
+    pub reused_bytes: u64,
+    pub installed_bytes: u64,
+    pub large_blobs: usize,
+    pub large_blob_bytes: u64,
+    pub cache_pruned_bytes: u64,
+    pub cache_pruned_files: usize,
+    pub git_commands: Vec<Vec<String>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BasicAuth {
+    pub username: String,
+    pub password: Option<String>,
+}
+
+struct HttpCtx {
+    client: reqwest::Client,
+    origin: Url,
+    auth: Option<BasicAuth>,
+}
+
+/// Run a fast clone into `opts.dest`.
+pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
+    ensure_clone_target_available(&opts.dest)?;
+    let mut clean_base = Url::parse(&opts.repo_url)
+        .with_context(|| format!("invalid repo URL: {}", opts.repo_url))?;
+    if !matches!(clean_base.scheme(), "http" | "https") {
+        bail!("fast-clone requires an http(s) gsvc repo URL");
+    }
+    if !clean_base.path().ends_with('/') {
+        let path = format!("{}/", clean_base.path());
+        clean_base.set_path(&path);
+    }
+    let ctx = HttpCtx {
+        client: reqwest::Client::builder().build()?,
+        origin: clean_base.clone(),
+        auth: opts.credential.clone(),
+    };
+    let manifest_url = clean_base.join("fast/clone-manifest")?;
+    let manifest: FastCloneManifest = get_json(&ctx, manifest_url).await?;
+    if manifest.version != 1 {
+        bail!(
+            "unsupported fast-clone manifest version {}",
+            manifest.version
+        );
+    }
+
+    let cache_dir = opts.cache_dir.clone().unwrap_or_else(default_cache_dir);
+    std::fs::create_dir_all(&cache_dir)
+        .with_context(|| format!("create cache dir {}", cache_dir.display()))?;
+
+    let mut stats = FastCloneStats {
+        packs: manifest.packs.len(),
+        large_blobs: manifest.large_blobs.len(),
+        ..Default::default()
+    };
+    for pack in &manifest.packs {
+        let _storage_id = Oid::from_hex(&pack.pack_id)
+            .with_context(|| format!("bad fast-clone pack id {}", pack.pack_id))?;
+        let pack_hash = Oid::from_hex(&pack.pack_hash)
+            .with_context(|| format!("bad fast-clone pack hash {}", pack.pack_hash))?;
+        stats.pack_bytes += pack.pack_bytes;
+        stats.idx_bytes += pack.idx_bytes;
+
+        let pack_cache = cache_dir.join(format!("pack-{}.pack", pack.pack_id));
+        let idx_cache = cache_dir.join(format!("pack-{}.idx", pack.pack_id));
+        let pack_url = resolve_artifact_url(&clean_base, &pack.pack_path)?;
+        let idx_url = resolve_artifact_url(&clean_base, &pack.idx_path)?;
+
+        if ensure_cached_artifact(&ctx, pack_url, &pack_cache, pack.pack_bytes, |path| {
+            validate_pack_cache(path, pack.pack_bytes, pack_hash)
+        })
+        .await?
+        {
+            stats.downloaded_bytes += pack.pack_bytes;
+        } else {
+            stats.reused_bytes += pack.pack_bytes;
+        }
+        if ensure_cached_artifact(&ctx, idx_url, &idx_cache, pack.idx_bytes, |path| {
+            validate_idx_cache(path, pack.idx_bytes, pack_hash)
+        })
+        .await?
+        {
+            stats.downloaded_bytes += pack.idx_bytes;
+        } else {
+            stats.reused_bytes += pack.idx_bytes;
+        }
+    }
+    for blob in &manifest.large_blobs {
+        let oid = Oid::from_hex(&blob.oid).with_context(|| format!("bad blob oid {}", blob.oid))?;
+        stats.large_blob_bytes += blob.bytes;
+        let blob_cache = cache_dir.join(format!("blob-{}.loose", blob.oid));
+        let blob_url = resolve_artifact_url(&clean_base, &blob.path)?;
+        if ensure_loose_blob_cached(&ctx, blob_url, &blob_cache, oid, blob.bytes).await? {
+            stats.downloaded_bytes += blob.bytes;
+        } else {
+            stats.reused_bytes += blob.bytes;
+        }
+    }
+
+    run_git_outside(&mut stats, &["init", "-q", opts.dest.to_str().unwrap()])?;
+    let git_dir = opts.dest.join(".git");
+    let pack_dir = git_dir.join("objects/pack");
+    std::fs::create_dir_all(&pack_dir)
+        .with_context(|| format!("create pack dir {}", pack_dir.display()))?;
+
+    for pack in manifest.packs.iter().filter(|pack| !pack.requires_fix_thin) {
+        let pack_cache = cache_dir.join(format!("pack-{}.pack", pack.pack_id));
+        let idx_cache = cache_dir.join(format!("pack-{}.idx", pack.pack_id));
+        let pack_dst = pack_dir.join(format!("pack-{}.pack", pack.pack_id));
+        let idx_dst = pack_dir.join(format!("pack-{}.idx", pack.pack_id));
+        link_or_copy(&pack_cache, &pack_dst)?;
+        link_or_copy(&idx_cache, &idx_dst)?;
+        stats.installed_bytes += pack.pack_bytes + pack.idx_bytes;
+    }
+    for blob in &manifest.large_blobs {
+        let blob_cache = cache_dir.join(format!("blob-{}.loose", blob.oid));
+        install_loose_object(&blob_cache, &git_dir, &blob.oid)?;
+        stats.installed_bytes += blob.bytes;
+    }
+    for pack in manifest.packs.iter().filter(|pack| pack.requires_fix_thin) {
+        let pack_cache = cache_dir.join(format!("pack-{}.pack", pack.pack_id));
+        let installed = fix_thin_pack(&mut stats, &opts.dest, &git_dir, &pack_cache)?;
+        stats.installed_bytes += installed;
+    }
+
+    write_refs(&git_dir, &manifest)?;
+    configure_remote(&mut stats, &opts.dest, &opts.repo_url, &manifest)?;
+
+    if opts.checkout && !manifest.refs.is_empty() {
+        run_git(&mut stats, &opts.dest, &["reset", "--hard", "-q", "HEAD"])?;
+    }
+    if let Some(max_bytes) = opts.cache_max_bytes {
+        let protected = protected_cache_entries(&manifest)?;
+        let (files, bytes) = prune_cache_dir(&cache_dir, max_bytes, &protected)?;
+        stats.cache_pruned_files = files;
+        stats.cache_pruned_bytes = bytes;
+    }
+    Ok(stats)
+}
+
+pub fn format_fast_clone_stats(prefix: &str, stats: &FastCloneStats) -> String {
+    let mut out = format!(
+        "{prefix} installed {} pack(s), {} loose blob(s), downloaded {:.2} MiB, reused {:.2} MiB",
+        stats.packs,
+        stats.large_blobs,
+        stats.downloaded_bytes as f64 / (1024.0 * 1024.0),
+        stats.reused_bytes as f64 / (1024.0 * 1024.0)
+    );
+    if stats.cache_pruned_files > 0 {
+        out.push_str(&format!(
+            ", pruned {:.2} MiB/{} file(s)",
+            stats.cache_pruned_bytes as f64 / (1024.0 * 1024.0),
+            stats.cache_pruned_files
+        ));
+    }
+    out
+}
+
+pub fn parse_cache_max_bytes(value: &str) -> Result<u64> {
+    let raw = value.trim();
+    if raw.is_empty() {
+        bail!("cache size cannot be empty");
+    }
+    let lower = raw.to_ascii_lowercase();
+    let suffixes = [
+        ("tib", 1024_u64.pow(4)),
+        ("tb", 1024_u64.pow(4)),
+        ("t", 1024_u64.pow(4)),
+        ("gib", 1024_u64.pow(3)),
+        ("gb", 1024_u64.pow(3)),
+        ("g", 1024_u64.pow(3)),
+        ("mib", 1024_u64.pow(2)),
+        ("mb", 1024_u64.pow(2)),
+        ("m", 1024_u64.pow(2)),
+        ("kib", 1024),
+        ("kb", 1024),
+        ("k", 1024),
+        ("b", 1),
+    ];
+    let (digits, multiplier) = suffixes
+        .iter()
+        .find_map(|(suffix, multiplier)| {
+            lower
+                .strip_suffix(suffix)
+                .map(|digits| (digits.trim(), *multiplier))
+        })
+        .unwrap_or((raw, 1));
+    let bytes = digits
+        .parse::<u64>()
+        .with_context(|| format!("invalid cache size {value:?}"))?;
+    bytes
+        .checked_mul(multiplier)
+        .ok_or_else(|| anyhow::anyhow!("cache size {value:?} is too large"))
+}
+
+/// Derive the default destination directory from a repository URL, matching `git clone` convention.
+pub fn default_dest_from_url(raw: &str) -> PathBuf {
+    let parsed = Url::parse(raw).ok();
+    let name = parsed
+        .as_ref()
+        .and_then(|u| u.path_segments().and_then(|mut s| s.next_back()))
+        .filter(|s| !s.is_empty())
+        .unwrap_or("repo");
+    let name = name.strip_suffix(".git").unwrap_or(name);
+    PathBuf::from(name)
+}
+
+async fn get_json<T: serde::de::DeserializeOwned>(ctx: &HttpCtx, url: Url) -> Result<T> {
+    let resp = authed_get(ctx, url.clone()).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        bail!("GET {url} failed with {status}: {body}");
+    }
+    Ok(resp.json::<T>().await?)
+}
+
+async fn ensure_cached_artifact<F>(
+    ctx: &HttpCtx,
+    url: Url,
+    path: &Path,
+    expected_bytes: u64,
+    validate: F,
+) -> Result<bool>
+where
+    F: Fn(&Path) -> Result<()>,
+{
+    if path.exists() {
+        match file_size(path)? {
+            Some(size) if size == expected_bytes => match validate(path) {
+                Ok(()) => return Ok(false),
+                Err(_) => {
+                    let _ = fs::remove_file(path);
+                }
+            },
+            Some(_) => {
+                let _ = fs::remove_file(path);
+            }
+            None => {}
+        }
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create cache parent {}", parent.display()))?;
+    }
+    let tmp = path.with_extension(format!(
+        "tmp-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    let mut resp = authed_get(ctx, url.clone()).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        bail!("GET {url} failed with {status}: {body}");
+    }
+    let mut out = tokio::fs::File::create(&tmp)
+        .await
+        .with_context(|| format!("create temp artifact {}", tmp.display()))?;
+    let mut written = 0u64;
+    while let Some(chunk) = resp.chunk().await? {
+        written += chunk.len() as u64;
+        out.write_all(&chunk).await?;
+    }
+    out.flush().await?;
+    drop(out);
+    if written != expected_bytes {
+        let _ = fs::remove_file(&tmp);
+        bail!(
+            "downloaded {} bytes from {}, expected {}",
+            written,
+            url,
+            expected_bytes
+        );
+    }
+    if let Err(err) = validate(&tmp) {
+        let _ = fs::remove_file(&tmp);
+        return Err(err).with_context(|| format!("validate artifact from {url}"));
+    }
+    let _ = fs::remove_file(path);
+    fs::rename(&tmp, path).with_context(|| format!("commit cache artifact {}", path.display()))?;
+    Ok(true)
+}
+
+async fn ensure_loose_blob_cached(
+    ctx: &HttpCtx,
+    url: Url,
+    path: &Path,
+    oid: Oid,
+    expected_bytes: u64,
+) -> Result<bool> {
+    if path.exists() {
+        match validate_loose_blob_cache(path, oid, expected_bytes) {
+            Ok(()) => return Ok(false),
+            Err(_) => {
+                let _ = fs::remove_file(path);
+            }
+        }
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create cache parent {}", parent.display()))?;
+    }
+    let tmp = path.with_extension(format!(
+        "tmp-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    let mut resp = authed_get(ctx, url.clone()).send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        bail!("GET {url} failed with {status}: {body}");
+    }
+    let mut hasher = BlobOidHasher::new(expected_bytes);
+    let file = fs::File::create(&tmp)
+        .with_context(|| format!("create temp loose object {}", tmp.display()))?;
+    let mut enc = flate2::write::ZlibEncoder::new(file, Compression::default());
+    enc.write_all(format!("blob {expected_bytes}\0").as_bytes())?;
+    let mut written = 0u64;
+    while let Some(chunk) = resp.chunk().await? {
+        written += chunk.len() as u64;
+        hasher.update(&chunk);
+        enc.write_all(&chunk)?;
+    }
+    let file = enc.finish()?;
+    file.sync_all()?;
+    if written != expected_bytes {
+        let _ = fs::remove_file(&tmp);
+        bail!(
+            "downloaded {} bytes from {}, expected {}",
+            written,
+            url,
+            expected_bytes
+        );
+    }
+    let actual = hasher.finalize();
+    if actual != oid {
+        let _ = fs::remove_file(&tmp);
+        bail!(
+            "blob {} failed oid verification: downloaded {}",
+            oid.to_hex(),
+            actual.to_hex()
+        );
+    }
+    validate_loose_blob_cache(&tmp, oid, expected_bytes)?;
+    let _ = fs::remove_file(path);
+    fs::rename(&tmp, path)
+        .with_context(|| format!("commit loose-object cache {}", path.display()))?;
+    Ok(true)
+}
+
+fn validate_pack_cache(path: &Path, expected_bytes: u64, pack_hash: Oid) -> Result<()> {
+    let mut file = fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let len = file
+        .metadata()
+        .with_context(|| format!("stat {}", path.display()))?
+        .len();
+    if len != expected_bytes {
+        bail!(
+            "pack cache {} has {} bytes, expected {}",
+            path.display(),
+            len,
+            expected_bytes
+        );
+    }
+    if len < 32 {
+        bail!("pack cache {} is too short", path.display());
+    }
+    let mut magic = [0u8; 4];
+    file.read_exact(&mut magic)
+        .with_context(|| format!("read pack header {}", path.display()))?;
+    if &magic != b"PACK" {
+        bail!("pack cache {} has bad PACK header", path.display());
+    }
+    let mut trailer = [0u8; 20];
+    file.seek(SeekFrom::End(-20))
+        .with_context(|| format!("seek pack trailer {}", path.display()))?;
+    file.read_exact(&mut trailer)
+        .with_context(|| format!("read pack trailer {}", path.display()))?;
+    let actual = Oid::from_bytes(&trailer)?;
+    if actual != pack_hash {
+        bail!(
+            "pack cache {} trailer is {}, expected {}",
+            path.display(),
+            actual.to_hex(),
+            pack_hash.to_hex()
+        );
+    }
+    Ok(())
+}
+
+fn validate_idx_cache(path: &Path, expected_bytes: u64, pack_hash: Oid) -> Result<()> {
+    let bytes = fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    if bytes.len() as u64 != expected_bytes {
+        bail!(
+            "idx cache {} has {} bytes, expected {}",
+            path.display(),
+            bytes.len(),
+            expected_bytes
+        );
+    }
+    if bytes.len() < 40 {
+        bail!("idx cache {} is too short", path.display());
+    }
+    IdxV2::parse(&bytes).with_context(|| format!("parse idx {}", path.display()))?;
+    let pack_hash_off = bytes.len() - 40;
+    let idx_hash_off = bytes.len() - 20;
+    let actual_pack = Oid::from_bytes(&bytes[pack_hash_off..idx_hash_off])?;
+    if actual_pack != pack_hash {
+        bail!(
+            "idx cache {} points at pack {}, expected {}",
+            path.display(),
+            actual_pack.to_hex(),
+            pack_hash.to_hex()
+        );
+    }
+    let mut hasher = Sha1::new();
+    hasher.update(&bytes[..idx_hash_off]);
+    let digest: [u8; 20] = hasher.finalize().into();
+    if digest.as_slice() != &bytes[idx_hash_off..] {
+        bail!("idx cache {} has bad checksum", path.display());
+    }
+    Ok(())
+}
+
+fn validate_loose_blob_cache(path: &Path, oid: Oid, expected_bytes: u64) -> Result<()> {
+    let file = fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut decoder = flate2::read::ZlibDecoder::new(file);
+    let mut hasher = BlobOidHasher::new(expected_bytes);
+    let mut header = Vec::with_capacity(32);
+    let mut saw_header = false;
+    let mut content_bytes = 0u64;
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = decoder
+            .read(&mut buf)
+            .with_context(|| format!("inflate loose blob {}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        let mut data = &buf[..n];
+        if !saw_header {
+            let Some(pos) = data.iter().position(|b| *b == 0) else {
+                header.extend_from_slice(data);
+                if header.len() > 64 {
+                    bail!("loose blob {} has oversized header", path.display());
+                }
+                continue;
+            };
+            header.extend_from_slice(&data[..pos]);
+            let header_text = std::str::from_utf8(&header)
+                .with_context(|| format!("decode loose blob header {}", path.display()))?;
+            let expected_header = format!("blob {expected_bytes}");
+            if header_text != expected_header {
+                bail!(
+                    "loose blob {} has header {:?}, expected {:?}",
+                    path.display(),
+                    header_text,
+                    expected_header
+                );
+            }
+            saw_header = true;
+            data = &data[pos + 1..];
+        }
+        content_bytes += data.len() as u64;
+        hasher.update(data);
+    }
+    if !saw_header {
+        bail!("loose blob {} is missing object header", path.display());
+    }
+    if content_bytes != expected_bytes {
+        bail!(
+            "loose blob {} has {} bytes, expected {}",
+            path.display(),
+            content_bytes,
+            expected_bytes
+        );
+    }
+    let actual = hasher.finalize();
+    if actual != oid {
+        bail!(
+            "loose blob {} hashes to {}, expected {}",
+            path.display(),
+            actual.to_hex(),
+            oid.to_hex()
+        );
+    }
+    Ok(())
+}
+
+fn protected_cache_entries(manifest: &FastCloneManifest) -> Result<HashSet<String>> {
+    let mut protected = HashSet::new();
+    for pack in &manifest.packs {
+        let _storage_id = Oid::from_hex(&pack.pack_id)
+            .with_context(|| format!("bad fast-clone pack id {}", pack.pack_id))?;
+        protected.insert(format!("pack-{}.pack", pack.pack_id));
+        protected.insert(format!("pack-{}.idx", pack.pack_id));
+    }
+    for blob in &manifest.large_blobs {
+        let oid = Oid::from_hex(&blob.oid).with_context(|| format!("bad blob oid {}", blob.oid))?;
+        protected.insert(format!("blob-{}.loose", oid));
+    }
+    Ok(protected)
+}
+
+fn prune_cache_dir(
+    cache_dir: &Path,
+    max_bytes: u64,
+    protected: &HashSet<String>,
+) -> Result<(usize, u64)> {
+    let mut total = 0u64;
+    let mut candidates = Vec::new();
+    for entry in match fs::read_dir(cache_dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok((0, 0)),
+        Err(e) => return Err(e).with_context(|| format!("read cache dir {}", cache_dir.display())),
+    } {
+        let entry = entry.with_context(|| format!("read cache dir {}", cache_dir.display()))?;
+        let meta = entry
+            .metadata()
+            .with_context(|| format!("stat cache entry {}", entry.path().display()))?;
+        if !meta.is_file() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(|s| s.to_string()) else {
+            continue;
+        };
+        if !is_cache_artifact_name(&name) {
+            continue;
+        }
+        total = total.saturating_add(meta.len());
+        if !protected.contains(&name) {
+            candidates.push((
+                meta.modified().unwrap_or(UNIX_EPOCH),
+                entry.path(),
+                meta.len(),
+            ));
+        }
+    }
+    if total <= max_bytes {
+        return Ok((0, 0));
+    }
+    candidates.sort_by_key(|(modified, _, _)| *modified);
+    let mut pruned_files = 0usize;
+    let mut pruned_bytes = 0u64;
+    for (_, path, bytes) in candidates {
+        if total <= max_bytes {
+            break;
+        }
+        match fs::remove_file(&path) {
+            Ok(()) => {
+                total = total.saturating_sub(bytes);
+                pruned_files += 1;
+                pruned_bytes = pruned_bytes.saturating_add(bytes);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e).with_context(|| format!("remove {}", path.display())),
+        }
+    }
+    Ok((pruned_files, pruned_bytes))
+}
+
+fn is_cache_artifact_name(name: &str) -> bool {
+    (name.starts_with("pack-") && (name.ends_with(".pack") || name.ends_with(".idx")))
+        || (name.starts_with("blob-") && name.ends_with(".loose"))
+}
+
+fn authed_get(ctx: &HttpCtx, url: Url) -> reqwest::RequestBuilder {
+    let req = ctx.client.get(url.clone());
+    if same_origin(&ctx.origin, &url) {
+        if let Some(auth) = &ctx.auth {
+            return req.basic_auth(auth.username.clone(), auth.password.clone());
+        }
+    }
+    req
+}
+
+fn same_origin(a: &Url, b: &Url) -> bool {
+    a.scheme() == b.scheme()
+        && a.host_str() == b.host_str()
+        && a.port_or_known_default() == b.port_or_known_default()
+}
+
+fn resolve_artifact_url(repo_base: &Url, value: &str) -> Result<Url> {
+    match Url::parse(value) {
+        Ok(u) => Ok(u),
+        Err(_) => Ok(repo_base.join(value)?),
+    }
+}
+
+fn ensure_clone_target_available(dest: &Path) -> Result<()> {
+    if !dest.exists() {
+        return Ok(());
+    }
+    if !dest.is_dir() {
+        bail!(
+            "destination exists and is not a directory: {}",
+            dest.display()
+        );
+    }
+    if dest
+        .read_dir()
+        .with_context(|| format!("read destination {}", dest.display()))?
+        .next()
+        .is_some()
+    {
+        bail!("destination directory is not empty: {}", dest.display());
+    }
+    Ok(())
+}
+
+fn write_refs(git_dir: &Path, manifest: &FastCloneManifest) -> Result<()> {
+    let mut packed = String::from("# pack-refs with: peeled fully-peeled sorted\n");
+    for r in &manifest.refs {
+        if let Some(name) = packed_ref_name(&r.name) {
+            packed.push_str(&r.oid);
+            packed.push(' ');
+            packed.push_str(&name);
+            packed.push('\n');
+        }
+    }
+    std::fs::write(git_dir.join("packed-refs"), packed)
+        .with_context(|| format!("write {}", git_dir.join("packed-refs").display()))?;
+
+    let head_target = manifest
+        .head
+        .as_deref()
+        .unwrap_or("refs/heads/main")
+        .to_string();
+    std::fs::write(git_dir.join("HEAD"), format!("ref: {head_target}\n"))
+        .with_context(|| format!("write {}", git_dir.join("HEAD").display()))?;
+
+    if let Some(head_ref) = manifest.refs.iter().find(|r| r.name == head_target) {
+        write_loose_ref(git_dir, &head_target, &head_ref.oid)?;
+    }
+    Ok(())
+}
+
+fn packed_ref_name(name: &str) -> Option<String> {
+    if let Some(short) = name.strip_prefix("refs/heads/") {
+        Some(format!("refs/remotes/origin/{short}"))
+    } else if name.starts_with("refs/tags/") || name.starts_with("refs/") {
+        Some(name.to_string())
+    } else {
+        None
+    }
+}
+
+fn write_loose_ref(git_dir: &Path, name: &str, oid: &str) -> Result<()> {
+    ensure_safe_ref_name(name)?;
+    let path = git_dir.join(name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create ref dir {}", parent.display()))?;
+    }
+    std::fs::write(&path, format!("{oid}\n"))
+        .with_context(|| format!("write loose ref {}", path.display()))?;
+    Ok(())
+}
+
+fn ensure_safe_ref_name(name: &str) -> Result<()> {
+    let path = Path::new(name);
+    if path.is_absolute() {
+        bail!("absolute ref path in manifest: {name}");
+    }
+    for c in path.components() {
+        if matches!(
+            c,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        ) {
+            bail!("unsafe ref path in manifest: {name}");
+        }
+    }
+    Ok(())
+}
+
+fn configure_remote(
+    stats: &mut FastCloneStats,
+    dest: &Path,
+    repo_url: &str,
+    manifest: &FastCloneManifest,
+) -> Result<()> {
+    run_git(stats, dest, &["config", "remote.origin.url", repo_url])?;
+    run_git(
+        stats,
+        dest,
+        &[
+            "config",
+            "remote.origin.fetch",
+            "+refs/heads/*:refs/remotes/origin/*",
+        ],
+    )?;
+    if let Some(head) = manifest.head.as_deref() {
+        if let Some(branch) = head.strip_prefix("refs/heads/") {
+            run_git(
+                stats,
+                dest,
+                &["config", &format!("branch.{branch}.remote"), "origin"],
+            )?;
+            run_git(
+                stats,
+                dest,
+                &["config", &format!("branch.{branch}.merge"), head],
+            )?;
+            run_git(
+                stats,
+                dest,
+                &[
+                    "symbolic-ref",
+                    "refs/remotes/origin/HEAD",
+                    &format!("refs/remotes/origin/{branch}"),
+                ],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn run_git_outside(stats: &mut FastCloneStats, args: &[&str]) -> Result<()> {
+    stats
+        .git_commands
+        .push(args.iter().map(|s| s.to_string()).collect());
+    let out = Command::new("git")
+        .args(args)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .context("spawn git")?;
+    if !out.status.success() {
+        bail!(
+            "git {} failed:\n{}{}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn run_git(stats: &mut FastCloneStats, cwd: &Path, args: &[&str]) -> Result<()> {
+    stats
+        .git_commands
+        .push(args.iter().map(|s| s.to_string()).collect());
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .output()
+        .context("spawn git")?;
+    if !out.status.success() {
+        bail!(
+            "git {} failed in {}:\n{}{}",
+            args.join(" "),
+            cwd.display(),
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn fix_thin_pack(
+    stats: &mut FastCloneStats,
+    cwd: &Path,
+    git_dir: &Path,
+    pack_cache: &Path,
+) -> Result<u64> {
+    stats.git_commands.push(vec![
+        "index-pack".to_string(),
+        "--fix-thin".to_string(),
+        "--stdin".to_string(),
+        format!("<{}", pack_cache.display()),
+    ]);
+    let input = fs::File::open(pack_cache)
+        .with_context(|| format!("open thin pack cache {}", pack_cache.display()))?;
+    let out = Command::new("git")
+        .args(["index-pack", "--fix-thin", "--stdin"])
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .stdin(Stdio::from(input))
+        .output()
+        .context("spawn git")?;
+    if !out.status.success() {
+        bail!(
+            "git index-pack --fix-thin --stdin failed in {} for {}:\n{}{}",
+            cwd.display(),
+            pack_cache.display(),
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let pack_hash = parse_index_pack_output(&out.stdout)?;
+    let pack_dir = git_dir.join("objects/pack");
+    let pack_dst = pack_dir.join(format!("pack-{pack_hash}.pack"));
+    let idx_dst = pack_dir.join(format!("pack-{pack_hash}.idx"));
+    Ok(file_size(&pack_dst)?.unwrap_or(0) + file_size(&idx_dst)?.unwrap_or(0))
+}
+
+fn parse_index_pack_output(stdout: &[u8]) -> Result<String> {
+    let text = String::from_utf8_lossy(stdout);
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(hash) = line
+            .strip_prefix("pack")
+            .map(str::trim_start)
+            .filter(|hash| !hash.is_empty())
+        {
+            if hash.len() == 40 && hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+                return Ok(hash.to_string());
+            }
+        }
+    }
+    bail!("git index-pack did not report a pack hash: {text:?}")
+}
+
+fn link_or_copy(src: &Path, dst: &Path) -> Result<()> {
+    if file_size(dst)? == Some(file_size(src)?.unwrap_or(0)) {
+        return Ok(());
+    }
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create install parent {}", parent.display()))?;
+    }
+    match std::fs::hard_link(src, dst) {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            std::fs::copy(src, dst)
+                .with_context(|| format!("copy {} to {}", src.display(), dst.display()))?;
+            Ok(())
+        }
+    }
+}
+
+fn install_loose_object(src: &Path, git_dir: &Path, oid: &str) -> Result<()> {
+    if oid.len() != 40 || !oid.bytes().all(|b| b.is_ascii_hexdigit()) {
+        bail!("bad loose object oid: {oid}");
+    }
+    let (dir, file) = oid.split_at(2);
+    let dst = git_dir.join("objects").join(dir).join(file);
+    if dst.exists() {
+        return Ok(());
+    }
+    link_or_copy(src, &dst)
+}
+
+fn file_size(path: &Path) -> Result<Option<u64>> {
+    match std::fs::metadata(path) {
+        Ok(m) => Ok(Some(m.len())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("stat {}", path.display())),
+    }
+}
+
+/// Default pack/idx/blob cache dir: `~/.cache/tensorlake/git-fast-clone` (or the platform cache dir).
+fn default_cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("tensorlake")
+        .join("git-fast-clone")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_dest_uses_repo_segment_from_project_scoped_url() {
+        assert_eq!(
+            default_dest_from_url("http://localhost:8080/demo/myrepo"),
+            PathBuf::from("myrepo")
+        );
+        assert_eq!(
+            default_dest_from_url("https://git.example.com/demo/myrepo.git"),
+            PathBuf::from("myrepo")
+        );
+    }
+
+    #[test]
+    fn parse_cache_max_bytes_accepts_suffixes() {
+        assert_eq!(parse_cache_max_bytes("512").unwrap(), 512);
+        assert_eq!(
+            parse_cache_max_bytes("2GiB").unwrap(),
+            2 * 1024 * 1024 * 1024
+        );
+        assert_eq!(parse_cache_max_bytes("10 mb").unwrap(), 10 * 1024 * 1024);
+    }
+}

--- a/crates/cli/src/commands/git/fastclone.rs
+++ b/crates/cli/src/commands/git/fastclone.rs
@@ -349,11 +349,17 @@ pub fn default_dest_from_url(raw: &str) -> PathBuf {
 async fn get_json<T: serde::de::DeserializeOwned>(ctx: &HttpCtx, url: Url) -> Result<T> {
     let resp = authed_get(ctx, url.clone()).send().await?;
     let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .with_context(|| format!("GET {url} ({status}): failed reading response body"))?;
     if !status.is_success() {
-        let body = resp.text().await.unwrap_or_default();
         bail!("GET {url} failed with {status}: {body}");
     }
-    Ok(resp.json::<T>().await?)
+    serde_json::from_str(&body).with_context(|| {
+        let preview: String = body.chars().take(500).collect();
+        format!("GET {url} ({status}): failed to decode JSON response body: {preview:?}")
+    })
 }
 
 async fn ensure_cached_artifact<F>(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -278,6 +278,22 @@ enum SshKeysCommands {
 
 #[derive(Subcommand)]
 enum GitCommands {
+    /// Fast-clone a repo: install trusted pack artifacts directly, then leave a normal Git checkout
+    Clone {
+        /// Repo name
+        repo: String,
+        /// Destination directory (default: derived from the repo name)
+        dest: Option<std::path::PathBuf>,
+        /// Pack/idx/blob artifact cache directory (default: platform cache dir)
+        #[arg(long)]
+        cache_dir: Option<std::path::PathBuf>,
+        /// Prune old cached artifacts after clone; accepts K/M/G/T suffixes
+        #[arg(long, value_parser = commands::git::parse_cache_max_bytes)]
+        cache_max_bytes: Option<u64>,
+        /// Install objects/refs without checking out the worktree
+        #[arg(long)]
+        no_checkout: bool,
+    },
     /// Create an empty repo
     Create {
         /// Repo name
@@ -2012,6 +2028,16 @@ async fn run_ssh_keys_command(ctx: &CliContext, subcmd: SshKeysCommands) -> erro
 
 async fn run_git_command(ctx: &CliContext, subcmd: GitCommands) -> error::Result<()> {
     match subcmd {
+        GitCommands::Clone {
+            repo,
+            dest,
+            cache_dir,
+            cache_max_bytes,
+            no_checkout,
+        } => {
+            commands::git::clone_repo(ctx, &repo, dest, cache_dir, cache_max_bytes, no_checkout)
+                .await
+        }
         GitCommands::Create {
             repo,
             default_branch,
@@ -2152,6 +2178,32 @@ mod tests {
 
     #[test]
     fn git_commands_parse() {
+        match parse_command([
+            "tl",
+            "git",
+            "clone",
+            "demo",
+            "dest-dir",
+            "--cache-max-bytes",
+            "2GiB",
+            "--no-checkout",
+        ]) {
+            Commands::Git(GitCommands::Clone {
+                repo,
+                dest,
+                cache_dir,
+                cache_max_bytes,
+                no_checkout,
+            }) => {
+                assert_eq!(repo, "demo");
+                assert_eq!(dest, Some(std::path::PathBuf::from("dest-dir")));
+                assert_eq!(cache_dir, None);
+                assert_eq!(cache_max_bytes, Some(2 * 1024 * 1024 * 1024));
+                assert!(no_checkout);
+            }
+            _ => panic!("expected git clone command"),
+        }
+
         match parse_command(["tl", "git", "create", "demo", "--default-branch", "trunk"]) {
             Commands::Git(GitCommands::Create {
                 repo,

--- a/crates/gsvc-codec/Cargo.toml
+++ b/crates/gsvc-codec/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "gsvc-codec"
+version.workspace = true
+# Vendored verbatim from artifact_storage, which targets edition 2021 (not tensorlake's edition 2024).
+# Pinned explicitly to keep this a byte-for-byte-diffable copy of the upstream crate.
+edition = "2021"
+license.workspace = true
+description = "git object & packfile codec (hashing, pack v2 read/write with delta resolution, idx v2)"
+
+[dependencies]
+parking_lot.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+bytes.workspace = true
+sha1.workspace = true
+sha2.workspace = true
+flate2.workspace = true
+crc32fast.workspace = true
+rayon.workspace = true
+hex.workspace = true
+tempfile.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+futures.workspace = true

--- a/crates/gsvc-codec/src/async_stream.rs
+++ b/crates/gsvc-codec/src/async_stream.rs
@@ -1,0 +1,846 @@
+//! Async-native streaming packfile I/O.
+//!
+//! Unlike the whole-buffer [`build_pack`](crate::build_pack)/[`parse_pack`](crate::parse_pack), and
+//! unlike a `spawn_blocking` bridge, this drives the pack codec from `async` directly: every I/O
+//! wait (reading the request body, writing the response, fetching/storing objects) is `.await`ed, so
+//! a transfer occupies a cheap task — **not** an OS thread — for its lifetime. Concurrency is then
+//! bounded by memory and connections, not by a fixed blocking-thread pool. Only the bounded CPU
+//! bursts (per-object inflate/deflate) run inline between awaits.
+//!
+//! The codec stays I/O-agnostic via four small traits the caller implements:
+//! * [`ByteSource`] — pull the next chunk of input (the request body);
+//! * [`ByteSink`] — push a chunk of output (the response body);
+//! * [`AsyncPackSink`] — receive parsed objects; large blobs are *pushed* as plaintext so the caller
+//!   can chunk them straight to the store without a pull-based reader;
+//! * [`ChunkSource`] — supply a large blob's bytes when writing it into an outgoing pack.
+
+use std::future::Future;
+use std::io;
+
+use bytes::Bytes;
+use flate2::{Compress, Compression, Decompress, FlushCompress, FlushDecompress, Status};
+use sha1::{Digest, Sha1};
+
+use crate::delta::apply_delta;
+use crate::{CodecError, Kind, Object, Oid};
+
+const PACK_MAGIC: &[u8; 4] = b"PACK";
+const PACK_VERSION: u32 = 2;
+
+const T_COMMIT: u8 = 1;
+const T_TREE: u8 = 2;
+const T_BLOB: u8 = 3;
+const T_TAG: u8 = 4;
+const T_OFS_DELTA: u8 = 6;
+const T_REF_DELTA: u8 = 7;
+
+/// Blobs at or below this size must be retained in memory while parsing a pack, because git may
+/// delta-compress later objects against them. It matches git's default `core.bigFileThreshold`
+/// (512 MiB): git never deltifies an object larger than this, so a bigger blob can never be a delta
+/// base and is safe to stream straight through without keeping its bytes. (A non-default client that
+/// *raises* `bigFileThreshold` could defeat this; the practical effect is only a rejected push, never
+/// corruption.)
+const DELTA_BASE_MAX: u64 = 512 * 1024 * 1024;
+
+// ── caller-implemented async I/O traits ──────────────────────────────────────
+
+/// An async source of input bytes (e.g. an HTTP request body). `next` yields the next chunk, or
+/// `None` at end of input.
+pub trait ByteSource {
+    fn next(&mut self) -> impl Future<Output = io::Result<Option<Bytes>>> + Send;
+}
+
+/// An async sink for output bytes (e.g. an HTTP response body).
+pub trait ByteSink {
+    fn send(&mut self, bytes: Bytes) -> impl Future<Output = io::Result<()>> + Send;
+}
+
+/// An async source of a single large object's plaintext, chunk by chunk (e.g. a chunked blob read
+/// from the store). `None` ends the object.
+pub trait ChunkSource {
+    fn next(&mut self) -> impl Future<Output = Result<Option<Bytes>, CodecError>> + Send;
+}
+
+/// Where a streamed pack's objects go. Small/delta-resolved objects arrive whole via [`object`];
+/// a large blob arrives as a `begin` → repeated `data` (plaintext) → `end` sequence so the caller
+/// can content-chunk it to the store as it streams, never buffering the whole blob.
+pub trait AsyncPackSink {
+    fn object(
+        &mut self,
+        oid: Oid,
+        kind: Kind,
+        data: Bytes,
+    ) -> impl Future<Output = Result<(), CodecError>> + Send;
+
+    fn large_blob_begin(
+        &mut self,
+        size: u64,
+    ) -> impl Future<Output = Result<(), CodecError>> + Send;
+    fn large_blob_data(
+        &mut self,
+        data: &[u8],
+    ) -> impl Future<Output = Result<(), CodecError>> + Send;
+    fn large_blob_end(&mut self) -> impl Future<Output = Result<(), CodecError>> + Send;
+}
+
+// ── reader ───────────────────────────────────────────────────────────────────
+
+/// A buffered, SHA-1-hashing async reader over a [`ByteSource`]. Every consumed body byte is folded
+/// into the running pack trailer hash; the trailer itself is read raw and excluded.
+struct AsyncHashingSource<Src> {
+    src: Src,
+    cur: Bytes,
+    off: usize,
+    hasher: Sha1,
+    consumed: u64,
+    eof: bool,
+    /// Reused inflate output buffer, so a half-million-object pack doesn't allocate (and free) a
+    /// fresh scratch buffer for every single object.
+    scratch: Vec<u8>,
+}
+
+impl<Src: ByteSource> AsyncHashingSource<Src> {
+    fn new(src: Src) -> Self {
+        AsyncHashingSource {
+            src,
+            cur: Bytes::new(),
+            off: 0,
+            hasher: Sha1::new(),
+            consumed: 0,
+            eof: false,
+            scratch: vec![0u8; 64 * 1024],
+        }
+    }
+
+    /// Ensure at least one byte is buffered. Returns `false` at end of input.
+    async fn fill(&mut self) -> io::Result<bool> {
+        while self.off >= self.cur.len() {
+            match self.src.next().await? {
+                Some(b) => {
+                    self.cur = b;
+                    self.off = 0;
+                }
+                None => {
+                    self.eof = true;
+                    return Ok(false);
+                }
+            }
+        }
+        Ok(true)
+    }
+
+    fn available(&self) -> &[u8] {
+        &self.cur[self.off..]
+    }
+
+    fn consume(&mut self, n: usize) {
+        let n = n.min(self.cur.len() - self.off);
+        self.hasher.update(&self.cur[self.off..self.off + n]);
+        self.off += n;
+        self.consumed += n as u64;
+    }
+
+    async fn read_byte(&mut self) -> Result<u8, CodecError> {
+        if !self.fill().await.map_err(io_err)? {
+            return Err(CodecError::PackTooShort);
+        }
+        let b = self.cur[self.off];
+        self.consume(1);
+        Ok(b)
+    }
+
+    async fn read_be_u32(&mut self) -> Result<u32, CodecError> {
+        let mut b = [0u8; 4];
+        for x in &mut b {
+            *x = self.read_byte().await?;
+        }
+        Ok(u32::from_be_bytes(b))
+    }
+
+    /// Read `n` raw bytes **without** hashing (only the trailer uses this).
+    async fn read_raw(&mut self, n: usize) -> Result<Vec<u8>, CodecError> {
+        let mut out = Vec::with_capacity(n);
+        while out.len() < n {
+            if !self.fill().await.map_err(io_err)? {
+                return Err(CodecError::PackTooShort);
+            }
+            let take = (n - out.len()).min(self.cur.len() - self.off);
+            out.extend_from_slice(&self.cur[self.off..self.off + take]);
+            self.off += take; // raw: not hashed
+        }
+        Ok(out)
+    }
+
+    /// Inflate one object's `expected` plaintext bytes into a `Vec`.
+    async fn inflate_object(&mut self, expected: usize) -> Result<Vec<u8>, CodecError> {
+        let mut dec = Decompress::new(true);
+        let mut out = Vec::with_capacity(expected);
+        // Borrow the shared scratch buffer for the duration (also sidesteps borrowing `self` both
+        // mutably for the buffer and immutably for `available()`); restored on the success path.
+        let mut scratch = std::mem::take(&mut self.scratch);
+        loop {
+            if !self.fill().await.map_err(io_err)? {
+                return Err(CodecError::Inflate("truncated zlib stream".into()));
+            }
+            let (bi, bo) = (dec.total_in(), dec.total_out());
+            let status = dec
+                .decompress(self.available(), &mut scratch, FlushDecompress::None)
+                .map_err(|e| CodecError::Inflate(e.to_string()))?;
+            let cin = (dec.total_in() - bi) as usize;
+            let cout = (dec.total_out() - bo) as usize;
+            self.consume(cin);
+            out.extend_from_slice(&scratch[..cout]);
+            if status == Status::StreamEnd {
+                break;
+            }
+        }
+        self.scratch = scratch;
+        if out.len() != expected {
+            return Err(CodecError::Inflate(format!(
+                "expected {expected} bytes, produced {}",
+                out.len()
+            )));
+        }
+        Ok(out)
+    }
+
+    /// Inflate one large blob, pushing its plaintext to `sink` as it decompresses (never buffered).
+    /// Like [`inflate_large`](Self::inflate_large), but also returns the full inflated bytes so the
+    /// blob can be kept as a delta base. Used for large blobs small enough that git might
+    /// delta-compress against them. The bytes still flow through the sink's large-blob (chunked
+    /// storage) path; we just also retain them.
+    async fn inflate_large_retained<S: AsyncPackSink>(
+        &mut self,
+        sink: &mut S,
+        expected: u64,
+    ) -> Result<Vec<u8>, CodecError> {
+        let data = self.inflate_object(expected as usize).await?;
+        sink.large_blob_begin(expected).await?;
+        sink.large_blob_data(&data).await?;
+        sink.large_blob_end().await?;
+        Ok(data)
+    }
+
+    async fn inflate_large<S: AsyncPackSink>(
+        &mut self,
+        sink: &mut S,
+        expected: u64,
+    ) -> Result<(), CodecError> {
+        sink.large_blob_begin(expected).await?;
+        let mut dec = Decompress::new(true);
+        let mut scratch = std::mem::take(&mut self.scratch);
+        let mut produced = 0u64;
+        loop {
+            if !self.fill().await.map_err(io_err)? {
+                return Err(CodecError::Inflate("truncated zlib stream".into()));
+            }
+            let (bi, bo) = (dec.total_in(), dec.total_out());
+            let status = dec
+                .decompress(self.available(), &mut scratch, FlushDecompress::None)
+                .map_err(|e| CodecError::Inflate(e.to_string()))?;
+            let cin = (dec.total_in() - bi) as usize;
+            let cout = (dec.total_out() - bo) as usize;
+            self.consume(cin);
+            if cout > 0 {
+                sink.large_blob_data(&scratch[..cout]).await?;
+                produced += cout as u64;
+            }
+            if status == Status::StreamEnd {
+                break;
+            }
+        }
+        self.scratch = scratch;
+        if produced != expected {
+            return Err(CodecError::Inflate(format!(
+                "large blob: expected {expected} bytes, produced {produced}"
+            )));
+        }
+        sink.large_blob_end().await?;
+        Ok(())
+    }
+}
+
+/// Resolves a thin-pack `REF_DELTA` base that isn't contained in the pack itself. The server backs
+/// this with its **on-demand** object store, so a push resolves only the handful of bases it
+/// references rather than loading the whole repo into memory. `Ok(None)` means "no such base".
+pub trait BaseResolver {
+    fn resolve_base(
+        &mut self,
+        oid: &Oid,
+    ) -> impl std::future::Future<Output = Result<Option<Object>, CodecError>> + Send;
+}
+
+/// A [`BaseResolver`] for self-contained packs (no external thin-pack bases) — every `REF_DELTA`
+/// base must appear earlier in the pack.
+pub struct NoBases;
+
+impl BaseResolver for NoBases {
+    async fn resolve_base(&mut self, _oid: &Oid) -> Result<Option<Object>, CodecError> {
+        Ok(None)
+    }
+}
+
+/// Parse a v2 packfile from an async [`ByteSource`], resolving deltas, streaming blobs of at least
+/// `large_threshold` bytes to the sink and materializing everything else. `resolver` supplies
+/// external bases for thin-pack `REF_DELTA`s on demand. Returns the pack trailer oid.
+pub async fn parse_pack_streaming_async<Src, R, Sink>(
+    src: Src,
+    large_threshold: u64,
+    resolver: &mut R,
+    sink: &mut Sink,
+) -> Result<Oid, CodecError>
+where
+    Src: ByteSource,
+    R: BaseResolver,
+    Sink: AsyncPackSink,
+{
+    let mut s = AsyncHashingSource::new(src);
+
+    let mut magic = [0u8; 4];
+    for b in &mut magic {
+        *b = s.read_byte().await?;
+    }
+    if &magic != PACK_MAGIC {
+        return Err(CodecError::BadPackMagic);
+    }
+    let version = s.read_be_u32().await?;
+    if version != PACK_VERSION {
+        return Err(CodecError::BadPackVersion(version));
+    }
+    let count = s.read_be_u32().await?;
+
+    // Resolved objects are kept here only so later entries can delta against them. The bytes are
+    // `Bytes` (refcounted), so the copy handed to the sink shares this one allocation rather than
+    // duplicating every object — roughly halving peak memory on a large push.
+    let mut bases: std::collections::HashMap<Oid, (Kind, Bytes)> =
+        std::collections::HashMap::with_capacity(
+            (count as usize).min(crate::pack::PREALLOC_HINT_CAP),
+        );
+    let mut by_offset: std::collections::HashMap<u64, Oid> =
+        std::collections::HashMap::with_capacity(
+            (count as usize).min(crate::pack::PREALLOC_HINT_CAP),
+        );
+    let mut offset: u64 = 12;
+
+    for _ in 0..count {
+        let entry_start = offset;
+        let (ty, size, header_len) = read_entry_header(&mut s).await?;
+        offset += header_len;
+
+        match ty {
+            T_BLOB if size >= large_threshold => {
+                let before = s.consumed;
+                if size <= DELTA_BASE_MAX {
+                    // Storage-wise this is a large blob (streamed to the chunk store), but git may
+                    // still delta-compress later objects against it — so we materialize it once and
+                    // keep it as a resolvable delta base for the rest of the pack, while feeding the
+                    // same bytes through the sink's large-blob path for chunked storage.
+                    let data = s.inflate_large_retained(sink, size).await?;
+                    offset += s.consumed - before;
+                    let oid = crate::object::hash(Kind::Blob, &data);
+                    by_offset.insert(entry_start, oid);
+                    bases.insert(oid, (Kind::Blob, Bytes::from(data)));
+                } else {
+                    // Above git's delta threshold: never a delta base, so stream without retaining.
+                    s.inflate_large(sink, size).await?;
+                    offset += s.consumed - before;
+                }
+            }
+            T_COMMIT | T_TREE | T_BLOB | T_TAG => {
+                let kind = Kind::from_pack_type(ty)?;
+                let before = s.consumed;
+                let data = Bytes::from(s.inflate_object(size as usize).await?);
+                offset += s.consumed - before;
+                let oid = crate::object::hash(kind, &data);
+                by_offset.insert(entry_start, oid);
+                bases.insert(oid, (kind, data.clone())); // refcount bump, shares the allocation
+                sink.object(oid, kind, data).await?;
+            }
+            T_OFS_DELTA => {
+                let rel = read_offset_varint(&mut s, &mut offset).await?;
+                let base_off = entry_start
+                    .checked_sub(rel)
+                    .ok_or(CodecError::BadDeltaBaseOffset)?;
+                let before = s.consumed;
+                let delta = s.inflate_object(size as usize).await?;
+                offset += s.consumed - before;
+                let base_oid = *by_offset
+                    .get(&base_off)
+                    .ok_or(CodecError::MissingDeltaBaseOffset(base_off))?;
+                let (bkind, bdata) = bases
+                    .get(&base_oid)
+                    .ok_or(CodecError::MissingDeltaBaseOffset(base_off))?;
+                let result = Bytes::from(apply_delta(bdata, &delta)?);
+                let kind = *bkind;
+                let oid = crate::object::hash(kind, &result);
+                by_offset.insert(entry_start, oid);
+                bases.insert(oid, (kind, result.clone()));
+                emit_resolved_object(sink, large_threshold, oid, kind, result).await?;
+            }
+            T_REF_DELTA => {
+                let mut base = [0u8; 20];
+                for b in &mut base {
+                    *b = s.read_byte().await?;
+                }
+                offset += 20;
+                let base_oid = Oid::from_bytes(&base)?;
+                let before = s.consumed;
+                let delta = s.inflate_object(size as usize).await?;
+                offset += s.consumed - before;
+                let (bkind, bdata): (Kind, Bytes) = if let Some((k, d)) = bases.get(&base_oid) {
+                    (*k, d.clone())
+                } else if let Some(obj) = resolver.resolve_base(&base_oid).await? {
+                    (obj.kind, obj.data.clone())
+                } else {
+                    return Err(CodecError::MissingDeltaBaseOid(base_oid));
+                };
+                let result = Bytes::from(apply_delta(&bdata, &delta)?);
+                let oid = crate::object::hash(bkind, &result);
+                by_offset.insert(entry_start, oid);
+                bases.insert(oid, (bkind, result.clone()));
+                emit_resolved_object(sink, large_threshold, oid, bkind, result).await?;
+            }
+            other => return Err(CodecError::BadPackType(other)),
+        }
+    }
+
+    let computed: [u8; 20] = s.hasher.clone().finalize().into();
+    let trailer = s.read_raw(20).await?;
+    if trailer != computed {
+        return Err(CodecError::PackChecksumMismatch);
+    }
+    Ok(Oid::from_array(computed))
+}
+
+async fn emit_resolved_object<S: AsyncPackSink>(
+    sink: &mut S,
+    large_threshold: u64,
+    oid: Oid,
+    kind: Kind,
+    data: Bytes,
+) -> Result<(), CodecError> {
+    if kind == Kind::Blob && data.len() as u64 >= large_threshold {
+        sink.large_blob_begin(data.len() as u64).await?;
+        sink.large_blob_data(&data).await?;
+        sink.large_blob_end().await?;
+    } else {
+        sink.object(oid, kind, data).await?;
+    }
+    Ok(())
+}
+
+async fn read_entry_header<Src: ByteSource>(
+    s: &mut AsyncHashingSource<Src>,
+) -> Result<(u8, u64, u64), CodecError> {
+    let c = s.read_byte().await?;
+    let ty = (c >> 4) & 0x07;
+    let mut size = (c & 0x0f) as u64;
+    let mut shift = 4u32;
+    let mut cont = c & 0x80 != 0;
+    let mut len = 1u64;
+    while cont {
+        let c = s.read_byte().await?;
+        len += 1;
+        size |= ((c & 0x7f) as u64) << shift;
+        shift += 7;
+        cont = c & 0x80 != 0;
+    }
+    Ok((ty, size, len))
+}
+
+async fn read_offset_varint<Src: ByteSource>(
+    s: &mut AsyncHashingSource<Src>,
+    offset: &mut u64,
+) -> Result<u64, CodecError> {
+    let mut c = s.read_byte().await?;
+    *offset += 1;
+    let mut off = (c & 0x7f) as u64;
+    while c & 0x80 != 0 {
+        c = s.read_byte().await?;
+        *offset += 1;
+        off = ((off + 1) << 7) | (c & 0x7f) as u64;
+    }
+    Ok(off)
+}
+
+// ── writer ───────────────────────────────────────────────────────────────────
+
+/// Streams a v2 packfile to an async [`ByteSink`], compressing each object as it goes and keeping
+/// the running trailer hash. Large blobs are pulled from a [`ChunkSource`] and compressed
+/// incrementally, so the response is produced without materializing the pack or any large object.
+pub struct AsyncPackWriter<S> {
+    sink: S,
+    hasher: Sha1,
+    remaining: u32,
+    /// zlib level for the objects written into this pack. A fetch builds an **ephemeral wire pack**
+    /// that is recompressed on every request and discarded, so it favors a fast level (deflate is the
+    /// single-stream throughput ceiling); stored packs that are written once and read many keep a
+    /// higher level.
+    level: Compression,
+    /// Output buffer: pack bytes accumulate here and flush to the sink in ~`BATCH`-sized pieces, so
+    /// downstream framing (e.g. side-band pkt-lines) carries useful payloads, not one per object.
+    buf: Vec<u8>,
+}
+
+impl<S: ByteSink> AsyncPackWriter<S> {
+    /// Flush threshold for the output batch buffer.
+    const BATCH: usize = 32 * 1024;
+
+    /// Begin a pack of `object_count` objects compressed at zlib `level` (0–9; buffers the 12-byte
+    /// header). Serving passes a low level for speed; storage passes a higher one for ratio.
+    pub async fn new(sink: S, object_count: u32, level: u32) -> Result<Self, CodecError> {
+        let mut w = AsyncPackWriter {
+            sink,
+            hasher: Sha1::new(),
+            remaining: object_count,
+            level: Compression::new(level.min(9)),
+            buf: Vec::with_capacity(Self::BATCH + 4096),
+        };
+        let mut header = Vec::with_capacity(12);
+        header.extend_from_slice(PACK_MAGIC);
+        header.extend_from_slice(&PACK_VERSION.to_be_bytes());
+        header.extend_from_slice(&object_count.to_be_bytes());
+        w.emit(&header).await?;
+        Ok(w)
+    }
+
+    /// Hash + buffer pack bytes, flushing to the sink when the batch fills.
+    async fn emit(&mut self, bytes: &[u8]) -> Result<(), CodecError> {
+        self.hasher.update(bytes);
+        self.buf.extend_from_slice(bytes);
+        if self.buf.len() >= Self::BATCH {
+            let batch = std::mem::take(&mut self.buf);
+            self.buf.reserve(Self::BATCH + 4096);
+            self.sink.send(Bytes::from(batch)).await.map_err(io_err)?;
+        }
+        Ok(())
+    }
+
+    /// Append a fully-in-memory object.
+    pub async fn write_object(&mut self, kind: Kind, data: &[u8]) -> Result<(), CodecError> {
+        let mut header = Vec::with_capacity(8);
+        write_entry_header(&mut header, kind.pack_type(), data.len() as u64);
+        self.emit(&header).await?;
+        let compressed = deflate(data, self.level)?;
+        self.emit(&compressed).await?;
+        self.remaining = self.remaining.saturating_sub(1);
+        Ok(())
+    }
+
+    /// Append a pre-built object frame (entry header + compressed body) produced by [`object_frame`].
+    /// The bytes are hashed and buffered exactly like a [`write_object`](Self::write_object) result,
+    /// so a caller can deflate many objects off-thread in parallel and feed the frames back **in pack
+    /// order** — moving the per-object CPU burst off the single async task and across cores.
+    pub async fn write_frame(&mut self, frame: &[u8]) -> Result<(), CodecError> {
+        self.emit(frame).await?;
+        self.remaining = self.remaining.saturating_sub(1);
+        Ok(())
+    }
+
+    /// Append raw pack bytes verbatim — already-compressed object entries copied from a stored pack
+    /// (its 12-byte header and 20-byte trailer stripped) — without re-deflating. The bytes are still
+    /// hashed into this pack's trailer. The caller must follow the span with [`mark_written`] to
+    /// account for the objects it contains. Used to splice a base pack's body into a larger pack so
+    /// the bulk of a clone is reused, not recompressed.
+    ///
+    /// [`mark_written`]: Self::mark_written
+    pub async fn write_raw(&mut self, bytes: &[u8]) -> Result<(), CodecError> {
+        self.emit(bytes).await
+    }
+
+    /// Account for `n` objects written via [`write_raw`](Self::write_raw) verbatim spans, so the
+    /// final object-count check in [`finish`](Self::finish) balances.
+    pub fn mark_written(&mut self, n: u32) {
+        self.remaining = self.remaining.saturating_sub(n);
+    }
+
+    /// Append a blob by streaming and compressing its `size` plaintext bytes pulled from `src`.
+    pub async fn write_blob_streaming<C: ChunkSource>(
+        &mut self,
+        size: u64,
+        mut src: C,
+    ) -> Result<(), CodecError> {
+        let mut header = Vec::with_capacity(8);
+        write_entry_header(&mut header, T_BLOB, size);
+        self.emit(&header).await?;
+
+        let mut comp = Compress::new(self.level, true);
+        let mut scratch = vec![0u8; 64 * 1024];
+        let mut plain = 0u64;
+        while let Some(chunk) = src.next().await? {
+            plain += chunk.len() as u64;
+            let mut in_off = 0;
+            while in_off < chunk.len() {
+                let (bi, bo) = (comp.total_in(), comp.total_out());
+                comp.compress(&chunk[in_off..], &mut scratch, FlushCompress::None)
+                    .map_err(|e| CodecError::Io(e.to_string()))?;
+                in_off += (comp.total_in() - bi) as usize;
+                let cout = (comp.total_out() - bo) as usize;
+                if cout > 0 {
+                    self.emit(&scratch[..cout]).await?;
+                }
+                if comp.total_in() - bi == 0 && cout == 0 {
+                    break;
+                }
+            }
+        }
+        // Flush the deflate stream.
+        loop {
+            let bo = comp.total_out();
+            let status = comp
+                .compress(&[], &mut scratch, FlushCompress::Finish)
+                .map_err(|e| CodecError::Io(e.to_string()))?;
+            let cout = (comp.total_out() - bo) as usize;
+            if cout > 0 {
+                self.emit(&scratch[..cout]).await?;
+            }
+            if status == Status::StreamEnd {
+                break;
+            }
+        }
+        if plain != size {
+            return Err(CodecError::Io(format!(
+                "blob stream produced {plain} bytes, declared {size}"
+            )));
+        }
+        self.remaining = self.remaining.saturating_sub(1);
+        Ok(())
+    }
+
+    /// Finish the pack: flush the buffer, send the SHA-1 trailer, and return the pack id.
+    pub async fn finish(mut self) -> Result<Oid, CodecError> {
+        if self.remaining != 0 {
+            return Err(CodecError::Io(format!(
+                "pack declared more objects than written ({} missing)",
+                self.remaining
+            )));
+        }
+        if !self.buf.is_empty() {
+            let batch = std::mem::take(&mut self.buf);
+            self.sink.send(Bytes::from(batch)).await.map_err(io_err)?;
+        }
+        let digest: [u8; 20] = self.hasher.finalize().into();
+        self.sink
+            .send(Bytes::copy_from_slice(&digest))
+            .await
+            .map_err(io_err)?;
+        Ok(Oid::from_array(digest))
+    }
+}
+
+/// Build one complete packfile object entry — varint type/size header followed by the zlib-deflated
+/// body — for a fully-in-memory object at zlib `level` (0–9). Pure and allocation-local, so frames
+/// can be produced concurrently off-thread and later written in order via
+/// [`AsyncPackWriter::write_frame`].
+pub fn object_frame(kind: Kind, data: &[u8], level: u32) -> Result<Vec<u8>, CodecError> {
+    let mut frame = Vec::with_capacity(8 + data.len() / 2 + 16);
+    write_entry_header(&mut frame, kind.pack_type(), data.len() as u64);
+    let compressed = deflate(data, Compression::new(level.min(9)))?;
+    frame.extend_from_slice(&compressed);
+    Ok(frame)
+}
+
+fn write_entry_header(out: &mut Vec<u8>, ty: u8, mut size: u64) {
+    let mut byte = (ty << 4) | (size as u8 & 0x0f);
+    size >>= 4;
+    while size != 0 {
+        out.push(byte | 0x80);
+        byte = (size & 0x7f) as u8;
+        size >>= 7;
+    }
+    out.push(byte);
+}
+
+fn deflate(data: &[u8], level: Compression) -> Result<Vec<u8>, CodecError> {
+    use std::io::Write;
+    let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), level);
+    enc.write_all(data)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    enc.finish().map_err(|e| CodecError::Io(e.to_string()))
+}
+
+fn io_err(e: io::Error) -> CodecError {
+    CodecError::Io(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{build_pack, parse_pack};
+
+    /// A `ByteSource` that hands out a buffer in fixed-size pieces.
+    struct VecSource {
+        data: Vec<u8>,
+        pos: usize,
+        step: usize,
+    }
+    impl ByteSource for VecSource {
+        async fn next(&mut self) -> io::Result<Option<Bytes>> {
+            if self.pos >= self.data.len() {
+                return Ok(None);
+            }
+            let end = (self.pos + self.step).min(self.data.len());
+            let b = Bytes::copy_from_slice(&self.data[self.pos..end]);
+            self.pos = end;
+            Ok(Some(b))
+        }
+    }
+
+    struct OneShot(Option<Bytes>);
+    impl ChunkSource for OneShot {
+        async fn next(&mut self) -> Result<Option<Bytes>, CodecError> {
+            Ok(self.0.take())
+        }
+    }
+
+    #[derive(Default)]
+    struct CollectSink {
+        objects: Vec<(Oid, Kind, Vec<u8>)>,
+        large: Vec<(Oid, Vec<u8>)>,
+        cur: Vec<u8>,
+        cur_size: u64,
+    }
+    impl AsyncPackSink for CollectSink {
+        async fn object(&mut self, oid: Oid, kind: Kind, data: Bytes) -> Result<(), CodecError> {
+            self.objects.push((oid, kind, data.to_vec()));
+            Ok(())
+        }
+        async fn large_blob_begin(&mut self, size: u64) -> Result<(), CodecError> {
+            self.cur = Vec::new();
+            self.cur_size = size;
+            Ok(())
+        }
+        async fn large_blob_data(&mut self, data: &[u8]) -> Result<(), CodecError> {
+            self.cur.extend_from_slice(data);
+            Ok(())
+        }
+        async fn large_blob_end(&mut self) -> Result<(), CodecError> {
+            assert_eq!(self.cur.len() as u64, self.cur_size);
+            let oid = crate::object::hash(Kind::Blob, &self.cur);
+            self.large.push((oid, std::mem::take(&mut self.cur)));
+            Ok(())
+        }
+    }
+
+    fn sample() -> Vec<Object> {
+        vec![
+            Object::new(Kind::Blob, &b"hello async\n"[..]),
+            Object::new(
+                Kind::Commit,
+                &b"tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n"[..],
+            ),
+            Object::new(Kind::Blob, vec![0x33u8; 250_000]),
+            Object::new(Kind::Tree, &b""[..]),
+        ]
+    }
+
+    #[test]
+    fn async_parse_matches_build_pack() {
+        let objects = sample();
+        let built = build_pack(&objects).unwrap();
+        let mut sink = CollectSink::default();
+        let id = futures::executor::block_on(parse_pack_streaming_async(
+            VecSource {
+                data: built.data.clone(),
+                pos: 0,
+                step: 1000,
+            },
+            u64::MAX,
+            &mut NoBases,
+            &mut sink,
+        ))
+        .unwrap();
+        assert_eq!(id, built.pack_hash);
+        assert_eq!(sink.objects.len(), objects.len());
+        for (orig, (oid, kind, data)) in objects.iter().zip(&sink.objects) {
+            assert_eq!(*oid, orig.id());
+            assert_eq!(*kind, orig.kind);
+            assert_eq!(data.as_slice(), orig.data.as_ref());
+        }
+    }
+
+    #[test]
+    fn async_parse_streams_large_blobs() {
+        let objects = sample();
+        let built = build_pack(&objects).unwrap();
+        let mut sink = CollectSink::default();
+        // Odd-sized input pieces + a low threshold to route the 250k blob through the stream path.
+        futures::executor::block_on(parse_pack_streaming_async(
+            VecSource {
+                data: built.data,
+                pos: 0,
+                step: 333,
+            },
+            100_000,
+            &mut NoBases,
+            &mut sink,
+        ))
+        .unwrap();
+        assert_eq!(sink.large.len(), 1);
+        assert_eq!(sink.large[0].0, objects[2].id());
+        assert_eq!(sink.objects.len(), 3);
+    }
+
+    /// A `Send` sink that appends to a shared buffer (so we can read it back after the writer moves
+    /// it in).
+    #[derive(Clone)]
+    struct SharedSink(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+    impl ByteSink for SharedSink {
+        async fn send(&mut self, bytes: Bytes) -> io::Result<()> {
+            self.0.lock().unwrap().extend_from_slice(&bytes);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_frame_matches_write_object_byte_for_byte() {
+        // The parallel-compression path (object_frame + write_frame) must produce exactly the same
+        // pack bytes — including the trailer hash — as the serial write_object path.
+        let objs = sample();
+        let serial = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let framed = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        futures::executor::block_on(async {
+            let mut w = AsyncPackWriter::new(SharedSink(serial.clone()), objs.len() as u32, 6)
+                .await
+                .unwrap();
+            for o in &objs {
+                w.write_object(o.kind, &o.data).await.unwrap();
+            }
+            w.finish().await.unwrap();
+
+            let mut w = AsyncPackWriter::new(SharedSink(framed.clone()), objs.len() as u32, 6)
+                .await
+                .unwrap();
+            for o in &objs {
+                let frame = object_frame(o.kind, &o.data, 6).unwrap();
+                w.write_frame(&frame).await.unwrap();
+            }
+            w.finish().await.unwrap();
+        });
+        assert_eq!(*serial.lock().unwrap(), *framed.lock().unwrap());
+    }
+
+    #[test]
+    fn async_writer_roundtrips_through_parser() {
+        let big = vec![0x9eu8; 300_000];
+        let out = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        futures::executor::block_on(async {
+            let mut w = AsyncPackWriter::new(SharedSink(out.clone()), 2, 6)
+                .await
+                .unwrap();
+            w.write_object(Kind::Blob, b"a small object\n")
+                .await
+                .unwrap();
+            w.write_blob_streaming(big.len() as u64, OneShot(Some(Bytes::from(big.clone()))))
+                .await
+                .unwrap();
+            w.finish().await.unwrap();
+        });
+
+        let packed = out.lock().unwrap().clone();
+        let parsed = parse_pack(&packed, |_| None).unwrap();
+        assert_eq!(parsed.objects.len(), 2);
+        assert_eq!(parsed.objects[0].1.data.as_ref(), b"a small object\n");
+        assert_eq!(parsed.objects[1].1.data.as_ref(), big.as_slice());
+    }
+}

--- a/crates/gsvc-codec/src/bitmap.rs
+++ b/crates/gsvc-codec/src/bitmap.rs
@@ -1,0 +1,273 @@
+//! Reachability bitmaps (design §7, §14.2) — the structure that makes clone/fetch fast.
+//!
+//! Walking the object graph to answer "what objects are reachable from these wants but not these
+//! haves?" is `O(history)`. A reachability bitmap precomputes, for a chosen commit, the set of all
+//! objects reachable from it as a bitset over object **positions**, so the same query becomes a few
+//! bitwise `OR` / `AND-NOT` passes over machine words — independent of history depth.
+//!
+//! Position space (we own both writer and reader, so this is our own layout, not git's `.bitmap`):
+//! * positions `0..P` are the objects of a packfile, in its index's **sorted-oid order** (so a
+//!   position maps to an oid via [`IdxV2::oid_at_position`](crate::IdxV2::oid_at_position));
+//! * positions `P..P+L` are **large blobs** referenced by the history but stored globally (outside
+//!   the pack), listed explicitly in [`PackBitmaps::large_blobs`].
+//!
+//! [`PackBitmaps`] stores one [`Bitmap`] per selected commit (the ref tips). Generation walks the
+//! graph once per tip at compaction time (off the hot path); serving then needs no walk at all.
+
+use crate::{CodecError, Oid};
+
+const BITMAP_MAGIC: &[u8; 4] = b"GBMP";
+const BITMAP_VERSION: u32 = 1;
+
+/// A growable bitset over object positions, stored as 64-bit words (little-endian on disk).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Bitmap {
+    words: Vec<u64>,
+}
+
+impl Bitmap {
+    /// An empty bitmap sized to hold at least `nbits` bits (it also grows on demand via [`set`]).
+    pub fn with_capacity(nbits: usize) -> Bitmap {
+        Bitmap {
+            words: vec![0u64; nbits.div_ceil(64)],
+        }
+    }
+
+    /// Set bit `i`, growing the backing store if needed.
+    pub fn set(&mut self, i: usize) {
+        let w = i / 64;
+        if w >= self.words.len() {
+            self.words.resize(w + 1, 0);
+        }
+        self.words[w] |= 1u64 << (i % 64);
+    }
+
+    /// Whether bit `i` is set.
+    pub fn get(&self, i: usize) -> bool {
+        let w = i / 64;
+        w < self.words.len() && (self.words[w] >> (i % 64)) & 1 == 1
+    }
+
+    /// `self |= other` (union).
+    pub fn or_assign(&mut self, other: &Bitmap) {
+        if other.words.len() > self.words.len() {
+            self.words.resize(other.words.len(), 0);
+        }
+        for (a, b) in self.words.iter_mut().zip(&other.words) {
+            *a |= *b;
+        }
+    }
+
+    /// `self &= !other` (set difference — remove everything in `other`).
+    pub fn andnot_assign(&mut self, other: &Bitmap) {
+        for (a, b) in self.words.iter_mut().zip(&other.words) {
+            *a &= !*b;
+        }
+    }
+
+    /// Number of set bits.
+    pub fn count_ones(&self) -> usize {
+        self.words.iter().map(|w| w.count_ones() as usize).sum()
+    }
+
+    /// Iterate the positions of all set bits, ascending.
+    pub fn iter_ones(&self) -> impl Iterator<Item = usize> + '_ {
+        self.words.iter().enumerate().flat_map(|(wi, &word)| {
+            let base = wi * 64;
+            BitIter { word, base }
+        })
+    }
+}
+
+/// Iterates set bits of one word by repeatedly clearing the lowest set bit.
+struct BitIter {
+    word: u64,
+    base: usize,
+}
+
+impl Iterator for BitIter {
+    type Item = usize;
+    fn next(&mut self) -> Option<usize> {
+        if self.word == 0 {
+            return None;
+        }
+        let tz = self.word.trailing_zeros() as usize;
+        self.word &= self.word - 1; // clear lowest set bit
+        Some(self.base + tz)
+    }
+}
+
+/// A set of reachability bitmaps for one packfile: the large-blob position table plus one bitmap
+/// per selected tip commit. Serialized (zlib-compressed) alongside the pack as its `.bitmap`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PackBitmaps {
+    /// Number of objects in the pack (positions `0..pack_object_count`).
+    pub pack_object_count: u32,
+    /// Large blobs referenced by the history but stored outside the pack (positions
+    /// `pack_object_count..pack_object_count + large_blobs.len()`).
+    pub large_blobs: Vec<Oid>,
+    /// One reachability bitmap per **selected commit**, keyed by oid. The selection is the ref tips
+    /// plus sampled interior commits (merges and a periodic sample), so fetch/clone negotiation
+    /// points usually land on a commit that already has a bitmap.
+    pub commits: Vec<(Oid, Bitmap)>,
+}
+
+impl PackBitmaps {
+    /// Total number of positions covered (pack objects + large blobs).
+    pub fn total_positions(&self) -> usize {
+        self.pack_object_count as usize + self.large_blobs.len()
+    }
+
+    /// The reachability bitmap for commit `oid`, if one was selected for it.
+    pub fn bitmap_for(&self, oid: &Oid) -> Option<&Bitmap> {
+        self.commits.iter().find(|(o, _)| o == oid).map(|(_, b)| b)
+    }
+
+    /// The oid at `position`: a pack object (resolved via `idx`) for low positions, or a large blob
+    /// for high ones. `None` if out of range.
+    pub fn oid_at(&self, position: usize, idx: &crate::IdxV2) -> Option<Oid> {
+        let p = self.pack_object_count as usize;
+        if position < p {
+            Some(idx.oid_at_position(position))
+        } else {
+            self.large_blobs.get(position - p).copied()
+        }
+    }
+
+    /// Serialize to a compact, zlib-compressed byte blob.
+    pub fn encode(&self) -> Result<Vec<u8>, CodecError> {
+        use std::io::Write;
+        let mut raw = Vec::new();
+        raw.extend_from_slice(BITMAP_MAGIC);
+        raw.extend_from_slice(&BITMAP_VERSION.to_be_bytes());
+        raw.extend_from_slice(&self.pack_object_count.to_be_bytes());
+        raw.extend_from_slice(&(self.large_blobs.len() as u32).to_be_bytes());
+        for oid in &self.large_blobs {
+            raw.extend_from_slice(oid.as_bytes());
+        }
+        raw.extend_from_slice(&(self.commits.len() as u32).to_be_bytes());
+        for (oid, bm) in &self.commits {
+            raw.extend_from_slice(oid.as_bytes());
+            raw.extend_from_slice(&(bm.words.len() as u32).to_be_bytes());
+            for w in &bm.words {
+                raw.extend_from_slice(&w.to_le_bytes());
+            }
+        }
+        let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        enc.write_all(&raw)
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        enc.finish().map_err(|e| CodecError::Io(e.to_string()))
+    }
+
+    /// Parse a blob produced by [`encode`](Self::encode).
+    pub fn decode(bytes: &[u8]) -> Result<PackBitmaps, CodecError> {
+        use std::io::Read;
+        let mut raw = Vec::new();
+        flate2::read::ZlibDecoder::new(bytes)
+            .read_to_end(&mut raw)
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+
+        let mut r = Cursor { buf: &raw, pos: 0 };
+        if r.take(4)? != BITMAP_MAGIC {
+            return Err(CodecError::BadObject("bad bitmap magic".into()));
+        }
+        let version = u32::from_be_bytes(r.take(4)?.try_into().unwrap());
+        if version != BITMAP_VERSION {
+            return Err(CodecError::BadObject(format!("bitmap version {version}")));
+        }
+        let pack_object_count = u32::from_be_bytes(r.take(4)?.try_into().unwrap());
+        let l = u32::from_be_bytes(r.take(4)?.try_into().unwrap()) as usize;
+        let mut large_blobs = Vec::with_capacity(l);
+        for _ in 0..l {
+            large_blobs.push(Oid::from_bytes(r.take(20)?)?);
+        }
+        let t = u32::from_be_bytes(r.take(4)?.try_into().unwrap()) as usize;
+        let mut commits = Vec::with_capacity(t);
+        for _ in 0..t {
+            let oid = Oid::from_bytes(r.take(20)?)?;
+            let nwords = u32::from_be_bytes(r.take(4)?.try_into().unwrap()) as usize;
+            let mut words = Vec::with_capacity(nwords);
+            for _ in 0..nwords {
+                words.push(u64::from_le_bytes(r.take(8)?.try_into().unwrap()));
+            }
+            commits.push((oid, Bitmap { words }));
+        }
+        Ok(PackBitmaps {
+            pack_object_count,
+            large_blobs,
+            commits,
+        })
+    }
+}
+
+/// Minimal forward byte cursor for decoding.
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn take(&mut self, n: usize) -> Result<&'a [u8], CodecError> {
+        let s = self
+            .buf
+            .get(self.pos..self.pos + n)
+            .ok_or_else(|| CodecError::BadObject("truncated bitmap".into()))?;
+        self.pos += n;
+        Ok(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn oid(b: u8) -> Oid {
+        Oid::from_array([b; 20])
+    }
+
+    #[test]
+    fn bitmap_set_get_and_ops() {
+        let mut a = Bitmap::with_capacity(10);
+        a.set(1);
+        a.set(64);
+        a.set(200);
+        assert!(a.get(1) && a.get(64) && a.get(200));
+        assert!(!a.get(2));
+        assert_eq!(a.count_ones(), 3);
+        assert_eq!(a.iter_ones().collect::<Vec<_>>(), vec![1, 64, 200]);
+
+        let mut b = Bitmap::with_capacity(10);
+        b.set(64);
+        b.set(5);
+
+        let mut u = a.clone();
+        u.or_assign(&b);
+        assert_eq!(u.iter_ones().collect::<Vec<_>>(), vec![1, 5, 64, 200]);
+
+        let mut d = a.clone();
+        d.andnot_assign(&b); // remove 64
+        assert_eq!(d.iter_ones().collect::<Vec<_>>(), vec![1, 200]);
+    }
+
+    #[test]
+    fn pack_bitmaps_roundtrip() {
+        let mut bm0 = Bitmap::with_capacity(5);
+        bm0.set(0);
+        bm0.set(3);
+        let mut bm1 = Bitmap::with_capacity(5);
+        bm1.set(1);
+        bm1.set(4); // a large-blob position (pack_object_count = 4 → position 4 is large_blobs[0])
+
+        let pb = PackBitmaps {
+            pack_object_count: 4,
+            large_blobs: vec![oid(0xaa)],
+            commits: vec![(oid(0x01), bm0), (oid(0x02), bm1)],
+        };
+        let encoded = pb.encode().unwrap();
+        let decoded = PackBitmaps::decode(&encoded).unwrap();
+        assert_eq!(decoded, pb);
+        assert_eq!(decoded.total_positions(), 5);
+        assert!(decoded.bitmap_for(&oid(0x01)).unwrap().get(3));
+        assert_eq!(decoded.large_blobs[0], oid(0xaa));
+    }
+}

--- a/crates/gsvc-codec/src/chunkloc.rs
+++ b/crates/gsvc-codec/src/chunkloc.rs
@@ -1,0 +1,30 @@
+//! [`ChunkLoc`] — where a content-addressed chunk physically lives.
+//!
+//! Defined here in the codec (the crate both `gsvc-store` and `gsvc-meta` depend on) so there is a
+//! single shared type rather than two identical structs across the storage/metadata boundary.
+
+use serde::{Deserialize, Serialize};
+
+/// The storage location of a CDC chunk: the **zstd-compressed** chunk bytes occupy
+/// `[offset, offset+length)` inside the chunk pack `chunkpacks/<pack_id>`.
+///
+/// Chunks are always zstd-compressed (zstd stores incompressible data as near-raw blocks, so there
+/// is no expansion to guard against — no raw/compressed branch). `length` is the **compressed**
+/// length. The content address (the chunk's `ChunkHash`) is taken over the **uncompressed** bytes,
+/// so compression never affects dedup.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChunkLoc {
+    /// Content-addressed id of the chunk pack holding this chunk.
+    pub pack_id: String,
+    /// Byte offset of the compressed chunk bytes within that pack.
+    pub offset: u64,
+    /// Length in bytes of the stored (compressed) representation.
+    pub length: u32,
+}
+
+impl ChunkLoc {
+    /// The byte range of this chunk within its pack.
+    pub fn range(&self) -> std::ops::Range<u64> {
+        self.offset..self.offset + self.length as u64
+    }
+}

--- a/crates/gsvc-codec/src/commitgraph.rs
+++ b/crates/gsvc-codec/src/commitgraph.rs
@@ -1,0 +1,312 @@
+//! Commit-graph with generation numbers (design §7) — accelerates reachability without parsing
+//! commits.
+//!
+//! A reachability walk normally parses each commit object to find its parents. A commit-graph
+//! precomputes, per commit, its **parents** and its **generation number** — `gen(c) = 1 +
+//! max(gen(parent))`, with parentless commits at generation 1. Generation numbers give a cheap
+//! reachability cutoff: every commit reachable from `c` has generation `≤ gen(c)`, so when walking
+//! down from a set of tips to decide whether they reach a target `t`, any commit with generation
+//! `< gen(t)` can be skipped — it cannot be `t` nor reach it. The graph is generated at compaction
+//! time (off the hot path) and stored alongside the pack as its `.graph`.
+
+use std::collections::HashMap;
+
+use crate::{CodecError, Oid};
+
+const GRAPH_MAGIC: &[u8; 4] = b"GCGF";
+const GRAPH_VERSION: u32 = 1;
+
+/// One commit's node: its root tree, parents, and generation number. Storing the root tree lets a
+/// reachability walk descend into a commit's content (its tree) without inflating the commit object.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommitNode {
+    pub oid: Oid,
+    pub generation: u32,
+    pub root_tree: Oid,
+    pub parents: Vec<Oid>,
+}
+
+/// A commit-graph: the parents + generation number of every commit in a pack. Entries are kept
+/// sorted by oid for a compact, deterministic encoding; an index supports O(1) lookup.
+#[derive(Clone, Debug, Default)]
+pub struct CommitGraph {
+    entries: Vec<CommitNode>,
+    index: HashMap<Oid, usize>,
+}
+
+impl PartialEq for CommitGraph {
+    fn eq(&self, other: &Self) -> bool {
+        self.entries == other.entries
+    }
+}
+impl Eq for CommitGraph {}
+
+impl CommitGraph {
+    /// Build a commit-graph from a `commit oid -> (root tree, parent oids)` map. Generation numbers
+    /// are computed iteratively (no recursion, so arbitrarily deep histories are safe); a parent
+    /// absent from the map (e.g. a boundary/shallow commit) contributes generation 0.
+    pub fn build(commits: &HashMap<Oid, (Oid, Vec<Oid>)>) -> CommitGraph {
+        let mut generation: HashMap<Oid, u32> = HashMap::with_capacity(commits.len());
+        // Iterative post-order: for each commit, resolve all in-graph parents' generations first.
+        let mut stack: Vec<Oid> = commits.keys().copied().collect();
+        let mut on_path: std::collections::HashSet<Oid> = std::collections::HashSet::new();
+        while let Some(oid) = stack.last().copied() {
+            if generation.contains_key(&oid) {
+                stack.pop();
+                continue;
+            }
+            let parents = match commits.get(&oid) {
+                Some((_, p)) => p,
+                None => {
+                    // Not actually a graph commit (shouldn't happen for a stack seeded from keys).
+                    stack.pop();
+                    continue;
+                }
+            };
+            // Find an in-graph parent whose generation isn't known yet; resolve it first.
+            let mut pending: Option<Oid> = None;
+            for p in parents {
+                if commits.contains_key(p) && !generation.contains_key(p) && !on_path.contains(p) {
+                    pending = Some(*p);
+                    break;
+                }
+            }
+            match pending {
+                Some(p) => {
+                    on_path.insert(oid);
+                    stack.push(p);
+                }
+                None => {
+                    // All in-graph parents resolved (or cyclic/boundary): gen = 1 + max(parent gen).
+                    let g = parents
+                        .iter()
+                        .map(|p| generation.get(p).copied().unwrap_or(0))
+                        .max()
+                        .unwrap_or(0)
+                        + 1;
+                    generation.insert(oid, g);
+                    on_path.remove(&oid);
+                    stack.pop();
+                }
+            }
+        }
+
+        let mut entries: Vec<CommitNode> = commits
+            .iter()
+            .map(|(oid, (root_tree, parents))| CommitNode {
+                oid: *oid,
+                generation: generation.get(oid).copied().unwrap_or(1),
+                root_tree: *root_tree,
+                parents: parents.clone(),
+            })
+            .collect();
+        entries.sort_by(|a, b| a.oid.as_bytes().cmp(b.oid.as_bytes()));
+        let index = entries
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.oid, i))
+            .collect();
+        CommitGraph { entries, index }
+    }
+
+    /// Number of commits in the graph.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the graph holds no commits.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Whether `oid` is a commit in this graph.
+    pub fn contains(&self, oid: &Oid) -> bool {
+        self.index.contains_key(oid)
+    }
+
+    /// The generation number of `oid`, or `None` if it isn't in the graph.
+    pub fn generation(&self, oid: &Oid) -> Option<u32> {
+        self.index.get(oid).map(|&i| self.entries[i].generation)
+    }
+
+    /// The parents of `oid`, or `None` if it isn't in the graph.
+    pub fn parents(&self, oid: &Oid) -> Option<&[Oid]> {
+        self.index
+            .get(oid)
+            .map(|&i| self.entries[i].parents.as_slice())
+    }
+
+    /// The root tree of commit `oid`, or `None` if it isn't in the graph.
+    pub fn root_tree(&self, oid: &Oid) -> Option<Oid> {
+        self.index.get(oid).map(|&i| self.entries[i].root_tree)
+    }
+
+    /// All nodes, sorted by oid.
+    pub fn nodes(&self) -> &[CommitNode] {
+        &self.entries
+    }
+
+    /// Serialize to a compact, zlib-compressed byte blob (stored as the pack's `.graph`).
+    pub fn encode(&self) -> Result<Vec<u8>, CodecError> {
+        use std::io::Write;
+        let mut raw = Vec::new();
+        raw.extend_from_slice(GRAPH_MAGIC);
+        raw.extend_from_slice(&GRAPH_VERSION.to_be_bytes());
+        raw.extend_from_slice(&(self.entries.len() as u32).to_be_bytes());
+        for n in &self.entries {
+            raw.extend_from_slice(n.oid.as_bytes());
+            raw.extend_from_slice(&n.generation.to_be_bytes());
+            raw.extend_from_slice(n.root_tree.as_bytes());
+            raw.extend_from_slice(&(n.parents.len() as u16).to_be_bytes());
+            for p in &n.parents {
+                raw.extend_from_slice(p.as_bytes());
+            }
+        }
+        let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        enc.write_all(&raw)
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        enc.finish().map_err(|e| CodecError::Io(e.to_string()))
+    }
+
+    /// Parse a blob produced by [`encode`](Self::encode).
+    pub fn decode(bytes: &[u8]) -> Result<CommitGraph, CodecError> {
+        use std::io::Read;
+        let mut raw = Vec::new();
+        flate2::read::ZlibDecoder::new(bytes)
+            .read_to_end(&mut raw)
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+
+        let mut r = GraphCursor { buf: &raw, pos: 0 };
+        if r.take(4)? != GRAPH_MAGIC {
+            return Err(CodecError::BadObject("bad commit-graph magic".into()));
+        }
+        let version = u32::from_be_bytes(r.take(4)?.try_into().unwrap());
+        if version != GRAPH_VERSION {
+            return Err(CodecError::BadObject(format!(
+                "commit-graph version {version}"
+            )));
+        }
+        let count = u32::from_be_bytes(r.take(4)?.try_into().unwrap()) as usize;
+        let mut entries = Vec::with_capacity(count);
+        for _ in 0..count {
+            let oid = Oid::from_bytes(r.take(20)?)?;
+            let generation = u32::from_be_bytes(r.take(4)?.try_into().unwrap());
+            let root_tree = Oid::from_bytes(r.take(20)?)?;
+            let np = u16::from_be_bytes(r.take(2)?.try_into().unwrap()) as usize;
+            let mut parents = Vec::with_capacity(np);
+            for _ in 0..np {
+                parents.push(Oid::from_bytes(r.take(20)?)?);
+            }
+            entries.push(CommitNode {
+                oid,
+                generation,
+                root_tree,
+                parents,
+            });
+        }
+        let index = entries
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (n.oid, i))
+            .collect();
+        Ok(CommitGraph { entries, index })
+    }
+}
+
+struct GraphCursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> GraphCursor<'a> {
+    fn take(&mut self, n: usize) -> Result<&'a [u8], CodecError> {
+        let s = self
+            .buf
+            .get(self.pos..self.pos + n)
+            .ok_or_else(|| CodecError::BadObject("truncated commit-graph".into()))?;
+        self.pos += n;
+        Ok(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn oid(b: u8) -> Oid {
+        Oid::from_array([b; 20])
+    }
+
+    // A distinct dummy root-tree oid per commit (its value is irrelevant to generation numbers).
+    fn tree(b: u8) -> Oid {
+        Oid::from_array([0x80 | b; 20])
+    }
+
+    #[test]
+    fn generations_follow_longest_path() {
+        // c0 ← c1 ← c2, and a side branch c0 ← c3, merge c4 = {c2, c3}.
+        let (c0, c1, c2, c3, c4) = (oid(0), oid(1), oid(2), oid(3), oid(4));
+        let mut m = HashMap::new();
+        m.insert(c0, (tree(0), vec![]));
+        m.insert(c1, (tree(1), vec![c0]));
+        m.insert(c2, (tree(2), vec![c1]));
+        m.insert(c3, (tree(3), vec![c0]));
+        m.insert(c4, (tree(4), vec![c2, c3]));
+        let g = CommitGraph::build(&m);
+        assert_eq!(g.generation(&c0), Some(1));
+        assert_eq!(g.generation(&c1), Some(2));
+        assert_eq!(g.generation(&c2), Some(3));
+        assert_eq!(g.generation(&c3), Some(2));
+        // Merge generation = 1 + max(gen(c2)=3, gen(c3)=2) = 4.
+        assert_eq!(g.generation(&c4), Some(4));
+        assert_eq!(g.parents(&c4).unwrap(), &[c2, c3]);
+        assert_eq!(g.root_tree(&c2), Some(tree(2)));
+        assert!(g.contains(&c1));
+        assert!(!g.contains(&oid(9)));
+    }
+
+    #[test]
+    fn boundary_parents_count_as_zero() {
+        // c1's parent c0 is NOT in the graph (a boundary/shallow commit).
+        let (c0, c1) = (oid(10), oid(11));
+        let mut m = HashMap::new();
+        m.insert(c1, (tree(11), vec![c0]));
+        let g = CommitGraph::build(&m);
+        assert_eq!(g.generation(&c1), Some(1)); // 1 + max(0) = 1
+        assert!(!g.contains(&c0));
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let (c0, c1, c2) = (oid(1), oid(2), oid(3));
+        let mut m = HashMap::new();
+        m.insert(c0, (tree(1), vec![]));
+        m.insert(c1, (tree(2), vec![c0]));
+        m.insert(c2, (tree(3), vec![c1, c0]));
+        let g = CommitGraph::build(&m);
+        let bytes = g.encode().unwrap();
+        let g2 = CommitGraph::decode(&bytes).unwrap();
+        assert_eq!(g, g2);
+        assert_eq!(g2.generation(&c2), Some(3));
+        assert_eq!(g2.root_tree(&c2), Some(tree(3)));
+        assert_eq!(g2.parents(&c2).unwrap(), &[c1, c0]);
+    }
+
+    #[test]
+    fn deep_linear_history_does_not_overflow() {
+        // A long chain would blow a recursive implementation's stack; the iterative build must not.
+        let mut m = HashMap::new();
+        let mut prev: Option<Oid> = None;
+        let mut last = oid(0);
+        for i in 0..20_000u32 {
+            let mut b = [0u8; 20];
+            b[0..4].copy_from_slice(&i.to_be_bytes());
+            let o = Oid::from_array(b);
+            m.insert(o, (tree(0), prev.into_iter().collect()));
+            prev = Some(o);
+            last = o;
+        }
+        let g = CommitGraph::build(&m);
+        assert_eq!(g.generation(&last), Some(20_000));
+    }
+}

--- a/crates/gsvc-codec/src/delta.rs
+++ b/crates/gsvc-codec/src/delta.rs
@@ -1,0 +1,369 @@
+//! Git delta encoding/decoding (the copy/insert instruction stream used by `OFS_DELTA` and
+//! `REF_DELTA` packfile entries).
+
+use crate::CodecError;
+
+/// Read a little-endian base-128 varint (git's "size" encoding) from `buf` at `*pos`.
+pub(crate) fn read_size_varint(buf: &[u8], pos: &mut usize) -> Result<u64, CodecError> {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+        let c = *buf.get(*pos).ok_or(CodecError::TruncatedDelta)?;
+        *pos += 1;
+        result |= ((c & 0x7f) as u64) << shift;
+        if c & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(CodecError::TruncatedDelta);
+        }
+    }
+    Ok(result)
+}
+
+/// Apply a git delta stream to `base`, producing the target object bytes.
+///
+/// The stream begins with the (varint) source and target sizes, followed by a sequence of
+/// copy (high bit set) and insert (high bit clear) instructions.
+pub fn apply_delta(base: &[u8], delta: &[u8]) -> Result<Vec<u8>, CodecError> {
+    let mut pos = 0usize;
+
+    let src_size = read_size_varint(delta, &mut pos)?;
+    if src_size as usize != base.len() {
+        return Err(CodecError::DeltaBaseSizeMismatch {
+            expected: src_size,
+            actual: base.len() as u64,
+        });
+    }
+    let tgt_size = read_size_varint(delta, &mut pos)? as usize;
+    let mut out = Vec::with_capacity(tgt_size);
+
+    while pos < delta.len() {
+        let op = delta[pos];
+        pos += 1;
+        if op & 0x80 != 0 {
+            // Copy from base: variable offset (4 optional bytes) and size (3 optional bytes).
+            let mut cp_off: u64 = 0;
+            let mut cp_size: u64 = 0;
+            for (i, mask) in [0x01u8, 0x02, 0x04, 0x08].into_iter().enumerate() {
+                if op & mask != 0 {
+                    cp_off |=
+                        (*delta.get(pos).ok_or(CodecError::TruncatedDelta)? as u64) << (8 * i);
+                    pos += 1;
+                }
+            }
+            for (i, mask) in [0x10u8, 0x20, 0x40].into_iter().enumerate() {
+                if op & mask != 0 {
+                    cp_size |=
+                        (*delta.get(pos).ok_or(CodecError::TruncatedDelta)? as u64) << (8 * i);
+                    pos += 1;
+                }
+            }
+            if cp_size == 0 {
+                cp_size = 0x10000;
+            }
+            let start = cp_off as usize;
+            let end = start
+                .checked_add(cp_size as usize)
+                .ok_or(CodecError::TruncatedDelta)?;
+            let slice = base
+                .get(start..end)
+                .ok_or(CodecError::DeltaCopyOutOfRange {
+                    start: start as u64,
+                    end: end as u64,
+                    base_len: base.len() as u64,
+                })?;
+            out.extend_from_slice(slice);
+        } else if op != 0 {
+            // Insert: the opcode byte itself is the literal length.
+            let len = op as usize;
+            let end = pos.checked_add(len).ok_or(CodecError::TruncatedDelta)?;
+            let slice = delta.get(pos..end).ok_or(CodecError::TruncatedDelta)?;
+            out.extend_from_slice(slice);
+            pos = end;
+        } else {
+            // 0x00 is reserved and must not appear.
+            return Err(CodecError::ReservedDeltaOpcode);
+        }
+    }
+
+    if out.len() != tgt_size {
+        return Err(CodecError::DeltaTargetSizeMismatch {
+            expected: tgt_size as u64,
+            actual: out.len() as u64,
+        });
+    }
+    Ok(out)
+}
+
+/// Produce a (non-optimized) delta encoding the transformation from `base` to `target`.
+///
+/// This emits the two size headers followed by a single insert of the whole target — i.e. a
+/// valid, decodable delta that performs no copies. It exists so we can round-trip the
+/// decoder/encoder and exercise `REF_DELTA`/`OFS_DELTA` write paths in tests; the production
+/// delta-compressor (window matching) is a separate optimization.
+pub fn encode_trivial_delta(base: &[u8], target: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_size_varint(&mut out, base.len() as u64);
+    write_size_varint(&mut out, target.len() as u64);
+    // Insert ops carry at most 127 bytes each.
+    for chunk in target.chunks(0x7f) {
+        out.push(chunk.len() as u8);
+        out.extend_from_slice(chunk);
+    }
+    out
+}
+
+/// Block size that must match to start a copy. Bigger → fewer/cheaper index entries but misses
+/// short common runs; 16 mirrors git's diff-delta granularity.
+const DELTA_BLOCK: usize = 16;
+/// Cap on candidate base positions examined per block hash (bounds worst-case time).
+const DELTA_MAX_CANDIDATES: usize = 8;
+
+/// A precomputed content-block index of a base object, reusable across many targets.
+///
+/// Building the index is the expensive part of delta encoding, so the pack repacker indexes each
+/// candidate base **once** and encodes every object in its delta window against the cached index —
+/// instead of rebuilding the base index per (base, target) pair (which was the dominant compaction
+/// cost). Hash matches are byte-verified, so collisions only cost a missed copy, never corruption.
+pub struct DeltaIndex {
+    base: Vec<u8>,
+    /// block content hash → base offsets (earliest first, so copies prefer small offsets).
+    index: std::collections::HashMap<u64, Vec<u32>>,
+}
+
+impl DeltaIndex {
+    /// Index every `DELTA_BLOCK`-byte window of `base`.
+    pub fn build(base: &[u8]) -> DeltaIndex {
+        let mut index: std::collections::HashMap<u64, Vec<u32>> = std::collections::HashMap::new();
+        if base.len() >= DELTA_BLOCK {
+            for i in 0..=base.len() - DELTA_BLOCK {
+                index
+                    .entry(block_hash(&base[i..i + DELTA_BLOCK]))
+                    .or_default()
+                    .push(i as u32);
+            }
+        }
+        DeltaIndex {
+            base: base.to_vec(),
+            index,
+        }
+    }
+
+    /// Length of the indexed base.
+    pub fn base_len(&self) -> usize {
+        self.base.len()
+    }
+
+    /// Encode the delta transforming this index's base into `target`.
+    pub fn encode(&self, target: &[u8]) -> Vec<u8> {
+        let base = &self.base;
+        let mut out = Vec::new();
+        write_size_varint(&mut out, base.len() as u64);
+        write_size_varint(&mut out, target.len() as u64);
+
+        let mut pending: Vec<u8> = Vec::new();
+        let mut t = 0usize;
+        while t < target.len() {
+            let mut best_len = 0usize;
+            let mut best_off = 0usize;
+            if t + DELTA_BLOCK <= target.len() {
+                if let Some(cands) = self.index.get(&block_hash(&target[t..t + DELTA_BLOCK])) {
+                    for &b in cands.iter().take(DELTA_MAX_CANDIDATES) {
+                        let b = b as usize;
+                        if base[b..b + DELTA_BLOCK] != target[t..t + DELTA_BLOCK] {
+                            continue; // hash collision
+                        }
+                        let mut len = DELTA_BLOCK;
+                        while b + len < base.len()
+                            && t + len < target.len()
+                            && base[b + len] == target[t + len]
+                        {
+                            len += 1;
+                        }
+                        len = len.min(0xFF_FFFF); // copy size fits in 3 bytes
+                        if len > best_len {
+                            best_len = len;
+                            best_off = b;
+                        }
+                    }
+                }
+            }
+            if best_len >= DELTA_BLOCK {
+                flush_insert(&mut out, &mut pending);
+                emit_copy(&mut out, best_off as u64, best_len as u64);
+                t += best_len;
+            } else {
+                pending.push(target[t]);
+                t += 1;
+                if pending.len() == 0x7f {
+                    flush_insert(&mut out, &mut pending);
+                }
+            }
+        }
+        flush_insert(&mut out, &mut pending);
+        out
+    }
+}
+
+/// Produce an optimized git delta from `base` to `target` (convenience over [`DeltaIndex`]). For
+/// repeated encodes against the same base, build a [`DeltaIndex`] once and reuse it.
+pub fn encode_delta(base: &[u8], target: &[u8]) -> Vec<u8> {
+    DeltaIndex::build(base).encode(target)
+}
+
+fn block_hash(b: &[u8]) -> u64 {
+    // FNV-1a over the block (exact match is byte-verified by the caller).
+    let mut h = 0xcbf29ce484222325u64;
+    for &x in b {
+        h ^= x as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    h
+}
+
+/// Flush buffered literals as insert instructions (each ≤ 0x7f bytes).
+fn flush_insert(out: &mut Vec<u8>, pending: &mut Vec<u8>) {
+    for chunk in pending.chunks(0x7f) {
+        out.push(chunk.len() as u8);
+        out.extend_from_slice(chunk);
+    }
+    pending.clear();
+}
+
+/// Emit a copy instruction: opcode (high bit set) with a mask bit per present offset/size byte,
+/// followed by those little-endian bytes.
+fn emit_copy(out: &mut Vec<u8>, off: u64, size: u64) {
+    let mut op = 0x80u8;
+    let mut bytes = Vec::with_capacity(7);
+    for i in 0..4 {
+        let b = ((off >> (8 * i)) & 0xff) as u8;
+        if b != 0 {
+            op |= 1 << i;
+            bytes.push(b);
+        }
+    }
+    for i in 0..3 {
+        let b = ((size >> (8 * i)) & 0xff) as u8;
+        if b != 0 {
+            op |= 0x10 << i;
+            bytes.push(b);
+        }
+    }
+    out.push(op);
+    out.extend_from_slice(&bytes);
+}
+
+pub(crate) fn write_size_varint(out: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let mut byte = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if v == 0 {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn size_varint_roundtrip() {
+        for v in [0u64, 1, 127, 128, 300, 16384, 1 << 35] {
+            let mut buf = Vec::new();
+            write_size_varint(&mut buf, v);
+            let mut pos = 0;
+            assert_eq!(read_size_varint(&buf, &mut pos).unwrap(), v);
+            assert_eq!(pos, buf.len());
+        }
+    }
+
+    #[test]
+    fn trivial_delta_roundtrips() {
+        let base = b"the quick brown fox";
+        let target = b"a completely different target string of some length";
+        let d = encode_trivial_delta(base, target);
+        let got = apply_delta(base, &d).unwrap();
+        assert_eq!(&got, target);
+    }
+
+    #[test]
+    fn optimized_delta_roundtrips_and_compresses() {
+        // A target that shares long runs with the base (an edit in the middle) should round-trip
+        // exactly and encode much smaller than the target itself.
+        let base: Vec<u8> = (0..4096u32).map(|i| (i * 31 + 7) as u8).collect();
+        let mut target = base.clone();
+        target.splice(2000..2010, b"INSERTED!!".iter().copied());
+        let d = encode_delta(&base, &target);
+        assert_eq!(apply_delta(&base, &d).unwrap(), target);
+        assert!(
+            d.len() < target.len() / 4,
+            "delta {} vs target {}",
+            d.len(),
+            target.len()
+        );
+    }
+
+    #[test]
+    fn optimized_delta_handles_unrelated_and_empty() {
+        let base = b"the quick brown fox jumps over the lazy dog";
+        let target = b"completely unrelated content here, no overlap at all really";
+        assert_eq!(
+            apply_delta(base, &encode_delta(base, target)).unwrap(),
+            target
+        );
+        // Empty base / empty target edge cases.
+        assert_eq!(
+            apply_delta(b"", &encode_delta(b"", b"hello")).unwrap(),
+            b"hello"
+        );
+        assert_eq!(apply_delta(base, &encode_delta(base, b"")).unwrap(), b"");
+    }
+
+    #[test]
+    fn copy_instruction_applies() {
+        // Hand-built delta: base len 5, target len 5, copy 5 bytes from offset 0.
+        let base = b"hello";
+        let mut delta = Vec::new();
+        write_size_varint(&mut delta, 5);
+        write_size_varint(&mut delta, 5);
+        delta.push(0x80 | 0x01 | 0x10); // copy, offset byte + size byte
+        delta.push(0x00); // offset 0
+        delta.push(0x05); // size 5
+        let got = apply_delta(base, &delta).unwrap();
+        assert_eq!(&got, b"hello");
+    }
+
+    #[test]
+    fn mixed_copy_and_insert() {
+        // target = base[0..3] + "XYZ" + base[3..6]
+        let base = b"ABCDEF";
+        let mut delta = Vec::new();
+        write_size_varint(&mut delta, 6);
+        write_size_varint(&mut delta, 9);
+        delta.push(0x80 | 0x01 | 0x10);
+        delta.push(0); // off 0
+        delta.push(3); // size 3 -> "ABC"
+        delta.push(3); // insert 3
+        delta.extend_from_slice(b"XYZ");
+        delta.push(0x80 | 0x01 | 0x10);
+        delta.push(3); // off 3
+        delta.push(3); // size 3 -> "DEF"
+        let got = apply_delta(base, &delta).unwrap();
+        assert_eq!(&got, b"ABCXYZDEF");
+    }
+
+    #[test]
+    fn rejects_base_size_mismatch() {
+        let mut delta = Vec::new();
+        write_size_varint(&mut delta, 99);
+        write_size_varint(&mut delta, 0);
+        assert!(apply_delta(b"short", &delta).is_err());
+    }
+}

--- a/crates/gsvc-codec/src/error.rs
+++ b/crates/gsvc-codec/src/error.rs
@@ -1,0 +1,56 @@
+use crate::Oid;
+
+/// Errors produced by the codec layer.
+#[derive(Debug, thiserror::Error)]
+pub enum CodecError {
+    #[error("oid must be 20 bytes, got {0}")]
+    BadOidLen(usize),
+    #[error("invalid oid hex: {0}")]
+    BadOidHex(String),
+    #[error("unknown object kind: {0}")]
+    BadKind(String),
+    #[error("malformed git object: {0}")]
+    BadObject(String),
+    #[error("invalid pack object type code: {0}")]
+    BadPackType(u8),
+
+    #[error("pack too short")]
+    PackTooShort,
+    #[error("bad pack magic (expected 'PACK')")]
+    BadPackMagic,
+    #[error("unsupported pack version: {0}")]
+    BadPackVersion(u32),
+    #[error("pack checksum (trailer SHA-1) mismatch")]
+    PackChecksumMismatch,
+    #[error("OFS_DELTA base offset underflows pack start")]
+    BadDeltaBaseOffset,
+    #[error("OFS_DELTA references missing base at offset {0}")]
+    MissingDeltaBaseOffset(u64),
+    #[error("REF_DELTA references missing base oid {0}")]
+    MissingDeltaBaseOid(Oid),
+    #[error("pack contains duplicate object oid {0}")]
+    DuplicateObject(Oid),
+
+    #[error("idx too short / truncated")]
+    IdxTooShort,
+    #[error("bad idx magic")]
+    BadIdxMagic,
+    #[error("unsupported idx version: {0}")]
+    BadIdxVersion(u32),
+
+    #[error("truncated delta stream")]
+    TruncatedDelta,
+    #[error("reserved delta opcode 0x00")]
+    ReservedDeltaOpcode,
+    #[error("delta base size mismatch: header says {expected}, base is {actual}")]
+    DeltaBaseSizeMismatch { expected: u64, actual: u64 },
+    #[error("delta target size mismatch: header says {expected}, produced {actual}")]
+    DeltaTargetSizeMismatch { expected: u64, actual: u64 },
+    #[error("delta copy out of range: [{start},{end}) of base len {base_len}")]
+    DeltaCopyOutOfRange { start: u64, end: u64, base_len: u64 },
+
+    #[error("zlib inflate error: {0}")]
+    Inflate(String),
+    #[error("io error: {0}")]
+    Io(String),
+}

--- a/crates/gsvc-codec/src/graph.rs
+++ b/crates/gsvc-codec/src/graph.rs
@@ -1,0 +1,353 @@
+//! Reachability parsing: pulling the outbound oid references out of commit, tree, and tag objects.
+//!
+//! This is the minimum git object grammar needed to walk the object graph for `upload-pack`
+//! (which objects does a clone need?) and for GC mark-sweep (which objects are still reachable?).
+//! It is deliberately tolerant — it extracts the links it understands and ignores the rest — and
+//! pure (no I/O), so the traversal driver lives in the server/GC layers that own object lookup.
+
+use crate::{CodecError, Kind, Object, Oid};
+
+/// One entry in a tree object.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TreeEntry {
+    /// The git file mode, parsed from its octal ASCII (e.g. `0o100644`, `0o40000` for a subtree).
+    pub mode: u32,
+    pub name: Vec<u8>,
+    pub oid: Oid,
+}
+
+impl TreeEntry {
+    /// Whether this entry points at a subtree (mode `040000`).
+    pub fn is_tree(&self) -> bool {
+        self.mode == 0o040000
+    }
+    /// Whether this entry is a gitlink/submodule (mode `160000`) — a commit in *another* repo,
+    /// never present in this repo's object set, so reachability must not follow it.
+    pub fn is_gitlink(&self) -> bool {
+        self.mode == 0o160000
+    }
+    /// Whether this entry is a blob (a regular file, executable, or symlink).
+    pub fn is_blob(&self) -> bool {
+        !self.is_tree() && !self.is_gitlink()
+    }
+}
+
+/// What a single object points at, for reachability. The traversal driver folds these into a
+/// work-list, classifying each referent so it can apply partial-clone filters (e.g. skip blobs).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Links {
+    /// Commits referenced (a commit's parents, or a tag's commit target).
+    pub commits: Vec<Oid>,
+    /// Trees referenced (a commit's root tree, or a tree's subtrees).
+    pub trees: Vec<Oid>,
+    /// Blobs referenced (a tree's file entries).
+    pub blobs: Vec<Oid>,
+    /// Annotated-tag targets whose kind isn't statically known from the referrer (rare nested
+    /// tags); the driver resolves their kind when it looks them up.
+    pub tags: Vec<Oid>,
+}
+
+/// The root tree and parent commits of a commit object.
+pub fn commit_links(data: &[u8]) -> Result<(Oid, Vec<Oid>), CodecError> {
+    let mut tree: Option<Oid> = None;
+    let mut parents = Vec::new();
+    for line in data.split(|&b| b == b'\n') {
+        if line.is_empty() {
+            break; // blank line terminates the header; the message follows.
+        }
+        if let Some(rest) = line.strip_prefix(b"tree ") {
+            tree = Some(parse_hex_oid(rest)?);
+        } else if let Some(rest) = line.strip_prefix(b"parent ") {
+            parents.push(parse_hex_oid(rest)?);
+        } else if !starts_with_known_commit_header(line) {
+            // `author`/`committer`/`gpgsig`/continuation lines — not references; keep scanning.
+        }
+    }
+    let tree = tree.ok_or_else(|| CodecError::BadObject("commit has no tree".into()))?;
+    Ok((tree, parents))
+}
+
+/// The target object of an annotated tag, plus its declared type if present.
+pub fn tag_target(data: &[u8]) -> Result<(Oid, Option<Kind>), CodecError> {
+    let mut target: Option<Oid> = None;
+    let mut kind: Option<Kind> = None;
+    for line in data.split(|&b| b == b'\n') {
+        if line.is_empty() {
+            break;
+        }
+        if let Some(rest) = line.strip_prefix(b"object ") {
+            target = Some(parse_hex_oid(rest)?);
+        } else if let Some(rest) = line.strip_prefix(b"type ") {
+            kind = Kind::from_str(&String::from_utf8_lossy(rest)).ok();
+        }
+    }
+    let target = target.ok_or_else(|| CodecError::BadObject("tag has no object".into()))?;
+    Ok((target, kind))
+}
+
+/// Parse a tree object's entries: a sequence of `<octal-mode> <name>\0<20-byte-oid>`.
+pub fn tree_entries(data: &[u8]) -> Result<Vec<TreeEntry>, CodecError> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    while pos < data.len() {
+        // mode (octal ASCII) up to the space.
+        let sp = data[pos..]
+            .iter()
+            .position(|&b| b == b' ')
+            .ok_or_else(|| CodecError::BadObject("tree entry missing mode separator".into()))?;
+        let mode = parse_octal(&data[pos..pos + sp])?;
+        pos += sp + 1;
+        // name up to the NUL.
+        let nul = data[pos..]
+            .iter()
+            .position(|&b| b == 0)
+            .ok_or_else(|| CodecError::BadObject("tree entry missing name terminator".into()))?;
+        let name = data[pos..pos + nul].to_vec();
+        pos += nul + 1;
+        // 20 raw oid bytes.
+        if pos + 20 > data.len() {
+            return Err(CodecError::BadObject("tree entry truncated oid".into()));
+        }
+        let oid = Oid::from_bytes(&data[pos..pos + 20])?;
+        pos += 20;
+        out.push(TreeEntry { mode, name, oid });
+    }
+    Ok(out)
+}
+
+/// Extract the outbound links of any object. Blobs have none.
+pub fn links_of(obj: &Object) -> Result<Links, CodecError> {
+    let mut links = Links::default();
+    match obj.kind {
+        Kind::Blob => {}
+        Kind::Commit => {
+            let (tree, parents) = commit_links(&obj.data)?;
+            links.trees.push(tree);
+            links.commits.extend(parents);
+        }
+        Kind::Tag => {
+            let (target, kind) = tag_target(&obj.data)?;
+            match kind {
+                Some(Kind::Commit) => links.commits.push(target),
+                Some(Kind::Tree) => links.trees.push(target),
+                Some(Kind::Blob) => links.blobs.push(target),
+                Some(Kind::Tag) | None => links.tags.push(target),
+            }
+        }
+        Kind::Tree => {
+            for e in tree_entries(&obj.data)? {
+                if e.is_tree() {
+                    links.trees.push(e.oid);
+                } else if e.is_blob() {
+                    links.blobs.push(e.oid);
+                }
+                // gitlinks are intentionally dropped: the referent lives in another repo.
+            }
+        }
+    }
+    Ok(links)
+}
+
+fn starts_with_known_commit_header(line: &[u8]) -> bool {
+    line.starts_with(b"author ")
+        || line.starts_with(b"committer ")
+        || line.starts_with(b"gpgsig")
+        || line.starts_with(b" ")
+        || line.starts_with(b"encoding ")
+        || line.starts_with(b"mergetag ")
+}
+
+fn parse_hex_oid(b: &[u8]) -> Result<Oid, CodecError> {
+    // Take exactly the leading 40 hex chars (some lines carry a trailing label, e.g. parent oids
+    // never do, but be defensive).
+    let hex = &b[..b.len().min(40)];
+    Oid::from_hex(&String::from_utf8_lossy(hex))
+}
+
+fn parse_octal(b: &[u8]) -> Result<u32, CodecError> {
+    let s =
+        std::str::from_utf8(b).map_err(|_| CodecError::BadObject("non-utf8 tree mode".into()))?;
+    u32::from_str_radix(s, 8).map_err(|_| CodecError::BadObject(format!("bad tree mode {s:?}")))
+}
+
+/// Serialize tree entries into git's canonical on-disk form.
+pub fn encode_tree(entries: &[TreeEntry]) -> Vec<u8> {
+    let mut items: Vec<&TreeEntry> = entries.iter().collect();
+    items.sort_by(|a, b| tree_entry_cmp(a, b));
+    let mut out = Vec::new();
+    for e in items {
+        out.extend_from_slice(format!("{:o}", e.mode).as_bytes());
+        out.push(b' ');
+        out.extend_from_slice(&e.name);
+        out.push(0);
+        out.extend_from_slice(e.oid.as_bytes());
+    }
+    out
+}
+
+fn tree_entry_cmp(a: &TreeEntry, b: &TreeEntry) -> std::cmp::Ordering {
+    let alen = a.name.len() + a.is_tree() as usize;
+    let blen = b.name.len() + b.is_tree() as usize;
+    for i in 0..alen.min(blen) {
+        let ca = if i < a.name.len() { a.name[i] } else { b'/' };
+        let cb = if i < b.name.len() { b.name[i] } else { b'/' };
+        if ca != cb {
+            return ca.cmp(&cb);
+        }
+    }
+    alen.cmp(&blen)
+}
+
+/// Assemble a commit object with canonical commit headers.
+pub fn encode_commit(
+    tree: Oid,
+    parents: &[Oid],
+    author: (&str, &str),
+    committer: (&str, &str),
+    message: &str,
+    when_secs: u64,
+) -> Object {
+    let mut body = Vec::new();
+    body.extend_from_slice(format!("tree {}\n", tree.to_hex()).as_bytes());
+    for p in parents {
+        body.extend_from_slice(format!("parent {}\n", p.to_hex()).as_bytes());
+    }
+    body.extend_from_slice(
+        format!("author {} <{}> {when_secs} +0000\n", author.0, author.1).as_bytes(),
+    );
+    body.extend_from_slice(
+        format!(
+            "committer {} <{}> {when_secs} +0000\n",
+            committer.0, committer.1
+        )
+        .as_bytes(),
+    );
+    body.push(b'\n');
+    body.extend_from_slice(message.as_bytes());
+    if !message.ends_with('\n') {
+        body.push(b'\n');
+    }
+    Object::new(Kind::Commit, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn oid(b: u8) -> Oid {
+        Oid::from_array([b; 20])
+    }
+
+    #[test]
+    fn encode_tree_round_trips_through_tree_entries_in_git_order() {
+        let entries = vec![
+            TreeEntry {
+                mode: 0o100644,
+                name: b"file.txt".to_vec(),
+                oid: oid(0x11),
+            },
+            TreeEntry {
+                mode: 0o040000,
+                name: b"dir".to_vec(),
+                oid: oid(0x22),
+            },
+            TreeEntry {
+                mode: 0o100755,
+                name: b"dir.txt".to_vec(),
+                oid: oid(0x33),
+            },
+        ];
+        let encoded = encode_tree(&entries);
+        let decoded = tree_entries(&encoded).unwrap();
+        let names: Vec<&[u8]> = decoded.iter().map(|e| e.name.as_slice()).collect();
+        assert_eq!(names, vec![&b"dir.txt"[..], &b"dir"[..], &b"file.txt"[..]]);
+        assert_eq!(encode_tree(&decoded), encoded);
+    }
+
+    #[test]
+    fn encode_commit_round_trips_through_commit_links() {
+        let tree = oid(0xaa);
+        let parents = vec![oid(0xb1), oid(0xb2)];
+        let obj = encode_commit(
+            tree,
+            &parents,
+            ("Ada", "ada@x"),
+            ("Bob", "bob@x"),
+            "hello",
+            1_700_000_000,
+        );
+        assert_eq!(obj.kind, Kind::Commit);
+        let (got_tree, got_parents) = commit_links(&obj.data).unwrap();
+        assert_eq!(got_tree, tree);
+        assert_eq!(got_parents, parents);
+        assert!(obj.data.ends_with(b"\nhello\n"));
+    }
+
+    #[test]
+    fn parses_commit_tree_and_parents() {
+        let t = oid(0x11);
+        let p1 = oid(0x22);
+        let p2 = oid(0x33);
+        let body = format!(
+            "tree {}\nparent {}\nparent {}\nauthor A <a@x> 1 +0000\ncommitter A <a@x> 1 +0000\n\nmsg\n",
+            t.to_hex(),
+            p1.to_hex(),
+            p2.to_hex()
+        );
+        let (tree, parents) = commit_links(body.as_bytes()).unwrap();
+        assert_eq!(tree, t);
+        assert_eq!(parents, vec![p1, p2]);
+    }
+
+    #[test]
+    fn root_commit_has_no_parents() {
+        let body = format!(
+            "tree {}\nauthor A <a@x> 1 +0000\ncommitter A <a@x> 1 +0000\n\nroot\n",
+            oid(0x11).to_hex()
+        );
+        let (tree, parents) = commit_links(body.as_bytes()).unwrap();
+        assert_eq!(tree, oid(0x11));
+        assert!(parents.is_empty());
+    }
+
+    #[test]
+    fn parses_tree_entries_with_modes() {
+        // Build `100644 file\0<oid>` + `40000 sub\0<oid>` + `160000 mod\0<oid>`.
+        let mut data = Vec::new();
+        let push = |data: &mut Vec<u8>, mode: &str, name: &str, o: Oid| {
+            data.extend_from_slice(mode.as_bytes());
+            data.push(b' ');
+            data.extend_from_slice(name.as_bytes());
+            data.push(0);
+            data.extend_from_slice(o.as_bytes());
+        };
+        push(&mut data, "100644", "file", oid(0xaa));
+        push(&mut data, "40000", "sub", oid(0xbb));
+        push(&mut data, "160000", "mod", oid(0xcc));
+        let entries = tree_entries(&data).unwrap();
+        assert_eq!(entries.len(), 3);
+        assert!(entries[0].is_blob());
+        assert_eq!(entries[0].oid, oid(0xaa));
+        assert!(entries[1].is_tree());
+        assert!(entries[2].is_gitlink());
+
+        // Reachability folds the blob + subtree but drops the gitlink.
+        let obj = Object::new(Kind::Tree, data);
+        let links = links_of(&obj).unwrap();
+        assert_eq!(links.trees, vec![oid(0xbb)]);
+        assert_eq!(links.blobs, vec![oid(0xaa)]);
+    }
+
+    #[test]
+    fn parses_tag_target() {
+        let body = format!(
+            "object {}\ntype commit\ntag v1\ntagger A <a@x> 1 +0000\n\nrelease\n",
+            oid(0x44).to_hex()
+        );
+        let (target, kind) = tag_target(body.as_bytes()).unwrap();
+        assert_eq!(target, oid(0x44));
+        assert_eq!(kind, Some(Kind::Commit));
+        let links = links_of(&Object::new(Kind::Tag, body.into_bytes())).unwrap();
+        assert_eq!(links.commits, vec![oid(0x44)]);
+    }
+}

--- a/crates/gsvc-codec/src/idx.rs
+++ b/crates/gsvc-codec/src/idx.rs
@@ -1,0 +1,241 @@
+//! Pack index v2 (`.idx`) writing and lookup.
+//!
+//! The cold read path (§7) reads the small `.idx` from object storage, binary-searches it for a
+//! wanted oid, and issues a byte-range GET into the `.pack` at the resulting offset — never
+//! downloading the whole pack.
+
+use sha1::{Digest, Sha1};
+
+use crate::pack::PackedEntry;
+use crate::{CodecError, Oid};
+
+const IDX_MAGIC: [u8; 4] = [0xff, 0x74, 0x4f, 0x63]; // "\377tOc"
+const IDX_VERSION: u32 = 2;
+const FANOUT_LEN: usize = 256;
+/// Offsets ≥ 2^31 are stored in a 64-bit secondary table; the primary slot holds an index into it.
+const LARGE_OFFSET_FLAG: u32 = 0x8000_0000;
+
+/// Serialize a v2 pack index for `entries` (any order; sorted internally), tied to `pack_hash`.
+pub fn write_idx_v2(entries: &[PackedEntry], pack_hash: Oid) -> Vec<u8> {
+    let mut sorted = entries.to_vec();
+    sorted.sort_by(|a, b| a.oid.as_bytes().cmp(b.oid.as_bytes()));
+    let n = sorted.len();
+
+    let mut out = Vec::with_capacity(8 + 256 * 4 + n * (20 + 4 + 4) + 40);
+    out.extend_from_slice(&IDX_MAGIC);
+    out.extend_from_slice(&IDX_VERSION.to_be_bytes());
+
+    // Fanout: cumulative count of oids whose first byte is ≤ i.
+    let mut fanout = [0u32; FANOUT_LEN];
+    for e in &sorted {
+        fanout[e.oid.first_byte() as usize] += 1;
+    }
+    let mut acc = 0u32;
+    for slot in fanout.iter_mut() {
+        acc += *slot;
+        *slot = acc;
+    }
+    for v in fanout {
+        out.extend_from_slice(&v.to_be_bytes());
+    }
+
+    // Sorted oids.
+    for e in &sorted {
+        out.extend_from_slice(e.oid.as_bytes());
+    }
+    // CRC-32 of each packed object.
+    for e in &sorted {
+        out.extend_from_slice(&e.crc32.to_be_bytes());
+    }
+
+    // Offsets: small ones inline; large ones flagged with an index into the 64-bit table.
+    let mut large: Vec<u64> = Vec::new();
+    for e in &sorted {
+        if e.offset < LARGE_OFFSET_FLAG as u64 {
+            out.extend_from_slice(&(e.offset as u32).to_be_bytes());
+        } else {
+            let idx = large.len() as u32;
+            out.extend_from_slice(&(LARGE_OFFSET_FLAG | idx).to_be_bytes());
+            large.push(e.offset);
+        }
+    }
+    for off in &large {
+        out.extend_from_slice(&off.to_be_bytes());
+    }
+
+    // Trailers: pack hash, then idx self-hash.
+    out.extend_from_slice(pack_hash.as_bytes());
+    let mut h = Sha1::new();
+    h.update(&out);
+    let digest: [u8; 20] = h.finalize().into();
+    out.extend_from_slice(&digest);
+    out
+}
+
+/// A parsed, queryable view over v2 idx bytes. Borrows the buffer; cheap to construct.
+pub struct IdxV2<'a> {
+    buf: &'a [u8],
+    count: usize,
+    oids_off: usize,
+    crc_off: usize,
+    offsets_off: usize,
+    large_off: usize,
+}
+
+impl<'a> IdxV2<'a> {
+    /// Parse and validate the header of a v2 idx.
+    pub fn parse(buf: &'a [u8]) -> Result<IdxV2<'a>, CodecError> {
+        if buf.len() < 8 + 256 * 4 + 40 {
+            return Err(CodecError::IdxTooShort);
+        }
+        if buf[0..4] != IDX_MAGIC {
+            return Err(CodecError::BadIdxMagic);
+        }
+        let version = u32::from_be_bytes(buf[4..8].try_into().unwrap());
+        if version != IDX_VERSION {
+            return Err(CodecError::BadIdxVersion(version));
+        }
+        let fanout_off = 8;
+        let count = u32::from_be_bytes(
+            buf[fanout_off + 255 * 4..fanout_off + 256 * 4]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let oids_off = fanout_off + 256 * 4;
+        let crc_off = oids_off + count * 20;
+        let offsets_off = crc_off + count * 4;
+        let large_off = offsets_off + count * 4;
+        if large_off + 40 > buf.len() {
+            return Err(CodecError::IdxTooShort);
+        }
+        Ok(IdxV2 {
+            buf,
+            count,
+            oids_off,
+            crc_off,
+            offsets_off,
+            large_off,
+        })
+    }
+
+    /// Number of objects indexed.
+    pub fn len(&self) -> usize {
+        self.count
+    }
+
+    /// Whether the index is empty.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    fn oid_at(&self, i: usize) -> Oid {
+        let s = self.oids_off + i * 20;
+        Oid::from_bytes(&self.buf[s..s + 20]).expect("20 bytes")
+    }
+
+    /// CRC-32 recorded for the object at sorted position `i`.
+    pub fn crc_at(&self, i: usize) -> u32 {
+        let s = self.crc_off + i * 4;
+        u32::from_be_bytes(self.buf[s..s + 4].try_into().unwrap())
+    }
+
+    /// Byte offset within the pack for the object at sorted position `i` (resolves large offsets).
+    pub fn offset_at(&self, i: usize) -> u64 {
+        let s = self.offsets_off + i * 4;
+        let raw = u32::from_be_bytes(self.buf[s..s + 4].try_into().unwrap());
+        if raw & LARGE_OFFSET_FLAG == 0 {
+            raw as u64
+        } else {
+            let idx = (raw & !LARGE_OFFSET_FLAG) as usize;
+            let ls = self.large_off + idx * 8;
+            u64::from_be_bytes(self.buf[ls..ls + 8].try_into().unwrap())
+        }
+    }
+
+    /// Binary-search for `oid`, returning its byte offset within the pack if present.
+    pub fn find_offset(&self, oid: &Oid) -> Option<u64> {
+        let (mut lo, mut hi) = (0usize, self.count);
+        while lo < hi {
+            let mid = (lo + hi) / 2;
+            match self.oid_at(mid).as_bytes().cmp(oid.as_bytes()) {
+                std::cmp::Ordering::Less => lo = mid + 1,
+                std::cmp::Ordering::Greater => hi = mid,
+                std::cmp::Ordering::Equal => return Some(self.offset_at(mid)),
+            }
+        }
+        None
+    }
+
+    /// Whether `oid` is present in this index.
+    pub fn contains(&self, oid: &Oid) -> bool {
+        self.find_offset(oid).is_some()
+    }
+
+    /// The oid at sorted position `i` — its **bitmap position** (reachability bitmaps index objects
+    /// by their sorted rank in the index). Panics if `i >= len()`.
+    pub fn oid_at_position(&self, i: usize) -> Oid {
+        self.oid_at(i)
+    }
+
+    /// The sorted position (bitmap index) of `oid`, if present.
+    pub fn position(&self, oid: &Oid) -> Option<usize> {
+        let (mut lo, mut hi) = (0usize, self.count);
+        while lo < hi {
+            let mid = (lo + hi) / 2;
+            match self.oid_at(mid).as_bytes().cmp(oid.as_bytes()) {
+                std::cmp::Ordering::Less => lo = mid + 1,
+                std::cmp::Ordering::Greater => hi = mid,
+                std::cmp::Ordering::Equal => return Some(mid),
+            }
+        }
+        None
+    }
+
+    /// Iterate all oids in sorted order.
+    pub fn iter_oids(&self) -> impl Iterator<Item = Oid> + '_ {
+        (0..self.count).map(move |i| self.oid_at(i))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::Kind;
+    use crate::pack::build_pack;
+    use crate::Object;
+
+    #[test]
+    fn idx_lookup_matches_pack_offsets() {
+        let objects = vec![
+            Object::new(Kind::Blob, &b"alpha"[..]),
+            Object::new(Kind::Blob, &b"beta"[..]),
+            Object::new(Kind::Blob, &b"gamma"[..]),
+            Object::new(Kind::Commit, &b"some commit data"[..]),
+        ];
+        let built = build_pack(&objects).unwrap();
+        let idx = write_idx_v2(&built.entries, built.pack_hash);
+        let parsed = IdxV2::parse(&idx).unwrap();
+
+        assert_eq!(parsed.len(), objects.len());
+        for e in &built.entries {
+            assert_eq!(parsed.find_offset(&e.oid), Some(e.offset));
+            assert!(parsed.contains(&e.oid));
+        }
+        // A random oid is absent.
+        assert_eq!(parsed.find_offset(&Oid::ZERO), None);
+    }
+
+    #[test]
+    fn idx_oids_are_sorted() {
+        let objects: Vec<Object> = (0..50u8)
+            .map(|i| Object::new(Kind::Blob, vec![i; (i as usize) + 1]))
+            .collect();
+        let built = build_pack(&objects).unwrap();
+        let idx = write_idx_v2(&built.entries, built.pack_hash);
+        let parsed = IdxV2::parse(&idx).unwrap();
+        let oids: Vec<Oid> = parsed.iter_oids().collect();
+        let mut sorted = oids.clone();
+        sorted.sort_by(|a, b| a.as_bytes().cmp(b.as_bytes()));
+        assert_eq!(oids, sorted);
+    }
+}

--- a/crates/gsvc-codec/src/latency.rs
+++ b/crates/gsvc-codec/src/latency.rs
@@ -1,0 +1,110 @@
+//! A tiny lock-free latency histogram for backend-operation timing.
+//!
+//! Fixed buckets with per-bucket atomic counters, plus a running sum + count. Lives in the shared
+//! base crate so both the object store and the FDB client can record into one without a new
+//! dependency edge; the server exports the snapshot through OpenTelemetry and the compatibility
+//! metrics endpoint.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Upper bucket bounds in **seconds** (the implicit `+Inf` bucket is added on render). Spans
+/// sub-millisecond cache/NVMe ops through multi-second cold S3 reads.
+pub const LATENCY_BUCKETS_SECS: [f64; 9] = [0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0];
+
+/// Same bounds in microseconds (the unit `observe` takes), to avoid float comparison on the hot path.
+const BUCKETS_MICROS: [u64; 9] = [
+    500, 1_000, 5_000, 10_000, 50_000, 100_000, 500_000, 1_000_000, 5_000_000,
+];
+
+/// A bucketed latency histogram with atomic counters (cheap to share via `Arc`).
+#[derive(Default)]
+pub struct LatencyHist {
+    /// One counter per bucket in [`LATENCY_BUCKETS_SECS`]; index `len` would be `+Inf`.
+    buckets: [AtomicU64; 9],
+    sum_micros: AtomicU64,
+    count: AtomicU64,
+}
+
+impl LatencyHist {
+    /// Record one observation of `micros` microseconds.
+    pub fn observe(&self, micros: u64) {
+        let idx = BUCKETS_MICROS.iter().position(|&b| micros <= b);
+        if let Some(i) = idx {
+            self.buckets[i].fetch_add(1, Ordering::Relaxed);
+        }
+        // (over the last bound → only counted in +Inf, derived at render from `count`)
+        self.sum_micros.fetch_add(micros, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// A consistent-enough snapshot for rendering.
+    pub fn snapshot(&self) -> HistSnapshot {
+        let mut buckets = [0u64; 9];
+        for (i, b) in self.buckets.iter().enumerate() {
+            buckets[i] = b.load(Ordering::Relaxed);
+        }
+        HistSnapshot {
+            buckets,
+            sum_secs: self.sum_micros.load(Ordering::Relaxed) as f64 / 1e6,
+            count: self.count.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// A point-in-time copy of a [`LatencyHist`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HistSnapshot {
+    /// Per-bucket counts aligned with [`LATENCY_BUCKETS_SECS`] (non-cumulative).
+    pub buckets: [u64; 9],
+    pub sum_secs: f64,
+    pub count: u64,
+}
+
+impl HistSnapshot {
+    /// Render Prometheus-compatible histogram lines for `name` with the given label set
+    /// (e.g. `op=\"read\"`), emitting cumulative `_bucket` series plus `_sum` and `_count`.
+    pub fn render(&self, out: &mut String, name: &str, labels: &str) {
+        let sep = if labels.is_empty() { "" } else { "," };
+        let mut cumulative = 0u64;
+        for (i, edge) in LATENCY_BUCKETS_SECS.iter().enumerate() {
+            cumulative += self.buckets[i];
+            out.push_str(&format!(
+                "{name}_bucket{{{labels}{sep}le=\"{edge}\"}} {cumulative}\n"
+            ));
+        }
+        out.push_str(&format!(
+            "{name}_bucket{{{labels}{sep}le=\"+Inf\"}} {}\n",
+            self.count
+        ));
+        out.push_str(&format!("{name}_sum{{{labels}}} {}\n", self.sum_secs));
+        out.push_str(&format!("{name}_count{{{labels}}} {}\n", self.count));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_and_render_cumulative() {
+        let h = LatencyHist::default();
+        h.observe(300); // ≤ 0.0005s bucket
+        h.observe(2_000); // ≤ 0.005s
+        h.observe(9_000_000); // over the last bound → +Inf only
+        let snap = h.snapshot();
+        assert_eq!(snap.count, 3);
+        let mut out = String::new();
+        snap.render(&mut out, "test_seconds", "op=\"x\"");
+        // First bucket has the 300µs sample.
+        assert!(
+            out.contains("test_seconds_bucket{op=\"x\",le=\"0.0005\"} 1"),
+            "{out}"
+        );
+        // +Inf is cumulative over everything.
+        assert!(
+            out.contains("test_seconds_bucket{op=\"x\",le=\"+Inf\"} 3"),
+            "{out}"
+        );
+        assert!(out.contains("test_seconds_count{op=\"x\"} 3"), "{out}");
+    }
+}

--- a/crates/gsvc-codec/src/lib.rs
+++ b/crates/gsvc-codec/src/lib.rs
@@ -1,0 +1,56 @@
+//! `gsvc-codec` — the git object & packfile codec for the fast git service.
+//!
+//! This crate is a pure, dependency-light implementation of the parts of git's on-disk format we
+//! need on the hot path:
+//!
+//! * [`Oid`] / [`ChunkHash`] — object and chunk addresses.
+//! * [`Object`] / [`Kind`] / [`hash`] — the git object model and content hashing.
+//! * [`pack`] — packfile v2 read (full `OFS_DELTA`/`REF_DELTA` resolution) and write.
+//! * [`idx`] — pack index v2 generation and oid→offset lookup for byte-range serving.
+//! * [`delta`] — the delta instruction codec shared by the pack reader and (eventually) repacker.
+//!
+//! It deliberately has no I/O, async, or storage concerns — those live in `gsvc-store` and above —
+//! so it stays trivially testable and reusable.
+
+pub mod async_stream;
+mod bitmap;
+mod chunkloc;
+mod commitgraph;
+mod delta;
+mod error;
+pub mod graph;
+mod idx;
+pub mod latency;
+mod object;
+mod oid;
+mod pack;
+
+pub use async_stream::{
+    object_frame, parse_pack_streaming_async, AsyncPackSink, AsyncPackWriter, BaseResolver,
+    ByteSink, ByteSource, ChunkSource, NoBases,
+};
+pub use bitmap::{Bitmap, PackBitmaps};
+pub use chunkloc::ChunkLoc;
+pub use commitgraph::{CommitGraph, CommitNode};
+pub use delta::{apply_delta, encode_delta, encode_trivial_delta, DeltaIndex};
+pub use error::CodecError;
+pub use graph::{
+    commit_links, encode_commit, encode_tree, links_of, tag_target, tree_entries, Links, TreeEntry,
+};
+pub use idx::{write_idx_v2, IdxV2};
+pub use object::{hash, BlobOidHasher, Kind, Object};
+pub use oid::{ChunkHash, Oid};
+pub use pack::{
+    build_pack, build_pack_at_level, build_pack_delta, build_pack_delta_for_serving,
+    decode_pack_object_index_sidecar, decode_pack_source_index_sidecar,
+    encode_pack_object_index_sidecar, encode_pack_source_index_sidecar,
+    inflate_full_payload_range_to_temp, pack_ref_delta_bases, parse_pack,
+    plan_pack_file_optimization, plan_pack_tree_index, plan_pack_tree_index_with_external_bases,
+    read_pack_entry, resolve_pack_file, resolve_pack_file_with_log_context, resolve_pack_parallel,
+    resolve_scanned_pack_with_external_bases, resolve_scanned_pack_with_log_context,
+    stream_indexed_full_blob_range_to_temp, stream_indexed_full_blob_to_temp,
+    write_pack_object_index_sidecar, write_pack_source_index_sidecar, BuiltPack, ExternalBase,
+    FileBackedBlob, PackCommitIndexEntry, PackEntry, PackObjectEntry, PackObjectKind,
+    PackOptimizationPlan, PackResolveLogContext, PackTreeIndexEntry, PackTreeIndexPlan,
+    PackedEntry, ParsedPack, ReceivePackSpooler, ResolvedPack, ScannedPack,
+};

--- a/crates/gsvc-codec/src/object.rs
+++ b/crates/gsvc-codec/src/object.rs
@@ -1,0 +1,184 @@
+//! Git object model and hashing.
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
+
+use crate::{CodecError, Oid};
+
+/// The four git object kinds.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
+pub enum Kind {
+    Commit,
+    Tree,
+    Blob,
+    Tag,
+}
+
+impl Kind {
+    /// The loose-header keyword (`commit`, `tree`, `blob`, `tag`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Kind::Commit => "commit",
+            Kind::Tree => "tree",
+            Kind::Blob => "blob",
+            Kind::Tag => "tag",
+        }
+    }
+
+    /// Parse from the loose-header keyword. (Inherent, not the `FromStr` trait: it takes the git
+    /// keyword set specifically and returns our [`CodecError`].)
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Result<Kind, CodecError> {
+        Ok(match s {
+            "commit" => Kind::Commit,
+            "tree" => Kind::Tree,
+            "blob" => Kind::Blob,
+            "tag" => Kind::Tag,
+            other => return Err(CodecError::BadKind(other.to_string())),
+        })
+    }
+
+    /// The packfile type code (commit=1, tree=2, blob=3, tag=4).
+    pub fn pack_type(self) -> u8 {
+        match self {
+            Kind::Commit => 1,
+            Kind::Tree => 2,
+            Kind::Blob => 3,
+            Kind::Tag => 4,
+        }
+    }
+
+    /// Parse from a packfile non-delta type code.
+    pub fn from_pack_type(t: u8) -> Result<Kind, CodecError> {
+        Ok(match t {
+            1 => Kind::Commit,
+            2 => Kind::Tree,
+            3 => Kind::Blob,
+            4 => Kind::Tag,
+            other => return Err(CodecError::BadPackType(other)),
+        })
+    }
+}
+
+/// Compute a git object id over `data` of the given `kind`.
+///
+/// The hashed pre-image is the canonical loose form: `"<kind> <len>\0<data>"`.
+pub fn hash(kind: Kind, data: &[u8]) -> Oid {
+    let mut h = Sha1::new();
+    h.update(kind.as_str().as_bytes());
+    h.update(b" ");
+    h.update(data.len().to_string().as_bytes());
+    h.update(b"\0");
+    h.update(data);
+    let digest: [u8; 20] = h.finalize().into();
+    Oid::from_array(digest)
+}
+
+/// Incrementally computes a **blob**'s git oid from its bytes without holding them — for streaming
+/// large-object ingest, where the blob is chunked to the store as it arrives and never buffered.
+/// The git pre-image is `"blob <size>\0<data>"`, so the size must be known up front (it is: the
+/// packfile entry header declares it).
+pub struct BlobOidHasher {
+    hasher: Sha1,
+}
+
+impl BlobOidHasher {
+    /// Start hashing a blob of `size` bytes.
+    pub fn new(size: u64) -> BlobOidHasher {
+        let mut hasher = Sha1::new();
+        hasher.update(b"blob ");
+        hasher.update(size.to_string().as_bytes());
+        hasher.update(b"\0");
+        BlobOidHasher { hasher }
+    }
+
+    /// Feed the next run of blob bytes.
+    pub fn update(&mut self, data: &[u8]) {
+        self.hasher.update(data);
+    }
+
+    /// Finalize into the blob's oid.
+    pub fn finalize(self) -> Oid {
+        let digest: [u8; 20] = self.hasher.finalize().into();
+        Oid::from_array(digest)
+    }
+}
+
+/// A fully-materialized git object: its kind plus its raw (decompressed, un-deltified) bytes.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Object {
+    pub kind: Kind,
+    pub data: Bytes,
+}
+
+impl Object {
+    /// Build an object from owned bytes.
+    pub fn new(kind: Kind, data: impl Into<Bytes>) -> Object {
+        Object {
+            kind,
+            data: data.into(),
+        }
+    }
+
+    /// The object's git id (computed on demand).
+    pub fn id(&self) -> Oid {
+        hash(self.kind, &self.data)
+    }
+
+    /// Object payload length.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Whether the payload is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl std::fmt::Debug for Object {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Object {{ kind: {:?}, id: {}, len: {} }}",
+            self.kind,
+            self.id(),
+            self.data.len()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Ground-truth hashes from the reference git implementation.
+    #[test]
+    fn empty_blob_hash() {
+        let o = Object::new(Kind::Blob, &b""[..]);
+        assert_eq!(o.id().to_hex(), "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391");
+    }
+
+    #[test]
+    fn empty_tree_hash() {
+        let o = Object::new(Kind::Tree, &b""[..]);
+        assert_eq!(o.id().to_hex(), "4b825dc642cb6eb9a060e54bf8d69288fbee4904");
+    }
+
+    #[test]
+    fn hello_blob_hash() {
+        // `printf 'hello\n' | git hash-object --stdin`
+        let o = Object::new(Kind::Blob, &b"hello\n"[..]);
+        assert_eq!(o.id().to_hex(), "ce013625030ba8dba906f756967f9e9ca394464a");
+    }
+
+    #[test]
+    fn kind_roundtrip() {
+        for k in [Kind::Commit, Kind::Tree, Kind::Blob, Kind::Tag] {
+            assert_eq!(Kind::from_str(k.as_str()).unwrap(), k);
+            assert_eq!(Kind::from_pack_type(k.pack_type()).unwrap(), k);
+        }
+        assert!(Kind::from_str("nope").is_err());
+    }
+}

--- a/crates/gsvc-codec/src/oid.rs
+++ b/crates/gsvc-codec/src/oid.rs
@@ -1,0 +1,183 @@
+//! Object identifiers.
+//!
+//! [`Oid`] is a git object id (SHA-1, 20 bytes). [`ChunkHash`] is a content-defined-chunk
+//! address (SHA-256, 32 bytes) used by the large-object/CDC path, which is independent of git's
+//! own object naming.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use crate::CodecError;
+
+/// A git object id: a 20-byte SHA-1 digest.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Oid([u8; 20]);
+
+impl Oid {
+    /// Number of raw bytes in an [`Oid`].
+    pub const SIZE: usize = 20;
+    /// Number of hex characters in a rendered [`Oid`].
+    pub const HEX_SIZE: usize = 40;
+    /// The all-zero oid, used by git to mean "no object" (e.g. ref creation/deletion).
+    pub const ZERO: Oid = Oid([0u8; 20]);
+
+    /// Construct from exactly 20 raw bytes.
+    pub fn from_bytes(b: &[u8]) -> Result<Oid, CodecError> {
+        if b.len() != Self::SIZE {
+            return Err(CodecError::BadOidLen(b.len()));
+        }
+        let mut a = [0u8; 20];
+        a.copy_from_slice(b);
+        Ok(Oid(a))
+    }
+
+    /// Construct directly from a fixed array.
+    #[inline]
+    pub const fn from_array(a: [u8; 20]) -> Oid {
+        Oid(a)
+    }
+
+    /// Parse from a 40-char lowercase/uppercase hex string.
+    pub fn from_hex(s: &str) -> Result<Oid, CodecError> {
+        if s.len() != Self::HEX_SIZE {
+            return Err(CodecError::BadOidHex(s.to_string()));
+        }
+        let mut a = [0u8; 20];
+        hex::decode_to_slice(s, &mut a).map_err(|_| CodecError::BadOidHex(s.to_string()))?;
+        Ok(Oid(a))
+    }
+
+    /// Raw bytes.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; 20] {
+        &self.0
+    }
+
+    /// Lowercase hex rendering.
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+
+    /// The first byte, used for the idx fanout table and S3 sharding prefix.
+    #[inline]
+    pub fn first_byte(&self) -> u8 {
+        self.0[0]
+    }
+
+    /// Two-hex-char shard prefix (e.g. `s3://blobs/<prefix>/<oid>`).
+    pub fn shard_prefix(&self) -> String {
+        hex::encode([self.0[0]])
+    }
+
+    /// Whether this is the all-zero oid.
+    #[inline]
+    pub fn is_zero(&self) -> bool {
+        self.0 == [0u8; 20]
+    }
+}
+
+impl fmt::Display for Oid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+impl fmt::Debug for Oid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Oid({})", self.to_hex())
+    }
+}
+
+/// A content-defined-chunk address: a 32-byte SHA-256 digest.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ChunkHash([u8; 32]);
+
+impl ChunkHash {
+    /// Number of raw bytes.
+    pub const SIZE: usize = 32;
+
+    /// Hash arbitrary content into a chunk address.
+    pub fn of(data: &[u8]) -> ChunkHash {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(data);
+        ChunkHash(h.finalize().into())
+    }
+
+    /// Construct from raw bytes.
+    pub fn from_bytes(b: &[u8]) -> Result<ChunkHash, CodecError> {
+        if b.len() != Self::SIZE {
+            return Err(CodecError::BadOidLen(b.len()));
+        }
+        let mut a = [0u8; 32];
+        a.copy_from_slice(b);
+        Ok(ChunkHash(a))
+    }
+
+    /// Parse from a 64-char lowercase hex string.
+    pub fn from_hex(s: &str) -> Result<ChunkHash, CodecError> {
+        let bytes = hex::decode(s).map_err(|_| CodecError::BadOidHex(s.to_string()))?;
+        ChunkHash::from_bytes(&bytes)
+    }
+
+    /// Raw bytes.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Lowercase hex rendering.
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+
+    /// Two-hex-char shard prefix for S3 layout (`s3://chunks/<prefix>/<hash>`).
+    pub fn shard_prefix(&self) -> String {
+        hex::encode([self.0[0]])
+    }
+}
+
+impl fmt::Display for ChunkHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+impl fmt::Debug for ChunkHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ChunkHash({})", self.to_hex())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oid_hex_roundtrip() {
+        let h = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
+        let o = Oid::from_hex(h).unwrap();
+        assert_eq!(o.to_hex(), h);
+        assert_eq!(o.first_byte(), 0xe6);
+        assert_eq!(o.shard_prefix(), "e6");
+        assert!(!o.is_zero());
+        assert!(Oid::ZERO.is_zero());
+    }
+
+    #[test]
+    fn oid_bad_inputs() {
+        assert!(Oid::from_hex("abc").is_err());
+        assert!(Oid::from_bytes(&[0u8; 19]).is_err());
+        assert!(Oid::from_hex("zz9de29bb2d1d6434b8b29ae775ad8c2e48c5391").is_err());
+    }
+
+    #[test]
+    fn chunk_hash_stable() {
+        let a = ChunkHash::of(b"hello");
+        let b = ChunkHash::of(b"hello");
+        let c = ChunkHash::of(b"world");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_eq!(a.as_bytes().len(), 32);
+    }
+}

--- a/crates/gsvc-codec/src/pack.rs
+++ b/crates/gsvc-codec/src/pack.rs
@@ -1,0 +1,5436 @@
+//! Packfile v2 reading and writing.
+//!
+//! The writer emits canonical, non-deltified v2 packs (binaries/large objects never reach this
+//! path — see `gsvc-bigobj`). The reader resolves the full entry grammar including `OFS_DELTA`
+//! and `REF_DELTA`, with an optional external base resolver for thin packs received over the wire.
+
+use std::collections::{HashMap, VecDeque};
+use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use bytes::Bytes;
+use flate2::write::ZlibEncoder;
+use flate2::{Compression, Decompress, FlushDecompress, Status};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
+
+use crate::delta::apply_delta;
+use crate::{CodecError, Kind, Object, Oid};
+
+const PACK_MAGIC: &[u8; 4] = b"PACK";
+const PACK_VERSION: u32 = 2;
+const PARALLEL_RESOLVE_BATCH: usize = 1024;
+
+/// Chunk size for the parallel external-ref filter after resolve.
+const EXTERNAL_REF_FILTER_CHUNK: usize = 64 * 1024;
+
+/// Bounded queue depth (in per-object tree-entry batches) for the source-index writer thread.
+const SOURCE_INDEX_WRITER_QUEUE: usize = 4096;
+
+// Packfile entry type codes.
+const T_COMMIT: u8 = 1;
+const T_TREE: u8 = 2;
+const T_BLOB: u8 = 3;
+const T_TAG: u8 = 4;
+const T_OFS_DELTA: u8 = 6;
+const T_REF_DELTA: u8 = 7;
+
+/// Cap for the up-front allocation hint taken from a pack's self-declared object count. That count
+/// lives in the 12-byte header and is **attacker-controlled**, so a lying value (e.g. `u32::MAX`) fed
+/// straight into `Vec::with_capacity(count)` would try to reserve hundreds of GB — and an allocation
+/// failure *aborts the whole process* (it can't be caught). We therefore use the count only as a
+/// *hint*, pre-sizing up to this cap and letting the collection grow naturally for genuinely huge
+/// packs (a few reallocations, negligible beside parsing millions of objects). The parse loop still
+/// uses the real count and fails cleanly via `?` the moment it runs past the available bytes.
+pub(crate) const PREALLOC_HINT_CAP: usize = 1 << 20;
+
+/// Index metadata for one object as written into a pack: its id, byte offset within the pack,
+/// and the CRC-32 of its on-disk (header + compressed) representation. Feeds idx v2 generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PackedEntry {
+    pub oid: Oid,
+    pub offset: u64,
+    pub crc32: u32,
+}
+
+/// The result of building a pack: the bytes, the per-object index entries, and the pack trailer
+/// SHA-1 (also the pack's name in git).
+pub struct BuiltPack {
+    pub data: Vec<u8>,
+    pub entries: Vec<PackedEntry>,
+    pub object_entries: Vec<PackObjectEntry>,
+    pub pack_hash: Oid,
+}
+
+/// Encode `objects` into a non-deltified v2 packfile.
+pub fn build_pack(objects: &[Object]) -> Result<BuiltPack, CodecError> {
+    build_pack_at_level(objects, PUSH_COMPRESSION)
+}
+
+/// Compression level for the **push-time** pack. Deliberately fast (level 1): a freshly-received
+/// pack is transient — background compaction soon repacks it delta-compressed at a higher ratio — so
+/// minimizing CPU on the push hot path beats squeezing out bytes that get rewritten minutes later.
+const PUSH_COMPRESSION: u32 = 1;
+type SortedObjectIds = Vec<Oid>;
+
+/// Persistable metadata for one object entry in a pack. Unlike the legacy `(oid, offset)` location
+/// rows, this includes enough information for background workers to reason about pack contents and
+/// range-read non-delta entries without replaying the full resolver.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PackObjectEntry {
+    pub oid: Oid,
+    pub kind: PackObjectKind,
+    pub resolved_kind: Kind,
+    pub offset: u64,
+    pub compressed_offset: u64,
+    pub compressed_len: u64,
+    pub declared_size: u64,
+    pub resolved_size: u64,
+    pub crc32: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PackObjectKind {
+    Full(Kind),
+    OfsDelta {
+        base_offset: u64,
+        base_oid: Oid,
+        depth: u32,
+    },
+    RefDelta {
+        base_oid: Oid,
+        depth: u32,
+    },
+}
+
+const OBJECT_INDEX_MAGIC: &[u8; 8] = b"GSOBIDX1";
+const SOURCE_INDEX_MAGIC: &[u8; 8] = b"GSSRCIX1";
+
+pub fn write_pack_object_index_sidecar<'a, W, I>(
+    mut writer: W,
+    object_count: usize,
+    entries: I,
+) -> Result<(), CodecError>
+where
+    W: Write,
+    I: IntoIterator<Item = &'a PackObjectEntry>,
+{
+    writer
+        .write_all(OBJECT_INDEX_MAGIC)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    write_u64(&mut writer, object_count as u64)?;
+    for entry in entries {
+        write_pack_object_index_entry(&mut writer, entry)?;
+    }
+    writer.flush().map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(())
+}
+
+fn write_pack_object_index_entry<W: Write>(
+    writer: &mut W,
+    entry: &PackObjectEntry,
+) -> Result<(), CodecError> {
+    write_oid(writer, &entry.oid)?;
+    match &entry.kind {
+        PackObjectKind::Full(kind) => {
+            write_u8(writer, 0)?;
+            write_kind(writer, *kind)?;
+        }
+        PackObjectKind::OfsDelta {
+            base_offset,
+            base_oid,
+            depth,
+        } => {
+            write_u8(writer, 1)?;
+            write_u64(writer, *base_offset)?;
+            write_oid(writer, base_oid)?;
+            write_u32(writer, *depth)?;
+        }
+        PackObjectKind::RefDelta { base_oid, depth } => {
+            write_u8(writer, 2)?;
+            write_oid(writer, base_oid)?;
+            write_u32(writer, *depth)?;
+        }
+    }
+    write_kind(writer, entry.resolved_kind)?;
+    write_u64(writer, entry.offset)?;
+    write_u64(writer, entry.compressed_offset)?;
+    write_u64(writer, entry.compressed_len)?;
+    write_u64(writer, entry.declared_size)?;
+    write_u64(writer, entry.resolved_size)?;
+    write_u32(writer, entry.crc32)?;
+    Ok(())
+}
+
+pub fn encode_pack_object_index_sidecar(
+    entries: &[PackObjectEntry],
+) -> Result<Vec<u8>, CodecError> {
+    let mut out = Vec::with_capacity(entries.len().saturating_mul(80).saturating_add(16));
+    write_pack_object_index_sidecar(&mut out, entries.len(), entries.iter())?;
+    Ok(out)
+}
+
+pub fn decode_pack_object_index_sidecar(
+    sidecar: &[u8],
+) -> Result<Vec<PackObjectEntry>, CodecError> {
+    let mut cursor = std::io::Cursor::new(sidecar);
+    let mut magic = [0u8; 8];
+    cursor
+        .read_exact(&mut magic)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    if &magic != OBJECT_INDEX_MAGIC {
+        return Err(CodecError::Io("invalid object-index sidecar magic".into()));
+    }
+    let count = read_u64(&mut cursor)?;
+    let count_usize = usize::try_from(count)
+        .map_err(|_| CodecError::Io("object-index sidecar count overflows usize".into()))?;
+    let mut entries = Vec::with_capacity(count_usize.min(PREALLOC_HINT_CAP));
+    for _ in 0..count_usize {
+        let oid = read_oid(&mut cursor)?;
+        let kind = match read_u8(&mut cursor)? {
+            0 => PackObjectKind::Full(read_kind(&mut cursor)?),
+            1 => PackObjectKind::OfsDelta {
+                base_offset: read_u64(&mut cursor)?,
+                base_oid: read_oid(&mut cursor)?,
+                depth: read_u32(&mut cursor)?,
+            },
+            2 => PackObjectKind::RefDelta {
+                base_oid: read_oid(&mut cursor)?,
+                depth: read_u32(&mut cursor)?,
+            },
+            other => {
+                return Err(CodecError::Io(format!(
+                    "invalid object-index sidecar kind tag {other}"
+                )))
+            }
+        };
+        entries.push(PackObjectEntry {
+            oid,
+            kind,
+            resolved_kind: read_kind(&mut cursor)?,
+            offset: read_u64(&mut cursor)?,
+            compressed_offset: read_u64(&mut cursor)?,
+            compressed_len: read_u64(&mut cursor)?,
+            declared_size: read_u64(&mut cursor)?,
+            resolved_size: read_u64(&mut cursor)?,
+            crc32: read_u32(&mut cursor)?,
+        });
+    }
+    if cursor.position() != sidecar.len() as u64 {
+        return Err(CodecError::Io(
+            "object-index sidecar has trailing bytes".into(),
+        ));
+    }
+    Ok(entries)
+}
+
+/// Encode `objects` into a non-deltified v2 packfile at zlib `level`, deflating and hashing every
+/// object **in parallel** (the per-object work is independent), then assembling the pack serially.
+/// This is the dominant cost of a large first push, so the parallelism is what keeps a half-million-
+/// object push in single-digit seconds rather than minutes.
+pub fn build_pack_at_level(objects: &[Object], level: u32) -> Result<BuiltPack, CodecError> {
+    use rayon::prelude::*;
+
+    // Phase 1 (parallel): each object → (entry bytes [header + zlib], oid, crc32). All independent.
+    let prepared: Vec<(Vec<u8>, Oid, u32, Kind, u64, usize)> = objects
+        .par_iter()
+        .map(|obj| {
+            let mut entry_bytes = Vec::with_capacity(obj.data.len() / 2 + 16);
+            write_entry_header(
+                &mut entry_bytes,
+                obj.kind.pack_type(),
+                obj.data.len() as u64,
+            );
+            let compressed_header_len = entry_bytes.len();
+            let mut enc = ZlibEncoder::new(Vec::new(), Compression::new(level));
+            enc.write_all(&obj.data)
+                .map_err(|e| CodecError::Io(e.to_string()))?;
+            let compressed = enc.finish().map_err(|e| CodecError::Io(e.to_string()))?;
+            entry_bytes.extend_from_slice(&compressed);
+            let crc = crc32fast::hash(&entry_bytes);
+            Ok((
+                entry_bytes,
+                obj.id(),
+                crc,
+                obj.kind,
+                obj.data.len() as u64,
+                compressed_header_len,
+            ))
+        })
+        .collect::<Result<Vec<_>, CodecError>>()?;
+
+    // Phase 2 (serial): lay the entries out at their offsets and assemble the pack.
+    let total: usize = prepared.iter().map(|(b, ..)| b.len()).sum();
+    let mut out = Vec::with_capacity(12 + total + 20);
+    out.extend_from_slice(PACK_MAGIC);
+    out.extend_from_slice(&PACK_VERSION.to_be_bytes());
+    out.extend_from_slice(&(objects.len() as u32).to_be_bytes());
+    let mut entries = Vec::with_capacity(objects.len());
+    let mut object_entries = Vec::with_capacity(objects.len());
+    for (entry_bytes, oid, crc32, kind, declared_size, compressed_header_len) in prepared {
+        let offset = out.len() as u64;
+        let compressed_offset = offset + compressed_header_len as u64;
+        let compressed_len = (entry_bytes.len() - compressed_header_len) as u64;
+        entries.push(PackedEntry { oid, offset, crc32 });
+        object_entries.push(PackObjectEntry {
+            oid,
+            kind: PackObjectKind::Full(kind),
+            resolved_kind: kind,
+            offset,
+            compressed_offset,
+            compressed_len,
+            declared_size,
+            resolved_size: declared_size,
+            crc32,
+        });
+        out.extend_from_slice(&entry_bytes);
+    }
+
+    // Trailer: SHA-1 over everything written so far.
+    let mut h = Sha1::new();
+    h.update(&out);
+    let digest: [u8; 20] = h.finalize().into();
+    out.extend_from_slice(&digest);
+
+    Ok(BuiltPack {
+        data: out,
+        entries,
+        object_entries,
+        pack_hash: Oid::from_array(digest),
+    })
+}
+
+/// Tuning for [`build_pack_delta`].
+const DELTA_WINDOW: usize = 10;
+const DELTA_MAX_DEPTH: usize = 50;
+/// Serving packs trade a little ratio for materially cheaper client `index-pack`.
+const SERVING_DELTA_MAX_DEPTH: usize = 12;
+const DELTA_MAX_SIZE: usize = 1 << 20; // don't deltify objects above 1 MiB
+
+#[derive(Clone, Copy, Debug)]
+struct DeltaPackOptions {
+    window: usize,
+    max_depth: usize,
+    max_size: usize,
+    search_deltas: bool,
+}
+
+impl DeltaPackOptions {
+    fn default_compaction() -> DeltaPackOptions {
+        DeltaPackOptions {
+            window: DELTA_WINDOW,
+            max_depth: DELTA_MAX_DEPTH,
+            max_size: DELTA_MAX_SIZE,
+            search_deltas: true,
+        }
+    }
+
+    fn serving(search_deltas: bool) -> DeltaPackOptions {
+        DeltaPackOptions {
+            window: DELTA_WINDOW,
+            max_depth: SERVING_DELTA_MAX_DEPTH,
+            max_size: DELTA_MAX_SIZE,
+            search_deltas,
+        }
+    }
+}
+
+/// Encode `objects` into a **delta-compressed** v2 packfile. Each object is tried against a sliding
+/// window of recently-emitted same-type objects; if a delta against one is smaller than the object
+/// itself (and within the chain-depth limit), it is stored as an `OFS_DELTA`, otherwise full. Bases
+/// are always emitted before the deltas that reference them, so the result is self-contained and
+/// resolvable by [`parse_pack`]. Used by compaction to shrink repacked packs (design §10, §14.1).
+pub fn build_pack_delta(objects: &[Object]) -> Result<BuiltPack, CodecError> {
+    build_pack_delta_reuse(objects, &HashMap::new())
+}
+
+/// Encode `objects` into a delta-compressed pack tuned for clone serving rather than maximum ratio.
+///
+/// Git clients pay delta-chain cost during `index-pack`; keeping the chain ceiling well below git's
+/// default 50 improves full-clone latency on large repos while retaining the bulk of delta savings.
+pub fn build_pack_delta_for_serving(objects: &[Object]) -> Result<BuiltPack, CodecError> {
+    build_pack_delta_reuse_for_serving(objects, &HashMap::new())
+}
+
+/// An object's existing delta from a source pack, ready to re-emit verbatim while testing pack
+/// reuse behavior. Runtime GC paths use the file-backed/indexed pack model instead of this heap
+/// parser/rebuilder path.
+#[derive(Clone, Debug)]
+struct ReusableDelta {
+    base_oid: Oid,
+    /// Inflated delta length (the entry header's size field).
+    delta_len: u64,
+    /// The raw zlib stream of the delta instructions, copyable straight into the new pack.
+    zdelta: Vec<u8>,
+}
+
+fn build_pack_delta_reuse(
+    objects: &[Object],
+    reuse: &HashMap<Oid, ReusableDelta>,
+) -> Result<BuiltPack, CodecError> {
+    build_pack_delta_reuse_with_options(objects, reuse, DeltaPackOptions::default_compaction())
+}
+
+fn build_pack_delta_reuse_for_serving(
+    objects: &[Object],
+    reuse: &HashMap<Oid, ReusableDelta>,
+) -> Result<BuiltPack, CodecError> {
+    build_pack_delta_reuse_with_options(objects, reuse, DeltaPackOptions::serving(reuse.is_empty()))
+}
+
+fn build_pack_delta_reuse_with_options(
+    objects: &[Object],
+    reuse: &HashMap<Oid, ReusableDelta>,
+    opts: DeltaPackOptions,
+) -> Result<BuiltPack, CodecError> {
+    let n = objects.len();
+    // Hash every object once (used for the index, reuse lookup, and the entry record).
+    let ids: Vec<Oid> = objects.iter().map(|o| o.id()).collect();
+    let oid_to_idx: HashMap<Oid, usize> = ids.iter().enumerate().map(|(i, o)| (*o, i)).collect();
+
+    // Resolve reuse hints to in-set base indices (a hint whose base isn't in this pack is dropped).
+    let mut reuse_base: Vec<Option<usize>> = vec![None; n];
+    let mut reuse_rd: Vec<Option<&ReusableDelta>> = vec![None; n];
+    if !reuse.is_empty() {
+        for (i, id) in ids.iter().enumerate() {
+            if let Some(rd) = reuse.get(id) {
+                if let Some(&bi) = oid_to_idx.get(&rd.base_oid) {
+                    if bi != i {
+                        reuse_base[i] = Some(bi);
+                        reuse_rd[i] = Some(rd);
+                    }
+                }
+            }
+        }
+    }
+
+    // Primary order: group by type, then size descending (git's heuristic), so a smaller object
+    // tends to deltify against a larger, similar predecessor in the window.
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_by(|&a, &b| {
+        objects[a]
+            .kind
+            .pack_type()
+            .cmp(&objects[b].kind.pack_type())
+            .then(objects[b].data.len().cmp(&objects[a].data.len()))
+    });
+
+    // Emit order: the primary order, but every reused-delta base is emitted before its target
+    // (iterative DFS over reuse edges). A reuse edge that would form a cycle (conflicting source
+    // packs) is dropped so the order is always well-defined.
+    let mut emit_order: Vec<usize> = Vec::with_capacity(n);
+    let mut visited = vec![false; n];
+    let mut on_stack = vec![false; n];
+    for &start in &order {
+        if visited[start] {
+            continue;
+        }
+        let mut stack = vec![start];
+        while let Some(&oi) = stack.last() {
+            if visited[oi] {
+                stack.pop();
+                continue;
+            }
+            match reuse_base[oi] {
+                Some(bi) if !visited[bi] && !on_stack[bi] => {
+                    on_stack[oi] = true;
+                    stack.push(bi);
+                }
+                Some(bi) if on_stack[bi] => {
+                    // Cycle: break it by dropping this object's reuse.
+                    reuse_base[oi] = None;
+                    reuse_rd[oi] = None;
+                    visited[oi] = true;
+                    on_stack[oi] = false;
+                    emit_order.push(oi);
+                    stack.pop();
+                }
+                _ => {
+                    visited[oi] = true;
+                    on_stack[oi] = false;
+                    emit_order.push(oi);
+                    stack.pop();
+                }
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(64 + n * 32);
+    out.extend_from_slice(PACK_MAGIC);
+    out.extend_from_slice(&PACK_VERSION.to_be_bytes());
+    out.extend_from_slice(&(n as u32).to_be_bytes());
+
+    let mut entries = Vec::with_capacity(n);
+    let mut object_entries = Vec::with_capacity(n);
+    let mut emitted_offset: Vec<Option<u64>> = vec![None; n];
+    let mut emitted_depth: Vec<usize> = vec![0; n];
+    let mut window: VecDeque<(usize, crate::delta::DeltaIndex)> =
+        VecDeque::with_capacity(opts.window);
+
+    for &oi in &emit_order {
+        let obj = &objects[oi];
+        let offset = out.len() as u64;
+        let mut entry_bytes = Vec::new();
+        let mut object_kind = PackObjectKind::Full(obj.kind);
+        let mut declared_size = obj.data.len() as u64;
+
+        // Reuse path: copy the existing delta verbatim if its base is already emitted and the chain
+        // depth stays within bounds.
+        let reused = match (reuse_base[oi], reuse_rd[oi]) {
+            (Some(bi), Some(rd))
+                if emitted_offset[bi].is_some() && emitted_depth[bi] < opts.max_depth =>
+            {
+                let rel = offset - emitted_offset[bi].unwrap();
+                write_entry_header(&mut entry_bytes, T_OFS_DELTA, rd.delta_len);
+                write_offset_varint(&mut entry_bytes, rel);
+                let compressed_prefix_len = entry_bytes.len();
+                entry_bytes.extend_from_slice(&rd.zdelta);
+                object_kind = PackObjectKind::OfsDelta {
+                    base_offset: emitted_offset[bi].unwrap(),
+                    base_oid: rd.base_oid,
+                    depth: emitted_depth[bi] as u32 + 1,
+                };
+                declared_size = rd.delta_len;
+                Some((emitted_depth[bi] + 1, compressed_prefix_len))
+            }
+            _ => None,
+        };
+
+        let (depth, compressed_prefix_len) = if let Some(reused) = reused {
+            reused
+        } else {
+            // Sliding-window delta search (same as the from-scratch builder), disabled for
+            // serving-pack rebuilds that already have source-pack deltas to reuse.
+            let mut best: Option<(usize, Vec<u8>)> = None;
+            if opts.search_deltas && obj.data.len() <= opts.max_size {
+                for (bi, index) in &window {
+                    let base = &objects[*bi];
+                    if base.kind != obj.kind || index.base_len() > opts.max_size {
+                        continue;
+                    }
+                    if emitted_depth[*bi] + 1 > opts.max_depth {
+                        continue;
+                    }
+                    let delta = index.encode(&obj.data);
+                    if delta.len() < obj.data.len()
+                        && best.as_ref().is_none_or(|(_, d)| delta.len() < d.len())
+                    {
+                        best = Some((*bi, delta));
+                    }
+                }
+            }
+            match &best {
+                Some((bi, delta)) => {
+                    let base_offset = emitted_offset[*bi].expect("base emitted before delta");
+                    let rel = offset - base_offset;
+                    declared_size = delta.len() as u64;
+                    write_entry_header(&mut entry_bytes, T_OFS_DELTA, declared_size);
+                    write_offset_varint(&mut entry_bytes, rel);
+                    let compressed_prefix_len = entry_bytes.len();
+                    append_zlib(&mut entry_bytes, delta)?;
+                    object_kind = PackObjectKind::OfsDelta {
+                        base_offset,
+                        base_oid: ids[*bi],
+                        depth: emitted_depth[*bi] as u32 + 1,
+                    };
+                    (emitted_depth[*bi] + 1, compressed_prefix_len)
+                }
+                None => {
+                    declared_size = obj.data.len() as u64;
+                    write_entry_header(&mut entry_bytes, obj.kind.pack_type(), declared_size);
+                    let compressed_prefix_len = entry_bytes.len();
+                    append_zlib(&mut entry_bytes, &obj.data)?;
+                    object_kind = PackObjectKind::Full(obj.kind);
+                    (0, compressed_prefix_len)
+                }
+            }
+        };
+
+        let mut crc = crc32fast::Hasher::new();
+        crc.update(&entry_bytes);
+        let crc32 = crc.finalize();
+        let compressed_offset = offset + compressed_prefix_len as u64;
+        let compressed_len = (entry_bytes.len() - compressed_prefix_len) as u64;
+        entries.push(PackedEntry {
+            oid: ids[oi],
+            offset,
+            crc32,
+        });
+        object_entries.push(PackObjectEntry {
+            oid: ids[oi],
+            kind: object_kind,
+            resolved_kind: obj.kind,
+            offset,
+            compressed_offset,
+            compressed_len,
+            declared_size,
+            resolved_size: obj.data.len() as u64,
+            crc32,
+        });
+        out.extend_from_slice(&entry_bytes);
+
+        emitted_offset[oi] = Some(offset);
+        emitted_depth[oi] = depth;
+        if opts.search_deltas {
+            // Cache this object's delta index so later objects in the window can deltify against it.
+            window.push_back((oi, crate::delta::DeltaIndex::build(&obj.data)));
+            if window.len() > opts.window {
+                window.pop_front();
+            }
+        }
+    }
+
+    let mut h = Sha1::new();
+    h.update(&out);
+    let digest: [u8; 20] = h.finalize().into();
+    out.extend_from_slice(&digest);
+
+    Ok(BuiltPack {
+        data: out,
+        entries,
+        object_entries,
+        pack_hash: Oid::from_array(digest),
+    })
+}
+
+/// Zlib-compress `data` and append it to `out`.
+fn append_zlib(out: &mut Vec<u8>, data: &[u8]) -> Result<(), CodecError> {
+    let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(data)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    let compressed = enc.finish().map_err(|e| CodecError::Io(e.to_string()))?;
+    out.extend_from_slice(&compressed);
+    Ok(())
+}
+
+/// Write git's `OFS_DELTA` base-offset encoding (the exact inverse of [`read_offset_varint`]).
+fn write_offset_varint(out: &mut Vec<u8>, value: u64) {
+    let mut tmp = [0u8; 10];
+    let mut i = tmp.len() - 1;
+    tmp[i] = (value & 0x7f) as u8;
+    let mut v = value >> 7;
+    while v != 0 {
+        v -= 1;
+        i -= 1;
+        tmp[i] = 0x80 | (v & 0x7f) as u8;
+        v >>= 7;
+    }
+    out.extend_from_slice(&tmp[i..]);
+}
+
+/// Write a packfile object's type/size header (3-bit type, base-128 size, low 4 bits first).
+fn write_entry_header(out: &mut Vec<u8>, ty: u8, mut size: u64) {
+    let mut byte = (ty << 4) | (size as u8 & 0x0f);
+    size >>= 4;
+    while size != 0 {
+        out.push(byte | 0x80);
+        byte = (size & 0x7f) as u8;
+        size >>= 7;
+    }
+    out.push(byte);
+}
+
+/// A fully-parsed pack: objects in pack order, plus an offset→oid map for idx generation.
+pub struct ParsedPack {
+    pub objects: Vec<(Oid, Object)>,
+    pub offsets: Vec<PackedEntry>,
+}
+
+/// Parse a v2 packfile, resolving all deltas. `resolver` supplies bases for `REF_DELTA` entries
+/// whose base is not contained in this pack (thin packs); pass `|_| None` for self-contained packs.
+pub fn parse_pack<R>(data: &[u8], mut resolver: R) -> Result<ParsedPack, CodecError>
+where
+    R: FnMut(&Oid) -> Option<Object>,
+{
+    if data.len() < 12 + 20 {
+        return Err(CodecError::PackTooShort);
+    }
+    if &data[0..4] != PACK_MAGIC {
+        return Err(CodecError::BadPackMagic);
+    }
+    let version = u32::from_be_bytes(data[4..8].try_into().unwrap());
+    if version != PACK_VERSION {
+        return Err(CodecError::BadPackVersion(version));
+    }
+    let count = u32::from_be_bytes(data[8..12].try_into().unwrap()) as usize;
+
+    // Verify the trailer hash before trusting any bytes.
+    let body_end = data.len() - 20;
+    let mut h = Sha1::new();
+    h.update(&data[..body_end]);
+    let computed: [u8; 20] = h.finalize().into();
+    if computed != data[body_end..] {
+        return Err(CodecError::PackChecksumMismatch);
+    }
+
+    let mut pos = 12usize;
+    let mut by_offset: HashMap<u64, (Kind, Vec<u8>)> =
+        HashMap::with_capacity(count.min(PREALLOC_HINT_CAP));
+    let mut by_oid: HashMap<Oid, (Kind, Vec<u8>)> =
+        HashMap::with_capacity(count.min(PREALLOC_HINT_CAP));
+    let mut objects = Vec::with_capacity(count.min(PREALLOC_HINT_CAP));
+    let mut offsets = Vec::with_capacity(count.min(PREALLOC_HINT_CAP));
+
+    for _ in 0..count {
+        let entry_start = pos as u64;
+        let (ty, size) = read_entry_header(data, &mut pos)?;
+
+        let (kind, raw) = match ty {
+            T_COMMIT | T_TREE | T_BLOB | T_TAG => {
+                let (raw, _consumed) = inflate(&data[..body_end], &mut pos, size as usize)?;
+                (Kind::from_pack_type(ty)?, raw)
+            }
+            T_OFS_DELTA => {
+                let rel = read_offset_varint(data, &mut pos)?;
+                let base_off = entry_start
+                    .checked_sub(rel)
+                    .ok_or(CodecError::BadDeltaBaseOffset)?;
+                let (delta, _consumed) = inflate(&data[..body_end], &mut pos, size as usize)?;
+                let (bkind, bdata) = by_offset
+                    .get(&base_off)
+                    .ok_or(CodecError::MissingDeltaBaseOffset(base_off))?;
+                let target = apply_delta(bdata, &delta)?;
+                (*bkind, target)
+            }
+            T_REF_DELTA => {
+                let base_oid =
+                    Oid::from_bytes(data.get(pos..pos + 20).ok_or(CodecError::PackTooShort)?)?;
+                pos += 20;
+                let (delta, _consumed) = inflate(&data[..body_end], &mut pos, size as usize)?;
+                let (bkind, bdata) = if let Some((k, d)) = by_oid.get(&base_oid) {
+                    (*k, d.clone())
+                } else if let Some(obj) = resolver(&base_oid) {
+                    (obj.kind, obj.data.to_vec())
+                } else {
+                    return Err(CodecError::MissingDeltaBaseOid(base_oid));
+                };
+                let target = apply_delta(&bdata, &delta)?;
+                (bkind, target)
+            }
+            other => return Err(CodecError::BadPackType(other)),
+        };
+
+        let oid = crate::object::hash(kind, &raw);
+        let crc = {
+            let mut c = crc32fast::Hasher::new();
+            c.update(&data[entry_start as usize..pos]);
+            c.finalize()
+        };
+        by_offset.insert(entry_start, (kind, raw.clone()));
+        by_oid.insert(oid, (kind, raw.clone()));
+        offsets.push(PackedEntry {
+            oid,
+            offset: entry_start,
+            crc32: crc,
+        });
+        objects.push((oid, Object::new(kind, Bytes::from(raw))));
+    }
+
+    Ok(ParsedPack { objects, offsets })
+}
+
+#[cfg(test)]
+fn parse_pack_reuse(data: &[u8]) -> Result<Vec<(Oid, Object, Option<ReusableDelta>)>, CodecError> {
+    if data.len() < 12 + 20 {
+        return Err(CodecError::PackTooShort);
+    }
+    if &data[0..4] != PACK_MAGIC {
+        return Err(CodecError::BadPackMagic);
+    }
+    let version = u32::from_be_bytes(data[4..8].try_into().unwrap());
+    if version != PACK_VERSION {
+        return Err(CodecError::BadPackVersion(version));
+    }
+    let count = u32::from_be_bytes(data[8..12].try_into().unwrap()) as usize;
+
+    let body_end = data.len() - 20;
+    let mut h = Sha1::new();
+    h.update(&data[..body_end]);
+    let computed: [u8; 20] = h.finalize().into();
+    if computed != data[body_end..] {
+        return Err(CodecError::PackChecksumMismatch);
+    }
+
+    let mut pos = 12usize;
+    let mut by_offset: HashMap<u64, (Kind, Vec<u8>)> =
+        HashMap::with_capacity(count.min(PREALLOC_HINT_CAP));
+    let mut by_oid: HashMap<Oid, (Kind, Vec<u8>)> =
+        HashMap::with_capacity(count.min(PREALLOC_HINT_CAP));
+    let mut offset_to_oid: HashMap<u64, Oid> = HashMap::with_capacity(count.min(PREALLOC_HINT_CAP));
+    let mut out = Vec::with_capacity(count.min(PREALLOC_HINT_CAP));
+
+    for _ in 0..count {
+        let entry_start = pos as u64;
+        let (ty, size) = read_entry_header(data, &mut pos)?;
+
+        let (kind, raw, reuse) = match ty {
+            T_COMMIT | T_TREE | T_BLOB | T_TAG => {
+                let (raw, _) = inflate(&data[..body_end], &mut pos, size as usize)?;
+                (Kind::from_pack_type(ty)?, raw, None)
+            }
+            T_OFS_DELTA => {
+                let rel = read_offset_varint(data, &mut pos)?;
+                let base_off = entry_start
+                    .checked_sub(rel)
+                    .ok_or(CodecError::BadDeltaBaseOffset)?;
+                let cstart = pos;
+                let (delta, consumed) = inflate(&data[..body_end], &mut pos, size as usize)?;
+                let (bkind, bdata) = by_offset
+                    .get(&base_off)
+                    .ok_or(CodecError::MissingDeltaBaseOffset(base_off))?;
+                let target = apply_delta(bdata, &delta)?;
+                let base_oid = *offset_to_oid
+                    .get(&base_off)
+                    .ok_or(CodecError::MissingDeltaBaseOffset(base_off))?;
+                let rd = ReusableDelta {
+                    base_oid,
+                    delta_len: size,
+                    zdelta: data[cstart..cstart + consumed].to_vec(),
+                };
+                (*bkind, target, Some(rd))
+            }
+            T_REF_DELTA => {
+                let base_oid =
+                    Oid::from_bytes(data.get(pos..pos + 20).ok_or(CodecError::PackTooShort)?)?;
+                pos += 20;
+                let cstart = pos;
+                let (delta, consumed) = inflate(&data[..body_end], &mut pos, size as usize)?;
+                let (bkind, bdata) = by_oid
+                    .get(&base_oid)
+                    .map(|(k, d)| (*k, d.clone()))
+                    .ok_or(CodecError::MissingDeltaBaseOid(base_oid))?;
+                let target = apply_delta(&bdata, &delta)?;
+                let rd = ReusableDelta {
+                    base_oid,
+                    delta_len: size,
+                    zdelta: data[cstart..cstart + consumed].to_vec(),
+                };
+                (bkind, target, Some(rd))
+            }
+            other => return Err(CodecError::BadPackType(other)),
+        };
+
+        let oid = crate::object::hash(kind, &raw);
+        by_offset.insert(entry_start, (kind, raw.clone()));
+        by_oid.insert(oid, (kind, raw.clone()));
+        offset_to_oid.insert(entry_start, oid);
+        out.push((oid, Object::new(kind, Bytes::from(raw)), reuse));
+    }
+
+    Ok(out)
+}
+
+/// The result of a parallel parse: every object resolved, the source pack's trailer id (its content
+/// address, used as the stored pack id), and — computed in the same multi-core pass — the in-pack oid
+/// set and the set of oids the pack **references but does not contain** (its external dependencies).
+/// The latter two turn push connectivity validation from a full re-walk of history into a couple of
+/// set checks against the existing pool.
+pub struct ResolvedPack {
+    pub object_count: usize,
+    pub pack_hash: Oid,
+    /// Present when the received pack was thin: the self-contained replacement whose bytes must
+    /// be stored instead of the received ones (same storage id). `pack_hash` is its trailer.
+    pub fixed_thin_pack: Option<FixedThinPack>,
+    pub replayed_pack_entries: bool,
+    pub idx_file: tempfile::NamedTempFile,
+    pub idx_bytes: usize,
+    pub object_index_file: tempfile::NamedTempFile,
+    pub source_index_file: tempfile::NamedTempFile,
+    pub source_commit_entries: Vec<PackCommitIndexEntry>,
+    pub oids: Vec<Oid>,
+    pub external_refs: std::collections::HashSet<Oid>,
+    pub tag_targets: std::collections::HashMap<Oid, Oid>,
+    pub largest: Option<(Oid, u64)>,
+}
+
+/// A fully scanned receive-pack file: trailer verified and compressed entry ranges recorded.
+/// Delta and source-metadata resolution happens from the seekable temp file so the scanner does not
+/// retain inflated object payloads while request bytes are still arriving.
+pub struct ScannedPack {
+    pack_hash: Oid,
+    entries: Vec<ReceiveEntryMeta>,
+    pack_len: u64,
+    scan_ms: f64,
+    retained_payload_bytes: u64,
+    spilled_payload_bytes: u64,
+    predecode_budget_exhausted: bool,
+}
+
+#[derive(Clone, Copy, Default)]
+struct ScanResolveStats {
+    scan_ms: f64,
+    retained_payload_bytes: u64,
+    spilled_payload_bytes: u64,
+    predecode_budget_exhausted: bool,
+}
+
+impl ScannedPack {
+    pub fn pack_hash(&self) -> Oid {
+        self.pack_hash
+    }
+
+    pub fn pack_len(&self) -> u64 {
+        self.pack_len
+    }
+
+    pub fn retained_payload_bytes(&self) -> u64 {
+        self.retained_payload_bytes
+    }
+
+    pub fn spilled_payload_bytes(&self) -> u64 {
+        self.spilled_payload_bytes
+    }
+
+    pub fn predecode_budget_exhausted(&self) -> bool {
+        self.predecode_budget_exhausted
+    }
+
+    pub fn ref_delta_bases(&self) -> Vec<Oid> {
+        let mut bases = Vec::new();
+        for entry in &self.entries {
+            if let ReceiveEntryKind::RefDelta { base_oid } = entry.kind {
+                bases.push(base_oid);
+            }
+        }
+        bases.sort_unstable();
+        bases.dedup();
+        bases
+    }
+}
+
+/// A large blob resolved from a pack into a local temporary file.
+pub struct FileBackedBlob {
+    pub oid: Oid,
+    pub size: u64,
+    file: tempfile::NamedTempFile,
+}
+
+impl FileBackedBlob {
+    pub fn from_temp(oid: Oid, size: u64, file: tempfile::NamedTempFile) -> Self {
+        Self { oid, size, file }
+    }
+
+    pub fn path(&self) -> &Path {
+        self.file.path()
+    }
+}
+
+/// Bounded artifact extraction plan for a self-contained pack.
+///
+/// This never materializes all small objects for repacking. It only resolves the pack far enough to
+/// identify large blobs that should be extracted to the global artifact store, spilling those blobs
+/// to temporary files. This is the optimizer hot path for large first-push packs: keep the
+/// client-authored pack as the serving pack and publish extracted artifact side data without
+/// building a second full pack in memory.
+pub struct PackOptimizationPlan {
+    pub object_count: usize,
+    pub large_blobs: Vec<FileBackedBlob>,
+}
+
+/// One tree entry extracted from a pack for derived metadata indexing.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackTreeIndexEntry {
+    pub tree_oid: Oid,
+    pub mode: u32,
+    pub name: Vec<u8>,
+    pub oid: Oid,
+}
+
+/// One commit entry extracted from a pack for derived metadata indexing.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackCommitIndexEntry {
+    pub commit_oid: Oid,
+    pub root_tree: Oid,
+    pub parents: Vec<Oid>,
+}
+
+/// Bounded derived-index plan for source metadata.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PackTreeIndexPlan {
+    pub object_count: usize,
+    pub entries: Vec<PackTreeIndexEntry>,
+    pub commits: Vec<PackCommitIndexEntry>,
+}
+
+pub fn write_pack_source_index_sidecar<W: Write>(
+    mut writer: W,
+    plan: &PackTreeIndexPlan,
+) -> Result<(), CodecError> {
+    writer
+        .write_all(SOURCE_INDEX_MAGIC)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    write_u64(&mut writer, plan.object_count as u64)?;
+    write_u64(&mut writer, plan.entries.len() as u64)?;
+    write_u64(&mut writer, plan.commits.len() as u64)?;
+    for entry in &plan.entries {
+        write_pack_tree_index_entry(&mut writer, entry)?;
+    }
+    for commit in &plan.commits {
+        write_pack_commit_index_entry(&mut writer, commit)?;
+    }
+    writer.flush().map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(())
+}
+
+fn write_pack_tree_index_entry<W: Write>(
+    writer: &mut W,
+    entry: &PackTreeIndexEntry,
+) -> Result<(), CodecError> {
+    write_oid(writer, &entry.tree_oid)?;
+    write_u32(writer, entry.mode)?;
+    write_u64(writer, entry.name.len() as u64)?;
+    writer
+        .write_all(&entry.name)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    write_oid(writer, &entry.oid)?;
+    Ok(())
+}
+
+fn write_pack_commit_index_entry<W: Write>(
+    writer: &mut W,
+    commit: &PackCommitIndexEntry,
+) -> Result<(), CodecError> {
+    write_oid(writer, &commit.commit_oid)?;
+    write_oid(writer, &commit.root_tree)?;
+    write_u64(writer, commit.parents.len() as u64)?;
+    for parent in &commit.parents {
+        write_oid(writer, parent)?;
+    }
+    Ok(())
+}
+
+pub fn encode_pack_source_index_sidecar(plan: &PackTreeIndexPlan) -> Result<Vec<u8>, CodecError> {
+    let mut out = Vec::new();
+    write_pack_source_index_sidecar(&mut out, plan)?;
+    Ok(out)
+}
+
+pub fn decode_pack_source_index_sidecar(sidecar: &[u8]) -> Result<PackTreeIndexPlan, CodecError> {
+    let mut cursor = std::io::Cursor::new(sidecar);
+    let mut magic = [0u8; 8];
+    cursor
+        .read_exact(&mut magic)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    if &magic != SOURCE_INDEX_MAGIC {
+        return Err(CodecError::Io("invalid source-index sidecar magic".into()));
+    }
+    let object_count = usize::try_from(read_u64(&mut cursor)?)
+        .map_err(|_| CodecError::Io("source-index object count overflows usize".into()))?;
+    let tree_count = usize::try_from(read_u64(&mut cursor)?)
+        .map_err(|_| CodecError::Io("source-index tree count overflows usize".into()))?;
+    let commit_count = usize::try_from(read_u64(&mut cursor)?)
+        .map_err(|_| CodecError::Io("source-index commit count overflows usize".into()))?;
+    let mut entries = Vec::with_capacity(tree_count.min(PREALLOC_HINT_CAP));
+    for _ in 0..tree_count {
+        let tree_oid = read_oid(&mut cursor)?;
+        let mode = read_u32(&mut cursor)?;
+        let name_len = usize::try_from(read_u64(&mut cursor)?)
+            .map_err(|_| CodecError::Io("source-index name length overflows usize".into()))?;
+        let mut name = vec![0u8; name_len];
+        cursor
+            .read_exact(&mut name)
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        entries.push(PackTreeIndexEntry {
+            tree_oid,
+            mode,
+            name,
+            oid: read_oid(&mut cursor)?,
+        });
+    }
+    let mut commits = Vec::with_capacity(commit_count.min(PREALLOC_HINT_CAP));
+    for _ in 0..commit_count {
+        let commit_oid = read_oid(&mut cursor)?;
+        let root_tree = read_oid(&mut cursor)?;
+        let parent_count = usize::try_from(read_u64(&mut cursor)?)
+            .map_err(|_| CodecError::Io("source-index parent count overflows usize".into()))?;
+        let mut parents = Vec::with_capacity(parent_count);
+        for _ in 0..parent_count {
+            parents.push(read_oid(&mut cursor)?);
+        }
+        commits.push(PackCommitIndexEntry {
+            commit_oid,
+            root_tree,
+            parents,
+        });
+    }
+    if cursor.position() != sidecar.len() as u64 {
+        return Err(CodecError::Io(
+            "source-index sidecar has trailing bytes".into(),
+        ));
+    }
+    Ok(PackTreeIndexPlan {
+        object_count,
+        entries,
+        commits,
+    })
+}
+
+fn write_u8<W: Write>(writer: &mut W, value: u8) -> Result<(), CodecError> {
+    writer
+        .write_all(&[value])
+        .map_err(|e| CodecError::Io(e.to_string()))
+}
+
+fn write_u32<W: Write>(writer: &mut W, value: u32) -> Result<(), CodecError> {
+    writer
+        .write_all(&value.to_be_bytes())
+        .map_err(|e| CodecError::Io(e.to_string()))
+}
+
+fn write_u64<W: Write>(writer: &mut W, value: u64) -> Result<(), CodecError> {
+    writer
+        .write_all(&value.to_be_bytes())
+        .map_err(|e| CodecError::Io(e.to_string()))
+}
+
+fn write_oid<W: Write>(writer: &mut W, oid: &Oid) -> Result<(), CodecError> {
+    writer
+        .write_all(oid.as_bytes())
+        .map_err(|e| CodecError::Io(e.to_string()))
+}
+
+fn write_kind<W: Write>(writer: &mut W, kind: Kind) -> Result<(), CodecError> {
+    write_u8(writer, kind.pack_type())
+}
+
+fn read_u8<R: Read>(reader: &mut R) -> Result<u8, CodecError> {
+    let mut buf = [0u8; 1];
+    reader
+        .read_exact(&mut buf)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(buf[0])
+}
+
+fn read_u32<R: Read>(reader: &mut R) -> Result<u32, CodecError> {
+    let mut buf = [0u8; 4];
+    reader
+        .read_exact(&mut buf)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(u32::from_be_bytes(buf))
+}
+
+fn read_u64<R: Read>(reader: &mut R) -> Result<u64, CodecError> {
+    let mut buf = [0u8; 8];
+    reader
+        .read_exact(&mut buf)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(u64::from_be_bytes(buf))
+}
+
+fn read_oid<R: Read>(reader: &mut R) -> Result<Oid, CodecError> {
+    let mut bytes = [0u8; 20];
+    reader
+        .read_exact(&mut bytes)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(Oid::from_array(bytes))
+}
+
+fn read_kind<R: Read>(reader: &mut R) -> Result<Kind, CodecError> {
+    Kind::from_pack_type(read_u8(reader)?)
+}
+
+#[derive(Clone, Copy)]
+enum ReceiveEntryKind {
+    Full(Kind),
+    OfsDelta { base_offset: u64 },
+    RefDelta { base_oid: Oid },
+}
+
+struct ReceiveEntryMeta {
+    offset: u64,
+    compressed_offset: u64,
+    compressed_len: usize,
+    declared_size: u64,
+    kind: ReceiveEntryKind,
+    crc32: u32,
+    base_ref_count: u32,
+    oid: Option<Oid>,
+    resolved_kind: Option<Kind>,
+    resolved_size: Option<u64>,
+    predecoded_raw: Option<Vec<u8>>,
+    base_oid: Option<Oid>,
+    depth: u32,
+}
+
+struct StoredBase {
+    oid: Oid,
+    kind: Kind,
+    size: u64,
+    depth: u32,
+    remaining_refs: u32,
+    data: StoredBaseData,
+}
+
+/// Incrementally scans a received pack while the server spools the same bytes to disk.
+pub struct ReceivePackSpooler {
+    state: SpoolState,
+    buf: Vec<u8>,
+    pos: usize,
+    absolute_pos: u64,
+    hasher: Sha1,
+    entries: Vec<ReceiveEntryMeta>,
+    count: Option<usize>,
+    allow_ref_delta: bool,
+    started: std::time::Instant,
+}
+
+enum SpoolState {
+    Header,
+    Entry,
+    OfsDelta {
+        entry_offset: u64,
+        ty: u8,
+        declared_size: u64,
+        crc: crc32fast::Hasher,
+        rel: u64,
+        started: bool,
+    },
+    RefDelta {
+        entry_offset: u64,
+        ty: u8,
+        declared_size: u64,
+        crc: crc32fast::Hasher,
+        base: [u8; 20],
+        read: usize,
+    },
+    Inflate(Box<InflightEntry>),
+    Trailer {
+        trailer: [u8; 20],
+        read: usize,
+    },
+    Done,
+    Thin,
+}
+
+struct InflightEntry {
+    offset: u64,
+    compressed_offset: u64,
+    declared_size: u64,
+    kind: ReceiveEntryKind,
+    crc: crc32fast::Hasher,
+    dec: Decompress,
+    scratch: [u8; 16 * 1024],
+    object_hasher: Option<Sha1>,
+}
+
+struct ScannedResolution {
+    oid: Option<Oid>,
+    kind: Option<Kind>,
+    size: Option<u64>,
+    raw: Option<Vec<u8>>,
+    base_oid: Option<Oid>,
+    depth: u32,
+}
+
+impl ReceivePackSpooler {
+    pub fn new(allow_ref_delta: bool) -> Self {
+        Self {
+            state: SpoolState::Header,
+            buf: Vec::new(),
+            pos: 0,
+            absolute_pos: 0,
+            hasher: Sha1::new(),
+            entries: Vec::new(),
+            count: None,
+            allow_ref_delta,
+            started: std::time::Instant::now(),
+        }
+    }
+
+    pub fn push(&mut self, chunk: &[u8]) -> Result<(), CodecError> {
+        self.buf.extend_from_slice(chunk);
+        self.process()
+    }
+
+    pub fn finish(mut self) -> Result<Option<ScannedPack>, CodecError> {
+        self.process()?;
+        if matches!(self.state, SpoolState::Thin) {
+            return Ok(None);
+        }
+        if !matches!(self.state, SpoolState::Done) {
+            return Err(CodecError::PackTooShort);
+        }
+        if self.pos != self.buf.len() {
+            return Err(CodecError::PackTooShort);
+        }
+        let pack_len = self.absolute_pos;
+        Ok(Some(ScannedPack {
+            pack_hash: Oid::from_array(finalize_sha1(self.hasher)),
+            entries: self.entries,
+            pack_len,
+            scan_ms: elapsed_ms(self.started),
+            retained_payload_bytes: 0,
+            spilled_payload_bytes: 0,
+            predecode_budget_exhausted: false,
+        }))
+    }
+
+    fn process(&mut self) -> Result<(), CodecError> {
+        loop {
+            self.compact_buffer();
+            match std::mem::replace(&mut self.state, SpoolState::Done) {
+                SpoolState::Header => {
+                    if self.available() < 12 {
+                        self.state = SpoolState::Header;
+                        return Ok(());
+                    }
+                    let header = self.peek_exact(12)?;
+                    if &header[0..4] != PACK_MAGIC {
+                        return Err(CodecError::BadPackMagic);
+                    }
+                    let version = u32::from_be_bytes(header[4..8].try_into().unwrap());
+                    if version != PACK_VERSION {
+                        return Err(CodecError::BadPackVersion(version));
+                    }
+                    let count = u32::from_be_bytes(header[8..12].try_into().unwrap()) as usize;
+                    self.count = Some(count);
+                    self.entries = Vec::with_capacity(count.min(PREALLOC_HINT_CAP));
+                    self.consume_body(12, None)?;
+                    self.state = if count == 0 {
+                        SpoolState::Trailer {
+                            trailer: [0; 20],
+                            read: 0,
+                        }
+                    } else {
+                        SpoolState::Entry
+                    };
+                }
+                SpoolState::Entry => {
+                    let Some(count) = self.count else {
+                        return Err(CodecError::BadPackMagic);
+                    };
+                    if self.entries.len() == count {
+                        self.state = SpoolState::Trailer {
+                            trailer: [0; 20],
+                            read: 0,
+                        };
+                        continue;
+                    }
+                    let entry_offset = self.absolute_pos;
+                    let mut crc = crc32fast::Hasher::new();
+                    let Some((ty, declared_size, header_len)) = self.try_peek_entry_header()?
+                    else {
+                        self.state = SpoolState::Entry;
+                        return Ok(());
+                    };
+                    self.consume_body(header_len, Some(&mut crc))?;
+                    match ty {
+                        T_COMMIT | T_TREE | T_BLOB | T_TAG => {
+                            let kind = ReceiveEntryKind::Full(Kind::from_pack_type(ty)?);
+                            self.state = SpoolState::Inflate(Box::new(InflightEntry::new(
+                                entry_offset,
+                                self.absolute_pos,
+                                declared_size,
+                                kind,
+                                crc,
+                            )?));
+                        }
+                        T_OFS_DELTA => {
+                            self.state = SpoolState::OfsDelta {
+                                entry_offset,
+                                ty,
+                                declared_size,
+                                crc,
+                                rel: 0,
+                                started: false,
+                            };
+                        }
+                        T_REF_DELTA => {
+                            self.state = SpoolState::RefDelta {
+                                entry_offset,
+                                ty,
+                                declared_size,
+                                crc,
+                                base: [0; 20],
+                                read: 0,
+                            };
+                        }
+                        other => return Err(CodecError::BadPackType(other)),
+                    }
+                }
+                SpoolState::OfsDelta {
+                    entry_offset,
+                    ty,
+                    declared_size,
+                    mut crc,
+                    mut rel,
+                    mut started,
+                } => loop {
+                    let Some(b) = self.try_read_body_byte(Some(&mut crc))? else {
+                        self.state = SpoolState::OfsDelta {
+                            entry_offset,
+                            ty,
+                            declared_size,
+                            crc,
+                            rel,
+                            started,
+                        };
+                        return Ok(());
+                    };
+                    if started {
+                        rel = ((rel + 1) << 7) | (b & 0x7f) as u64;
+                    } else {
+                        rel = (b & 0x7f) as u64;
+                        started = true;
+                    }
+                    if b & 0x80 == 0 {
+                        let base_offset = entry_offset
+                            .checked_sub(rel)
+                            .ok_or(CodecError::BadDeltaBaseOffset)?;
+                        let base_idx = self
+                            .entries
+                            .binary_search_by_key(&base_offset, |entry| entry.offset)
+                            .map_err(|_| CodecError::MissingDeltaBaseOffset(base_offset))?;
+                        self.entries[base_idx].base_ref_count = self.entries[base_idx]
+                            .base_ref_count
+                            .checked_add(1)
+                            .ok_or_else(|| CodecError::Io("too many delta children".into()))?;
+                        self.state = SpoolState::Inflate(Box::new(InflightEntry::new(
+                            entry_offset,
+                            self.absolute_pos,
+                            declared_size,
+                            ReceiveEntryKind::OfsDelta { base_offset },
+                            crc,
+                        )?));
+                        break;
+                    }
+                },
+                SpoolState::RefDelta {
+                    entry_offset,
+                    ty,
+                    declared_size,
+                    mut crc,
+                    mut base,
+                    mut read,
+                } => {
+                    while read < 20 {
+                        let Some(b) = self.try_read_body_byte(Some(&mut crc))? else {
+                            self.state = SpoolState::RefDelta {
+                                entry_offset,
+                                ty,
+                                declared_size,
+                                crc,
+                                base,
+                                read,
+                            };
+                            return Ok(());
+                        };
+                        base[read] = b;
+                        read += 1;
+                    }
+                    if !self.allow_ref_delta {
+                        self.state = SpoolState::Thin;
+                        return Ok(());
+                    }
+                    self.state = SpoolState::Inflate(Box::new(InflightEntry::new(
+                        entry_offset,
+                        self.absolute_pos,
+                        declared_size,
+                        ReceiveEntryKind::RefDelta {
+                            base_oid: Oid::from_array(base),
+                        },
+                        crc,
+                    )?));
+                }
+                SpoolState::Inflate(mut entry) => {
+                    if !self.process_inflate(&mut entry)? {
+                        self.state = SpoolState::Inflate(entry);
+                        return Ok(());
+                    }
+                    self.push_scanned_entry(*entry)?;
+                    self.state = SpoolState::Entry;
+                }
+                SpoolState::Trailer {
+                    mut trailer,
+                    mut read,
+                } => {
+                    while read < 20 {
+                        let Some(b) = self.try_read_raw_byte()? else {
+                            self.state = SpoolState::Trailer { trailer, read };
+                            return Ok(());
+                        };
+                        trailer[read] = b;
+                        read += 1;
+                    }
+                    let computed = finalize_sha1(self.hasher.clone());
+                    if computed != trailer {
+                        return Err(CodecError::PackChecksumMismatch);
+                    }
+                    self.state = SpoolState::Done;
+                }
+                SpoolState::Done => {
+                    self.state = SpoolState::Done;
+                    return Ok(());
+                }
+                SpoolState::Thin => {
+                    self.state = SpoolState::Thin;
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    fn push_scanned_entry(&mut self, entry: InflightEntry) -> Result<(), CodecError> {
+        let compressed_len = (self.absolute_pos - entry.compressed_offset)
+            .try_into()
+            .map_err(|_| CodecError::PackTooShort)?;
+        let predecoded_oid = entry.object_hasher.clone().map(finalize_object_hash);
+        let InflightEntry {
+            offset,
+            compressed_offset,
+            declared_size,
+            kind,
+            crc,
+            ..
+        } = entry;
+        let resolution = self.try_resolve_scanned_entry(kind, declared_size, predecoded_oid)?;
+        self.entries.push(ReceiveEntryMeta {
+            offset,
+            compressed_offset,
+            compressed_len,
+            declared_size,
+            kind,
+            crc32: crc.finalize(),
+            base_ref_count: 0,
+            oid: resolution.oid,
+            resolved_kind: resolution.kind,
+            resolved_size: resolution.size,
+            predecoded_raw: resolution.raw,
+            base_oid: resolution.base_oid,
+            depth: resolution.depth,
+        });
+        Ok(())
+    }
+
+    fn try_resolve_scanned_entry(
+        &self,
+        kind: ReceiveEntryKind,
+        declared_size: u64,
+        full_oid: Option<Oid>,
+    ) -> Result<ScannedResolution, CodecError> {
+        match kind {
+            ReceiveEntryKind::Full(kind) => Ok(ScannedResolution {
+                oid: full_oid,
+                kind: full_oid.map(|_| kind),
+                size: full_oid.map(|_| declared_size),
+                raw: None,
+                base_oid: None,
+                depth: 0,
+            }),
+            ReceiveEntryKind::OfsDelta { base_offset } => {
+                let base_oid = self
+                    .entries
+                    .binary_search_by_key(&base_offset, |entry| entry.offset)
+                    .ok()
+                    .and_then(|base_idx| self.entries[base_idx].oid);
+                Ok(ScannedResolution {
+                    oid: None,
+                    kind: None,
+                    size: None,
+                    raw: None,
+                    base_oid,
+                    depth: 0,
+                })
+            }
+            ReceiveEntryKind::RefDelta { base_oid } => Ok(ScannedResolution {
+                oid: None,
+                kind: None,
+                size: None,
+                raw: None,
+                base_oid: Some(base_oid),
+                depth: 1,
+            }),
+        }
+    }
+
+    fn process_inflate(&mut self, entry: &mut InflightEntry) -> Result<bool, CodecError> {
+        loop {
+            if self.available() == 0 {
+                return Ok(false);
+            }
+            let input = &self.buf[self.pos..];
+            let before_in = entry.dec.total_in();
+            let before_out = entry.dec.total_out();
+            let status = entry
+                .dec
+                .decompress(input, &mut entry.scratch, FlushDecompress::None)
+                .map_err(|e| CodecError::Inflate(e.to_string()))?;
+            let consumed = (entry.dec.total_in() - before_in) as usize;
+            let produced = (entry.dec.total_out() - before_out) as usize;
+            self.consume_body(consumed, Some(&mut entry.crc))?;
+            if produced > 0 {
+                let bytes = &entry.scratch[..produced];
+                if let Some(hasher) = entry.object_hasher.as_mut() {
+                    hasher.update(bytes);
+                }
+            }
+            if matches!(status, Status::StreamEnd) {
+                let produced = entry.dec.total_out() as usize;
+                if produced != entry.declared_size as usize {
+                    return Err(CodecError::Inflate(format!(
+                        "expected {} bytes, produced {produced}",
+                        entry.declared_size
+                    )));
+                }
+                return Ok(true);
+            }
+            if entry.dec.total_in() == before_in && entry.dec.total_out() == before_out {
+                return Err(CodecError::Inflate("inflate made no progress".into()));
+            }
+        }
+    }
+
+    fn try_peek_entry_header(&self) -> Result<Option<(u8, u64, usize)>, CodecError> {
+        let Some(&first) = self.buf.get(self.pos) else {
+            return Ok(None);
+        };
+        let ty = (first >> 4) & 0x07;
+        let mut size = (first & 0x0f) as u64;
+        let mut shift = 4u32;
+        let mut b = first;
+        let mut read = 1usize;
+        while b & 0x80 != 0 {
+            let Some(&next) = self.buf.get(self.pos + read) else {
+                return Ok(None);
+            };
+            b = next;
+            size |= ((b & 0x7f) as u64) << shift;
+            shift += 7;
+            read += 1;
+        }
+        Ok(Some((ty, size, read)))
+    }
+
+    fn peek_exact(&self, n: usize) -> Result<&[u8], CodecError> {
+        self.buf
+            .get(self.pos..self.pos + n)
+            .ok_or(CodecError::PackTooShort)
+    }
+
+    fn try_read_body_byte(
+        &mut self,
+        crc: Option<&mut crc32fast::Hasher>,
+    ) -> Result<Option<u8>, CodecError> {
+        if self.available() == 0 {
+            return Ok(None);
+        }
+        let b = self.buf[self.pos];
+        self.consume_body(1, crc)?;
+        Ok(Some(b))
+    }
+
+    fn try_read_raw_byte(&mut self) -> Result<Option<u8>, CodecError> {
+        if self.available() == 0 {
+            return Ok(None);
+        }
+        let b = self.buf[self.pos];
+        self.pos += 1;
+        self.absolute_pos += 1;
+        Ok(Some(b))
+    }
+
+    fn consume_body(
+        &mut self,
+        n: usize,
+        crc: Option<&mut crc32fast::Hasher>,
+    ) -> Result<(), CodecError> {
+        let bytes = self
+            .buf
+            .get(self.pos..self.pos + n)
+            .ok_or(CodecError::PackTooShort)?;
+        self.hasher.update(bytes);
+        if let Some(crc) = crc {
+            crc.update(bytes);
+        }
+        self.pos += n;
+        self.absolute_pos += n as u64;
+        Ok(())
+    }
+
+    fn available(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
+    }
+
+    fn compact_buffer(&mut self) {
+        if self.pos > 64 * 1024 && self.pos * 2 > self.buf.len() {
+            self.buf.drain(..self.pos);
+            self.pos = 0;
+        }
+    }
+}
+
+impl InflightEntry {
+    fn new(
+        offset: u64,
+        compressed_offset: u64,
+        declared_size: u64,
+        kind: ReceiveEntryKind,
+        crc: crc32fast::Hasher,
+    ) -> Result<Self, CodecError> {
+        let full_kind = match kind {
+            ReceiveEntryKind::Full(kind) => Some(kind),
+            ReceiveEntryKind::OfsDelta { .. } | ReceiveEntryKind::RefDelta { .. } => None,
+        };
+        #[cfg(test)]
+        if full_kind == Some(Kind::Blob) {
+            STREAMED_FULL_BLOBS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(Self {
+            offset,
+            compressed_offset,
+            declared_size,
+            kind,
+            crc,
+            dec: Decompress::new(true),
+            scratch: [0; 16 * 1024],
+            object_hasher: full_kind.map(|kind| object_hasher(kind, declared_size)),
+        })
+    }
+}
+
+enum StoredBaseData {
+    Memory(Vec<u8>),
+    Spilled(tempfile::NamedTempFile),
+    ExternalPath(PathBuf),
+}
+
+#[cfg(test)]
+const LARGE_DELTA_BASE_SPILL_BYTES: usize = 1024;
+#[cfg(not(test))]
+const LARGE_DELTA_BASE_SPILL_BYTES: usize = 16 * 1024 * 1024;
+#[cfg(test)]
+const DELTA_BASE_MEMORY_BUDGET_BYTES: usize = 16 * 1024;
+#[cfg(not(test))]
+const DELTA_BASE_MEMORY_BUDGET_BYTES: usize = 256 * 1024 * 1024;
+#[cfg(test)]
+static SPILLED_DELTA_BASES: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+static STREAMED_DELTA_TARGETS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+#[cfg(test)]
+static STREAMED_FULL_BLOBS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+struct ResolvedData {
+    oid: Oid,
+    size: u64,
+    raw: Option<Vec<u8>>,
+    spilled: Option<tempfile::NamedTempFile>,
+    external_path: Option<PathBuf>,
+}
+
+/// A resolved object payload stored outside the current pack, used as a `REF_DELTA` base without
+/// materializing the payload in the codec heap.
+#[derive(Clone, Debug)]
+pub struct ExternalBase {
+    pub kind: Kind,
+    pub size: u64,
+    pub path: PathBuf,
+}
+
+fn store_delta_base(
+    oid: Oid,
+    kind: Kind,
+    depth: u32,
+    raw: Vec<u8>,
+    remaining_refs: u32,
+) -> Result<StoredBase, CodecError> {
+    let size = raw.len() as u64;
+    if raw.len() < LARGE_DELTA_BASE_SPILL_BYTES {
+        return Ok(StoredBase {
+            oid,
+            kind,
+            size,
+            depth,
+            remaining_refs,
+            data: StoredBaseData::Memory(raw),
+        });
+    }
+    let mut file = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    file.write_all(&raw)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    file.as_file_mut()
+        .flush()
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    #[cfg(test)]
+    SPILLED_DELTA_BASES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Ok(StoredBase {
+        oid,
+        kind,
+        size,
+        depth,
+        remaining_refs,
+        data: StoredBaseData::Spilled(file),
+    })
+}
+
+fn store_delta_base_with_memory_budget(
+    oid: Oid,
+    kind: Kind,
+    depth: u32,
+    raw: Vec<u8>,
+    remaining_refs: u32,
+    resident_base_bytes: &mut usize,
+) -> Result<StoredBase, CodecError> {
+    let size = raw.len();
+    if size < LARGE_DELTA_BASE_SPILL_BYTES
+        && resident_base_bytes
+            .checked_add(size)
+            .is_some_and(|next| next <= DELTA_BASE_MEMORY_BUDGET_BYTES)
+    {
+        *resident_base_bytes += size;
+        return Ok(StoredBase {
+            oid,
+            kind,
+            size: size as u64,
+            depth,
+            remaining_refs,
+            data: StoredBaseData::Memory(raw),
+        });
+    }
+
+    let mut file = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    file.write_all(&raw)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    file.as_file_mut()
+        .flush()
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    #[cfg(test)]
+    SPILLED_DELTA_BASES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Ok(StoredBase {
+        oid,
+        kind,
+        size: size as u64,
+        depth,
+        remaining_refs,
+        data: StoredBaseData::Spilled(file),
+    })
+}
+
+fn stored_base_resident_bytes(base: &StoredBase) -> usize {
+    match &base.data {
+        StoredBaseData::Memory(data) => data.len(),
+        StoredBaseData::Spilled(_) | StoredBaseData::ExternalPath(_) => 0,
+    }
+}
+
+fn store_spilled_delta_base(
+    oid: Oid,
+    kind: Kind,
+    size: u64,
+    depth: u32,
+    file: tempfile::NamedTempFile,
+    remaining_refs: u32,
+) -> StoredBase {
+    StoredBase {
+        oid,
+        kind,
+        size,
+        depth,
+        remaining_refs,
+        data: StoredBaseData::Spilled(file),
+    }
+}
+
+fn resolve_delta_from_base(
+    base: &StoredBase,
+    delta: &[u8],
+    target_size: usize,
+) -> Result<ResolvedData, CodecError> {
+    resolve_delta_from_base_with_spill_threshold(
+        base,
+        delta,
+        target_size,
+        LARGE_DELTA_BASE_SPILL_BYTES,
+    )
+}
+
+fn resolve_delta_from_base_with_spill_threshold(
+    base: &StoredBase,
+    delta: &[u8],
+    target_size: usize,
+    spill_threshold: usize,
+) -> Result<ResolvedData, CodecError> {
+    let should_stream_blob = base.kind == Kind::Blob
+        && (target_size >= spill_threshold || matches!(base.data, StoredBaseData::Spilled(_)));
+    if should_stream_blob {
+        let (oid, file) = apply_delta_to_spill(base, delta, target_size)?;
+        return Ok(ResolvedData {
+            oid,
+            size: target_size as u64,
+            raw: None,
+            spilled: Some(file),
+            external_path: None,
+        });
+    }
+
+    let base_data = materialize_base(base)?;
+    let raw = apply_delta(&base_data, delta)?;
+    if raw.len() != target_size {
+        return Err(CodecError::DeltaTargetSizeMismatch {
+            expected: target_size as u64,
+            actual: raw.len() as u64,
+        });
+    }
+    let oid = crate::object::hash(base.kind, &raw);
+    Ok(ResolvedData {
+        oid,
+        size: raw.len() as u64,
+        raw: Some(raw),
+        spilled: None,
+        external_path: None,
+    })
+}
+
+fn materialize_base(base: &StoredBase) -> Result<Vec<u8>, CodecError> {
+    match &base.data {
+        StoredBaseData::Memory(data) => Ok(data.clone()),
+        StoredBaseData::Spilled(file) => {
+            std::fs::read(file.path()).map_err(|e| CodecError::Io(e.to_string()))
+        }
+        StoredBaseData::ExternalPath(path) => {
+            std::fs::read(path).map_err(|e| CodecError::Io(e.to_string()))
+        }
+    }
+}
+
+fn apply_delta_to_spill(
+    base: &StoredBase,
+    delta: &[u8],
+    target_size: usize,
+) -> Result<(Oid, tempfile::NamedTempFile), CodecError> {
+    let mut pos = 0usize;
+    let src_size = crate::delta::read_size_varint(delta, &mut pos)?;
+    if src_size != base.size {
+        return Err(CodecError::DeltaBaseSizeMismatch {
+            expected: src_size,
+            actual: base.size,
+        });
+    }
+    let declared_target = crate::delta::read_size_varint(delta, &mut pos)? as usize;
+    if declared_target != target_size {
+        return Err(CodecError::DeltaTargetSizeMismatch {
+            expected: declared_target as u64,
+            actual: target_size as u64,
+        });
+    }
+
+    let mut out = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    let mut hasher = object_hasher(base.kind, target_size as u64);
+    let mut written = 0usize;
+    while pos < delta.len() {
+        let op = delta[pos];
+        pos += 1;
+        if op & 0x80 != 0 {
+            let mut cp_off: u64 = 0;
+            let mut cp_size: u64 = 0;
+            for (i, mask) in [0x01u8, 0x02, 0x04, 0x08].into_iter().enumerate() {
+                if op & mask != 0 {
+                    cp_off |=
+                        (*delta.get(pos).ok_or(CodecError::TruncatedDelta)? as u64) << (8 * i);
+                    pos += 1;
+                }
+            }
+            for (i, mask) in [0x10u8, 0x20, 0x40].into_iter().enumerate() {
+                if op & mask != 0 {
+                    cp_size |=
+                        (*delta.get(pos).ok_or(CodecError::TruncatedDelta)? as u64) << (8 * i);
+                    pos += 1;
+                }
+            }
+            if cp_size == 0 {
+                cp_size = 0x10000;
+            }
+            let end = cp_off
+                .checked_add(cp_size)
+                .ok_or(CodecError::TruncatedDelta)?;
+            if end > base.size {
+                return Err(CodecError::DeltaCopyOutOfRange {
+                    start: cp_off,
+                    end,
+                    base_len: base.size,
+                });
+            }
+            copy_base_range_to_output(base, cp_off, cp_size, &mut out, &mut hasher)?;
+            written = written
+                .checked_add(cp_size as usize)
+                .ok_or(CodecError::TruncatedDelta)?;
+        } else if op != 0 {
+            let len = op as usize;
+            let end = pos.checked_add(len).ok_or(CodecError::TruncatedDelta)?;
+            let bytes = delta.get(pos..end).ok_or(CodecError::TruncatedDelta)?;
+            out.write_all(bytes)
+                .map_err(|e| CodecError::Io(e.to_string()))?;
+            hasher.update(bytes);
+            written = written.checked_add(len).ok_or(CodecError::TruncatedDelta)?;
+            pos = end;
+        } else {
+            return Err(CodecError::ReservedDeltaOpcode);
+        }
+    }
+    if written != target_size {
+        return Err(CodecError::DeltaTargetSizeMismatch {
+            expected: target_size as u64,
+            actual: written as u64,
+        });
+    }
+    out.as_file_mut()
+        .flush()
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    #[cfg(test)]
+    STREAMED_DELTA_TARGETS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Ok((finalize_object_hash(hasher), out))
+}
+
+fn copy_base_range_to_output(
+    base: &StoredBase,
+    offset: u64,
+    mut len: u64,
+    out: &mut tempfile::NamedTempFile,
+    hasher: &mut Sha1,
+) -> Result<(), CodecError> {
+    const CHUNK: usize = 64 * 1024;
+    match &base.data {
+        StoredBaseData::Memory(data) => {
+            let start = offset as usize;
+            let end = start
+                .checked_add(len as usize)
+                .ok_or(CodecError::TruncatedDelta)?;
+            let bytes = data
+                .get(start..end)
+                .ok_or(CodecError::DeltaCopyOutOfRange {
+                    start: offset,
+                    end: offset + len,
+                    base_len: data.len() as u64,
+                })?;
+            out.write_all(bytes)
+                .map_err(|e| CodecError::Io(e.to_string()))?;
+            hasher.update(bytes);
+        }
+        StoredBaseData::Spilled(file) => {
+            let input =
+                std::fs::File::open(file.path()).map_err(|e| CodecError::Io(e.to_string()))?;
+            let mut buf = [0u8; CHUNK];
+            let mut read_offset = offset;
+            while len > 0 {
+                let n = (len as usize).min(buf.len());
+                read_exact_at(&input, read_offset, &mut buf[..n])?;
+                out.write_all(&buf[..n])
+                    .map_err(|e| CodecError::Io(e.to_string()))?;
+                hasher.update(&buf[..n]);
+                read_offset += n as u64;
+                len -= n as u64;
+            }
+        }
+        StoredBaseData::ExternalPath(path) => {
+            let input = std::fs::File::open(path).map_err(|e| CodecError::Io(e.to_string()))?;
+            let mut buf = [0u8; CHUNK];
+            let mut read_offset = offset;
+            while len > 0 {
+                let n = (len as usize).min(buf.len());
+                read_exact_at(&input, read_offset, &mut buf[..n])?;
+                out.write_all(&buf[..n])
+                    .map_err(|e| CodecError::Io(e.to_string()))?;
+                hasher.update(&buf[..n]);
+                read_offset += n as u64;
+                len -= n as u64;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn object_hasher(kind: Kind, size: u64) -> Sha1 {
+    let mut h = Sha1::new();
+    h.update(kind.as_str().as_bytes());
+    h.update(b" ");
+    h.update(size.to_string().as_bytes());
+    h.update(b"\0");
+    h
+}
+
+fn finalize_object_hash(hasher: Sha1) -> Oid {
+    Oid::from_array(finalize_sha1(hasher))
+}
+
+fn finalize_sha1(hasher: Sha1) -> [u8; 20] {
+    hasher.finalize().into()
+}
+
+fn write_idx_v2_from_receive_entries(
+    entries: &[ReceiveEntryMeta],
+    pack_hash: Oid,
+) -> Result<Vec<u8>, CodecError> {
+    const IDX_MAGIC: [u8; 4] = [0xff, 0x74, 0x4f, 0x63];
+    const IDX_VERSION: u32 = 2;
+    const FANOUT_LEN: usize = 256;
+    const LARGE_OFFSET_FLAG: u32 = 0x8000_0000;
+
+    let mut sorted: Vec<(Oid, usize)> = entries
+        .iter()
+        .enumerate()
+        .map(|(idx, entry)| {
+            entry
+                .oid
+                .map(|oid| (oid, idx))
+                .ok_or_else(|| CodecError::Io("missing resolved oid".into()))
+        })
+        .collect::<Result<_, _>>()?;
+    sorted.sort_by(|(a, _), (b, _)| a.as_bytes().cmp(b.as_bytes()));
+    let n = entries.len();
+    let mut out = Vec::with_capacity(8 + 256 * 4 + n * (20 + 4 + 4) + 40);
+    out.extend_from_slice(&IDX_MAGIC);
+    out.extend_from_slice(&IDX_VERSION.to_be_bytes());
+
+    let mut fanout = [0u32; FANOUT_LEN];
+    for &(oid, _) in &sorted {
+        fanout[oid.first_byte() as usize] += 1;
+    }
+    let mut acc = 0u32;
+    for slot in fanout.iter_mut() {
+        acc += *slot;
+        *slot = acc;
+    }
+    for v in fanout {
+        out.extend_from_slice(&v.to_be_bytes());
+    }
+
+    for &(oid, _) in &sorted {
+        out.extend_from_slice(oid.as_bytes());
+    }
+    for &(_, idx) in &sorted {
+        out.extend_from_slice(&entries[idx].crc32.to_be_bytes());
+    }
+
+    let mut large: Vec<u64> = Vec::new();
+    for &(_, idx) in &sorted {
+        let offset = entries[idx].offset;
+        if offset < LARGE_OFFSET_FLAG as u64 {
+            out.extend_from_slice(&(offset as u32).to_be_bytes());
+        } else {
+            let large_idx = large.len() as u32;
+            out.extend_from_slice(&(LARGE_OFFSET_FLAG | large_idx).to_be_bytes());
+            large.push(offset);
+        }
+    }
+    for off in &large {
+        out.extend_from_slice(&off.to_be_bytes());
+    }
+
+    out.extend_from_slice(pack_hash.as_bytes());
+    let mut h = Sha1::new();
+    h.update(&out);
+    let digest: [u8; 20] = h.finalize().into();
+    out.extend_from_slice(&digest);
+    Ok(out)
+}
+
+fn pack_object_entry_from_receive_entry(
+    entry: &ReceiveEntryMeta,
+) -> Result<PackObjectEntry, CodecError> {
+    let oid = entry
+        .oid
+        .ok_or_else(|| CodecError::Io("missing resolved oid".into()))?;
+    let resolved_kind = entry
+        .resolved_kind
+        .ok_or_else(|| CodecError::Io("missing resolved kind".into()))?;
+    let resolved_size = entry
+        .resolved_size
+        .ok_or_else(|| CodecError::Io("missing resolved size".into()))?;
+    let kind = match entry.kind {
+        ReceiveEntryKind::Full(kind) => PackObjectKind::Full(kind),
+        ReceiveEntryKind::OfsDelta { base_offset } => PackObjectKind::OfsDelta {
+            base_offset,
+            base_oid: entry
+                .base_oid
+                .ok_or_else(|| CodecError::Io("missing OFS_DELTA base oid".into()))?,
+            depth: entry.depth,
+        },
+        ReceiveEntryKind::RefDelta { base_oid } => PackObjectKind::RefDelta {
+            base_oid,
+            depth: entry.depth,
+        },
+    };
+    Ok(PackObjectEntry {
+        oid,
+        kind,
+        resolved_kind,
+        offset: entry.offset,
+        compressed_offset: entry.compressed_offset,
+        compressed_len: entry.compressed_len as u64,
+        declared_size: entry.declared_size,
+        resolved_size,
+        crc32: entry.crc32,
+    })
+}
+
+fn write_resolved_pack_object_index_file(
+    entries: &[ReceiveEntryMeta],
+) -> Result<(tempfile::NamedTempFile, SortedObjectIds), CodecError> {
+    let mut file = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    let mut oids = Vec::with_capacity(entries.len().min(PREALLOC_HINT_CAP));
+    {
+        let mut writer = BufWriter::new(file.as_file_mut());
+        writer
+            .write_all(OBJECT_INDEX_MAGIC)
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        write_u64(&mut writer, entries.len() as u64)?;
+        for entry in entries {
+            let object_entry = pack_object_entry_from_receive_entry(entry)?;
+            oids.push(object_entry.oid);
+            write_pack_object_index_entry(&mut writer, &object_entry)?;
+        }
+        writer.flush().map_err(|e| CodecError::Io(e.to_string()))?;
+    }
+    oids.sort_unstable();
+    if let Some(duplicate) = oids
+        .windows(2)
+        .find_map(|pair| (pair[0] == pair[1]).then_some(pair[0]))
+    {
+        return Err(CodecError::DuplicateObject(duplicate));
+    }
+    Ok((file, oids))
+}
+
+fn write_temp_bytes(data: Vec<u8>) -> Result<tempfile::NamedTempFile, CodecError> {
+    let mut file = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    file.write_all(&data)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    file.as_file_mut()
+        .flush()
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(file)
+}
+
+struct SourceIndexFileWriter {
+    file: tempfile::NamedTempFile,
+    writer: BufWriter<std::fs::File>,
+    tree_count: u64,
+}
+
+impl SourceIndexFileWriter {
+    fn new(object_count: usize) -> Result<Self, CodecError> {
+        let file = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+        let mut writer = BufWriter::new(
+            file.as_file()
+                .try_clone()
+                .map_err(|e| CodecError::Io(e.to_string()))?,
+        );
+        writer
+            .write_all(SOURCE_INDEX_MAGIC)
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        write_u64(&mut writer, object_count as u64)?;
+        write_u64(&mut writer, 0)?;
+        write_u64(&mut writer, 0)?;
+        Ok(Self {
+            file,
+            writer,
+            tree_count: 0,
+        })
+    }
+
+    fn append_tree_entries(
+        &mut self,
+        entries: impl IntoIterator<Item = PackTreeIndexEntry>,
+    ) -> Result<(), CodecError> {
+        for entry in entries {
+            write_pack_tree_index_entry(&mut self.writer, &entry)?;
+            self.tree_count = self
+                .tree_count
+                .checked_add(1)
+                .ok_or_else(|| CodecError::Io("source-index tree count overflow".into()))?;
+        }
+        Ok(())
+    }
+
+    fn finish(
+        mut self,
+        commits: &[PackCommitIndexEntry],
+        object_count: u64,
+    ) -> Result<tempfile::NamedTempFile, CodecError> {
+        for commit in commits {
+            write_pack_commit_index_entry(&mut self.writer, commit)?;
+        }
+        self.writer
+            .flush()
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        drop(self.writer);
+
+        let file = self.file.as_file_mut();
+        // Patch every header count. `object_count` is passed at finish time because fix-thin
+        // appends external-base entries after the writer was created with the scanned count; the
+        // GC derived-index materializer validates this header against the manifest obj_count and
+        // a mismatch defers tree/commit indexing forever.
+        file.seek(SeekFrom::Start(SOURCE_INDEX_MAGIC.len() as u64))
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        write_u64(file, object_count)?;
+        write_u64(file, self.tree_count)?;
+        write_u64(file, commits.len() as u64)?;
+        file.seek(SeekFrom::End(0))
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        file.flush().map_err(|e| CodecError::Io(e.to_string()))?;
+
+        Ok(self.file)
+    }
+}
+
+#[derive(Default)]
+struct ResolveEntryMetrics {
+    full_blob_ms: f64,
+    full_non_blob_ms: f64,
+    delta_ms: f64,
+    link_ms: f64,
+    base_store_ms: f64,
+    source_index_write_ms: f64,
+    full_objects: usize,
+    ofs_deltas: usize,
+    streamed_blobs: usize,
+    spilled_delta_bases: usize,
+    peak_delta_base_resident_bytes: usize,
+}
+
+struct ResolveEntryOutput {
+    oid: Oid,
+    kind: Kind,
+    size: u64,
+    base_oid: Option<Oid>,
+    depth: u32,
+    raw: Option<Vec<u8>>,
+    spilled: Option<tempfile::NamedTempFile>,
+    external_path: Option<PathBuf>,
+    refs: Vec<Oid>,
+    tag_target: Option<Oid>,
+    tree_entries: Vec<PackTreeIndexEntry>,
+    commit: Option<PackCommitIndexEntry>,
+    metrics: ResolveEntryMetrics,
+}
+
+struct ResolveEntriesOutput {
+    refs: Vec<Oid>,
+    tag_targets: HashMap<Oid, Oid>,
+    source_index_file: tempfile::NamedTempFile,
+    commit_entries: Vec<PackCommitIndexEntry>,
+    largest: Option<(Oid, u64)>,
+    metrics: ResolveEntryMetrics,
+    fixed_thin_pack: Option<FixedThinPack>,
+}
+
+/// A self-contained replacement for a received **thin** pack: the original bytes with every
+/// external `REF_DELTA` base appended as a full object, the entry count patched, and the trailer
+/// recomputed. Thin packs must never be manifested verbatim — their `REF_DELTA` records point at
+/// objects outside the pack, which breaks stock clients on clone/fetch (`unresolved deltas`).
+pub struct FixedThinPack {
+    pub file: tempfile::NamedTempFile,
+    pub len: u64,
+    pub pack_hash: Oid,
+}
+
+fn merge_metrics(dst: &mut ResolveEntryMetrics, src: ResolveEntryMetrics) {
+    dst.full_blob_ms += src.full_blob_ms;
+    dst.full_non_blob_ms += src.full_non_blob_ms;
+    dst.delta_ms += src.delta_ms;
+    dst.link_ms += src.link_ms;
+    dst.base_store_ms += src.base_store_ms;
+    dst.source_index_write_ms += src.source_index_write_ms;
+    dst.full_objects += src.full_objects;
+    dst.ofs_deltas += src.ofs_deltas;
+    dst.streamed_blobs += src.streamed_blobs;
+    dst.spilled_delta_bases += src.spilled_delta_bases;
+    dst.peak_delta_base_resident_bytes = dst
+        .peak_delta_base_resident_bytes
+        .max(src.peak_delta_base_resident_bytes);
+}
+
+fn resolve_entries_from_scanned_metadata(
+    entries: &[ReceiveEntryMeta],
+) -> Result<Option<ResolveEntriesOutput>, CodecError> {
+    let mut refs = Vec::new();
+    let mut tag_targets = HashMap::new();
+    let mut source_index = SourceIndexFileWriter::new(entries.len())?;
+    let mut commit_entries = Vec::new();
+    let mut largest = None;
+    let mut metrics = ResolveEntryMetrics::default();
+
+    for entry in entries {
+        let (Some(oid), Some(kind), Some(size)) =
+            (entry.oid, entry.resolved_kind, entry.resolved_size)
+        else {
+            return Ok(None);
+        };
+
+        match entry.kind {
+            ReceiveEntryKind::Full(_) => metrics.full_objects += 1,
+            ReceiveEntryKind::OfsDelta { .. } => metrics.ofs_deltas += 1,
+            ReceiveEntryKind::RefDelta { .. } => return Ok(None),
+        }
+
+        if largest.is_none_or(|(_, max)| size > max) {
+            largest = Some((oid, size));
+        }
+
+        match kind {
+            Kind::Blob => {
+                if entry.predecoded_raw.is_none() {
+                    metrics.streamed_blobs += 1;
+                }
+            }
+            Kind::Commit | Kind::Tree | Kind::Tag => {
+                let Some(raw) = entry.predecoded_raw.as_ref() else {
+                    return Ok(None);
+                };
+                let link_started = std::time::Instant::now();
+                let links = collect_links(oid, kind, raw, &mut refs, &mut tag_targets)?;
+                if let Some((root_tree, parents)) = links.commit {
+                    commit_entries.push(PackCommitIndexEntry {
+                        commit_oid: oid,
+                        root_tree,
+                        parents,
+                    });
+                }
+                metrics.link_ms += elapsed_ms(link_started);
+                let source_index_started = std::time::Instant::now();
+                source_index.append_tree_entries(links.tree_entries)?;
+                metrics.source_index_write_ms += elapsed_ms(source_index_started);
+            }
+        }
+    }
+    let source_index_started = std::time::Instant::now();
+    let source_index_file = source_index.finish(&commit_entries, entries.len() as u64)?;
+    metrics.source_index_write_ms += elapsed_ms(source_index_started);
+
+    Ok(Some(ResolveEntriesOutput {
+        refs,
+        tag_targets,
+        source_index_file,
+        commit_entries,
+        largest,
+        metrics,
+        // Fast path is only reachable for delta-free packs, which are never thin.
+        fixed_thin_pack: None,
+    }))
+}
+
+fn resolve_receive_entry(
+    file: &std::fs::File,
+    entry: &ReceiveEntryMeta,
+    base: Option<&StoredBase>,
+    external_bases: &HashMap<Oid, ExternalBase>,
+) -> Result<ResolveEntryOutput, CodecError> {
+    let mut metrics = ResolveEntryMetrics::default();
+    let predecoded = match (
+        entry.resolved_kind,
+        entry.oid,
+        entry.resolved_size,
+        entry.predecoded_raw.as_ref(),
+    ) {
+        (Some(kind), Some(oid), Some(size), Some(raw)) => Some((
+            kind,
+            ResolvedData {
+                oid,
+                size,
+                raw: Some(raw.clone()),
+                spilled: None,
+                external_path: None,
+            },
+            entry.base_oid,
+            entry.depth,
+        )),
+        (Some(kind @ Kind::Blob), Some(oid), Some(size), None)
+            if matches!(entry.kind, ReceiveEntryKind::Full(_)) && entry.base_ref_count == 0 =>
+        {
+            Some((
+                kind,
+                ResolvedData {
+                    oid,
+                    size,
+                    raw: None,
+                    spilled: None,
+                    external_path: None,
+                },
+                None,
+                0,
+            ))
+        }
+        _ => None,
+    };
+    let (kind, resolved, base_oid, depth) = if let Some(predecoded) = predecoded {
+        predecoded
+    } else {
+        match entry.kind {
+            ReceiveEntryKind::Full(kind) => {
+                metrics.full_objects += 1;
+                let full_started = std::time::Instant::now();
+                let resolved = if let Some(raw) = entry.predecoded_raw.as_ref() {
+                    let oid = entry
+                        .oid
+                        .ok_or_else(|| CodecError::Io("missing predecoded oid".into()))?;
+                    ResolvedData {
+                        oid,
+                        size: raw.len() as u64,
+                        raw: Some(raw.clone()),
+                        spilled: None,
+                        external_path: None,
+                    }
+                } else if let (Kind::Blob, Some(oid), Some(size), 0) =
+                    (kind, entry.oid, entry.resolved_size, entry.base_ref_count)
+                {
+                    ResolvedData {
+                        oid,
+                        size,
+                        raw: None,
+                        spilled: None,
+                        external_path: None,
+                    }
+                } else if kind == Kind::Blob {
+                    let needs_base = entry.base_ref_count > 0;
+                    let should_spill =
+                        needs_base && entry.declared_size >= LARGE_DELTA_BASE_SPILL_BYTES as u64;
+                    let should_stream = !needs_base || should_spill;
+                    if should_stream {
+                        metrics.streamed_blobs += 1;
+                        stream_full_blob_at(file, entry, should_spill)?
+                    } else {
+                        let raw = inflate_entry_at(file, entry)?;
+                        let size = raw.len() as u64;
+                        let oid = crate::object::hash(kind, &raw);
+                        ResolvedData {
+                            oid,
+                            size,
+                            raw: Some(raw),
+                            spilled: None,
+                            external_path: None,
+                        }
+                    }
+                } else {
+                    let raw = inflate_entry_at(file, entry)?;
+                    let size = raw.len() as u64;
+                    let oid = crate::object::hash(kind, &raw);
+                    ResolvedData {
+                        oid,
+                        size,
+                        raw: Some(raw),
+                        spilled: None,
+                        external_path: None,
+                    }
+                };
+                let full_elapsed = elapsed_ms(full_started);
+                if kind == Kind::Blob {
+                    metrics.full_blob_ms += full_elapsed;
+                } else {
+                    metrics.full_non_blob_ms += full_elapsed;
+                }
+                (kind, resolved, None, 0)
+            }
+            ReceiveEntryKind::OfsDelta { base_offset } => {
+                metrics.ofs_deltas += 1;
+                let delta_started = std::time::Instant::now();
+                let delta = inflate_entry_at(file, entry)?;
+                let base = base.ok_or(CodecError::MissingDeltaBaseOffset(base_offset))?;
+                let target_size = delta_target_size(&delta, base.size)?;
+                let resolved = resolve_delta_from_base(base, &delta, target_size as usize)?;
+                metrics.delta_ms += elapsed_ms(delta_started);
+                (base.kind, resolved, Some(base.oid), base.depth + 1)
+            }
+            ReceiveEntryKind::RefDelta { base_oid } => {
+                metrics.ofs_deltas += 1;
+                let delta_started = std::time::Instant::now();
+                let delta = inflate_entry_at(file, entry)?;
+                let Some(external) = external_bases.get(&base_oid) else {
+                    return Err(CodecError::MissingDeltaBaseOid(base_oid));
+                };
+                let base = StoredBase {
+                    oid: base_oid,
+                    kind: external.kind,
+                    size: external.size,
+                    depth: 0,
+                    remaining_refs: 1,
+                    data: StoredBaseData::ExternalPath(external.path.clone()),
+                };
+                let target_size = delta_target_size(&delta, base.size)?;
+                let resolved = resolve_delta_from_base(&base, &delta, target_size as usize)?;
+                metrics.delta_ms += elapsed_ms(delta_started);
+                (external.kind, resolved, Some(base_oid), 1)
+            }
+        }
+    };
+
+    let mut refs = Vec::new();
+    let mut tag_targets = HashMap::new();
+    let mut tree_entries = Vec::new();
+    let mut commit = None;
+    if let Some(raw) = resolved.raw.as_ref() {
+        let link_started = std::time::Instant::now();
+        let links = collect_links(resolved.oid, kind, raw, &mut refs, &mut tag_targets)?;
+        tree_entries = links.tree_entries;
+        if let Some((root_tree, parents)) = links.commit {
+            commit = Some(PackCommitIndexEntry {
+                commit_oid: resolved.oid,
+                root_tree,
+                parents,
+            });
+        }
+        metrics.link_ms += elapsed_ms(link_started);
+    }
+
+    Ok(ResolveEntryOutput {
+        oid: resolved.oid,
+        kind,
+        size: resolved.size,
+        base_oid,
+        depth,
+        raw: resolved.raw,
+        spilled: resolved.spilled,
+        external_path: resolved.external_path,
+        refs,
+        tag_target: tag_targets.remove(&resolved.oid),
+        tree_entries,
+        commit,
+        metrics,
+    })
+}
+
+fn pack_type_of(kind: Kind) -> u8 {
+    match kind {
+        Kind::Commit => T_COMMIT,
+        Kind::Tree => T_TREE,
+        Kind::Blob => T_BLOB,
+        Kind::Tag => T_TAG,
+    }
+}
+
+/// Git pack entry header, delegating to the shared varint encoder.
+fn encode_pack_entry_header(kind: Kind, size: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(10);
+    write_entry_header(&mut out, pack_type_of(kind), size);
+    out
+}
+
+/// Writer tee for fix-thin appends: bytes go to the output file while the pack trailer SHA-1 and
+/// the per-entry CRC-32 accumulate.
+struct FixThinWriter<'a> {
+    out: &'a mut std::io::BufWriter<std::fs::File>,
+    sha: &'a mut Sha1,
+    crc: &'a mut crc32fast::Hasher,
+    written: u64,
+}
+
+impl std::io::Write for FixThinWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.out.write_all(buf)?;
+        self.sha.update(buf);
+        self.crc.update(buf);
+        self.written += buf.len() as u64;
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.out.flush()
+    }
+}
+
+/// Exact, concurrency-safe OID de-duplication for outgoing pack references. Kernel-scale packs
+/// emit hundreds of millions of tree-entry refs but only about one unique OID per pack object;
+/// deduping inside the parallel resolve workers keeps duplicate refs out of the serial merge
+/// loop and bounds resident ref memory to the unique set.
+struct ShardedOidSet {
+    shards: Vec<std::sync::Mutex<std::collections::HashSet<Oid>>>,
+}
+
+impl ShardedOidSet {
+    const SHARDS: usize = 256;
+
+    fn new() -> Self {
+        Self {
+            shards: (0..Self::SHARDS).map(|_| Default::default()).collect(),
+        }
+    }
+
+    /// Insert, returning `true` when the OID was not already present. OIDs are cryptographic
+    /// hashes, so the first byte is a uniform shard key.
+    fn insert(&self, oid: &Oid) -> bool {
+        self.shards[oid.first_byte() as usize % Self::SHARDS]
+            .lock()
+            .expect("oid shard poisoned")
+            .insert(*oid)
+    }
+}
+
+fn resolve_receive_entries_parallel(
+    file: &std::fs::File,
+    pack_len: u64,
+    entries: &mut Vec<ReceiveEntryMeta>,
+    external_bases: &HashMap<Oid, ExternalBase>,
+) -> Result<ResolveEntriesOutput, CodecError> {
+    let offset_to_idx: HashMap<u64, usize> = entries
+        .iter()
+        .enumerate()
+        .map(|(idx, entry)| (entry.offset, idx))
+        .collect();
+    let mut children: Vec<Vec<usize>> = (0..entries.len()).map(|_| Vec::new()).collect();
+    let mut base_idx_for_entry = vec![None; entries.len()];
+    let mut ready = VecDeque::new();
+    for (idx, entry) in entries.iter().enumerate() {
+        match entry.kind {
+            ReceiveEntryKind::Full(_) | ReceiveEntryKind::RefDelta { .. } => ready.push_back(idx),
+            ReceiveEntryKind::OfsDelta { base_offset } => {
+                let base_idx = *offset_to_idx
+                    .get(&base_offset)
+                    .ok_or(CodecError::MissingDeltaBaseOffset(base_offset))?;
+                children[base_idx].push(idx);
+                base_idx_for_entry[idx] = Some(base_idx);
+            }
+        }
+    }
+
+    let mut bases: Vec<Option<StoredBase>> = (0..entries.len()).map(|_| None).collect();
+    let seen_refs = ShardedOidSet::new();
+    let mut refs = Vec::new();
+    let mut tag_targets = HashMap::new();
+    // Source-index rows are written by a dedicated thread so serializing tens of GiB of tree
+    // entries does not stall the merge loop between rayon batches.
+    let (tree_entry_tx, tree_entry_rx) =
+        std::sync::mpsc::sync_channel::<Vec<PackTreeIndexEntry>>(SOURCE_INDEX_WRITER_QUEUE);
+    let object_count = entries.len();
+    let source_index_writer =
+        std::thread::spawn(move || -> Result<SourceIndexFileWriter, CodecError> {
+            let mut source_index = SourceIndexFileWriter::new(object_count)?;
+            while let Ok(batch) = tree_entry_rx.recv() {
+                source_index.append_tree_entries(batch)?;
+            }
+            Ok(source_index)
+        });
+    let mut commit_entries = Vec::new();
+    let mut largest = None;
+    let mut metrics = ResolveEntryMetrics::default();
+    let mut resolved_count = 0usize;
+    let mut resident_base_bytes = 0usize;
+    let mut peak_resident_base_bytes = 0usize;
+
+    while !ready.is_empty() {
+        let take = ready.len().min(PARALLEL_RESOLVE_BATCH);
+        let mut batch = Vec::with_capacity(take);
+        for _ in 0..take {
+            if let Some(idx) = ready.pop_front() {
+                batch.push(idx);
+            }
+        }
+        let results: Vec<(usize, Result<ResolveEntryOutput, CodecError>)> = batch
+            .par_iter()
+            .map(|&idx| {
+                let base = base_idx_for_entry[idx].and_then(|base_idx| bases[base_idx].as_ref());
+                let mut result = resolve_receive_entry(file, &entries[idx], base, external_bases);
+                if let Ok(resolved) = result.as_mut() {
+                    // Drop already-seen outgoing refs here, on the worker, so the serial merge
+                    // below only appends novel OIDs.
+                    resolved.refs.retain(|oid| seen_refs.insert(oid));
+                }
+                (idx, result)
+            })
+            .collect();
+
+        let mut newly_ready = Vec::new();
+        for (idx, result) in results {
+            let mut resolved = result?;
+            entries[idx].oid = Some(resolved.oid);
+            entries[idx].resolved_kind = Some(resolved.kind);
+            entries[idx].resolved_size = Some(resolved.size);
+            entries[idx].base_oid = resolved.base_oid;
+            entries[idx].depth = resolved.depth;
+            if largest.is_none_or(|(_, max)| resolved.size > max) {
+                largest = Some((resolved.oid, resolved.size));
+            }
+            refs.append(&mut resolved.refs);
+            if let Some(tag_target) = resolved.tag_target {
+                tag_targets.insert(resolved.oid, tag_target);
+            }
+            if !resolved.tree_entries.is_empty() {
+                let source_index_started = std::time::Instant::now();
+                if tree_entry_tx.send(resolved.tree_entries).is_err() {
+                    // Writer thread failed; surface its error below by breaking out through join.
+                    drop(tree_entry_tx);
+                    return Err(source_index_writer
+                        .join()
+                        .map_err(|_| CodecError::Io("source-index writer panicked".into()))?
+                        .err()
+                        .unwrap_or_else(|| {
+                            CodecError::Io("source-index writer stopped unexpectedly".into())
+                        }));
+                }
+                resolved.metrics.source_index_write_ms += elapsed_ms(source_index_started);
+            }
+            if let Some(commit) = resolved.commit {
+                commit_entries.push(commit);
+            }
+            if entries[idx].base_ref_count > 0 {
+                let base_store_started = std::time::Instant::now();
+                let resolved_oid = resolved.oid;
+                let resolved_size = resolved.size;
+                let base = match (resolved.raw, resolved.spilled, resolved.external_path) {
+                    (Some(raw), None, None) => {
+                        let base = store_delta_base_with_memory_budget(
+                            resolved_oid,
+                            resolved.kind,
+                            resolved.depth,
+                            raw,
+                            entries[idx].base_ref_count,
+                            &mut resident_base_bytes,
+                        )?;
+                        if matches!(base.data, StoredBaseData::Spilled(_)) {
+                            resolved.metrics.spilled_delta_bases += 1;
+                        }
+                        peak_resident_base_bytes =
+                            peak_resident_base_bytes.max(resident_base_bytes);
+                        base
+                    }
+                    (None, Some(file), None) => {
+                        resolved.metrics.spilled_delta_bases += 1;
+                        store_spilled_delta_base(
+                            resolved_oid,
+                            resolved.kind,
+                            resolved_size,
+                            resolved.depth,
+                            file,
+                            entries[idx].base_ref_count,
+                        )
+                    }
+                    (None, None, Some(path)) => {
+                        resolved.metrics.spilled_delta_bases += 1;
+                        StoredBase {
+                            oid: resolved_oid,
+                            kind: resolved.kind,
+                            size: resolved_size,
+                            depth: resolved.depth,
+                            remaining_refs: entries[idx].base_ref_count,
+                            data: StoredBaseData::ExternalPath(path),
+                        }
+                    }
+                    (None, None, None) if entries[idx].base_ref_count == 0 => unreachable!(),
+                    _ => return Err(CodecError::Io("invalid resolved base state".into())),
+                };
+                bases[idx] = Some(base);
+                resolved.metrics.base_store_ms += elapsed_ms(base_store_started);
+            }
+            for child in &children[idx] {
+                newly_ready.push(*child);
+            }
+            if let Some(base_idx) = base_idx_for_entry[idx] {
+                if let Some(base) = bases[base_idx].as_mut() {
+                    base.remaining_refs = base.remaining_refs.saturating_sub(1);
+                    if base.remaining_refs == 0 {
+                        resident_base_bytes =
+                            resident_base_bytes.saturating_sub(stored_base_resident_bytes(base));
+                        bases[base_idx] = None;
+                    }
+                }
+            }
+            merge_metrics(&mut metrics, resolved.metrics);
+            resolved_count += 1;
+        }
+        // Keep delta-base residency bounded: resolve children before unrelated roots.
+        for child in newly_ready.into_iter().rev() {
+            ready.push_front(child);
+        }
+    }
+
+    if resolved_count != entries.len() {
+        return Err(CodecError::Io(format!(
+            "resolved {resolved_count} of {} pack entries",
+            entries.len()
+        )));
+    }
+    metrics.peak_delta_base_resident_bytes = peak_resident_base_bytes;
+
+    // Thin pack: append every external REF_DELTA base as a full object so the manifested pack is
+    // self-contained. Appended entries flow into the idx and `.objects`; their links flow into
+    // `.sources` (via the still-live writer thread), the commit index, and the connectivity ref
+    // set, exactly as if they had been part of the received pack.
+    let fixed_thin_pack = if external_bases.is_empty() {
+        None
+    } else {
+        let mut appended_refs: Vec<Oid> = Vec::new();
+        let fixed = append_external_bases(AppendExternalBases {
+            journal: file,
+            pack_len,
+            entries,
+            external_bases,
+            tree_entry_tx: &tree_entry_tx,
+            commit_entries: &mut commit_entries,
+            refs: &mut appended_refs,
+            tag_targets: &mut tag_targets,
+        })?;
+        for oid in appended_refs {
+            if seen_refs.insert(&oid) {
+                refs.push(oid);
+            }
+        }
+        Some(fixed)
+    };
+
+    let source_index_started = std::time::Instant::now();
+    drop(tree_entry_tx);
+    let source_index = source_index_writer
+        .join()
+        .map_err(|_| CodecError::Io("source-index writer panicked".into()))??;
+    let source_index_file = source_index.finish(&commit_entries, entries.len() as u64)?;
+    metrics.source_index_write_ms += elapsed_ms(source_index_started);
+
+    Ok(ResolveEntriesOutput {
+        refs,
+        tag_targets,
+        source_index_file,
+        commit_entries,
+        largest,
+        metrics,
+        fixed_thin_pack,
+    })
+}
+
+struct AppendExternalBases<'a> {
+    journal: &'a std::fs::File,
+    pack_len: u64,
+    entries: &'a mut Vec<ReceiveEntryMeta>,
+    external_bases: &'a HashMap<Oid, ExternalBase>,
+    tree_entry_tx: &'a std::sync::mpsc::SyncSender<Vec<PackTreeIndexEntry>>,
+    commit_entries: &'a mut Vec<PackCommitIndexEntry>,
+    refs: &'a mut Vec<Oid>,
+    tag_targets: &'a mut HashMap<Oid, Oid>,
+}
+
+/// Build the fix-thin replacement pack: copy the received bytes minus the trailer with the entry
+/// count patched, append each external base as a full (zlib) object streamed from its spill file,
+/// then write the recomputed SHA-1 trailer. Appended entry metadata is pushed onto `entries` and
+/// non-blob bases contribute their links.
+fn append_external_bases(input: AppendExternalBases<'_>) -> Result<FixedThinPack, CodecError> {
+    let AppendExternalBases {
+        journal,
+        pack_len,
+        entries,
+        external_bases,
+        tree_entry_tx,
+        commit_entries,
+        refs,
+        tag_targets,
+    } = input;
+    let io_err = |e: std::io::Error| CodecError::Io(e.to_string());
+    let body_len = pack_len
+        .checked_sub(20)
+        .ok_or_else(|| CodecError::Io("thin pack shorter than its trailer".into()))?;
+
+    let out_file = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    let mut out = std::io::BufWriter::new(
+        out_file
+            .as_file()
+            .try_clone()
+            .map_err(|e| CodecError::Io(e.to_string()))?,
+    );
+    let mut sha = Sha1::new();
+    use std::io::Write as _;
+
+    // Header with the entry count patched to include the appended bases.
+    let mut header = [0u8; 12];
+    read_exact_at(journal, 0, &mut header)?;
+    let count = u32::from_be_bytes(header[8..12].try_into().unwrap())
+        .checked_add(external_bases.len() as u32)
+        .ok_or_else(|| CodecError::Io("fix-thin entry count overflow".into()))?;
+    header[8..12].copy_from_slice(&count.to_be_bytes());
+    out.write_all(&header).map_err(io_err)?;
+    sha.update(header);
+
+    // Original entry bytes (past the header, minus the trailer).
+    let mut offset = 12u64;
+    let mut buf = vec![0u8; 1024 * 1024];
+    while offset < body_len {
+        let n = ((body_len - offset) as usize).min(buf.len());
+        read_exact_at(journal, offset, &mut buf[..n])?;
+        out.write_all(&buf[..n]).map_err(io_err)?;
+        sha.update(&buf[..n]);
+        offset += n as u64;
+    }
+
+    // Append each base, in oid order for determinism.
+    let mut bases: Vec<(&Oid, &ExternalBase)> = external_bases.iter().collect();
+    bases.sort_by_key(|(oid, _)| *(*oid));
+    let mut out_len = body_len;
+    for (oid, base) in bases {
+        let entry_offset = out_len;
+        let mut crc = crc32fast::Hasher::new();
+        let header = encode_pack_entry_header(base.kind, base.size);
+        out.write_all(&header).map_err(io_err)?;
+        sha.update(&header);
+        crc.update(&header);
+        out_len += header.len() as u64;
+        let compressed_offset = out_len;
+
+        let payload = std::fs::File::open(&base.path).map_err(io_err)?;
+        let mut reader = std::io::BufReader::new(payload);
+        let mut tee = FixThinWriter {
+            out: &mut out,
+            sha: &mut sha,
+            crc: &mut crc,
+            written: 0,
+        };
+        let mut enc = flate2::write::ZlibEncoder::new(&mut tee, flate2::Compression::new(6));
+        std::io::copy(&mut reader, &mut enc).map_err(io_err)?;
+        enc.finish().map_err(io_err)?;
+        let compressed_len = tee.written;
+        out_len += compressed_len;
+
+        // Links for non-blob bases: their children must count for connectivity and the derived
+        // tree/commit indexes, exactly as for in-pack objects.
+        if base.kind != Kind::Blob {
+            let raw = std::fs::read(&base.path).map_err(io_err)?;
+            let links = collect_links(*oid, base.kind, &raw, refs, tag_targets)?;
+            if !links.tree_entries.is_empty() {
+                tree_entry_tx.send(links.tree_entries).map_err(|_| {
+                    CodecError::Io("source-index writer stopped during fix-thin".into())
+                })?;
+            }
+            if let Some((root_tree, parents)) = links.commit {
+                commit_entries.push(PackCommitIndexEntry {
+                    commit_oid: *oid,
+                    root_tree,
+                    parents,
+                });
+            }
+        }
+
+        entries.push(ReceiveEntryMeta {
+            offset: entry_offset,
+            compressed_offset,
+            compressed_len: compressed_len as usize,
+            declared_size: base.size,
+            kind: ReceiveEntryKind::Full(base.kind),
+            crc32: crc.finalize(),
+            base_ref_count: 0,
+            oid: Some(*oid),
+            resolved_kind: Some(base.kind),
+            resolved_size: Some(base.size),
+            predecoded_raw: None,
+            base_oid: None,
+            depth: 0,
+        });
+    }
+
+    let trailer = finalize_sha1(sha);
+    out.write_all(&trailer).map_err(io_err)?;
+    out.flush().map_err(io_err)?;
+    drop(out);
+    Ok(FixedThinPack {
+        file: out_file,
+        len: out_len + 20,
+        pack_hash: Oid::from_array(trailer),
+    })
+}
+
+/// Resolve and index a received pack from a local temp file without memory-mapping the whole pack.
+///
+/// The first pass walks the file sequentially to validate the pack, compute per-entry CRCs, and record
+/// each compressed entry range. The second pass inflates one compressed entry at a time, resolving
+/// offset-deltas while retaining only objects still needed as future delta bases. That keeps memory
+/// proportional to object metadata plus live delta bases, not to the compressed pack size.
+pub fn resolve_pack_file(path: impl AsRef<Path>) -> Result<Option<ResolvedPack>, CodecError> {
+    resolve_pack_file_with_log_context(path, PackResolveLogContext::default())
+}
+
+/// Request context attached to resolver instrumentation.
+#[derive(Clone, Copy, Default)]
+pub struct PackResolveLogContext<'a> {
+    pub project: &'a str,
+    pub repo: &'a str,
+    pub actor: &'a str,
+}
+
+/// Resolve and index a received pack, attaching caller context to instrumentation logs.
+pub fn resolve_pack_file_with_log_context(
+    path: impl AsRef<Path>,
+    log_context: PackResolveLogContext<'_>,
+) -> Result<Option<ResolvedPack>, CodecError> {
+    let path = path.as_ref();
+    let started = std::time::Instant::now();
+    let mut file = std::fs::File::open(path).map_err(|e| CodecError::Io(e.to_string()))?;
+    let pack_len = file
+        .metadata()
+        .map_err(|e| CodecError::Io(e.to_string()))?
+        .len();
+    let scan_started = std::time::Instant::now();
+    let (pack_hash, mut entries) = match scan_received_pack(&mut file, pack_len, false)? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    let scan_ms = elapsed_ms(scan_started);
+    resolve_scanned_pack_inner(ResolveScannedPackInner {
+        file: &file,
+        pack_len,
+        pack_hash,
+        entries: &mut entries,
+        scan_stats: ScanResolveStats {
+            scan_ms,
+            spilled_payload_bytes: 0,
+            ..ScanResolveStats::default()
+        },
+        started,
+        external_bases: &HashMap::new(),
+        log_context,
+    })
+}
+
+pub fn resolve_scanned_pack_with_log_context(
+    file: &std::fs::File,
+    scanned: ScannedPack,
+    log_context: PackResolveLogContext<'_>,
+) -> Result<Option<ResolvedPack>, CodecError> {
+    resolve_scanned_pack_with_external_bases(file, scanned, &HashMap::new(), log_context)
+}
+
+pub fn resolve_scanned_pack_with_external_bases(
+    file: &std::fs::File,
+    mut scanned: ScannedPack,
+    external_bases: &HashMap<Oid, ExternalBase>,
+    log_context: PackResolveLogContext<'_>,
+) -> Result<Option<ResolvedPack>, CodecError> {
+    let started = std::time::Instant::now();
+    let retained_payload_bytes = scanned.retained_payload_bytes;
+    let spilled_payload_bytes = scanned.spilled_payload_bytes;
+    let predecode_budget_exhausted = scanned.predecode_budget_exhausted;
+    resolve_scanned_pack_inner(ResolveScannedPackInner {
+        file,
+        pack_len: scanned.pack_len,
+        pack_hash: scanned.pack_hash,
+        entries: &mut scanned.entries,
+        scan_stats: ScanResolveStats {
+            scan_ms: scanned.scan_ms,
+            retained_payload_bytes,
+            spilled_payload_bytes,
+            predecode_budget_exhausted,
+        },
+        started,
+        external_bases,
+        log_context,
+    })
+}
+
+struct ResolveScannedPackInner<'a, 'ctx> {
+    file: &'a std::fs::File,
+    pack_len: u64,
+    pack_hash: Oid,
+    entries: &'a mut Vec<ReceiveEntryMeta>,
+    scan_stats: ScanResolveStats,
+    started: std::time::Instant,
+    external_bases: &'a HashMap<Oid, ExternalBase>,
+    log_context: PackResolveLogContext<'ctx>,
+}
+
+fn resolve_scanned_pack_inner(
+    input: ResolveScannedPackInner<'_, '_>,
+) -> Result<Option<ResolvedPack>, CodecError> {
+    let ResolveScannedPackInner {
+        file,
+        pack_len,
+        pack_hash,
+        entries,
+        scan_stats,
+        started,
+        external_bases,
+        log_context,
+    } = input;
+    let active_base_count = entries
+        .iter()
+        .filter(|entry| entry.base_ref_count > 0)
+        .count();
+    let resolve_started = std::time::Instant::now();
+    let (resolved, replayed_pack_entries) =
+        if let Some(resolved) = resolve_entries_from_scanned_metadata(entries)? {
+            (resolved, false)
+        } else {
+            (
+                resolve_receive_entries_parallel(file, pack_len, entries, external_bases)?,
+                true,
+            )
+        };
+    let resolve_entries_ms = elapsed_ms(resolve_started);
+    // A thin pack resolves against a fixed (self-contained) replacement: its length and trailer
+    // hash describe the bytes that will actually be stored and indexed.
+    if !external_bases.is_empty() && resolved.fixed_thin_pack.is_none() {
+        // Never manifest thin bytes: whichever resolve path ran must have produced the
+        // self-contained replacement when external bases exist.
+        return Err(CodecError::Io(
+            "thin pack resolved without a fix-thin replacement".into(),
+        ));
+    }
+    let (pack_len, pack_hash) = match &resolved.fixed_thin_pack {
+        Some(fixed) => (fixed.len, fixed.pack_hash),
+        None => (pack_len, pack_hash),
+    };
+    finish_resolved_pack(ResolvedPackFinish {
+        pack_len,
+        pack_hash,
+        entries,
+        scan_stats,
+        started,
+        log_context,
+        active_base_count,
+        resolved,
+        replayed_pack_entries,
+        resolve_entries_ms,
+    })
+}
+
+struct ResolvedPackFinish<'entries, 'ctx> {
+    pack_len: u64,
+    pack_hash: Oid,
+    entries: &'entries [ReceiveEntryMeta],
+    scan_stats: ScanResolveStats,
+    started: std::time::Instant,
+    log_context: PackResolveLogContext<'ctx>,
+    active_base_count: usize,
+    resolved: ResolveEntriesOutput,
+    replayed_pack_entries: bool,
+    resolve_entries_ms: f64,
+}
+
+fn finish_resolved_pack(
+    input: ResolvedPackFinish<'_, '_>,
+) -> Result<Option<ResolvedPack>, CodecError> {
+    let ResolvedPackFinish {
+        pack_len,
+        pack_hash,
+        entries,
+        scan_stats,
+        started,
+        log_context,
+        active_base_count,
+        resolved,
+        replayed_pack_entries,
+        resolve_entries_ms,
+    } = input;
+    let index_metadata_started = std::time::Instant::now();
+    let (object_index_file, oids) = write_resolved_pack_object_index_file(entries)?;
+    let index_metadata_ms = elapsed_ms(index_metadata_started);
+    let idx_started = std::time::Instant::now();
+    let idx_data = write_idx_v2_from_receive_entries(entries, pack_hash)?;
+    let idx_bytes = idx_data.len();
+    let idx_file = write_temp_bytes(idx_data)?;
+    let idx_ms = elapsed_ms(idx_started);
+    let external_refs_started = std::time::Instant::now();
+    // Refs were deduplicated during resolve; filter the unique set against the pack's own OIDs in
+    // parallel — kernel-scale packs carry tens of millions of unique refs.
+    let refs = resolved.refs;
+    let external_refs: std::collections::HashSet<Oid> = refs
+        .par_chunks(EXTERNAL_REF_FILTER_CHUNK)
+        .fold(std::collections::HashSet::new, |mut acc, chunk| {
+            acc.extend(chunk.iter().filter(|oid| oids.binary_search(oid).is_err()));
+            acc
+        })
+        .reduce(std::collections::HashSet::new, |mut a, mut b| {
+            if a.len() < b.len() {
+                std::mem::swap(&mut a, &mut b);
+            }
+            a.extend(b);
+            a
+        });
+    let external_refs_ms = elapsed_ms(external_refs_started);
+
+    tracing::info!(
+        project = log_context.project,
+        repo = log_context.repo,
+        actor = log_context.actor,
+        pack_id = %pack_hash.to_hex(),
+        pack_bytes = pack_len,
+        objects = entries.len(),
+        full_objects = resolved.metrics.full_objects,
+        ofs_deltas = resolved.metrics.ofs_deltas,
+        streamed_blobs = resolved.metrics.streamed_blobs,
+        active_delta_bases = active_base_count,
+        spilled_delta_bases = resolved.metrics.spilled_delta_bases,
+        peak_delta_base_resident_bytes = resolved.metrics.peak_delta_base_resident_bytes,
+        external_refs = external_refs.len(),
+        idx_bytes,
+        replayed_pack_entries,
+        scanner_retained_payload_bytes = scan_stats.retained_payload_bytes,
+        scanner_spilled_payload_bytes = scan_stats.spilled_payload_bytes,
+        scanner_predecode_budget_exhausted = scan_stats.predecode_budget_exhausted,
+        scan_ms = scan_stats.scan_ms,
+        resolve_entries_ms,
+        index_metadata_ms,
+        idx_ms,
+        source_index_ms = resolved.metrics.source_index_write_ms,
+        external_refs_ms,
+        full_blob_cpu_ms = resolved.metrics.full_blob_ms,
+        full_non_blob_cpu_ms = resolved.metrics.full_non_blob_ms,
+        delta_cpu_ms = resolved.metrics.delta_ms,
+        link_cpu_ms = resolved.metrics.link_ms,
+        base_store_cpu_ms = resolved.metrics.base_store_ms,
+        total_ms = elapsed_ms(started),
+        "pack resolver: complete"
+    );
+
+    Ok(Some(ResolvedPack {
+        object_count: entries.len(),
+        pack_hash,
+        fixed_thin_pack: resolved.fixed_thin_pack,
+        replayed_pack_entries,
+        idx_file,
+        idx_bytes,
+        object_index_file,
+        source_index_file: resolved.source_index_file,
+        source_commit_entries: resolved.commit_entries,
+        oids,
+        external_refs,
+        tag_targets: resolved.tag_targets,
+        largest: resolved.largest,
+    }))
+}
+
+fn elapsed_ms(started: std::time::Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
+}
+
+/// Inspect a self-contained pack for artifact extraction without materializing small objects.
+///
+/// Returns `Ok(None)` for packs with `REF_DELTA` entries because those packs are thin and cannot be
+/// interpreted without external bases. The caller should mark such packs optimized in place.
+pub fn plan_pack_file_optimization(
+    path: impl AsRef<Path>,
+    large_threshold: u64,
+) -> Result<Option<PackOptimizationPlan>, CodecError> {
+    let path = path.as_ref();
+    let mut file = std::fs::File::open(path).map_err(|e| CodecError::Io(e.to_string()))?;
+    let pack_len = file
+        .metadata()
+        .map_err(|e| CodecError::Io(e.to_string()))?
+        .len();
+    let (_, mut entries) = match scan_received_pack(&mut file, pack_len, false)? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+
+    let active_base_count = entries
+        .iter()
+        .filter(|entry| entry.base_ref_count > 0)
+        .count();
+    let mut resolved_bases: HashMap<u64, StoredBase> =
+        HashMap::with_capacity(active_base_count.min(PREALLOC_HINT_CAP));
+    let mut large_blobs = Vec::new();
+    let spill_threshold = large_threshold.min(usize::MAX as u64) as usize;
+
+    for entry in &mut entries {
+        let offset = entry.offset;
+        let entry_kind = entry.kind;
+        let base_ref_count = entry.base_ref_count;
+        let (kind, resolved, base_oid, depth) = match entry_kind {
+            ReceiveEntryKind::Full(kind) => {
+                let resolved = if kind == Kind::Blob && entry.declared_size >= large_threshold {
+                    stream_full_blob_at(&file, entry, true)?
+                } else if base_ref_count > 0 {
+                    let raw = inflate_entry_at(&file, entry)?;
+                    let size = raw.len() as u64;
+                    let oid = crate::object::hash(kind, &raw);
+                    ResolvedData {
+                        oid,
+                        size,
+                        raw: Some(raw),
+                        spilled: None,
+                        external_path: None,
+                    }
+                } else {
+                    stream_full_object_at(&file, entry, kind, false)?
+                };
+                (kind, resolved, None, 0)
+            }
+            ReceiveEntryKind::OfsDelta { base_offset } => {
+                let delta = inflate_entry_at(&file, entry)?;
+                let base = resolved_bases
+                    .get(&base_offset)
+                    .ok_or(CodecError::MissingDeltaBaseOffset(base_offset))?;
+                let target_size = delta_target_size(&delta, base.size)?;
+                let resolved = resolve_delta_from_base_with_spill_threshold(
+                    base,
+                    &delta,
+                    target_size as usize,
+                    spill_threshold,
+                )?;
+                (base.kind, resolved, Some(base.oid), base.depth + 1)
+            }
+            ReceiveEntryKind::RefDelta { base_oid } => {
+                return Err(CodecError::MissingDeltaBaseOid(base_oid));
+            }
+        };
+
+        entry.oid = Some(resolved.oid);
+        entry.resolved_kind = Some(kind);
+        entry.resolved_size = Some(resolved.size);
+        entry.base_oid = base_oid;
+        entry.depth = depth;
+        let is_large_blob = kind == Kind::Blob && resolved.size >= large_threshold;
+
+        let mut base_raw = None;
+        let mut base_spilled = None;
+        if is_large_blob {
+            let blob_file = match (&resolved.raw, &resolved.spilled) {
+                (Some(raw), None) => write_temp(raw)?,
+                (None, Some(file)) => copy_temp(file.path())?,
+                _ => return Err(CodecError::Io("invalid resolved blob state".into())),
+            };
+            large_blobs.push(FileBackedBlob {
+                oid: resolved.oid,
+                size: resolved.size,
+                file: blob_file,
+            });
+        }
+
+        if base_ref_count > 0 {
+            let resolved_oid = resolved.oid;
+            let resolved_size = resolved.size;
+            if is_large_blob {
+                match (resolved.raw, resolved.spilled) {
+                    (Some(raw), None) => base_raw = Some(raw),
+                    (None, Some(file)) => base_spilled = Some(file),
+                    _ => return Err(CodecError::Io("invalid resolved base state".into())),
+                }
+            } else {
+                base_raw = resolved.raw;
+                base_spilled = resolved.spilled;
+            }
+            let base = match (base_raw, base_spilled) {
+                (Some(raw), None) => {
+                    store_delta_base(resolved_oid, kind, depth, raw, base_ref_count)?
+                }
+                (None, Some(file)) => store_spilled_delta_base(
+                    resolved_oid,
+                    kind,
+                    resolved_size,
+                    depth,
+                    file,
+                    base_ref_count,
+                ),
+                _ => return Err(CodecError::Io("invalid resolved base state".into())),
+            };
+            resolved_bases.insert(offset, base);
+        }
+        if let ReceiveEntryKind::OfsDelta { base_offset } = entry_kind {
+            if let Some(base) = resolved_bases.get_mut(&base_offset) {
+                base.remaining_refs = base.remaining_refs.saturating_sub(1);
+                if base.remaining_refs == 0 {
+                    resolved_bases.remove(&base_offset);
+                }
+            }
+        }
+    }
+
+    Ok(Some(PackOptimizationPlan {
+        object_count: entries.len(),
+        large_blobs,
+    }))
+}
+
+/// Inspect a self-contained pack and extract tree-entry metadata without retaining blob payloads.
+///
+/// Returns `Ok(None)` for thin packs with `REF_DELTA` entries. The caller can retry after a later
+/// derived-index path has an external-base resolver.
+pub fn plan_pack_tree_index(
+    path: impl AsRef<Path>,
+    spill_threshold: u64,
+) -> Result<Option<PackTreeIndexPlan>, CodecError> {
+    plan_pack_tree_index_with_external_bases(path, spill_threshold, &HashMap::new())
+}
+
+/// Return the external base oids referenced by `REF_DELTA` entries in a pack.
+pub fn pack_ref_delta_bases(path: impl AsRef<Path>) -> Result<Vec<Oid>, CodecError> {
+    let path = path.as_ref();
+    let mut file = std::fs::File::open(path).map_err(|e| CodecError::Io(e.to_string()))?;
+    let pack_len = file
+        .metadata()
+        .map_err(|e| CodecError::Io(e.to_string()))?
+        .len();
+    let (_, entries) = match scan_received_pack(&mut file, pack_len, true)? {
+        Some(v) => v,
+        None => return Ok(Vec::new()),
+    };
+    let mut out = Vec::new();
+    for entry in entries {
+        if let ReceiveEntryKind::RefDelta { base_oid } = entry.kind {
+            out.push(base_oid);
+        }
+    }
+    Ok(out)
+}
+
+/// Build a derived tree/commit index plan, resolving `REF_DELTA` entries through `external_bases`.
+/// Returns `Ok(None)` when the pack is thin and one or more external bases are unavailable.
+pub fn plan_pack_tree_index_with_external_bases(
+    path: impl AsRef<Path>,
+    spill_threshold: u64,
+    external_bases: &HashMap<Oid, ExternalBase>,
+) -> Result<Option<PackTreeIndexPlan>, CodecError> {
+    let path = path.as_ref();
+    let mut file = std::fs::File::open(path).map_err(|e| CodecError::Io(e.to_string()))?;
+    let pack_len = file
+        .metadata()
+        .map_err(|e| CodecError::Io(e.to_string()))?
+        .len();
+    let (_, mut entries) = match scan_received_pack(&mut file, pack_len, true)? {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+
+    let active_base_count = entries
+        .iter()
+        .filter(|entry| entry.base_ref_count > 0)
+        .count();
+    let mut resolved_bases: HashMap<u64, StoredBase> =
+        HashMap::with_capacity(active_base_count.min(PREALLOC_HINT_CAP));
+    let mut tree_entries_out = Vec::new();
+    let mut commit_entries_out = Vec::new();
+    let spill_threshold = spill_threshold.min(usize::MAX as u64) as usize;
+
+    for entry in &mut entries {
+        let offset = entry.offset;
+        let entry_kind = entry.kind;
+        let base_ref_count = entry.base_ref_count;
+        let (kind, resolved, base_oid, depth) = match entry_kind {
+            ReceiveEntryKind::Full(kind) => {
+                let resolved =
+                    if kind == Kind::Blob && entry.declared_size >= spill_threshold as u64 {
+                        stream_full_blob_at(&file, entry, true)?
+                    } else if kind == Kind::Tree || kind == Kind::Commit || base_ref_count > 0 {
+                        let raw = inflate_entry_at(&file, entry)?;
+                        let size = raw.len() as u64;
+                        let oid = crate::object::hash(kind, &raw);
+                        ResolvedData {
+                            oid,
+                            size,
+                            raw: Some(raw),
+                            spilled: None,
+                            external_path: None,
+                        }
+                    } else {
+                        continue;
+                    };
+                (kind, resolved, None, 0)
+            }
+            ReceiveEntryKind::OfsDelta { base_offset } => {
+                let delta = inflate_entry_at(&file, entry)?;
+                let base = resolved_bases
+                    .get(&base_offset)
+                    .ok_or(CodecError::MissingDeltaBaseOffset(base_offset))?;
+                let target_size = delta_target_size(&delta, base.size)?;
+                let resolved = resolve_delta_from_base_with_spill_threshold(
+                    base,
+                    &delta,
+                    target_size as usize,
+                    spill_threshold,
+                )?;
+                (base.kind, resolved, Some(base.oid), base.depth + 1)
+            }
+            ReceiveEntryKind::RefDelta { base_oid } => {
+                let Some(base) = external_bases.get(&base_oid) else {
+                    return Ok(None);
+                };
+                let delta = inflate_entry_at(&file, entry)?;
+                let target_size = delta_target_size(&delta, base.size)?;
+                let stored_base = StoredBase {
+                    oid: base_oid,
+                    kind: base.kind,
+                    size: base.size,
+                    depth: 0,
+                    remaining_refs: 1,
+                    data: StoredBaseData::ExternalPath(base.path.clone()),
+                };
+                let resolved = resolve_delta_from_base_with_spill_threshold(
+                    &stored_base,
+                    &delta,
+                    target_size as usize,
+                    spill_threshold,
+                )?;
+                let kind = base.kind;
+                (kind, resolved, Some(base_oid), 1)
+            }
+        };
+
+        entry.oid = Some(resolved.oid);
+        entry.resolved_kind = Some(kind);
+        entry.resolved_size = Some(resolved.size);
+        entry.base_oid = base_oid;
+        entry.depth = depth;
+        if kind == Kind::Tree {
+            if let Some(raw) = resolved.raw.as_ref() {
+                for e in crate::graph::tree_entries(raw)? {
+                    tree_entries_out.push(PackTreeIndexEntry {
+                        tree_oid: resolved.oid,
+                        mode: e.mode,
+                        name: e.name,
+                        oid: e.oid,
+                    });
+                }
+            }
+        } else if kind == Kind::Commit {
+            if let Some(raw) = resolved.raw.as_ref() {
+                let (root_tree, parents) = crate::graph::commit_links(raw)?;
+                commit_entries_out.push(PackCommitIndexEntry {
+                    commit_oid: resolved.oid,
+                    root_tree,
+                    parents,
+                });
+            }
+        }
+
+        if base_ref_count > 0 {
+            let resolved_oid = resolved.oid;
+            let resolved_size = resolved.size;
+            let base = match (resolved.raw, resolved.spilled) {
+                (Some(raw), None) => {
+                    store_delta_base(resolved_oid, kind, depth, raw, base_ref_count)?
+                }
+                (None, Some(file)) => store_spilled_delta_base(
+                    resolved_oid,
+                    kind,
+                    resolved_size,
+                    depth,
+                    file,
+                    base_ref_count,
+                ),
+                _ => return Err(CodecError::Io("invalid resolved base state".into())),
+            };
+            resolved_bases.insert(offset, base);
+        }
+        if let ReceiveEntryKind::OfsDelta { base_offset } = entry_kind {
+            if let Some(base) = resolved_bases.get_mut(&base_offset) {
+                base.remaining_refs = base.remaining_refs.saturating_sub(1);
+                if base.remaining_refs == 0 {
+                    resolved_bases.remove(&base_offset);
+                }
+            }
+        }
+    }
+
+    Ok(Some(PackTreeIndexPlan {
+        object_count: entries.len(),
+        entries: tree_entries_out,
+        commits: commit_entries_out,
+    }))
+}
+
+fn write_temp(bytes: &[u8]) -> Result<tempfile::NamedTempFile, CodecError> {
+    let mut file = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    file.write_all(bytes)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    file.as_file_mut()
+        .flush()
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(file)
+}
+
+fn copy_temp(path: &Path) -> Result<tempfile::NamedTempFile, CodecError> {
+    let mut input = std::fs::File::open(path).map_err(|e| CodecError::Io(e.to_string()))?;
+    let mut output = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    std::io::copy(&mut input, &mut output).map_err(|e| CodecError::Io(e.to_string()))?;
+    output
+        .as_file_mut()
+        .flush()
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(output)
+}
+
+/// Resolve every object in a **self-contained** pack by spilling `data` to a temp file and using the
+/// same file-backed indexer as receive-pack.
+///
+/// Returns `Ok(None)` if the pack carries any `REF_DELTA` entry — that's a thin pack whose bases live
+/// outside it (an incremental fetch/push), which the streaming parser resolves on demand against the
+/// repo. Those packs are small, so the streaming path is already fast.
+pub fn resolve_pack_parallel(data: &[u8]) -> Result<Option<ResolvedPack>, CodecError> {
+    let mut tmp = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    tmp.write_all(data)
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    tmp.as_file_mut()
+        .flush()
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    resolve_pack_file(tmp.path())
+}
+
+struct LinkOutput {
+    commit: Option<(Oid, Vec<Oid>)>,
+    tree_entries: Vec<PackTreeIndexEntry>,
+}
+
+fn collect_links(
+    oid: Oid,
+    kind: Kind,
+    bytes: &[u8],
+    refs: &mut Vec<Oid>,
+    tag_targets: &mut std::collections::HashMap<Oid, Oid>,
+) -> Result<LinkOutput, CodecError> {
+    match kind {
+        Kind::Blob => Ok(LinkOutput {
+            commit: None,
+            tree_entries: Vec::new(),
+        }),
+        Kind::Commit => {
+            let (tree, parents) = crate::graph::commit_links(bytes)?;
+            refs.push(tree);
+            refs.extend(parents.iter().copied());
+            Ok(LinkOutput {
+                commit: Some((tree, parents)),
+                tree_entries: Vec::new(),
+            })
+        }
+        Kind::Tree => {
+            let mut tree_entries = Vec::new();
+            for entry in crate::graph::tree_entries(bytes)? {
+                if entry.is_tree() || entry.is_blob() {
+                    refs.push(entry.oid);
+                }
+                tree_entries.push(PackTreeIndexEntry {
+                    tree_oid: oid,
+                    mode: entry.mode,
+                    name: entry.name,
+                    oid: entry.oid,
+                });
+            }
+            Ok(LinkOutput {
+                commit: None,
+                tree_entries,
+            })
+        }
+        Kind::Tag => {
+            let (target, target_kind) = crate::graph::tag_target(bytes)?;
+            tag_targets.insert(oid, target);
+            match target_kind {
+                Some(Kind::Commit | Kind::Tree | Kind::Blob | Kind::Tag) | None => {
+                    refs.push(target);
+                }
+            }
+            Ok(LinkOutput {
+                commit: None,
+                tree_entries: Vec::new(),
+            })
+        }
+    }
+}
+
+fn delta_target_size(delta: &[u8], expected_base_size: u64) -> Result<u64, CodecError> {
+    let mut pos = 0usize;
+    let base_size = crate::delta::read_size_varint(delta, &mut pos)?;
+    if base_size != expected_base_size {
+        return Err(CodecError::DeltaBaseSizeMismatch {
+            expected: base_size,
+            actual: expected_base_size,
+        });
+    }
+    crate::delta::read_size_varint(delta, &mut pos)
+}
+
+fn scan_received_pack(
+    file: &mut std::fs::File,
+    pack_len: u64,
+    allow_ref_delta: bool,
+) -> Result<Option<(Oid, Vec<ReceiveEntryMeta>)>, CodecError> {
+    if pack_len < 12 + 20 {
+        return Err(CodecError::PackTooShort);
+    }
+    let body_end = pack_len - 20;
+    let mut reader = PackBodyReader::new(file, body_end);
+    let mut header = [0u8; 12];
+    reader.read_body_exact(&mut header, None)?;
+    if &header[0..4] != PACK_MAGIC {
+        return Err(CodecError::BadPackMagic);
+    }
+    let version = u32::from_be_bytes(header[4..8].try_into().unwrap());
+    if version != PACK_VERSION {
+        return Err(CodecError::BadPackVersion(version));
+    }
+    let count = u32::from_be_bytes(header[8..12].try_into().unwrap()) as usize;
+    let mut entries = Vec::with_capacity(count.min(PREALLOC_HINT_CAP));
+
+    for _ in 0..count {
+        let offset = reader.position();
+        let mut crc = crc32fast::Hasher::new();
+        let (ty, declared_size) = read_entry_header_stream(&mut reader, &mut crc)?;
+        let kind = match ty {
+            T_COMMIT | T_TREE | T_BLOB | T_TAG => ReceiveEntryKind::Full(Kind::from_pack_type(ty)?),
+            T_OFS_DELTA => {
+                let rel = read_offset_varint_stream(&mut reader, &mut crc)?;
+                let base_offset = offset
+                    .checked_sub(rel)
+                    .ok_or(CodecError::BadDeltaBaseOffset)?;
+                let base_idx = entries
+                    .binary_search_by_key(&base_offset, |entry: &ReceiveEntryMeta| entry.offset)
+                    .map_err(|_| CodecError::MissingDeltaBaseOffset(base_offset))?;
+                entries[base_idx].base_ref_count = entries[base_idx]
+                    .base_ref_count
+                    .checked_add(1)
+                    .ok_or_else(|| CodecError::Io("too many delta children".into()))?;
+                ReceiveEntryKind::OfsDelta { base_offset }
+            }
+            T_REF_DELTA => {
+                let mut base = [0u8; 20];
+                reader.read_body_exact(&mut base, Some(&mut crc))?;
+                if !allow_ref_delta {
+                    return Ok(None);
+                }
+                ReceiveEntryKind::RefDelta {
+                    base_oid: Oid::from_array(base),
+                }
+            }
+            other => return Err(CodecError::BadPackType(other)),
+        };
+        let compressed_offset = reader.position();
+        let (predecoded_oid, predecoded_raw) = match kind {
+            ReceiveEntryKind::Full(kind) => {
+                let decoded =
+                    inflate_full_entry_stream(&mut reader, &mut crc, kind, declared_size as usize)?;
+                (Some(decoded.oid), decoded.raw)
+            }
+            ReceiveEntryKind::OfsDelta { .. } | ReceiveEntryKind::RefDelta { .. } => {
+                skip_inflate_stream(&mut reader, &mut crc, declared_size as usize)?;
+                (None, None)
+            }
+        };
+        let compressed_len = (reader.position() - compressed_offset)
+            .try_into()
+            .map_err(|_| CodecError::PackTooShort)?;
+        entries.push(ReceiveEntryMeta {
+            offset,
+            compressed_offset,
+            compressed_len,
+            declared_size,
+            kind,
+            crc32: crc.finalize(),
+            base_ref_count: 0,
+            oid: predecoded_oid,
+            resolved_kind: predecoded_oid.map(|_| match kind {
+                ReceiveEntryKind::Full(kind) => kind,
+                ReceiveEntryKind::OfsDelta { .. } | ReceiveEntryKind::RefDelta { .. } => {
+                    unreachable!()
+                }
+            }),
+            resolved_size: predecoded_oid.map(|_| declared_size),
+            predecoded_raw,
+            base_oid: None,
+            depth: 0,
+        });
+    }
+
+    if reader.position() != body_end {
+        return Err(CodecError::PackTooShort);
+    }
+    let mut trailer = [0u8; 20];
+    reader.read_raw_exact(&mut trailer)?;
+    let computed: [u8; 20] = reader.finalize_hash();
+    if computed != trailer {
+        return Err(CodecError::PackChecksumMismatch);
+    }
+    Ok(Some((Oid::from_array(computed), entries)))
+}
+
+struct PackBodyReader<'a> {
+    file: &'a mut std::fs::File,
+    body_end: u64,
+    pos: u64,
+    buf: Vec<u8>,
+    buf_pos: usize,
+    buf_len: usize,
+    hasher: Sha1,
+}
+
+impl<'a> PackBodyReader<'a> {
+    fn new(file: &'a mut std::fs::File, body_end: u64) -> Self {
+        Self {
+            file,
+            body_end,
+            pos: 0,
+            buf: vec![0; 64 * 1024],
+            buf_pos: 0,
+            buf_len: 0,
+            hasher: Sha1::new(),
+        }
+    }
+
+    fn position(&self) -> u64 {
+        self.pos
+    }
+
+    fn fill_body(&mut self) -> Result<(), CodecError> {
+        if self.buf_pos < self.buf_len {
+            return Ok(());
+        }
+        if self.pos >= self.body_end {
+            return Err(CodecError::PackTooShort);
+        }
+        let remaining = (self.body_end - self.pos) as usize;
+        let to_read = remaining.min(self.buf.len());
+        let n = self
+            .file
+            .read(&mut self.buf[..to_read])
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        if n == 0 {
+            return Err(CodecError::PackTooShort);
+        }
+        self.buf_pos = 0;
+        self.buf_len = n;
+        Ok(())
+    }
+
+    fn available_body(&mut self) -> Result<&[u8], CodecError> {
+        self.fill_body()?;
+        Ok(&self.buf[self.buf_pos..self.buf_len])
+    }
+
+    fn consume_body(
+        &mut self,
+        n: usize,
+        crc: Option<&mut crc32fast::Hasher>,
+    ) -> Result<(), CodecError> {
+        if self.buf_pos + n > self.buf_len {
+            return Err(CodecError::PackTooShort);
+        }
+        let bytes = &self.buf[self.buf_pos..self.buf_pos + n];
+        self.hasher.update(bytes);
+        if let Some(crc) = crc {
+            crc.update(bytes);
+        }
+        self.buf_pos += n;
+        self.pos += n as u64;
+        Ok(())
+    }
+
+    fn read_body_byte(&mut self, crc: Option<&mut crc32fast::Hasher>) -> Result<u8, CodecError> {
+        self.fill_body()?;
+        let b = self.buf[self.buf_pos];
+        self.consume_body(1, crc)?;
+        Ok(b)
+    }
+
+    fn read_body_exact(
+        &mut self,
+        mut out: &mut [u8],
+        mut crc: Option<&mut crc32fast::Hasher>,
+    ) -> Result<(), CodecError> {
+        while !out.is_empty() {
+            self.fill_body()?;
+            let n = out.len().min(self.buf_len - self.buf_pos);
+            out[..n].copy_from_slice(&self.buf[self.buf_pos..self.buf_pos + n]);
+            match crc.as_deref_mut() {
+                Some(c) => self.consume_body(n, Some(c))?,
+                None => self.consume_body(n, None)?,
+            }
+            out = &mut out[n..];
+        }
+        Ok(())
+    }
+
+    fn read_raw_exact(&mut self, mut out: &mut [u8]) -> Result<(), CodecError> {
+        while self.buf_pos < self.buf_len && !out.is_empty() {
+            let n = out.len().min(self.buf_len - self.buf_pos);
+            out[..n].copy_from_slice(&self.buf[self.buf_pos..self.buf_pos + n]);
+            self.buf_pos += n;
+            out = &mut out[n..];
+        }
+        self.file
+            .read_exact(out)
+            .map_err(|e| CodecError::Io(e.to_string()))
+    }
+
+    fn finalize_hash(self) -> [u8; 20] {
+        self.hasher.finalize().into()
+    }
+}
+
+fn read_entry_header_stream(
+    reader: &mut PackBodyReader<'_>,
+    crc: &mut crc32fast::Hasher,
+) -> Result<(u8, u64), CodecError> {
+    let c = reader.read_body_byte(Some(crc))?;
+    let ty = (c >> 4) & 0x07;
+    let mut size = (c & 0x0f) as u64;
+    let mut shift = 4u32;
+    let mut cont = c & 0x80 != 0;
+    while cont {
+        let c = reader.read_body_byte(Some(crc))?;
+        size |= ((c & 0x7f) as u64) << shift;
+        shift += 7;
+        cont = c & 0x80 != 0;
+    }
+    Ok((ty, size))
+}
+
+fn read_offset_varint_stream(
+    reader: &mut PackBodyReader<'_>,
+    crc: &mut crc32fast::Hasher,
+) -> Result<u64, CodecError> {
+    let mut c = reader.read_body_byte(Some(crc))?;
+    let mut off = (c & 0x7f) as u64;
+    while c & 0x80 != 0 {
+        c = reader.read_body_byte(Some(crc))?;
+        off = ((off + 1) << 7) | (c & 0x7f) as u64;
+    }
+    Ok(off)
+}
+
+fn skip_inflate_stream(
+    reader: &mut PackBodyReader<'_>,
+    crc: &mut crc32fast::Hasher,
+    expected: usize,
+) -> Result<usize, CodecError> {
+    let mut dec = Decompress::new(true);
+    let mut scratch = [0u8; 16 * 1024];
+    loop {
+        let input = reader.available_body()?;
+        let before_in = dec.total_in();
+        let before_out = dec.total_out();
+        let status = dec
+            .decompress(input, &mut scratch, FlushDecompress::None)
+            .map_err(|e| CodecError::Inflate(e.to_string()))?;
+        let consumed = (dec.total_in() - before_in) as usize;
+        reader.consume_body(consumed, Some(crc))?;
+        if matches!(status, Status::StreamEnd) {
+            break;
+        }
+        if dec.total_in() == before_in && dec.total_out() == before_out {
+            return Err(CodecError::Inflate("inflate made no progress".into()));
+        }
+    }
+    let consumed = dec.total_in() as usize;
+    let produced = dec.total_out() as usize;
+    if produced != expected {
+        return Err(CodecError::Inflate(format!(
+            "expected {expected} bytes, produced {produced}"
+        )));
+    }
+    Ok(consumed)
+}
+
+struct PredecodedFullEntry {
+    oid: Oid,
+    raw: Option<Vec<u8>>,
+}
+
+fn inflate_full_entry_stream(
+    reader: &mut PackBodyReader<'_>,
+    crc: &mut crc32fast::Hasher,
+    kind: Kind,
+    expected: usize,
+) -> Result<PredecodedFullEntry, CodecError> {
+    #[cfg(test)]
+    if kind == Kind::Blob {
+        STREAMED_FULL_BLOBS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    let mut dec = Decompress::new(true);
+    let mut scratch = [0u8; 16 * 1024];
+    let mut hasher = object_hasher(kind, expected as u64);
+    loop {
+        let input = reader.available_body()?;
+        let before_in = dec.total_in();
+        let before_out = dec.total_out();
+        let status = dec
+            .decompress(input, &mut scratch, FlushDecompress::None)
+            .map_err(|e| CodecError::Inflate(e.to_string()))?;
+        let consumed = (dec.total_in() - before_in) as usize;
+        let produced = (dec.total_out() - before_out) as usize;
+        reader.consume_body(consumed, Some(crc))?;
+        if produced > 0 {
+            let bytes = &scratch[..produced];
+            hasher.update(bytes);
+        }
+        if matches!(status, Status::StreamEnd) {
+            break;
+        }
+        if dec.total_in() == before_in && dec.total_out() == before_out {
+            return Err(CodecError::Inflate("inflate made no progress".into()));
+        }
+    }
+    let produced = dec.total_out() as usize;
+    if produced != expected {
+        return Err(CodecError::Inflate(format!(
+            "expected {expected} bytes, produced {produced}"
+        )));
+    }
+    Ok(PredecodedFullEntry {
+        oid: finalize_object_hash(hasher),
+        raw: None,
+    })
+}
+
+fn inflate_entry_at(file: &std::fs::File, entry: &ReceiveEntryMeta) -> Result<Vec<u8>, CodecError> {
+    let mut compressed = vec![0u8; entry.compressed_len];
+    read_exact_at(file, entry.compressed_offset, &mut compressed)?;
+    let mut pos = 0usize;
+    let (raw, consumed) = inflate(&compressed, &mut pos, entry.declared_size as usize)?;
+    if consumed != entry.compressed_len {
+        return Err(CodecError::Inflate(format!(
+            "expected {} compressed bytes, consumed {consumed}",
+            entry.compressed_len
+        )));
+    }
+    Ok(raw)
+}
+
+fn stream_full_blob_at(
+    file: &std::fs::File,
+    entry: &ReceiveEntryMeta,
+    spill_to_file: bool,
+) -> Result<ResolvedData, CodecError> {
+    stream_full_object_at(file, entry, Kind::Blob, spill_to_file)
+}
+
+/// Stream one known full blob entry from `path` into a temporary file using persisted pack-entry
+/// metadata. This is the optimizer's indexed fast path: it range-reads and inflates the one object
+/// instead of replaying the pack resolver to rediscover it.
+pub fn stream_indexed_full_blob_to_temp(
+    path: impl AsRef<Path>,
+    entry: &PackObjectEntry,
+) -> Result<FileBackedBlob, CodecError> {
+    if entry.kind != PackObjectKind::Full(Kind::Blob) {
+        return Err(CodecError::Io("indexed entry is not a full blob".into()));
+    }
+    let file = std::fs::File::open(path.as_ref()).map_err(|e| CodecError::Io(e.to_string()))?;
+    let meta = ReceiveEntryMeta {
+        offset: entry.offset,
+        compressed_offset: entry.compressed_offset,
+        compressed_len: entry
+            .compressed_len
+            .try_into()
+            .map_err(|_| CodecError::Io("indexed compressed length exceeds usize".into()))?,
+        declared_size: entry.declared_size,
+        kind: ReceiveEntryKind::Full(Kind::Blob),
+        crc32: entry.crc32,
+        base_ref_count: 0,
+        oid: Some(entry.oid),
+        resolved_kind: Some(entry.resolved_kind),
+        resolved_size: Some(entry.resolved_size),
+        predecoded_raw: None,
+        base_oid: None,
+        depth: 0,
+    };
+    let resolved = stream_full_blob_at(&file, &meta, true)?;
+    if resolved.oid != entry.oid {
+        return Err(CodecError::Io(format!(
+            "indexed blob oid mismatch: expected {}, got {}",
+            entry.oid.to_hex(),
+            resolved.oid.to_hex()
+        )));
+    }
+    let file = resolved
+        .spilled
+        .ok_or_else(|| CodecError::Io("indexed blob was not spilled".into()))?;
+    Ok(FileBackedBlob {
+        oid: resolved.oid,
+        size: resolved.size,
+        file,
+    })
+}
+
+/// Inflate one indexed full blob from its compressed byte range. The caller supplies exactly
+/// `entry.compressed_len` bytes starting at `entry.compressed_offset`.
+pub fn stream_indexed_full_blob_range_to_temp(
+    compressed: &[u8],
+    entry: &PackObjectEntry,
+) -> Result<FileBackedBlob, CodecError> {
+    if entry.kind != PackObjectKind::Full(Kind::Blob) {
+        return Err(CodecError::Io("indexed entry is not a full blob".into()));
+    }
+    if compressed.len() as u64 != entry.compressed_len {
+        return Err(CodecError::Inflate(format!(
+            "expected {} compressed bytes, got {}",
+            entry.compressed_len,
+            compressed.len()
+        )));
+    }
+    let mut file = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    let mut hasher = object_hasher(Kind::Blob, entry.declared_size);
+    let mut dec = Decompress::new(true);
+    let mut output = [0u8; 64 * 1024];
+    let mut pos = 0usize;
+    let mut produced_total = 0u64;
+    let mut ended = false;
+    while pos < compressed.len() && !ended {
+        let before_in = dec.total_in();
+        let before_out = dec.total_out();
+        let status = dec
+            .decompress(&compressed[pos..], &mut output, FlushDecompress::None)
+            .map_err(|e| CodecError::Inflate(e.to_string()))?;
+        let consumed = (dec.total_in() - before_in) as usize;
+        let produced = (dec.total_out() - before_out) as usize;
+        if produced > 0 {
+            file.write_all(&output[..produced])
+                .map_err(|e| CodecError::Io(e.to_string()))?;
+            hasher.update(&output[..produced]);
+            produced_total += produced as u64;
+        }
+        pos += consumed;
+        if matches!(status, Status::StreamEnd) {
+            ended = true;
+        }
+        if consumed == 0 && produced == 0 {
+            return Err(CodecError::Inflate(
+                "indexed blob inflate made no progress".into(),
+            ));
+        }
+    }
+    if !ended || pos != compressed.len() || produced_total != entry.declared_size {
+        return Err(CodecError::Inflate(format!(
+            "indexed blob inflate mismatch: consumed {}/{}, produced {}/{}",
+            pos,
+            compressed.len(),
+            produced_total,
+            entry.declared_size
+        )));
+    }
+    let oid = finalize_object_hash(hasher);
+    if oid != entry.oid {
+        return Err(CodecError::Io(format!(
+            "indexed blob oid mismatch: expected {}, got {}",
+            entry.oid.to_hex(),
+            oid.to_hex()
+        )));
+    }
+    Ok(FileBackedBlob {
+        oid,
+        size: produced_total,
+        file,
+    })
+}
+
+pub fn inflate_full_payload_range_to_temp(
+    compressed: &[u8],
+    kind: Kind,
+    expected_oid: Oid,
+    expected_size: u64,
+) -> Result<tempfile::TempPath, CodecError> {
+    let mut file = tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?;
+    inflate_full_payload_range_to_writer(compressed, kind, expected_oid, expected_size, &mut file)?;
+    file.as_file_mut()
+        .flush()
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    Ok(file.into_temp_path())
+}
+
+fn inflate_full_payload_range_to_writer<W: Write>(
+    compressed: &[u8],
+    kind: Kind,
+    expected_oid: Oid,
+    expected_size: u64,
+    writer: &mut W,
+) -> Result<u64, CodecError> {
+    let mut hasher = object_hasher(kind, expected_size);
+    let mut dec = Decompress::new(true);
+    let mut output = [0u8; 64 * 1024];
+    let mut pos = 0usize;
+    let mut produced_total = 0u64;
+    let mut ended = false;
+    while pos < compressed.len() && !ended {
+        let before_in = dec.total_in();
+        let before_out = dec.total_out();
+        let status = dec
+            .decompress(&compressed[pos..], &mut output, FlushDecompress::None)
+            .map_err(|e| CodecError::Inflate(e.to_string()))?;
+        let consumed = (dec.total_in() - before_in) as usize;
+        let produced = (dec.total_out() - before_out) as usize;
+        if produced > 0 {
+            writer
+                .write_all(&output[..produced])
+                .map_err(|e| CodecError::Io(e.to_string()))?;
+            hasher.update(&output[..produced]);
+            produced_total += produced as u64;
+        }
+        pos += consumed;
+        if matches!(status, Status::StreamEnd) {
+            ended = true;
+        }
+        if consumed == 0 && produced == 0 {
+            return Err(CodecError::Inflate(
+                "full payload range inflate made no progress".into(),
+            ));
+        }
+    }
+    if !ended || pos != compressed.len() || produced_total != expected_size {
+        return Err(CodecError::Inflate(format!(
+            "full payload range inflate mismatch: consumed {}/{}, produced {}/{}",
+            pos,
+            compressed.len(),
+            produced_total,
+            expected_size
+        )));
+    }
+    let oid = finalize_object_hash(hasher);
+    if oid != expected_oid {
+        return Err(CodecError::Io(format!(
+            "full payload range oid mismatch: expected {}, got {}",
+            expected_oid.to_hex(),
+            oid.to_hex()
+        )));
+    }
+    Ok(produced_total)
+}
+
+fn stream_full_object_at(
+    file: &std::fs::File,
+    entry: &ReceiveEntryMeta,
+    kind: Kind,
+    spill_to_file: bool,
+) -> Result<ResolvedData, CodecError> {
+    const IN_CHUNK: usize = 64 * 1024;
+    const OUT_CHUNK: usize = 64 * 1024;
+
+    let mut out_file = if spill_to_file {
+        Some(tempfile::NamedTempFile::new().map_err(|e| CodecError::Io(e.to_string()))?)
+    } else {
+        None
+    };
+    let mut hasher = object_hasher(kind, entry.declared_size);
+    let mut dec = Decompress::new(true);
+    let mut input = [0u8; IN_CHUNK];
+    let mut output = [0u8; OUT_CHUNK];
+    let mut input_offset = entry.compressed_offset;
+    let mut remaining = entry.compressed_len;
+    let mut consumed_total = 0usize;
+    let mut produced_total = 0u64;
+    let mut ended = false;
+
+    while remaining > 0 && !ended {
+        let n = remaining.min(input.len());
+        read_exact_at(file, input_offset, &mut input[..n])?;
+        input_offset += n as u64;
+        remaining -= n;
+
+        let mut chunk_pos = 0usize;
+        while chunk_pos < n {
+            let before_in = dec.total_in();
+            let before_out = dec.total_out();
+            let status = dec
+                .decompress(&input[chunk_pos..n], &mut output, FlushDecompress::None)
+                .map_err(|e| CodecError::Inflate(e.to_string()))?;
+            let consumed = (dec.total_in() - before_in) as usize;
+            let produced = (dec.total_out() - before_out) as usize;
+            if produced > 0 {
+                let bytes = &output[..produced];
+                hasher.update(bytes);
+                if let Some(file) = out_file.as_mut() {
+                    file.write_all(bytes)
+                        .map_err(|e| CodecError::Io(e.to_string()))?;
+                }
+                produced_total = produced_total
+                    .checked_add(produced as u64)
+                    .ok_or(CodecError::TruncatedDelta)?;
+            }
+            chunk_pos += consumed;
+            consumed_total += consumed;
+            if matches!(status, Status::StreamEnd) {
+                ended = true;
+                break;
+            }
+            if consumed == 0 && produced == 0 {
+                return Err(CodecError::Inflate("inflate made no progress".into()));
+            }
+        }
+    }
+
+    if !ended || consumed_total != entry.compressed_len || produced_total != entry.declared_size {
+        return Err(CodecError::Inflate(format!(
+            "expected {} compressed / {} produced bytes, consumed {consumed_total} / produced {produced_total}",
+            entry.compressed_len, entry.declared_size
+        )));
+    }
+
+    if let Some(file) = out_file.as_mut() {
+        file.as_file_mut()
+            .flush()
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        #[cfg(test)]
+        SPILLED_DELTA_BASES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    #[cfg(test)]
+    STREAMED_FULL_BLOBS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+    Ok(ResolvedData {
+        oid: finalize_object_hash(hasher),
+        size: produced_total,
+        raw: None,
+        spilled: out_file,
+        external_path: None,
+    })
+}
+
+#[cfg(unix)]
+fn read_exact_at(file: &std::fs::File, offset: u64, mut out: &mut [u8]) -> Result<(), CodecError> {
+    use std::os::unix::fs::FileExt;
+    let mut read_offset = offset;
+    while !out.is_empty() {
+        let n = file
+            .read_at(out, read_offset)
+            .map_err(|e| CodecError::Io(e.to_string()))?;
+        if n == 0 {
+            return Err(CodecError::PackTooShort);
+        }
+        read_offset += n as u64;
+        out = &mut out[n..];
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn read_exact_at(file: &std::fs::File, offset: u64, out: &mut [u8]) -> Result<(), CodecError> {
+    use std::io::{Seek, SeekFrom};
+    let mut file = file
+        .try_clone()
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|e| CodecError::Io(e.to_string()))?;
+    file.read_exact(out)
+        .map_err(|e| CodecError::Io(e.to_string()))
+}
+
+/// A single packfile entry, read at a byte offset without parsing the rest of the pack. Deltas are
+/// returned **unresolved** (with a reference to their base) so the caller can resolve the base
+/// on demand — possibly from another pack — rather than requiring the whole pack in memory.
+#[derive(Clone, Debug)]
+pub enum PackEntry {
+    /// A self-contained object.
+    Object { kind: Kind, data: Vec<u8> },
+    /// A delta against a base earlier in the same pack, identified by its absolute byte offset.
+    OfsDelta { base_offset: u64, delta: Vec<u8> },
+    /// A delta against a base identified by object id (may live in another pack).
+    RefDelta { base_oid: Oid, delta: Vec<u8> },
+}
+
+/// Read the single entry that begins at `offset` in `pack` (a complete packfile, trailer included).
+///
+/// This is the on-demand counterpart to [`parse_pack`]: it inflates exactly one entry's bytes —
+/// the zlib stream is self-terminating, so the trailing pack bytes are harmless — and returns
+/// deltas unresolved. It lets an object be materialized from its idx offset without inflating every
+/// other object in the pack. `offset` must be a genuine entry boundary (e.g. from the `.idx`).
+pub fn read_pack_entry(pack: &[u8], offset: u64) -> Result<PackEntry, CodecError> {
+    let entry_start = offset;
+    let mut pos = offset as usize;
+    let (ty, size) = read_entry_header(pack, &mut pos)?;
+    match ty {
+        T_COMMIT | T_TREE | T_BLOB | T_TAG => {
+            let (data, _) = inflate(pack, &mut pos, size as usize)?;
+            Ok(PackEntry::Object {
+                kind: Kind::from_pack_type(ty)?,
+                data,
+            })
+        }
+        T_OFS_DELTA => {
+            let rel = read_offset_varint(pack, &mut pos)?;
+            let base_offset = entry_start
+                .checked_sub(rel)
+                .ok_or(CodecError::BadDeltaBaseOffset)?;
+            let (delta, _) = inflate(pack, &mut pos, size as usize)?;
+            Ok(PackEntry::OfsDelta { base_offset, delta })
+        }
+        T_REF_DELTA => {
+            let base_oid =
+                Oid::from_bytes(pack.get(pos..pos + 20).ok_or(CodecError::PackTooShort)?)?;
+            pos += 20;
+            let (delta, _) = inflate(pack, &mut pos, size as usize)?;
+            Ok(PackEntry::RefDelta { base_oid, delta })
+        }
+        other => Err(CodecError::BadPackType(other)),
+    }
+}
+
+/// Parse a packfile object type/size header.
+fn read_entry_header(buf: &[u8], pos: &mut usize) -> Result<(u8, u64), CodecError> {
+    let c = *buf.get(*pos).ok_or(CodecError::PackTooShort)?;
+    *pos += 1;
+    let ty = (c >> 4) & 0x07;
+    let mut size = (c & 0x0f) as u64;
+    let mut shift = 4u32;
+    let mut cont = c & 0x80 != 0;
+    while cont {
+        let c = *buf.get(*pos).ok_or(CodecError::PackTooShort)?;
+        *pos += 1;
+        size |= ((c & 0x7f) as u64) << shift;
+        shift += 7;
+        cont = c & 0x80 != 0;
+    }
+    Ok((ty, size))
+}
+
+/// Parse the `OFS_DELTA` negative base-offset encoding.
+fn read_offset_varint(buf: &[u8], pos: &mut usize) -> Result<u64, CodecError> {
+    let mut c = *buf.get(*pos).ok_or(CodecError::PackTooShort)?;
+    *pos += 1;
+    let mut off = (c & 0x7f) as u64;
+    while c & 0x80 != 0 {
+        c = *buf.get(*pos).ok_or(CodecError::PackTooShort)?;
+        *pos += 1;
+        off = ((off + 1) << 7) | (c & 0x7f) as u64;
+    }
+    Ok(off)
+}
+
+/// Inflate exactly `expected` decompressed bytes starting at `buf[*pos]`, advancing `*pos` past
+/// the consumed compressed bytes.
+fn inflate(buf: &[u8], pos: &mut usize, expected: usize) -> Result<(Vec<u8>, usize), CodecError> {
+    let mut dec = Decompress::new(true);
+    let mut out = vec![0u8; expected];
+    let input = buf.get(*pos..).ok_or(CodecError::PackTooShort)?;
+    let status = dec
+        .decompress(input, &mut out, FlushDecompress::Finish)
+        .map_err(|e| CodecError::Inflate(e.to_string()))?;
+    let consumed = dec.total_in() as usize;
+    let produced = dec.total_out() as usize;
+    if produced != expected || !matches!(status, Status::StreamEnd | Status::Ok) {
+        return Err(CodecError::Inflate(format!(
+            "expected {expected} bytes, produced {produced}"
+        )));
+    }
+    out.truncate(produced);
+    *pos += consumed;
+    Ok((out, consumed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::delta::encode_trivial_delta;
+
+    #[test]
+    fn malicious_object_count_does_not_oom() {
+        // A 32-byte pack whose header lies about holding u32::MAX objects must be rejected promptly,
+        // not pre-allocate for billions of objects — that allocation would fail and *abort the
+        // process*. With the unclamped `with_capacity(count)` this aborted; the cap makes every parser
+        // return an error instead. (We can only assert the error, since an abort can't be caught.)
+        let mut data = Vec::new();
+        data.extend_from_slice(b"PACK");
+        data.extend_from_slice(&2u32.to_be_bytes());
+        data.extend_from_slice(&u32::MAX.to_be_bytes()); // count = 4.29 billion, but only 32 bytes
+        data.extend_from_slice(&[0u8; 20]); // trailer (won't verify)
+        assert!(resolve_pack_parallel(&data).is_err());
+        assert!(parse_pack(&data, |_| None).is_err());
+        assert!(parse_pack_reuse(&data).is_err());
+    }
+
+    fn objs() -> Vec<Object> {
+        vec![
+            Object::new(Kind::Blob, &b"hello\n"[..]),
+            Object::new(Kind::Blob, &b""[..]),
+            Object::new(
+                Kind::Commit,
+                &b"tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n"[..],
+            ),
+            Object::new(Kind::Blob, vec![0xABu8; 5000]), // forces multi-byte size header
+        ]
+    }
+
+    fn resolve_file(data: &[u8]) -> Result<Option<ResolvedPack>, CodecError> {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(data).unwrap();
+        tmp.as_file_mut().flush().unwrap();
+        resolve_pack_file(tmp.path())
+    }
+
+    fn resolved_object_entries(resolved: &ResolvedPack) -> Vec<PackObjectEntry> {
+        let sidecar = std::fs::read(resolved.object_index_file.path()).unwrap();
+        decode_pack_object_index_sidecar(&sidecar).unwrap()
+    }
+
+    fn resolved_idx_bytes(resolved: &ResolvedPack) -> Vec<u8> {
+        std::fs::read(resolved.idx_file.path()).unwrap()
+    }
+
+    fn resolved_source_index(resolved: &ResolvedPack) -> PackTreeIndexPlan {
+        let sidecar = std::fs::read(resolved.source_index_file.path()).unwrap();
+        decode_pack_source_index_sidecar(&sidecar).unwrap()
+    }
+
+    fn assert_file_resolver_matches_parse(data: &[u8]) -> ResolvedPack {
+        let resolved = resolve_file(data)
+            .unwrap()
+            .expect("self-contained pack resolves verbatim");
+        let parsed = parse_pack(data, |_| None).unwrap();
+        assert_eq!(resolved.object_count, parsed.objects.len());
+        let object_entries = resolved_object_entries(&resolved);
+        assert_eq!(object_entries.len(), parsed.objects.len());
+        assert_eq!(
+            crate::idx::IdxV2::parse(&resolved_idx_bytes(&resolved))
+                .unwrap()
+                .len(),
+            parsed.objects.len()
+        );
+
+        let mut want_oids: Vec<Oid> = parsed.objects.iter().map(|(oid, _)| *oid).collect();
+        want_oids.sort_unstable();
+        want_oids.dedup();
+        assert_eq!(resolved.oids, want_oids);
+
+        let max_object_size = parsed
+            .objects
+            .iter()
+            .map(|(_, obj)| obj.data.len() as u64)
+            .max()
+            .unwrap_or(0);
+        assert_eq!(
+            resolved.largest.map(|(_, size)| size),
+            Some(max_object_size)
+        );
+        for (oid, _) in parsed.objects {
+            assert!(object_entries
+                .iter()
+                .any(|entry| entry.oid == oid && entry.offset > 0));
+        }
+        resolved
+    }
+
+    #[test]
+    fn build_then_parse_roundtrips() {
+        let objects = objs();
+        let built = build_pack(&objects).unwrap();
+        assert_eq!(&built.data[0..4], b"PACK");
+        assert_eq!(built.entries.len(), objects.len());
+
+        let parsed = parse_pack(&built.data, |_| None).unwrap();
+        assert_eq!(parsed.objects.len(), objects.len());
+        for (orig, (oid, got)) in objects.iter().zip(parsed.objects.iter()) {
+            assert_eq!(*oid, orig.id());
+            assert_eq!(got.kind, orig.kind);
+            assert_eq!(got.data, orig.data);
+        }
+    }
+
+    #[test]
+    fn file_resolver_matches_parse_for_full_object_pack() {
+        let built = build_pack(&objs()).unwrap();
+        let resolved = assert_file_resolver_matches_parse(&built.data);
+        assert!(
+            resolved.replayed_pack_entries,
+            "source-bearing full-object packs should resolve from the file-backed resolver"
+        );
+    }
+
+    #[test]
+    fn file_resolver_streams_large_full_blobs_without_materializing_raw() {
+        let streamed_before = STREAMED_FULL_BLOBS.load(std::sync::atomic::Ordering::Relaxed);
+
+        let blob = Object::new(Kind::Blob, vec![0x53u8; LARGE_DELTA_BASE_SPILL_BYTES * 8]);
+        let blob_id = blob.id();
+        let built = build_pack(&[blob]).unwrap();
+        let resolved = assert_file_resolver_matches_parse(&built.data);
+
+        assert!(resolved.oids.binary_search(&blob_id).is_ok());
+        assert_eq!(
+            resolved.largest,
+            Some((blob_id, (LARGE_DELTA_BASE_SPILL_BYTES * 8) as u64))
+        );
+        assert!(
+            STREAMED_FULL_BLOBS.load(std::sync::atomic::Ordering::Relaxed) > streamed_before,
+            "large full blob should stream through the hasher"
+        );
+    }
+
+    #[test]
+    fn file_resolver_matches_parse_for_ofs_delta_pack() {
+        let base = Object::new(Kind::Blob, vec![0x42u8; 8000]);
+        let mut changed = vec![0x42u8; 8000];
+        changed[17] = 0x11;
+        changed[4097] = 0x22;
+        changed.extend_from_slice(b"tail");
+        let target = Object::new(Kind::Blob, changed);
+        let built = build_pack_delta(&[base, target]).unwrap();
+        assert!(built.entries.iter().any(|e| matches!(
+            read_pack_entry(&built.data, e.offset).unwrap(),
+            PackEntry::OfsDelta { .. }
+        )));
+        assert_file_resolver_matches_parse(&built.data);
+    }
+
+    #[test]
+    fn receive_spooler_records_ofs_delta_without_retaining_payload() {
+        let base = Object::new(Kind::Blob, vec![0x42u8; 8000]);
+        let mut changed = vec![0x42u8; 8000];
+        changed[17] = 0x11;
+        changed[4097] = 0x22;
+        changed.extend_from_slice(b"tail");
+        let target = Object::new(Kind::Blob, changed);
+        let built = build_pack_delta(&[base, target]).unwrap();
+
+        let mut spooler = ReceivePackSpooler::new(true);
+        for chunk in built.data.chunks(97) {
+            spooler.push(chunk).unwrap();
+        }
+        let scanned = spooler.finish().unwrap().expect("self-contained pack");
+        let delta_entry = scanned
+            .entries
+            .iter()
+            .find(|entry| matches!(entry.kind, ReceiveEntryKind::OfsDelta { .. }))
+            .expect("expected OFS_DELTA entry");
+
+        assert!(delta_entry.oid.is_none());
+        assert!(delta_entry.resolved_kind.is_none());
+        assert!(delta_entry.resolved_size.is_none());
+        assert!(delta_entry.predecoded_raw.is_none());
+        assert_eq!(scanned.retained_payload_bytes(), 0);
+        assert!(!scanned.predecode_budget_exhausted());
+    }
+
+    #[test]
+    fn receive_spooler_waits_for_split_entry_header_varint() {
+        let blob = Object::new(Kind::Blob, vec![0x42u8; 200]);
+        let built = build_pack(&[blob]).unwrap();
+
+        let mut spooler = ReceivePackSpooler::new(true);
+        spooler.push(&built.data[..13]).unwrap();
+        spooler.push(&built.data[13..]).unwrap();
+        let scanned = spooler.finish().unwrap().expect("self-contained pack");
+
+        assert_eq!(scanned.entries.len(), 1);
+    }
+
+    #[test]
+    fn scanned_small_delta_pack_resolves_from_file_backed_entries() {
+        let base = Object::new(Kind::Blob, vec![0x42u8; 8000]);
+        let mut changed = vec![0x42u8; 8000];
+        changed[17] = 0x11;
+        changed[4097] = 0x22;
+        changed.extend_from_slice(b"tail");
+        let target = Object::new(Kind::Blob, changed);
+        let built = build_pack_delta(&[base, target]).unwrap();
+
+        let mut spooler = ReceivePackSpooler::new(true);
+        spooler.push(&built.data).unwrap();
+        let scanned = spooler.finish().unwrap().expect("self-contained pack");
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&built.data).unwrap();
+        let resolved = resolve_scanned_pack_with_log_context(
+            file.as_file(),
+            scanned,
+            PackResolveLogContext::default(),
+        )
+        .unwrap()
+        .expect("self-contained pack");
+
+        assert!(resolved.replayed_pack_entries);
+    }
+
+    #[test]
+    fn scanner_metadata_does_not_retain_source_payloads() {
+        let blob = Object::new(Kind::Blob, vec![0x33u8; 300 * 1024]);
+        let tree_data = {
+            let mut data = Vec::new();
+            data.extend_from_slice(b"100644 large.bin\0");
+            data.extend_from_slice(blob.id().as_bytes());
+            data
+        };
+        let tree = Object::new(Kind::Tree, tree_data);
+        let commit = Object::new(
+            Kind::Commit,
+            format!(
+                "tree {}\nauthor A <a@example.com> 0 +0000\ncommitter A <a@example.com> 0 +0000\n\nmsg\n",
+                tree.id().to_hex()
+            )
+            .into_bytes(),
+        );
+        let blob_id = blob.id();
+        let tree_id = tree.id();
+        let commit_id = commit.id();
+        let built = build_pack(&[blob, tree, commit]).unwrap();
+
+        let mut spooler = ReceivePackSpooler::new(true);
+        spooler.push(&built.data).unwrap();
+        let scanned = spooler.finish().unwrap().expect("self-contained pack");
+
+        assert_eq!(scanned.retained_payload_bytes(), 0);
+        assert!(!scanned.predecode_budget_exhausted());
+        assert!(resolve_entries_from_scanned_metadata(&scanned.entries)
+            .unwrap()
+            .is_none());
+        assert!(scanned
+            .entries
+            .iter()
+            .find(|entry| entry.oid == Some(blob_id))
+            .expect("blob entry")
+            .predecoded_raw
+            .is_none());
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&built.data).unwrap();
+        let resolved = resolve_scanned_pack_with_log_context(
+            file.as_file(),
+            scanned,
+            PackResolveLogContext::default(),
+        )
+        .unwrap()
+        .expect("self-contained pack");
+        assert!(resolved.replayed_pack_entries);
+        assert_eq!(resolved.largest, Some((blob_id, 300 * 1024)));
+        assert!(resolved.external_refs.is_empty());
+        let source_index = resolved_source_index(&resolved);
+        assert!(source_index
+            .entries
+            .iter()
+            .any(|entry| entry.tree_oid == tree_id && entry.oid == blob_id));
+        assert_eq!(
+            resolved.source_commit_entries,
+            vec![PackCommitIndexEntry {
+                commit_oid: commit_id,
+                root_tree: tree_id,
+                parents: Vec::new(),
+            }]
+        );
+    }
+
+    #[test]
+    fn local_journal_resolver_resolves_ref_delta_from_external_base() {
+        let base = Object::new(Kind::Blob, &b"the original base content here"[..]);
+        let target = Object::new(
+            Kind::Blob,
+            &b"the original base content here, now extended"[..],
+        );
+        let delta = encode_trivial_delta(&base.data, &target.data);
+
+        let mut data = Vec::new();
+        data.extend_from_slice(PACK_MAGIC);
+        data.extend_from_slice(&PACK_VERSION.to_be_bytes());
+        data.extend_from_slice(&1u32.to_be_bytes());
+        write_entry_header(&mut data, T_REF_DELTA, delta.len() as u64);
+        data.extend_from_slice(base.id().as_bytes());
+        let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(&delta).unwrap();
+        data.extend_from_slice(&enc.finish().unwrap());
+        let mut h = Sha1::new();
+        h.update(&data);
+        let digest: [u8; 20] = h.finalize().into();
+        data.extend_from_slice(&digest);
+
+        let mut spooler = ReceivePackSpooler::new(true);
+        for chunk in data.chunks(13) {
+            spooler.push(chunk).unwrap();
+        }
+        let scanned = spooler.finish().unwrap().expect("local thin scan");
+        assert_eq!(scanned.ref_delta_bases(), vec![base.id()]);
+        assert_eq!(scanned.retained_payload_bytes(), 0);
+
+        let mut journal = tempfile::NamedTempFile::new().unwrap();
+        journal.write_all(&data).unwrap();
+        journal.as_file_mut().flush().unwrap();
+        let mut base_file = tempfile::NamedTempFile::new().unwrap();
+        base_file.write_all(&base.data).unwrap();
+        base_file.as_file_mut().flush().unwrap();
+        let mut external = HashMap::new();
+        external.insert(
+            base.id(),
+            ExternalBase {
+                kind: base.kind,
+                size: base.data.len() as u64,
+                path: base_file.path().to_path_buf(),
+            },
+        );
+
+        let resolved = resolve_scanned_pack_with_external_bases(
+            journal.as_file(),
+            scanned,
+            &external,
+            PackResolveLogContext::default(),
+        )
+        .unwrap()
+        .expect("local journal resolver result");
+        // Fix-thin appends the external base, so the resolved pack indexes both objects and is
+        // self-contained.
+        let mut expect = vec![base.id(), target.id()];
+        expect.sort();
+        assert_eq!(resolved.oids, expect);
+        assert!(resolved.external_refs.is_empty());
+        let fixed = resolved
+            .fixed_thin_pack
+            .as_ref()
+            .expect("thin pack must produce a fix-thin replacement");
+        assert_eq!(fixed.pack_hash, resolved.pack_hash);
+        // The .sources sidecar header must record the post-append object count: the GC
+        // derived-index materializer validates it against the manifest obj_count and would
+        // otherwise defer tree/commit indexing forever for every thin push.
+        let sidecar = std::fs::read(resolved.source_index_file.path()).unwrap();
+        let plan = decode_pack_source_index_sidecar(&sidecar).unwrap();
+        assert_eq!(
+            plan.object_count, resolved.object_count,
+            "sidecar object_count must match the manifest count including appended bases"
+        );
+        let entries = resolved_object_entries(&resolved);
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|entry| matches!(
+            entry.kind,
+            PackObjectKind::RefDelta { base_oid, depth } if base_oid == base.id() && depth == 1
+        )));
+        assert!(entries.iter().any(|entry| {
+            entry.oid == base.id() && matches!(entry.kind, PackObjectKind::Full(Kind::Blob))
+        }));
+    }
+
+    #[test]
+    fn file_resolver_extracts_annotated_tag_targets() {
+        let commit = Object::new(
+            Kind::Commit,
+            &b"tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\nauthor A <a@example.com> 0 +0000\ncommitter A <a@example.com> 0 +0000\n\nmsg\n"[..],
+        );
+        let tag_data = format!(
+            "object {}\ntype commit\ntag v1\ntagger A <a@example.com> 0 +0000\n\nrelease\n",
+            commit.id().to_hex()
+        );
+        let tag = Object::new(Kind::Tag, tag_data.into_bytes());
+        let tag_id = tag.id();
+        let commit_id = commit.id();
+        let built = build_pack(&[commit, tag]).unwrap();
+
+        let resolved = assert_file_resolver_matches_parse(&built.data);
+        assert_eq!(resolved.tag_targets.get(&tag_id), Some(&commit_id));
+        assert!(resolved
+            .external_refs
+            .contains(&Oid::from_hex("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap()));
+    }
+
+    #[test]
+    fn file_resolver_rejects_corrupt_trailer() {
+        let mut data = build_pack(&objs()).unwrap().data;
+        let last = data.len() - 1;
+        data[last] ^= 0xff;
+        assert!(matches!(
+            resolve_file(&data),
+            Err(CodecError::PackChecksumMismatch)
+        ));
+    }
+
+    #[test]
+    fn file_resolver_rejects_duplicate_object_ids() {
+        let obj = Object::new(Kind::Blob, &b"same object twice"[..]);
+        let built = build_pack(&[obj.clone(), obj.clone()]).unwrap();
+        assert!(matches!(
+            resolve_file(&built.data),
+            Err(CodecError::DuplicateObject(oid)) if oid == obj.id()
+        ));
+    }
+
+    #[test]
+    fn file_resolver_declines_ref_delta_thin_pack() {
+        let base = Object::new(Kind::Blob, vec![7u8; 4000]);
+        let target = Object::new(Kind::Blob, {
+            let mut v = vec![7u8; 4000];
+            v[10] = 9;
+            v
+        });
+        let delta = encode_trivial_delta(&base.data, &target.data);
+        let zdelta = {
+            let mut enc = ZlibEncoder::new(Vec::new(), Compression::new(1));
+            enc.write_all(&delta).unwrap();
+            enc.finish().unwrap()
+        };
+        let mut pack = Vec::new();
+        pack.extend_from_slice(PACK_MAGIC);
+        pack.extend_from_slice(&PACK_VERSION.to_be_bytes());
+        pack.extend_from_slice(&1u32.to_be_bytes());
+        write_entry_header(&mut pack, T_REF_DELTA, delta.len() as u64);
+        pack.extend_from_slice(base.id().as_bytes());
+        pack.extend_from_slice(&zdelta);
+        let mut h = Sha1::new();
+        h.update(&pack);
+        let digest: [u8; 20] = h.finalize().into();
+        pack.extend_from_slice(&digest);
+
+        assert!(resolve_file(&pack).unwrap().is_none());
+    }
+
+    #[test]
+    fn file_resolver_spills_large_delta_bases_to_scratch() {
+        let spilled_before = SPILLED_DELTA_BASES.load(std::sync::atomic::Ordering::Relaxed);
+        let streamed_delta_before =
+            STREAMED_DELTA_TARGETS.load(std::sync::atomic::Ordering::Relaxed);
+        let streamed_full_before = STREAMED_FULL_BLOBS.load(std::sync::atomic::Ordering::Relaxed);
+        let base = Object::new(Kind::Blob, vec![0x7bu8; LARGE_DELTA_BASE_SPILL_BYTES * 4]);
+        let mut changed = base.data.to_vec();
+        changed[3] = 0x01;
+        changed[LARGE_DELTA_BASE_SPILL_BYTES + 11] = 0x02;
+        changed.extend_from_slice(b"suffix");
+        let target = Object::new(Kind::Blob, changed);
+        let built = build_pack_delta(&[base, target]).unwrap();
+        assert!(built.entries.iter().any(|e| matches!(
+            read_pack_entry(&built.data, e.offset).unwrap(),
+            PackEntry::OfsDelta { .. }
+        )));
+
+        assert_file_resolver_matches_parse(&built.data);
+        assert!(
+            SPILLED_DELTA_BASES.load(std::sync::atomic::Ordering::Relaxed) > spilled_before,
+            "expected large delta base to spill to scratch"
+        );
+        assert!(
+            STREAMED_DELTA_TARGETS.load(std::sync::atomic::Ordering::Relaxed)
+                > streamed_delta_before,
+            "expected large blob delta target to stream to scratch"
+        );
+        assert!(
+            STREAMED_FULL_BLOBS.load(std::sync::atomic::Ordering::Relaxed) > streamed_full_before,
+            "expected large full blob base to stream directly to scratch"
+        );
+    }
+
+    #[test]
+    fn parallel_resolve_matches_sequential() {
+        // A delta-heavy pack (near-identical large blobs → OFS deltas) plus assorted small objects.
+        let base: Vec<u8> = (0..20_000u32)
+            .map(|i| (i.wrapping_mul(2654435761) >> 16) as u8)
+            .collect();
+        let mut objects = vec![
+            Object::new(
+                Kind::Commit,
+                &b"tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n"[..],
+            ),
+            Object::new(Kind::Blob, base.clone()),
+        ];
+        for k in 0..8u8 {
+            let mut v = base.clone();
+            let len = v.len();
+            for j in 0..40 {
+                v[(j * 311) % len] = k.wrapping_add(j as u8);
+            }
+            objects.push(Object::new(Kind::Blob, v));
+        }
+        let delta = build_pack_delta(&objects).unwrap();
+
+        // Parallel resolution returns Some (self-contained pack) with the same object metadata as the
+        // sequential parser, without retaining inflated payloads for the receive-pack verbatim path.
+        let resolved = resolve_pack_parallel(&delta.data)
+            .unwrap()
+            .expect("self-contained → Some");
+        let seq = parse_pack(&delta.data, |_| None).unwrap();
+        assert_eq!(resolved.object_count, objects.len());
+        let object_entries = resolved_object_entries(&resolved);
+        assert_eq!(object_entries.len(), objects.len());
+        // The idx built from the verbatim pack round-trips (sorted, correct count).
+        assert!(resolved.idx_bytes > 8 + 256 * 4);
+        let mut seq_oids: Vec<Oid> = seq.objects.iter().map(|(oid, _)| *oid).collect();
+        seq_oids.sort_unstable();
+        seq_oids.dedup();
+        assert_eq!(resolved.oids, seq_oids);
+        for (oid, obj) in &seq.objects {
+            assert!(resolved.oids.binary_search(oid).is_ok());
+            assert!(object_entries.iter().any(|entry| &entry.oid == oid));
+            assert!(obj.data.len() as u64 <= resolved.largest.unwrap().1);
+        }
+        assert!(resolved
+            .external_refs
+            .contains(&Oid::from_hex("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap()));
+    }
+
+    #[test]
+    fn indexed_full_blob_entry_streams_without_full_optimization_plan() {
+        let large = vec![42u8; 64 * 1024];
+        let objects = vec![
+            Object::new(Kind::Blob, &b"small"[..]),
+            Object::new(Kind::Blob, large.clone()),
+        ];
+        let built = build_pack(&objects).unwrap();
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&built.data).unwrap();
+
+        let resolved = resolve_pack_file(file.path())
+            .unwrap()
+            .expect("self-contained pack");
+        let large_oid = objects[1].id();
+        let object_entries = resolved_object_entries(&resolved);
+        let entry = object_entries
+            .iter()
+            .find(|entry| entry.oid == large_oid)
+            .expect("large blob indexed");
+        assert_eq!(entry.kind, PackObjectKind::Full(Kind::Blob));
+        assert_eq!(entry.declared_size, large.len() as u64);
+
+        let streamed = stream_indexed_full_blob_to_temp(file.path(), entry).unwrap();
+        assert_eq!(streamed.oid, large_oid);
+        assert_eq!(streamed.size, large.len() as u64);
+        assert_eq!(std::fs::read(streamed.path()).unwrap(), large);
+    }
+
+    #[test]
+    fn parallel_resolve_declines_thin_packs() {
+        // A REF_DELTA (thin) pack must return None so the caller falls back to the streaming parser.
+        let base = Object::new(Kind::Blob, vec![7u8; 4000]);
+        let target = Object::new(Kind::Blob, {
+            let mut v = vec![7u8; 4000];
+            v[10] = 9;
+            v
+        });
+        // Hand-build a 1-entry pack whose single object is a REF_DELTA against `base` (not in pack).
+        let zdelta = {
+            let d = encode_trivial_delta(&base.data, &target.data);
+            let mut enc = ZlibEncoder::new(Vec::new(), Compression::new(1));
+            enc.write_all(&d).unwrap();
+            enc.finish().unwrap()
+        };
+        let mut pack = Vec::new();
+        pack.extend_from_slice(PACK_MAGIC);
+        pack.extend_from_slice(&PACK_VERSION.to_be_bytes());
+        pack.extend_from_slice(&1u32.to_be_bytes());
+        // entry header: type=REF_DELTA(7), size = delta length
+        let dlen = encode_trivial_delta(&base.data, &target.data).len() as u64;
+        write_entry_header(&mut pack, 7, dlen);
+        pack.extend_from_slice(base.id().as_bytes());
+        pack.extend_from_slice(&zdelta);
+        let mut h = Sha1::new();
+        h.update(&pack);
+        let digest: [u8; 20] = h.finalize().into();
+        pack.extend_from_slice(&digest);
+
+        assert!(
+            resolve_pack_parallel(&pack).unwrap().is_none(),
+            "thin pack → None"
+        );
+    }
+
+    #[test]
+    fn entries_have_increasing_offsets() {
+        let built = build_pack(&objs()).unwrap();
+        let mut last = 0u64;
+        for e in &built.entries {
+            assert!(e.offset >= last);
+            last = e.offset;
+        }
+    }
+
+    #[test]
+    fn ref_delta_resolved_via_external_resolver() {
+        // Build a pack containing only a REF_DELTA whose base is supplied externally (thin pack).
+        let base = Object::new(Kind::Blob, &b"the original base content here"[..]);
+        let target_data = b"the original base content here, now extended".to_vec();
+        let delta = encode_trivial_delta(&base.data, &target_data);
+
+        let mut data = Vec::new();
+        data.extend_from_slice(PACK_MAGIC);
+        data.extend_from_slice(&PACK_VERSION.to_be_bytes());
+        data.extend_from_slice(&1u32.to_be_bytes());
+        write_entry_header(&mut data, T_REF_DELTA, delta.len() as u64);
+        data.extend_from_slice(base.id().as_bytes());
+        let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(&delta).unwrap();
+        data.extend_from_slice(&enc.finish().unwrap());
+        let mut h = Sha1::new();
+        h.update(&data);
+        let digest: [u8; 20] = h.finalize().into();
+        data.extend_from_slice(&digest);
+
+        let base_clone = base.clone();
+        let parsed = parse_pack(&data, move |oid| {
+            if *oid == base_clone.id() {
+                Some(base_clone.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+        assert_eq!(parsed.objects.len(), 1);
+        assert_eq!(parsed.objects[0].1.data.as_ref(), target_data.as_slice());
+    }
+
+    #[test]
+    fn read_pack_entry_materializes_one_object() {
+        // Every non-delta entry can be read directly from its idx offset, no whole-pack parse.
+        let objects = objs();
+        let built = build_pack(&objects).unwrap();
+        for (orig, e) in objects.iter().zip(built.entries.iter()) {
+            match read_pack_entry(&built.data, e.offset).unwrap() {
+                PackEntry::Object { kind, data } => {
+                    assert_eq!(kind, orig.kind);
+                    assert_eq!(data, orig.data.as_ref());
+                }
+                other => panic!("expected Object, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn read_pack_entry_returns_unresolved_ofs_delta() {
+        // Two near-identical blobs → the second is emitted as an OFS_DELTA against the first.
+        let base = Object::new(Kind::Blob, vec![0x42u8; 8000]);
+        let mut tweaked = vec![0x42u8; 8000];
+        tweaked.extend_from_slice(b" and a little more");
+        let target = Object::new(Kind::Blob, tweaked);
+        let built = build_pack_delta(&[base.clone(), target.clone()]).unwrap();
+
+        // Find the delta entry by reading each entry; resolve it against its base offset and confirm
+        // it reconstructs the target object.
+        let mut saw_delta = false;
+        for e in &built.entries {
+            if let PackEntry::OfsDelta { base_offset, delta } =
+                read_pack_entry(&built.data, e.offset).unwrap()
+            {
+                saw_delta = true;
+                let base_entry = read_pack_entry(&built.data, base_offset).unwrap();
+                let base_data = match base_entry {
+                    PackEntry::Object { data, .. } => data,
+                    _ => panic!("base of an OFS_DELTA should be a plain object here"),
+                };
+                let resolved = crate::delta::apply_delta(&base_data, &delta).unwrap();
+                let oid = crate::object::hash(Kind::Blob, &resolved);
+                assert!(oid == base.id() || oid == target.id());
+            }
+        }
+        assert!(saw_delta, "expected build_pack_delta to emit an OFS_DELTA");
+    }
+
+    #[test]
+    fn parse_pack_reuse_then_rebuild_preserves_objects_and_reuses_deltas() {
+        // Several similar blobs (so build_pack_delta produces OFS_DELTAs) plus a couple of others.
+        let mut objects = Vec::new();
+        for i in 0..6u8 {
+            let mut data = vec![0xA5u8; 4000];
+            data.extend_from_slice(format!(" variant {i}").as_bytes());
+            objects.push(Object::new(Kind::Blob, data));
+        }
+        objects.push(Object::new(Kind::Commit, &b"tree 0\n"[..]));
+
+        // Build with delta compression, then extract reusable deltas from it.
+        let built = build_pack_delta(&objects).unwrap();
+        let parsed = parse_pack_reuse(&built.data).unwrap();
+        let reuse_count = parsed.iter().filter(|(_, _, r)| r.is_some()).count();
+        assert!(
+            reuse_count > 0,
+            "the delta pack should contain reusable deltas"
+        );
+
+        let reuse: std::collections::HashMap<Oid, ReusableDelta> = parsed
+            .iter()
+            .filter_map(|(oid, _, r)| r.as_ref().map(|rd| (*oid, rd.clone())))
+            .collect();
+
+        // Rebuild reusing those deltas. The result must decode to exactly the same objects.
+        let rebuilt = build_pack_delta_reuse(&objects, &reuse).unwrap();
+        let out = parse_pack(&rebuilt.data, |_| None).unwrap();
+        assert_eq!(out.objects.len(), objects.len());
+        let mut got: Vec<(Oid, Vec<u8>)> = out
+            .objects
+            .iter()
+            .map(|(oid, o)| (*oid, o.data.to_vec()))
+            .collect();
+        got.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+        let mut want: Vec<(Oid, Vec<u8>)> =
+            objects.iter().map(|o| (o.id(), o.data.to_vec())).collect();
+        want.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+        assert_eq!(
+            got, want,
+            "rebuilt-with-reuse pack must reproduce every object"
+        );
+
+        // The rebuilt pack must actually contain delta entries (reuse fired, not all full).
+        let deltas = rebuilt
+            .entries
+            .iter()
+            .filter(|e| {
+                matches!(
+                    read_pack_entry(&rebuilt.data, e.offset).unwrap(),
+                    PackEntry::OfsDelta { .. } | PackEntry::RefDelta { .. }
+                )
+            })
+            .count();
+        assert!(deltas > 0, "rebuilt pack should retain delta entries");
+    }
+
+    #[test]
+    fn parse_pack_reuse_on_full_pack_has_no_reuse() {
+        let built = build_pack(&objs()).unwrap(); // build_pack = no deltas
+        let parsed = parse_pack_reuse(&built.data).unwrap();
+        assert!(parsed.iter().all(|(_, _, r)| r.is_none()));
+        assert_eq!(parsed.len(), objs().len());
+    }
+
+    #[test]
+    fn corrupt_trailer_is_rejected() {
+        let mut built = build_pack(&objs()).unwrap();
+        let n = built.data.len();
+        built.data[n - 1] ^= 0xff;
+        assert!(matches!(
+            parse_pack(&built.data, |_| None),
+            Err(CodecError::PackChecksumMismatch)
+        ));
+    }
+
+    #[test]
+    fn delta_pack_roundtrips_and_shrinks() {
+        // Several near-identical large blobs (each a small edit of the first) → the delta builder
+        // should store them as deltas, yielding a much smaller pack that still round-trips exactly.
+        let base: Vec<u8> = (0..20_000u32)
+            .map(|i| (i.wrapping_mul(2654435761) >> 16) as u8)
+            .collect();
+        let mut objects = vec![Object::new(Kind::Blob, base.clone())];
+        for k in 0..6u8 {
+            let mut v = base.clone();
+            let len = v.len();
+            for j in 0..50 {
+                v[j * 307 % len] = k.wrapping_add(j as u8);
+            }
+            objects.push(Object::new(Kind::Blob, v));
+        }
+
+        let full = build_pack(&objects).unwrap();
+        let delta = build_pack_delta(&objects).unwrap();
+        assert!(
+            delta.data.len() * 2 < full.data.len(),
+            "delta pack {} should be far smaller than full pack {}",
+            delta.data.len(),
+            full.data.len()
+        );
+
+        // Round-trips: every object resolves to its original bytes, ids match.
+        let parsed = parse_pack(&delta.data, |_| None).unwrap();
+        assert_eq!(parsed.objects.len(), objects.len());
+        let mut by_oid: std::collections::HashMap<Oid, &Object> =
+            objects.iter().map(|o| (o.id(), o)).collect();
+        for (oid, got) in &parsed.objects {
+            let orig = by_oid.remove(oid).expect("known oid");
+            assert_eq!(got.data, orig.data);
+        }
+        assert!(by_oid.is_empty(), "all objects present exactly once");
+    }
+
+    #[test]
+    fn delta_builder_object_entries_match_resolver() {
+        let base: Vec<u8> = (0..20_000u32)
+            .map(|i| (i.wrapping_mul(2654435761) >> 16) as u8)
+            .collect();
+        let mut objects = vec![Object::new(Kind::Blob, base.clone())];
+        for k in 0..6u8 {
+            let mut v = base.clone();
+            let len = v.len();
+            for j in 0..50 {
+                v[j * 307 % len] = k.wrapping_add(j as u8);
+            }
+            objects.push(Object::new(Kind::Blob, v));
+        }
+
+        let built = build_pack_delta_for_serving(&objects).unwrap();
+        assert_eq!(built.object_entries.len(), built.entries.len());
+        assert!(
+            built
+                .object_entries
+                .iter()
+                .any(|entry| matches!(entry.kind, PackObjectKind::OfsDelta { .. })),
+            "fixture should exercise delta entries"
+        );
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&built.data).unwrap();
+        let resolved = resolve_pack_file(file.path())
+            .unwrap()
+            .expect("self-contained pack");
+        let got: std::collections::HashMap<Oid, PackObjectEntry> = built
+            .object_entries
+            .iter()
+            .cloned()
+            .map(|entry| (entry.oid, entry))
+            .collect();
+        let want: std::collections::HashMap<Oid, PackObjectEntry> =
+            resolved_object_entries(&resolved)
+                .into_iter()
+                .map(|entry| (entry.oid, entry))
+                .collect();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn serving_delta_pack_caps_chain_depth() {
+        let base: Vec<u8> = (0..20_000u32)
+            .map(|i| (i.wrapping_mul(2654435761) >> 16) as u8)
+            .collect();
+        let mut objects = Vec::new();
+        for k in 0..40u8 {
+            let mut v = base.clone();
+            let len = v.len();
+            for j in 0..40 {
+                v[j * 307 % len] = k.wrapping_add(j as u8);
+            }
+            objects.push(Object::new(Kind::Blob, v));
+        }
+
+        let built = build_pack_delta_for_serving(&objects).unwrap();
+        let parsed = parse_pack(&built.data, |_| None).unwrap();
+        assert_eq!(parsed.objects.len(), objects.len());
+
+        let mut depths = std::collections::HashMap::<u64, usize>::new();
+        let mut max_depth = 0usize;
+        let mut saw_delta = false;
+        for entry in &built.entries {
+            let depth = match read_pack_entry(&built.data, entry.offset).unwrap() {
+                PackEntry::Object { .. } => 0,
+                PackEntry::OfsDelta { base_offset, .. } => {
+                    saw_delta = true;
+                    depths[&base_offset] + 1
+                }
+                PackEntry::RefDelta { .. } => {
+                    panic!("builder should emit OFS_DELTA, not REF_DELTA")
+                }
+            };
+            max_depth = max_depth.max(depth);
+            depths.insert(entry.offset, depth);
+        }
+        assert!(
+            saw_delta,
+            "serving pack should still delta-compress similar objects"
+        );
+        assert!(
+            max_depth <= SERVING_DELTA_MAX_DEPTH,
+            "serving pack depth {max_depth} exceeded cap {SERVING_DELTA_MAX_DEPTH}"
+        );
+    }
+
+    #[test]
+    fn serving_reuse_pack_caps_chain_depth_without_losing_deltas() {
+        let base: Vec<u8> = (0..20_000u32)
+            .map(|i| (i.wrapping_mul(2654435761) >> 16) as u8)
+            .collect();
+        let mut objects = Vec::new();
+        for k in 0..40u8 {
+            let mut v = base.clone();
+            let len = v.len();
+            for j in 0..40 {
+                v[j * 307 % len] = k.wrapping_add(j as u8);
+            }
+            objects.push(Object::new(Kind::Blob, v));
+        }
+
+        let source = build_pack_delta(&objects).unwrap();
+        let parsed = parse_pack_reuse(&source.data).unwrap();
+        let reuse: std::collections::HashMap<Oid, ReusableDelta> = parsed
+            .iter()
+            .filter_map(|(oid, _, r)| r.as_ref().map(|rd| (*oid, rd.clone())))
+            .collect();
+        assert!(
+            !reuse.is_empty(),
+            "source pack should provide reusable deltas"
+        );
+
+        let rebuilt = build_pack_delta_reuse_for_serving(&objects, &reuse).unwrap();
+        let out = parse_pack(&rebuilt.data, |_| None).unwrap();
+        assert_eq!(out.objects.len(), objects.len());
+
+        let mut depths = std::collections::HashMap::<u64, usize>::new();
+        let mut max_depth = 0usize;
+        let mut saw_delta = false;
+        for entry in &rebuilt.entries {
+            let depth = match read_pack_entry(&rebuilt.data, entry.offset).unwrap() {
+                PackEntry::Object { .. } => 0,
+                PackEntry::OfsDelta { base_offset, .. } => {
+                    saw_delta = true;
+                    depths[&base_offset] + 1
+                }
+                PackEntry::RefDelta { .. } => {
+                    panic!("builder should emit OFS_DELTA, not REF_DELTA")
+                }
+            };
+            max_depth = max_depth.max(depth);
+            depths.insert(entry.offset, depth);
+        }
+        assert!(saw_delta, "serving rebuild should reuse safe source deltas");
+        assert!(
+            max_depth <= SERVING_DELTA_MAX_DEPTH,
+            "serving reuse pack depth {max_depth} exceeded cap {SERVING_DELTA_MAX_DEPTH}"
+        );
+    }
+
+    #[test]
+    fn delta_pack_handles_singletons_and_mixed_types() {
+        // No two objects are similar; the builder must still produce a valid (mostly-full) pack.
+        let objects = objs();
+        let delta = build_pack_delta(&objects).unwrap();
+        let parsed = parse_pack(&delta.data, |_| None).unwrap();
+        assert_eq!(parsed.objects.len(), objects.len());
+        for obj in &objects {
+            assert!(parsed.objects.iter().any(|(oid, _)| *oid == obj.id()));
+        }
+    }
+}

--- a/crates/gsvc-codec/tests/git_interop.rs
+++ b/crates/gsvc-codec/tests/git_interop.rs
@@ -1,0 +1,345 @@
+//! Interop tests against the reference `git` implementation. These are the ground-truth oracle:
+//! a pack/idx we emit must be accepted by `git index-pack`/`git verify-pack`, and a pack git
+//! emits must parse cleanly with our reader.
+//!
+//! Skipped automatically if `git` is not on PATH.
+
+use std::path::Path;
+use std::process::Command;
+
+use gsvc_codec::{build_pack, build_pack_delta, parse_pack, write_idx_v2, Kind, Object};
+
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run(dir: &Path, args: &[&str]) -> std::process::Output {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("spawn git");
+    out
+}
+
+fn sample_objects() -> Vec<Object> {
+    vec![
+        Object::new(Kind::Blob, &b"hello, git interop\n"[..]),
+        Object::new(Kind::Blob, &b""[..]),
+        Object::new(Kind::Blob, vec![0x5a_u8; 70_000]), // multi-byte size header
+        Object::new(Kind::Tree, &b""[..]),
+        Object::new(
+            Kind::Blob,
+            &b"the quick brown fox jumps over the lazy dog"[..],
+        ),
+    ]
+}
+
+#[test]
+fn git_index_pack_accepts_our_pack() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    // `git index-pack` needs a repository (object dir) to resolve against.
+    assert!(run(dir.path(), &["init", "--bare", "-q"]).status.success());
+
+    let built = build_pack(&sample_objects()).unwrap();
+    let pack_path = dir.path().join("test.pack");
+    std::fs::write(&pack_path, &built.data).unwrap();
+
+    // index-pack fully validates: it re-inflates every object, checks the trailer, and (re)builds
+    // the index. If our pack were malformed, this fails.
+    let out = run(
+        dir.path(),
+        &["index-pack", "-v", pack_path.to_str().unwrap()],
+    );
+    assert!(
+        out.status.success(),
+        "git index-pack rejected our pack:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[test]
+fn git_index_pack_resolves_our_delta_pack() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    assert!(run(dir.path(), &["init", "--bare", "-q"]).status.success());
+
+    // Near-identical blobs so the builder emits OFS_DELTA entries; git must resolve the chain.
+    let base: Vec<u8> = (0..30_000u32)
+        .map(|i| (i.wrapping_mul(2654435761) >> 13) as u8)
+        .collect();
+    let mut objects = vec![Object::new(Kind::Blob, base.clone())];
+    for k in 1..6u8 {
+        let mut v = base.clone();
+        let len = v.len();
+        for j in 0..40usize {
+            v[(j * 521) % len] = k.wrapping_add(j as u8);
+        }
+        objects.push(Object::new(Kind::Blob, v));
+    }
+    let built = build_pack_delta(&objects).unwrap();
+    // Sanity: this pack really is smaller than the undeltified one (i.e. deltas were emitted).
+    assert!(built.data.len() < build_pack(&objects).unwrap().data.len());
+
+    let pack_path = dir.path().join("delta.pack");
+    let idx_path = dir.path().join("delta.idx");
+    std::fs::write(&pack_path, &built.data).unwrap();
+
+    // index-pack --strict fully resolves every delta and validates the object graph; it fails on a
+    // malformed delta or bad offset.
+    let out = run(
+        dir.path(),
+        &[
+            "index-pack",
+            "--strict",
+            "-o",
+            idx_path.to_str().unwrap(),
+            pack_path.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "git index-pack rejected our delta pack:\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // verify-pack lists every resolved object (oid + type + delta chain). All our oids must appear,
+    // proving git's delta resolution produced exactly our objects; and at least one is a real delta.
+    let verify = run(
+        dir.path(),
+        &["verify-pack", "-v", idx_path.to_str().unwrap()],
+    );
+    assert!(verify.status.success(), "verify-pack failed");
+    let listing = String::from_utf8_lossy(&verify.stdout);
+    for obj in &objects {
+        assert!(
+            listing.contains(&obj.id().to_hex()),
+            "git did not resolve object {}",
+            obj.id().to_hex()
+        );
+    }
+    // verify-pack's histogram prints a "chain length = N" line only when the pack contains deltas.
+    assert!(
+        listing.contains("chain length"),
+        "expected git to report a delta chain in the pack:\n{listing}"
+    );
+}
+
+#[test]
+fn git_verify_pack_accepts_our_idx() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let built = build_pack(&sample_objects()).unwrap();
+    let idx = write_idx_v2(&built.entries, built.pack_hash);
+
+    // git verify-pack wants the pair named pack-<hash>.{pack,idx}.
+    let stem = format!("pack-{}", built.pack_hash.to_hex());
+    let pack_path = dir.path().join(format!("{stem}.pack"));
+    let idx_path = dir.path().join(format!("{stem}.idx"));
+    std::fs::write(&pack_path, &built.data).unwrap();
+    std::fs::write(&idx_path, &idx).unwrap();
+
+    let out = run(
+        dir.path(),
+        &["verify-pack", "-v", idx_path.to_str().unwrap()],
+    );
+    assert!(
+        out.status.success(),
+        "git verify-pack rejected our idx:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    // Every object id we wrote should appear in verify-pack's listing.
+    let listing = String::from_utf8_lossy(&out.stdout);
+    for obj in sample_objects() {
+        assert!(
+            listing.contains(&obj.id().to_hex()),
+            "verify-pack listing missing {}",
+            obj.id()
+        );
+    }
+}
+
+#[test]
+fn we_parse_a_pack_git_produced() {
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    assert!(run(dir.path(), &["init", "-q"]).status.success());
+    // Make git produce real objects (blobs, a tree, a commit) and pack them.
+    std::fs::write(dir.path().join("a.txt"), b"first file\n").unwrap();
+    std::fs::write(dir.path().join("b.txt"), vec![b'x'; 40_000]).unwrap();
+    run(dir.path(), &["add", "."]);
+    run(
+        dir.path(),
+        &[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "-m",
+            "initial",
+        ],
+    );
+
+    // Build a pack of all reachable objects on stdout.
+    let rev = run(dir.path(), &["rev-list", "--objects", "--all"]);
+    assert!(rev.status.success());
+    let pack_out = Command::new("git")
+        .args(["pack-objects", "--stdout"])
+        .current_dir(dir.path())
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .map(|mut child| {
+            use std::io::Write;
+            child.stdin.take().unwrap().write_all(&rev.stdout).unwrap();
+            child.wait_with_output().unwrap()
+        })
+        .unwrap();
+    assert!(pack_out.status.success());
+    let pack_bytes = pack_out.stdout;
+    assert!(pack_bytes.len() > 12);
+
+    // git may emit deltas; our parser resolves them against in-pack bases.
+    let parsed = parse_pack(&pack_bytes, |_| None).expect("parse git's pack");
+    assert!(!parsed.objects.is_empty());
+
+    // Cross-check: every oid we computed should be a real object git can cat-file.
+    for (oid, _obj) in &parsed.objects {
+        let out = run(dir.path(), &["cat-file", "-t", &oid.to_hex()]);
+        assert!(
+            out.status.success(),
+            "git does not recognize parsed oid {oid}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+/// The fix-thin replacement for a received thin pack must be a fully valid standalone Git pack:
+/// `git index-pack --strict` re-inflates every object, resolves the in-pack REF_DELTA against the
+/// appended base, and verifies the recomputed trailer.
+#[test]
+fn git_index_pack_accepts_fix_thin_output() {
+    use gsvc_codec::{
+        encode_trivial_delta, ExternalBase, Kind, Object, PackResolveLogContext, ReceivePackSpooler,
+    };
+    use sha1::{Digest as _, Sha1};
+    use std::collections::HashMap;
+    use std::io::Write as _;
+
+    if !git_available() {
+        eprintln!("skipping: git not available");
+        return;
+    }
+
+    let base = Object::new(Kind::Blob, &b"the original base content for fix thin"[..]);
+    let target = Object::new(
+        Kind::Blob,
+        &b"the original base content for fix thin, now extended further"[..],
+    );
+    let delta = encode_trivial_delta(&base.data, &target.data);
+
+    // Thin pack: one REF_DELTA entry whose base is external.
+    let mut data = Vec::new();
+    data.extend_from_slice(b"PACK");
+    data.extend_from_slice(&2u32.to_be_bytes());
+    data.extend_from_slice(&1u32.to_be_bytes());
+    // Entry header: type 7 (REF_DELTA), size = delta.len() (< 16 keeps this simple? use varint).
+    let mut size = delta.len() as u64;
+    let mut byte = (7u8 << 4) | (size & 0x0f) as u8;
+    size >>= 4;
+    while size > 0 {
+        data.push(byte | 0x80);
+        byte = (size & 0x7f) as u8;
+        size >>= 7;
+    }
+    data.push(byte);
+    data.extend_from_slice(base.id().as_bytes());
+    let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+    enc.write_all(&delta).unwrap();
+    data.extend_from_slice(&enc.finish().unwrap());
+    let mut h = Sha1::new();
+    h.update(&data);
+    let digest: [u8; 20] = h.finalize().into();
+    data.extend_from_slice(&digest);
+
+    let mut spooler = ReceivePackSpooler::new(true);
+    spooler.push(&data).unwrap();
+    let scanned = spooler.finish().unwrap().expect("thin scan");
+
+    let mut journal = tempfile::NamedTempFile::new().unwrap();
+    journal.write_all(&data).unwrap();
+    journal.as_file_mut().flush().unwrap();
+    let mut base_file = tempfile::NamedTempFile::new().unwrap();
+    base_file.write_all(&base.data).unwrap();
+    base_file.as_file_mut().flush().unwrap();
+    let mut external = HashMap::new();
+    external.insert(
+        base.id(),
+        ExternalBase {
+            kind: base.kind,
+            size: base.data.len() as u64,
+            path: base_file.path().to_path_buf(),
+        },
+    );
+
+    let resolved = gsvc_codec::resolve_scanned_pack_with_external_bases(
+        journal.as_file(),
+        scanned,
+        &external,
+        PackResolveLogContext::default(),
+    )
+    .unwrap()
+    .expect("resolved thin pack");
+    let fixed = resolved
+        .fixed_thin_pack
+        .as_ref()
+        .expect("thin pack must produce a fix-thin replacement");
+    assert_eq!(resolved.pack_hash, fixed.pack_hash);
+    assert_eq!(resolved.object_count, 2, "delta target + appended base");
+    assert!(
+        resolved.oids.contains(&base.id()) && resolved.oids.contains(&target.id()),
+        "both objects must be indexed"
+    );
+    assert!(resolved.external_refs.is_empty());
+
+    let dir = tempfile::tempdir().unwrap();
+    assert!(run(dir.path(), &["init", "--bare", "-q"]).status.success());
+    let pack_path = dir.path().join("fixed.pack");
+    std::fs::copy(fixed.file.path(), &pack_path).unwrap();
+    assert_eq!(
+        std::fs::metadata(&pack_path).unwrap().len(),
+        fixed.len,
+        "reported fixed pack length must match the file"
+    );
+    let out = run(
+        dir.path(),
+        &["index-pack", "--strict", "-v", pack_path.to_str().unwrap()],
+    );
+    assert!(
+        out.status.success(),
+        "git index-pack rejected the fix-thin pack:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `tl git clone <repo> [dest]` — a fast-clone client that installs trusted gsvc pack/idx artifacts directly (via `<repo>/fast/clone-manifest`) instead of the normal Git smart-HTTP negotiation, then leaves an ordinary Git checkout pointed at the same remote for subsequent `git fetch`/`git push`.
- Vendors `crates/gsvc-codec` verbatim from `artifact_storage` (pinned to edition 2021 so it stays a byte-for-byte diffable copy), plus a client-side port of `gsvc-server`'s `fastclone.rs` and the `FastCloneManifest` wire types.
- Auth uses `tl`'s existing `mint_token_for_repo` flow instead of `GSVC_TOKEN`/`GSVC_AUTH_TOKEN` env vars.
- This replaces the standalone `gsvc` binary in `artifact_storage` (removed in a companion change there), which fixes the `libfdb_c.dylib` dyld rpath crash users hit on macOS — `tl` never links FoundationDB.
- `artifact_storage`'s `AGENTS.md` now notes that `gsvc-codec` and the fast-clone wire format are vendored here, so future changes to either should come with a companion PR against this repo.

## Test plan
- [x] `cargo build -p tensorlake-cli --bin tl`
- [x] `cargo test -p tensorlake-cli --bin tl` (185 passed, including new `git_commands_parse` clone case and `fastclone` unit tests)
- [x] `cargo clippy -p gsvc-codec --all-targets -- -D warnings` (clean)
- [x] `cargo clippy -p tensorlake-cli --all-targets -- -D warnings` (clean; unrelated pre-existing `cloud-sdk` clippy failure confirmed present on `main` too)
- [x] `cargo fmt -p tensorlake-cli -- --check`
- [x] `tl git clone --help` renders correctly
- [ ] End-to-end clone against a live gsvc server (needs a real project/repo + credentials — not exercised here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)