### PR TITLE
Fix miscompiled linux/aarch64 wheels causing TLS BadSignature failures

### DIFF
--- a/.github/scripts/verify_wheel.py
+++ b/.github/scripts/verify_wheel.py
@@ -2,16 +2,83 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import subprocess
 import tempfile
 import venv
 from pathlib import Path
+
+# Runs inside the wheel's venv. Distinguishes a healthy TLS stack (the request
+# reaches the API and fails auth) from miscompiled ring crypto in the Rust
+# extension (connection error such as "invalid peer certificate: BadSignature").
+_TLS_CHECK_SCRIPT = """\
+import sys
+
+from tensorlake._cloud_sdk import CloudApiClient, CloudApiClientError
+
+url = sys.argv[1]
+client = CloudApiClient(api_url=url, api_key="invalid")
+try:
+    client.introspect_api_key_json()
+except CloudApiClientError as exc:
+    kind = exc.args[0] if exc.args else None
+    if kind in ("sdk_usage", "remote_api"):
+        print(f"TLS check passed: got HTTP-level error {exc.args[:2]} from {url}")
+        sys.exit(0)
+    print(f"TLS check FAILED: expected an HTTP auth error from {url}, got: {exc!r}")
+    sys.exit(1)
+finally:
+    client.close()
+print(f"TLS check passed: request to {url} succeeded")
+"""
+
+_TLS_ERROR_SIGNATURES = (
+    "badsignature",
+    "invalid peer certificate",
+    "error sending request",
+    "connection",
+)
 
 
 def _venv_python(venv_dir: Path) -> Path:
     if os.name == "nt":
         return venv_dir / "Scripts" / "python.exe"
     return venv_dir / "bin" / "python"
+
+
+def _venv_scripts_dir(venv_dir: Path) -> Path:
+    if os.name == "nt":
+        return venv_dir / "Scripts"
+    return venv_dir / "bin"
+
+
+def _run_cli_check(venv_dir: Path, url: str) -> None:
+    scripts_dir = _venv_scripts_dir(venv_dir)
+    search_path = os.pathsep.join([str(scripts_dir), os.environ.get("PATH", "")])
+    cli = shutil.which("tensorlake", path=search_path)
+    if cli is None or not Path(cli).is_relative_to(venv_dir):
+        raise SystemExit(f"CLI check FAILED: no tensorlake executable in {scripts_dir}")
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("TENSORLAKE_")}
+    proc = subprocess.run(
+        [cli, "--api-key", "invalid", "--api-url", url, "whoami"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env=env,
+    )
+    output = proc.stdout + proc.stderr
+    lowered = output.lower()
+    matched = [s for s in _TLS_ERROR_SIGNATURES if s in lowered]
+    if matched:
+        raise SystemExit(
+            f"CLI check FAILED: TLS/connection error signatures {matched} in output:\n{output}"
+        )
+    if proc.returncode == 0:
+        raise SystemExit(
+            f"CLI check FAILED: expected auth failure for invalid API key, got exit 0:\n{output}"
+        )
+    print(f"CLI check passed: auth failure without TLS errors (exit {proc.returncode})")
 
 
 def main() -> int:
@@ -26,6 +93,18 @@ def main() -> int:
         "modules",
         nargs="+",
         help="Modules to import after installation",
+    )
+    parser.add_argument(
+        "--tls-check",
+        metavar="URL",
+        help="Make an HTTPS request to URL through the Rust _cloud_sdk extension and "
+        "require an HTTP-level auth error (catches miscompiled TLS crypto)",
+    )
+    parser.add_argument(
+        "--cli-check",
+        metavar="URL",
+        help="Run the wheel-bundled tensorlake CLI against URL with an invalid API key "
+        "and require an auth error rather than a TLS/connection error",
     )
     args = parser.parse_args()
 
@@ -65,6 +144,15 @@ def main() -> int:
             ],
             check=True,
         )
+
+        if args.tls_check:
+            subprocess.run(
+                [str(python), "-c", _TLS_CHECK_SCRIPT, args.tls_check],
+                check=True,
+            )
+
+        if args.cli_check:
+            _run_cli_check(venv_dir, args.cli_check)
 
     return 0
 

--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -49,10 +49,13 @@ jobs:
             target: x86_64
             manylinux: auto
             cloud_sdk_interpreter: /opt/python/cp310-cp310/bin/python
-          - os: namespace-profile-rust-builder-amd64
+          # Native arm64 runner + native PyPA image: the manylinux2014-cross image's
+          # GCC 4.8 miscompiles ring's aarch64 crypto (TLS BadSignature at runtime).
+          - os: ubuntu-24.04-arm
             target: aarch64
-            manylinux: auto
-            cloud_sdk_interpreter: python3
+            manylinux: '2014'
+            manylinux_container: quay.io/pypa/manylinux2014_aarch64:latest
+            cloud_sdk_interpreter: /opt/python/cp310-cp310/bin/python
           - os: macos-14
             target: aarch64
             rust_target: aarch64-apple-darwin
@@ -85,13 +88,12 @@ jobs:
       - name: Build Cloud SDK wheel
         uses: PyO3/maturin-action@v1
         env:
-          # ring's AArch64 assembly requires __ARM_ARCH; manylinux2014 cross GCC 4.8 doesn't define it.
-          CFLAGS_aarch64_unknown_linux_gnu: ${{ runner.os == 'Linux' && matrix.platform.target == 'aarch64' && '-D__ARM_ARCH=8' || '' }}
           CARGO_TARGET_DIR: target
         with:
           target: ${{ matrix.platform.target }}
           args: --manifest-path crates/rust-cloud-sdk-py/Cargo.toml --release --out dist-cloud-sdk -i ${{ matrix.platform.cloud_sdk_interpreter }}
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
+          container: ${{ matrix.platform.manylinux_container || '' }}
           sccache: 'true'
 
       - name: Bundle Cloud SDK extension into tensorlake wheel
@@ -101,19 +103,17 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:
-          # ring's AArch64 assembly requires __ARM_ARCH; manylinux2014 cross GCC 4.8 doesn't define it.
-          CFLAGS_aarch64_unknown_linux_gnu: ${{ runner.os == 'Linux' && matrix.platform.target == 'aarch64' && '-D__ARM_ARCH=8' || '' }}
           CARGO_TARGET_DIR: target
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
+          container: ${{ matrix.platform.manylinux_container || '' }}
           sccache: 'true'
 
       - name: Verify wheel imports Rust Cloud SDK extension
-        if: ${{ !(runner.os == 'Linux' && matrix.platform.target == 'aarch64') }}
         run: |
-          python .github/scripts/verify_wheel.py "dist/tensorlake-*.whl" tensorlake._cloud_sdk tensorlake.cli.deploy
+          python .github/scripts/verify_wheel.py "dist/tensorlake-*.whl" tensorlake._cloud_sdk tensorlake.cli.deploy --tls-check https://api.tensorlake.ai --cli-check https://api.tensorlake.ai
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish_test_pypi.yaml
+++ b/.github/workflows/publish_test_pypi.yaml
@@ -65,10 +65,13 @@ jobs:
             target: x86_64
             manylinux: auto
             cloud_sdk_interpreter: /opt/python/cp310-cp310/bin/python
-          - os: namespace-profile-rust-builder-amd64
+          # Native arm64 runner + native PyPA image: the manylinux2014-cross image's
+          # GCC 4.8 miscompiles ring's aarch64 crypto (TLS BadSignature at runtime).
+          - os: ubuntu-24.04-arm
             target: aarch64
-            manylinux: auto
-            cloud_sdk_interpreter: python3
+            manylinux: '2014'
+            manylinux_container: quay.io/pypa/manylinux2014_aarch64:latest
+            cloud_sdk_interpreter: /opt/python/cp310-cp310/bin/python
           - os: macos-14
             target: aarch64
             rust_target: aarch64-apple-darwin
@@ -104,13 +107,12 @@ jobs:
       - name: Build Cloud SDK wheel
         uses: PyO3/maturin-action@v1
         env:
-          # ring's AArch64 assembly requires __ARM_ARCH; manylinux2014 cross GCC 4.8 doesn't define it.
-          CFLAGS_aarch64_unknown_linux_gnu: ${{ runner.os == 'Linux' && matrix.platform.target == 'aarch64' && '-D__ARM_ARCH=8' || '' }}
           CARGO_TARGET_DIR: target
         with:
           target: ${{ matrix.platform.target }}
           args: --manifest-path crates/rust-cloud-sdk-py/Cargo.toml --release --out dist-cloud-sdk -i ${{ matrix.platform.cloud_sdk_interpreter }}
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
+          container: ${{ matrix.platform.manylinux_container || '' }}
           sccache: 'true'
 
       - name: Bundle Cloud SDK extension into tensorlake wheel
@@ -120,19 +122,17 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:
-          # ring's AArch64 assembly requires __ARM_ARCH; manylinux2014 cross GCC 4.8 doesn't define it.
-          CFLAGS_aarch64_unknown_linux_gnu: ${{ runner.os == 'Linux' && matrix.platform.target == 'aarch64' && '-D__ARM_ARCH=8' || '' }}
           CARGO_TARGET_DIR: target
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
+          container: ${{ matrix.platform.manylinux_container || '' }}
           sccache: 'true'
 
       - name: Verify wheel imports Rust Cloud SDK extension
-        if: ${{ !(runner.os == 'Linux' && matrix.platform.target == 'aarch64') }}
         run: |
-          python .github/scripts/verify_wheel.py "dist/tensorlake-*.whl" tensorlake._cloud_sdk tensorlake.cli.deploy
+          python .github/scripts/verify_wheel.py "dist/tensorlake-*.whl" tensorlake._cloud_sdk tensorlake.cli.deploy --tls-check https://api.tensorlake.ai --cli-check https://api.tensorlake.ai
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-codec"
-version = "0.5.56"
+version = "0.5.57"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.56"
+version = "0.5.57"
 dependencies = [
  "base64",
  "bollard",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.56"
+version = "0.5.57"
 dependencies = [
  "anyhow",
  "base64",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.56"
+version = "0.5.57"
 dependencies = [
  "napi",
  "napi-build",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.56"
+version = "0.5.57"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.56"
+version = "0.5.57"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.56"
+version = "0.5.57"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.56"
+version = "0.5.57"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.56",
+  "version": "0.5.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.56",
+      "version": "0.5.57",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",
@@ -1226,6 +1226,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1532,6 +1533,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1586,6 +1588,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2306,6 +2309,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2355,6 +2359,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2792,6 +2797,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2839,6 +2845,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.56",
+  "version": "0.5.57",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Problem

A user reported that all TensorLake API calls fail inside Docker on Apple Silicon Macs with:

```
CloudApiClientError: ('connection', None, '... client error (Connect): invalid peer certificate: BadSignature')
```

Reproduced in a native `linux/arm64` container with `tensorlake==0.5.55` — **every published linux/aarch64 wheel is affected** (x86_64, macOS, and Windows wheels are fine, as are the CLI tarballs and npm packages, which build natively).

## Root cause

#551 set `CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8` to get past ring's compile error `"ARM assembler must define __ARM_ARCH"`. That guard exists to reject unsuitable toolchains: the manylinux2014-**cross** image compiles with GCC **4.8.5**, which miscompiles ring's aarch64 RSA/SHA-256 code. The result is TLS signature verification computing wrong results at runtime. The wheel-verify step was also skipped for exactly this target (`if: !(Linux && aarch64)`), so the wheel shipped untested. Since the main wheel bundles the Rust CLI (`bindings = "bin"`), the pip-installed `tensorlake` CLI binary on arm64 Linux was broken too.

## Fix

- Build the linux/aarch64 wheel **natively on `ubuntu-24.04-arm`** with the native `quay.io/pypa/manylinux2014_aarch64` image (same approach as `publish_cli.yaml` / `publish_npm.yaml`). Wheel keeps the manylinux2014 tag.
- Remove the `-D__ARM_ARCH=8` override everywhere — if ring's guard fires again, the build must fail loudly.
- Run wheel verification on **all** targets, and extend `verify_wheel.py` with real HTTPS checks against `https://api.tensorlake.ai`:
  - `--tls-check`: calls `introspect_api_key_json()` through the Rust `_cloud_sdk` extension with an invalid key; requires an HTTP-level auth error, fails on connection/TLS errors.
  - `--cli-check`: runs the wheel-bundled `tensorlake --api-key invalid whoami`; requires auth failure without TLS error signatures.

  Note: this makes release wheel jobs depend on the live API being reachable — intentional, since import checks cannot catch miscompiled crypto.
- Bump version to 0.5.57 (lockstep).

## Validation (local, Apple Silicon Docker, linux/arm64)

- Published 0.5.55 wheel: new TLS check **fails** with `('connection', None, '... BadSignature')` ✅ (catches the regression)
- Wheel built with this exact configuration (`quay.io/pypa/manylinux2014_aarch64`, native arm64): imports, TLS check (`('sdk_usage', 401)`), and CLI check all **pass** ✅

## Follow-ups after merge

- Trigger the PyPI release for 0.5.57.
- Consider yanking the broken `*_aarch64` wheel files of affected releases (every release since #551, ~0.4.30+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)