### PR TITLE
Print root cause chain for CLI errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-codec"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "base64",
  "bollard",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "anyhow",
  "base64",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "napi",
  "napi-build",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.55"
+version = "0.5.56"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1462,6 +1462,19 @@ async fn main() {
             CliError::Cancelled => std::process::exit(1),
             _ => {
                 eprintln!("Error: {}", e);
+                // Walk the source chain: wrapped errors like reqwest's hide the
+                // root cause (DNS failure, connection refused, TLS, timeout)
+                // behind Display and only expose it via source().
+                let mut prev = e.to_string();
+                let mut source = std::error::Error::source(&e);
+                while let Some(cause) = source {
+                    let msg = cause.to_string();
+                    if !prev.contains(&msg) {
+                        eprintln!("  Caused by: {}", msg);
+                        prev = msg;
+                    }
+                    source = cause.source();
+                }
                 if ctx.debug {
                     eprintln!("\nDebug info:");
                     eprintln!("  {:?}", e);

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.55"
+version = "0.5.56"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.55"
+version = "0.5.56"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.54",
+  "version": "0.5.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.54",
+      "version": "0.5.56",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",
@@ -1226,7 +1226,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1533,7 +1532,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1588,7 +1586,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2309,7 +2306,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2359,7 +2355,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2797,7 +2792,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2845,7 +2839,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.54",
+  "version": "0.5.56",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Problem

A customer hit this inside a container:

```
root@5e0c801cf90:/app# tensorlake sbx ssh 0szw2tb8wy1cjbd4hhn78
Error: HTTP request failed: error sending request for url (https://api.tensorlake.ai/platform/v1/keys/introspect)
```

The message gives no hint of *why* the request failed. `reqwest::Error`'s `Display` intentionally stops at "error sending request for url (…)" — the real cause (DNS failure, connection refused, TLS problem, timeout, proxy issue) is only reachable via the error's `source()` chain, which the CLI never walked.

## Fix

The top-level error printer in `crates/cli/src/main.rs` now walks the full `source()` chain and prints each layer as a `Caused by:` line, skipping layers already embedded in the parent message to avoid duplication. This benefits every wrapped error in the CLI, not just this endpoint.

DNS failure:
```
Error: HTTP request failed: error sending request for url (https://.../platform/v1/keys/introspect)
  Caused by: client error (Connect)
  Caused by: dns error
  Caused by: failed to lookup address information: nodename nor servname provided, or not known
```

Connection refused:
```
Error: HTTP request failed: error sending request for url (http://127.0.0.1:59999/platform/v1/keys/introspect)
  Caused by: client error (Connect)
  Caused by: tcp connect error
  Caused by: Connection refused (os error 61)
```

## Release

Version bumped to 0.5.56 via `bump_version.py`; `Cargo.lock` and `typescript/package-lock.json` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)