### PR TITLE
Sync vendored gsvc-codec with upstream artifact_storage

### DIFF
--- a/crates/gsvc-codec/src/lib.rs
+++ b/crates/gsvc-codec/src/lib.rs
@@ -38,7 +38,7 @@ pub use graph::{
     commit_links, encode_commit, encode_tree, links_of, tag_target, tree_entries, Links, TreeEntry,
 };
 pub use idx::{write_idx_v2, IdxV2};
-pub use object::{hash, BlobOidHasher, Kind, Object};
+pub use object::{hash, BlobOidHasher, Kind, Object, ResumableBlobOidHasher};
 pub use oid::{ChunkHash, Oid};
 pub use pack::{
     build_pack, build_pack_at_level, build_pack_delta, build_pack_delta_for_serving,

--- a/crates/gsvc-codec/src/object.rs
+++ b/crates/gsvc-codec/src/object.rs
@@ -105,6 +105,157 @@ impl BlobOidHasher {
     }
 }
 
+/// A [`BlobOidHasher`] whose state can be exported and resumed — for verified-at-upload file
+/// hashing, where one file's bytes arrive across several requests (and possibly several pods).
+/// The state is the standard SHA-1 midstate (h0..h4), the processed pre-image length, and the
+/// sub-block remainder; importing it on another machine continues the exact same hash.
+///
+/// Hand-rolled compression is justified only because resumability requires it (the `sha1` crate
+/// does not expose midstates); correctness is pinned by differential tests against
+/// [`BlobOidHasher`] across arbitrary split points.
+pub struct ResumableBlobOidHasher {
+    h: [u32; 5],
+    /// Pre-image bytes fed so far (header + payload), including what sits in `buf`.
+    len: u64,
+    buf: [u8; 64],
+    buf_len: usize,
+}
+
+/// Serialized size of an exported hasher state.
+pub const RESUMABLE_HASHER_STATE_SIZE: usize = 20 + 8 + 1 + 64;
+
+impl ResumableBlobOidHasher {
+    /// Start hashing a blob of `size` payload bytes (the git pre-image is `"blob <size>\0"`).
+    pub fn new(size: u64) -> ResumableBlobOidHasher {
+        let mut h = ResumableBlobOidHasher {
+            h: [0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0],
+            len: 0,
+            buf: [0u8; 64],
+            buf_len: 0,
+        };
+        h.update(b"blob ");
+        h.update(size.to_string().as_bytes());
+        h.update(b"\0");
+        h
+    }
+
+    pub fn update(&mut self, mut data: &[u8]) {
+        self.len += data.len() as u64;
+        if self.buf_len > 0 {
+            let take = (64 - self.buf_len).min(data.len());
+            self.buf[self.buf_len..self.buf_len + take].copy_from_slice(&data[..take]);
+            self.buf_len += take;
+            data = &data[take..];
+            if self.buf_len == 64 {
+                let block = self.buf;
+                self.compress(&block);
+                self.buf_len = 0;
+            }
+        }
+        while data.len() >= 64 {
+            let (block, rest) = data.split_at(64);
+            let arr: [u8; 64] = block.try_into().expect("length checked");
+            self.compress(&arr);
+            data = rest;
+        }
+        if !data.is_empty() {
+            self.buf[..data.len()].copy_from_slice(data);
+            self.buf_len = data.len();
+        }
+    }
+
+    pub fn finalize(mut self) -> Oid {
+        let total_bits = self.len * 8;
+        self.update(&[0x80]);
+        // update() bumped len; padding must not count. Track bits from before the pad.
+        while self.buf_len != 56 {
+            self.update(&[0]);
+        }
+        let mut block = self.buf;
+        block[56..64].copy_from_slice(&total_bits.to_be_bytes());
+        self.compress(&block);
+        let mut out = [0u8; 20];
+        for (i, w) in self.h.iter().enumerate() {
+            out[i * 4..i * 4 + 4].copy_from_slice(&w.to_be_bytes());
+        }
+        Oid::from_array(out)
+    }
+
+    /// Export the midstate (fixed [`RESUMABLE_HASHER_STATE_SIZE`] bytes).
+    pub fn export_state(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(RESUMABLE_HASHER_STATE_SIZE);
+        for w in &self.h {
+            out.extend_from_slice(&w.to_be_bytes());
+        }
+        out.extend_from_slice(&self.len.to_be_bytes());
+        out.push(self.buf_len as u8);
+        out.extend_from_slice(&self.buf);
+        out
+    }
+
+    /// Resume from a state produced by [`Self::export_state`].
+    pub fn import_state(state: &[u8]) -> Result<ResumableBlobOidHasher, CodecError> {
+        if state.len() != RESUMABLE_HASHER_STATE_SIZE {
+            return Err(CodecError::Io(format!(
+                "hasher state must be {RESUMABLE_HASHER_STATE_SIZE} bytes, got {}",
+                state.len()
+            )));
+        }
+        let mut h = [0u32; 5];
+        for (i, w) in h.iter_mut().enumerate() {
+            *w = u32::from_be_bytes(state[i * 4..i * 4 + 4].try_into().expect("sized"));
+        }
+        let len = u64::from_be_bytes(state[20..28].try_into().expect("sized"));
+        let buf_len = state[28] as usize;
+        if buf_len >= 64 {
+            return Err(CodecError::Io("hasher buffer length out of range".into()));
+        }
+        let mut buf = [0u8; 64];
+        buf.copy_from_slice(&state[29..93]);
+        Ok(ResumableBlobOidHasher {
+            h,
+            len,
+            buf,
+            buf_len,
+        })
+    }
+
+    fn compress(&mut self, block: &[u8; 64]) {
+        let mut w = [0u32; 80];
+        for (i, chunk) in block.chunks_exact(4).enumerate() {
+            w[i] = u32::from_be_bytes(chunk.try_into().expect("sized"));
+        }
+        for i in 16..80 {
+            w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e] = self.h;
+        for (i, wi) in w.iter().enumerate() {
+            let (f, k) = match i {
+                0..=19 => ((b & c) | ((!b) & d), 0x5A827999u32),
+                20..=39 => (b ^ c ^ d, 0x6ED9EBA1),
+                40..=59 => ((b & c) | (b & d) | (c & d), 0x8F1BBCDC),
+                _ => (b ^ c ^ d, 0xCA62C1D6),
+            };
+            let tmp = a
+                .rotate_left(5)
+                .wrapping_add(f)
+                .wrapping_add(e)
+                .wrapping_add(k)
+                .wrapping_add(*wi);
+            e = d;
+            d = c;
+            c = b.rotate_left(30);
+            b = a;
+            a = tmp;
+        }
+        self.h[0] = self.h[0].wrapping_add(a);
+        self.h[1] = self.h[1].wrapping_add(b);
+        self.h[2] = self.h[2].wrapping_add(c);
+        self.h[3] = self.h[3].wrapping_add(d);
+        self.h[4] = self.h[4].wrapping_add(e);
+    }
+}
+
 /// A fully-materialized git object: its kind plus its raw (decompressed, un-deltified) bytes.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Object {
@@ -180,5 +331,70 @@ mod tests {
             assert_eq!(Kind::from_pack_type(k.pack_type()).unwrap(), k);
         }
         assert!(Kind::from_str("nope").is_err());
+    }
+}
+
+#[cfg(test)]
+mod resumable_hasher_tests {
+    use super::*;
+
+    /// Deterministic xorshift so failures reproduce.
+    fn rng(seed: &mut u64) -> u64 {
+        *seed ^= *seed << 13;
+        *seed ^= *seed >> 7;
+        *seed ^= *seed << 17;
+        *seed
+    }
+
+    /// The resumable hasher must agree with [`BlobOidHasher`] (and thus git) for every size,
+    /// under arbitrary update splits, and under export/import at every split point — including
+    /// splits inside the header, at block boundaries, and mid-block.
+    #[test]
+    fn matches_blob_oid_hasher_across_random_splits_and_resumes() {
+        let mut seed = 0x1234_5678_9abc_def0u64;
+        let sizes = [
+            0usize,
+            1,
+            55,
+            56,
+            63,
+            64,
+            65,
+            127,
+            128,
+            1000,
+            64 * 1024 + 17,
+        ];
+        for &size in &sizes {
+            let data: Vec<u8> = (0..size).map(|_| (rng(&mut seed) & 0xff) as u8).collect();
+            let mut reference = BlobOidHasher::new(size as u64);
+            reference.update(&data);
+            let expected = reference.finalize();
+
+            for _round in 0..8 {
+                let mut hasher = ResumableBlobOidHasher::new(size as u64);
+                let mut off = 0usize;
+                while off < data.len() {
+                    let take = 1 + (rng(&mut seed) as usize) % (data.len() - off);
+                    hasher.update(&data[off..off + take]);
+                    off += take;
+                    // Round-trip the midstate on every split: resume must be exact.
+                    hasher = ResumableBlobOidHasher::import_state(&hasher.export_state()).unwrap();
+                }
+                assert_eq!(
+                    hasher.finalize(),
+                    expected,
+                    "size {size}: resumable hash diverged"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn import_rejects_malformed_state() {
+        assert!(ResumableBlobOidHasher::import_state(&[0u8; 10]).is_err());
+        let mut bad = ResumableBlobOidHasher::new(4).export_state();
+        bad[28] = 64; // buf_len out of range
+        assert!(ResumableBlobOidHasher::import_state(&bad).is_err());
     }
 }

--- a/crates/gsvc-codec/src/pack.rs
+++ b/crates/gsvc-codec/src/pack.rs
@@ -897,6 +897,14 @@ impl ScannedPack {
         bases.dedup();
         bases
     }
+
+    /// Whether the pack carries any `REF_DELTA` entry — i.e. it is thin and its received bytes
+    /// can never be manifested as-is (the resolver must produce a self-contained replacement).
+    pub fn is_thin(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|entry| matches!(entry.kind, ReceiveEntryKind::RefDelta { .. }))
+    }
 }
 
 /// A large blob resolved from a pack into a local temporary file.
@@ -1172,6 +1180,7 @@ pub struct ReceivePackSpooler {
     entries: Vec<ReceiveEntryMeta>,
     count: Option<usize>,
     allow_ref_delta: bool,
+    seen_ref_delta: bool,
     started: std::time::Instant,
 }
 
@@ -1234,6 +1243,7 @@ impl ReceivePackSpooler {
             entries: Vec::new(),
             count: None,
             allow_ref_delta,
+            seen_ref_delta: false,
             started: std::time::Instant::now(),
         }
     }
@@ -1241,6 +1251,13 @@ impl ReceivePackSpooler {
     pub fn push(&mut self, chunk: &[u8]) -> Result<(), CodecError> {
         self.buf.extend_from_slice(chunk);
         self.process()
+    }
+
+    /// Whether any `REF_DELTA` entry header has been consumed so far. Available while bytes are
+    /// still streaming in, so a caller uploading the raw bytes in parallel can stop as soon as
+    /// the pack turns out to be thin (its bytes must never be manifested verbatim).
+    pub fn seen_ref_delta(&self) -> bool {
+        self.seen_ref_delta
     }
 
     pub fn finish(mut self) -> Result<Option<ScannedPack>, CodecError> {
@@ -1337,6 +1354,7 @@ impl ReceivePackSpooler {
                             };
                         }
                         T_REF_DELTA => {
+                            self.seen_ref_delta = true;
                             self.state = SpoolState::RefDelta {
                                 entry_offset,
                                 ty,


### PR DESCRIPTION
Companion sync PR required by artifact_storage's vendoring rule (`crates/gsvc-codec` is vendored verbatim here to back `tl git clone`). Verbatim re-sync of `crates/gsvc-codec/src` with artifact_storage `main`, covering two upstream changes:

- **Thin-push single-upload** ([artifact_storage#29](https://github.com/tensorlakeai/artifact_storage/pull/29)): additive public API — `ReceivePackSpooler::seen_ref_delta()` (REF_DELTA entries visible while bytes are still streaming in) and `ScannedPack::is_thin()`. Upstream, the server uses these to abort the raw thin multipart and store only the fix-thin replacement. No behavior change for the fast-clone client.
- **Verified-at-upload hashing** ([artifact_storage#26](https://github.com/tensorlakeai/artifact_storage/pull/26), missed by the previous sync): `ResumableBlobOidHasher` (exportable SHA-1 midstate) plus its `lib.rs` re-export.

No `FastCloneManifest` wire-format or fast-clone client behavior changes. `Cargo.toml` keeps its documented local adaptations (edition 2021 pin, workspace deps).

Validation: `cargo test -p gsvc-codec` (65 + 5 tests) and `cargo check -p tensorlake-cli` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)