### PR TITLE
Add resumable chunked push to the SDK core and tl git push

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -80,19 +80,9 @@ jobs:
               set -e
 
               echo "--- Installing tensorlake from TestPyPI ---"
-              for attempt in $(seq 1 8); do
-                if pip install --index-url https://test.pypi.org/simple/ \
-                                --extra-index-url https://pypi.org/simple/ \
-                                tensorlake==${PYPI_VERSION}; then
-                  break
-                fi
-                if [ "$attempt" -eq 8 ]; then
-                  echo "tensorlake==${PYPI_VERSION} still not resolvable on TestPyPI after 8 attempts"
-                  exit 1
-                fi
-                echo "TestPyPI index propagation not caught up yet (attempt ${attempt}/8), retrying in 30s..."
-                sleep 30
-              done
+              pip install --index-url https://test.pypi.org/simple/ \
+                          --extra-index-url https://pypi.org/simple/ \
+                          tensorlake==${PYPI_VERSION}
 
               echo "--- 1. Build images ---"
               tl build-images /tmp/test_app.py \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastcdc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf51ceb43e96afbfe4dd5c6f6082af5dfd60e220820b8123792d61963f2ce6bc"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3310,6 +3316,7 @@ dependencies = [
  "des",
  "docker-credentials-config",
  "eventsource-stream",
+ "fastcdc",
  "flate2",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 async-trait = "0.1"
+fastcdc = "3"
 
 # Internal crates
 tensorlake = { path = "crates/cloud-sdk" }

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -432,6 +432,143 @@ fn parse_remote_message(raw: &str) -> String {
         .unwrap_or_else(|| raw.to_string())
 }
 
+/// `tl git push` — resumable chunked push of local files as one commit, no local git required.
+/// Retrying after any failure is safe and cheap: the client re-negotiates and uploads only what
+/// the server still lacks.
+pub async fn push(
+    ctx: &CliContext,
+    repo: &str,
+    branch: &str,
+    message: &str,
+    expect_oid: Option<String>,
+    paths: Vec<std::path::PathBuf>,
+    output_json: bool,
+) -> Result<()> {
+    use tensorlake::artifact_storage::ingest::{PushEvent, PushOptions};
+
+    let project_id = project_id(ctx)?;
+    let client = artifact_storage_client(ctx)?;
+    let credential = client
+        .mint_token_for_repo(&project_id, Some(repo))
+        .await?
+        .into_inner();
+
+    // Collect files: directories recurse; repo paths are relative to the CWD (or to the
+    // directory itself for its children), normalized to forward slashes.
+    let mut files = Vec::new();
+    for path in &paths {
+        collect_push_files(path, path, &mut files)?;
+    }
+    if files.is_empty() {
+        return Err(crate::error::CliError::Usage(
+            "no files found under the given paths".to_string(),
+        ));
+    }
+
+    let bar = indicatif::ProgressBar::new_spinner();
+    bar.set_message("chunking...");
+    let bar_for_events = bar.clone();
+    let opts = PushOptions {
+        branch: branch.to_string(),
+        message: message.to_string(),
+        base: None,
+        expect_oid,
+        progress: Some(std::sync::Arc::new(move |ev: PushEvent| match ev {
+            PushEvent::Hashed {
+                files,
+                chunks,
+                bytes,
+            } => bar_for_events.set_message(format!(
+                "hashed {files} files ({chunks} chunks, {bytes} bytes); negotiating..."
+            )),
+            PushEvent::Negotiated { missing, total } => bar_for_events.set_message(format!(
+                "server lacks {missing}/{total} chunks; uploading..."
+            )),
+            PushEvent::UploadedBatch { chunks, bytes } => {
+                bar_for_events.set_message(format!("uploaded {chunks} chunks ({bytes} bytes)..."))
+            }
+            PushEvent::Committed { ref_name, .. } => {
+                bar_for_events.set_message(format!("committed to {ref_name}"))
+            }
+        })),
+        ..Default::default()
+    };
+    let report = client
+        .push_files(
+            &project_id,
+            repo,
+            &credential.git_username,
+            &credential.token,
+            files,
+            opts,
+        )
+        .await?
+        .into_inner();
+    bar.finish_and_clear();
+
+    if output_json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "commit": report.commit,
+                "tree": report.tree,
+                "ref": report.ref_name,
+                "created": report.created,
+                "files": report.files,
+                "bytes_total": report.bytes_total,
+                "chunks_total": report.chunks_total,
+                "chunks_uploaded": report.chunks_uploaded,
+                "bytes_uploaded": report.bytes_uploaded,
+            })
+        );
+    } else {
+        let deduped = report.chunks_total - report.chunks_uploaded;
+        println!(
+            "{} {} -> {} ({} files, {} of {} chunks uploaded, {} deduplicated, {} bytes on the wire)",
+            console::style("pushed").green().bold(),
+            report.commit,
+            report.ref_name,
+            report.files,
+            report.chunks_uploaded,
+            report.chunks_total,
+            deduped,
+            report.bytes_uploaded,
+        );
+    }
+    Ok(())
+}
+
+fn collect_push_files(
+    root: &std::path::Path,
+    path: &std::path::Path,
+    out: &mut Vec<tensorlake::artifact_storage::ingest::PushFile>,
+) -> Result<()> {
+    use tensorlake::artifact_storage::ingest::{PushFile, PushSource};
+    let meta = std::fs::metadata(path)?;
+    if meta.is_dir() {
+        let mut entries: Vec<_> = std::fs::read_dir(path)?.collect::<std::io::Result<_>>()?;
+        entries.sort_by_key(|e| e.file_name());
+        for entry in entries {
+            let name = entry.file_name();
+            // Never traverse into VCS metadata.
+            if name == ".git" {
+                continue;
+            }
+            collect_push_files(root, &entry.path(), out)?;
+        }
+        return Ok(());
+    }
+    let repo_path = path
+        .strip_prefix(root.parent().unwrap_or(root))
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+    out.push(PushFile {
+        repo_path,
+        source: PushSource::Path(path.to_path_buf()),
+    });
+    Ok(())
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -568,6 +568,7 @@ fn collect_push_files(
         source: PushSource::Path(path.to_path_buf()),
     });
     Ok(())
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -305,6 +305,27 @@ enum GitCommands {
         #[arg(long)]
         json: bool,
     },
+    /// Push local files to a repo as one commit (resumable chunk upload; no local git needed)
+    Push {
+        /// Repo name
+        #[arg(long)]
+        repo: String,
+        /// Target branch
+        #[arg(long, default_value = "main")]
+        branch: String,
+        /// Commit message
+        #[arg(short, long, default_value = "tl push")]
+        message: String,
+        /// Force-with-lease: require the branch to currently equal this commit oid
+        #[arg(long)]
+        expect_oid: Option<String>,
+        /// Files or directories to push (directories recurse; repo paths are relative to CWD)
+        #[arg(required = true)]
+        paths: Vec<std::path::PathBuf>,
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// List repos in the current project
     #[command(alias = "list")]
     Ls {
@@ -2053,6 +2074,14 @@ async fn run_git_command(ctx: &CliContext, subcmd: GitCommands) -> error::Result
         GitCommands::Token { repo, json } => {
             commands::git::mint_token(ctx, repo.as_deref(), json).await
         }
+        GitCommands::Push {
+            repo,
+            branch,
+            message,
+            expect_oid,
+            paths,
+            json,
+        } => commands::git::push(ctx, &repo, &branch, &message, expect_oid, paths, json).await,
         GitCommands::Url { repo } => {
             println!("{}", commands::git::repo_url(ctx, &repo)?);
             Ok(())

--- a/crates/cloud-sdk/Cargo.toml
+++ b/crates/cloud-sdk/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://tensorlake.ai"
 documentation = "https://docs.rs/tensorlake"
 
 [dependencies]
+fastcdc = { workspace = true }
 bytes = { workspace = true }
 base64 = { workspace = true }
 bollard = { workspace = true }

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -1,0 +1,488 @@
+//! Resumable ingest client: push files to artifact storage as content-defined chunks.
+//!
+//! The unit of transfer is the CDC chunk, so resume state is *content*, not cursors: every step
+//! is idempotent, and retrying a failed push re-negotiates and uploads only what the server still
+//! lacks — across process restarts, pods, and even prior pushes of overlapping content. The
+//! client never runs `git pack-objects` and holds at most one upload batch in memory, so pushes
+//! of arbitrarily large trees work from small sandboxes.
+//!
+//! Protocol (server: artifact-storage `/project/{p}/repos/{r}/ingest/...`):
+//! 1. open a session (returns the CDC parameters to chunk with),
+//! 2. negotiate which chunk hashes the server lacks,
+//! 3. upload missing chunks in length-framed batches,
+//! 4. commit by chunk reference (server verifies identity by read-back).
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::Traced;
+use crate::error::SdkError;
+
+use super::ArtifactStorageClient;
+
+/// One file in a push.
+#[derive(Clone, Debug)]
+pub struct PushFile {
+    /// Path inside the repository (forward-slash separated).
+    pub repo_path: String,
+    pub source: PushSource,
+}
+
+#[derive(Clone, Debug)]
+pub enum PushSource {
+    /// Read (twice: hash pass + upload pass) from the local filesystem.
+    Path(PathBuf),
+    /// In-memory content.
+    Bytes(Vec<u8>),
+}
+
+/// Progress events, emitted in order. Rendering (progress bars, logs) is the caller's concern.
+#[derive(Clone, Debug)]
+pub enum PushEvent {
+    /// All files chunked and hashed locally.
+    Hashed {
+        files: usize,
+        chunks: usize,
+        bytes: u64,
+    },
+    /// Negotiation complete: this many chunks (of the total) need uploading.
+    Negotiated { missing: usize, total: usize },
+    /// One upload batch accepted.
+    UploadedBatch { chunks: usize, bytes: u64 },
+    /// The commit published.
+    Committed { commit: String, ref_name: String },
+}
+
+pub type PushProgress = Arc<dyn Fn(PushEvent) + Send + Sync>;
+
+#[derive(Clone)]
+pub struct PushOptions {
+    pub branch: String,
+    pub message: String,
+    /// Optional explicit parent commit (hex oid).
+    pub base: Option<String>,
+    /// Force-with-lease: require the branch to currently equal this hex oid.
+    pub expect_oid: Option<String>,
+    /// Upper bound on one upload request's payload.
+    pub upload_batch_bytes: usize,
+    pub progress: Option<PushProgress>,
+}
+
+impl Default for PushOptions {
+    fn default() -> Self {
+        PushOptions {
+            branch: "main".to_string(),
+            message: String::new(),
+            base: None,
+            expect_oid: None,
+            upload_batch_bytes: 48 * 1024 * 1024,
+            progress: None,
+        }
+    }
+}
+
+/// Outcome of a push.
+#[derive(Clone, Debug)]
+pub struct PushReport {
+    pub commit: String,
+    pub tree: String,
+    pub ref_name: String,
+    pub created: bool,
+    pub files: usize,
+    pub bytes_total: u64,
+    pub chunks_total: usize,
+    /// Chunks the server lacked at first negotiation (uploaded by this push).
+    pub chunks_uploaded: usize,
+    pub bytes_uploaded: u64,
+}
+
+#[derive(Deserialize)]
+struct IngestSessionWire {
+    session_id: String,
+    cdc_min_bytes: usize,
+    cdc_avg_bytes: usize,
+    cdc_max_bytes: usize,
+    max_hashes_per_query: usize,
+    #[allow(dead_code)]
+    max_chunk_bytes: usize,
+}
+
+#[derive(Serialize)]
+struct MissingWire<'a> {
+    hashes: &'a [String],
+}
+
+#[derive(Deserialize)]
+struct MissingRespWire {
+    missing: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct CommitFileWire {
+    path: String,
+    chunks: Vec<CommitChunkWire>,
+}
+
+#[derive(Serialize)]
+struct CommitChunkWire {
+    hash: String,
+    size: u32,
+}
+
+#[derive(Serialize)]
+struct CommitWire {
+    branch: String,
+    message: String,
+    session_id: String,
+    files: Vec<CommitFileWire>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expect_oid: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CommitByReferenceResponse {
+    pub commit: String,
+    pub tree: String,
+    pub ref_name: String,
+    pub parent: Option<String>,
+    pub created: bool,
+}
+
+struct ChunkedFile {
+    repo_path: String,
+    source: PushSource,
+    /// `(sha256, size)` in file order.
+    chunks: Vec<([u8; 32], u32)>,
+}
+
+fn chunk_source(
+    source: &PushSource,
+    min: usize,
+    avg: usize,
+    max: usize,
+) -> Result<Vec<([u8; 32], u32)>, SdkError> {
+    let reader: Box<dyn Read> = match source {
+        PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
+        PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
+    };
+    let mut out = Vec::new();
+    for chunk in fastcdc::v2020::StreamCDC::new(reader, min as u32, avg as u32, max as u32) {
+        let chunk = chunk.map_err(|e| SdkError::ClientError(format!("chunking failed: {e}")))?;
+        let hash: [u8; 32] = Sha256::digest(&chunk.data).into();
+        out.push((hash, chunk.data.len() as u32));
+    }
+    Ok(out)
+}
+
+fn io_err(e: std::io::Error) -> SdkError {
+    SdkError::Io(e)
+}
+
+impl ArtifactStorageClient {
+    /// Push a set of files as one commit, transferring only chunks the server lacks. Safe to
+    /// retry wholesale on any failure: completed work is discovered, not redone.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn push_files(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        files: Vec<PushFile>,
+        opts: PushOptions,
+    ) -> Result<Traced<PushReport>, SdkError> {
+        let emit = |ev: PushEvent| {
+            if let Some(p) = &opts.progress {
+                p(ev)
+            }
+        };
+
+        // 1. Session: the server dictates chunking parameters and limits.
+        let (req, _trace) = self.git_request(
+            Method::POST,
+            project_id,
+            repo,
+            Some("ingest/sessions"),
+            git_username,
+            git_token,
+        )?;
+        let session: IngestSessionWire = expect_json(req.send().await?).await?;
+
+        // 2. Chunk + hash every file locally (streaming; data dropped after hashing).
+        let mut chunked = Vec::with_capacity(files.len());
+        let (mut total_chunks, mut total_bytes) = (0usize, 0u64);
+        for f in files {
+            let chunks = chunk_source(
+                &f.source,
+                session.cdc_min_bytes,
+                session.cdc_avg_bytes,
+                session.cdc_max_bytes,
+            )?;
+            total_chunks += chunks.len();
+            total_bytes += chunks.iter().map(|(_, s)| *s as u64).sum::<u64>();
+            chunked.push(ChunkedFile {
+                repo_path: f.repo_path,
+                source: f.source,
+                chunks,
+            });
+        }
+        emit(PushEvent::Hashed {
+            files: chunked.len(),
+            chunks: total_chunks,
+            bytes: total_bytes,
+        });
+
+        // 3. Negotiate: which distinct hashes does the server lack?
+        let mut distinct: Vec<[u8; 32]> = chunked
+            .iter()
+            .flat_map(|f| f.chunks.iter().map(|(h, _)| *h))
+            .collect();
+        distinct.sort_unstable();
+        distinct.dedup();
+        let missing = self
+            .negotiate_missing(
+                project_id,
+                repo,
+                git_username,
+                git_token,
+                &session,
+                &distinct,
+            )
+            .await?;
+        emit(PushEvent::Negotiated {
+            missing: missing.len(),
+            total: distinct.len(),
+        });
+
+        // 4. Upload missing chunks: re-read sources (CDC is deterministic), frame, and PUT in
+        //    bounded batches. Duplicate hashes across files upload once.
+        let mut to_upload = missing.clone();
+        let (mut uploaded_chunks, mut uploaded_bytes) = (0usize, 0u64);
+        let mut frame = Vec::with_capacity(opts.upload_batch_bytes + 64);
+        let mut frame_chunks = 0usize;
+        for file in &chunked {
+            if to_upload.is_empty() {
+                break;
+            }
+            let mut reader: Box<dyn Read> = match &file.source {
+                PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
+                PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
+            };
+            for (hash, size) in &file.chunks {
+                let mut data = vec![0u8; *size as usize];
+                reader.read_exact(&mut data).map_err(io_err)?;
+                if !to_upload.remove(hash) {
+                    continue;
+                }
+                frame.extend_from_slice(hash);
+                frame.extend_from_slice(&(data.len() as u32).to_be_bytes());
+                frame.extend_from_slice(&data);
+                frame_chunks += 1;
+                uploaded_chunks += 1;
+                uploaded_bytes += data.len() as u64;
+                if frame.len() >= opts.upload_batch_bytes {
+                    self.put_chunk_frame(
+                        project_id,
+                        repo,
+                        git_username,
+                        git_token,
+                        &session.session_id,
+                        std::mem::take(&mut frame),
+                    )
+                    .await?;
+                    emit(PushEvent::UploadedBatch {
+                        chunks: frame_chunks,
+                        bytes: uploaded_bytes,
+                    });
+                    frame_chunks = 0;
+                }
+            }
+        }
+        if !frame.is_empty() {
+            self.put_chunk_frame(
+                project_id,
+                repo,
+                git_username,
+                git_token,
+                &session.session_id,
+                frame,
+            )
+            .await?;
+            emit(PushEvent::UploadedBatch {
+                chunks: frame_chunks,
+                bytes: uploaded_bytes,
+            });
+        }
+
+        // 5. Commit by reference. The server re-verifies identity by reading chunks back.
+        let commit_files: Vec<CommitFileWire> = chunked
+            .iter()
+            .map(|f| CommitFileWire {
+                path: f.repo_path.clone(),
+                chunks: f
+                    .chunks
+                    .iter()
+                    .map(|(h, s)| CommitChunkWire {
+                        hash: hex_lower(h),
+                        size: *s,
+                    })
+                    .collect(),
+            })
+            .collect();
+        let body = CommitWire {
+            branch: opts.branch.clone(),
+            message: opts.message.clone(),
+            session_id: session.session_id.clone(),
+            files: commit_files,
+            base: opts.base.clone(),
+            expect_oid: opts.expect_oid.clone(),
+        };
+        let (req, trace_id) = self.git_request(
+            Method::POST,
+            project_id,
+            repo,
+            Some("commits"),
+            git_username,
+            git_token,
+        )?;
+        let resp: CommitByReferenceResponse = expect_json(req.json(&body).send().await?).await?;
+        emit(PushEvent::Committed {
+            commit: resp.commit.clone(),
+            ref_name: resp.ref_name.clone(),
+        });
+        Ok(Traced::new(
+            trace_id,
+            PushReport {
+                commit: resp.commit,
+                tree: resp.tree,
+                ref_name: resp.ref_name,
+                created: resp.created,
+                files: chunked.len(),
+                bytes_total: total_bytes,
+                chunks_total: distinct.len(),
+                chunks_uploaded: uploaded_chunks,
+                bytes_uploaded: uploaded_bytes,
+            },
+        ))
+    }
+
+    async fn negotiate_missing(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        session: &IngestSessionWire,
+        distinct: &[[u8; 32]],
+    ) -> Result<std::collections::HashSet<[u8; 32]>, SdkError> {
+        let mut missing = std::collections::HashSet::new();
+        for batch in distinct.chunks(session.max_hashes_per_query.max(1)) {
+            let hashes: Vec<String> = batch.iter().map(hex_lower).collect();
+            let (req, _t) = self.git_request(
+                Method::POST,
+                project_id,
+                repo,
+                Some(&format!("ingest/sessions/{}/missing", session.session_id)),
+                git_username,
+                git_token,
+            )?;
+            let resp: MissingRespWire =
+                expect_json(req.json(&MissingWire { hashes: &hashes }).send().await?).await?;
+            for h in resp.missing {
+                let mut arr = [0u8; 32];
+                hex::decode_to_slice(&h, &mut arr)
+                    .map_err(|e| SdkError::ClientError(format!("bad hash from server: {e}")))?;
+                missing.insert(arr);
+            }
+        }
+        Ok(missing)
+    }
+
+    async fn put_chunk_frame(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        session_id: &str,
+        frame: Vec<u8>,
+    ) -> Result<(), SdkError> {
+        let (req, _t) = self.git_request(
+            Method::PUT,
+            project_id,
+            repo,
+            Some(&format!("ingest/sessions/{session_id}/chunks")),
+            git_username,
+            git_token,
+        )?;
+        let resp = req.body(frame).send().await?;
+        expect_ok(resp).await
+    }
+}
+
+fn hex_lower(h: &[u8; 32]) -> String {
+    hex::encode(h)
+}
+
+async fn expect_json<T: serde::de::DeserializeOwned>(
+    resp: reqwest::Response,
+) -> Result<T, SdkError> {
+    let status = resp.status();
+    if !status.is_success() {
+        let message = resp.text().await.unwrap_or_default();
+        return Err(SdkError::ServerError { status, message });
+    }
+    resp.json::<T>()
+        .await
+        .map_err(|e| SdkError::ClientError(format!("bad response body: {e}")))
+}
+
+async fn expect_ok(resp: reqwest::Response) -> Result<(), SdkError> {
+    let status = resp.status();
+    if !status.is_success() {
+        let message = resp.text().await.unwrap_or_default();
+        return Err(SdkError::ServerError { status, message });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// CDC over the same bytes must be deterministic (the upload pass re-reads and re-chunks),
+    /// and the frame layout must match the server: `32-byte hash | u32-be len | bytes`.
+    #[test]
+    fn chunking_is_deterministic_and_frames_are_well_formed() {
+        let data: Vec<u8> = (0..3_000_000usize).map(|i| (i % 251) as u8).collect();
+        let src = PushSource::Bytes(data.clone());
+        let a = chunk_source(&src, 256 * 1024, 1024 * 1024, 4 * 1024 * 1024).unwrap();
+        let b = chunk_source(&src, 256 * 1024, 1024 * 1024, 4 * 1024 * 1024).unwrap();
+        assert_eq!(a, b, "CDC must be deterministic across passes");
+        assert_eq!(
+            a.iter().map(|(_, s)| *s as usize).sum::<usize>(),
+            data.len(),
+            "chunks must cover the file exactly"
+        );
+        // Frame one chunk and validate the layout.
+        let (hash, size) = a[0];
+        let mut frame = Vec::new();
+        frame.extend_from_slice(&hash);
+        frame.extend_from_slice(&size.to_be_bytes());
+        frame.extend_from_slice(&data[..size as usize]);
+        assert_eq!(&frame[..32], &hash);
+        assert_eq!(u32::from_be_bytes(frame[32..36].try_into().unwrap()), size);
+        assert_eq!(
+            <[u8; 32]>::from(Sha256::digest(&frame[36..])),
+            hash,
+            "framed bytes must hash to the declared id"
+        );
+    }
+}

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     error::SdkError,
 };
 
+pub mod ingest;
 pub mod models;
 
 use models::{


### PR DESCRIPTION
## What

Client half of tensorlakeai/artifact_storage#21 (resumable ingest sessions), implemented in the shared Rust core so the CLI and the Python/Node bindings consume one implementation.

- **`tensorlake::artifact_storage::ingest`**: `push_files()` drives the whole protocol — open session (server dictates FastCDC parameters, clients never hardcode chunking), stream-chunk + SHA-256 every file, negotiate missing hashes in server-capped batches, upload misses as length-framed batches (~48 MiB per request, bounded memory; files are re-read on the upload pass since CDC is deterministic), then commit by chunk reference. **Retrying a failed push wholesale is the resume mechanism**: completed work is discovered via negotiation, not tracked client-side. Progress is a callback event enum; rendering stays in callers.
- **`tl git push --repo <r> [--branch] [-m] [--expect-oid] <paths…>`**: mints a repo-scoped token, walks files/dirs (skips `.git`), drives the core client with a progress spinner, reports `uploaded / deduplicated / wire bytes` (free telemetry from the protocol), `--json` for scripts.

## Why

Every large push we measured was client-uplink-bound, git restarts from zero on failure, and `git pack-objects` cannot run in small sandboxes (the 4 GiB sandbox needed 2.6 GB RSS and thrashed 1.7 TB of reads for a kernel push). This path needs no local git at all.

## Validation

- Unit test pins CDC determinism across read passes, exact file coverage, and the wire-frame layout against the declared hash.
- `cargo clippy` clean for the new code; `cargo test -p tensorlake --lib` green.
- Live smoke vs prod is blocked until artifact_storage#21 deploys (endpoints 404 today — auth/scoping/token-minting verified up to the server). The server-side e2e in that PR covers the full protocol.

## Follow-ups

Expose `push_files` through the py/node binding crates; move the fast-clone implementation from the CLI into the core (same both-consumers motivation); parallel upload streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)