### PR TITLE
Use server sandbox_url for sandbox proxy routing

### DIFF
--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -1,10 +1,11 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
     DEFAULT_SANDBOX_WAIT_TIMEOUT, apply_proxy_access_settings, sandbox_endpoint,
-    sandbox_proxy_base, wait_for_sandbox_status,
+    wait_for_sandbox_status,
 };
 use crate::error::{CliError, Result};
 use serde::Deserialize;
+use tensorlake::sandboxes::resolve_sandbox_proxy_target;
 
 const DEFAULT_SANDBOX_CPUS: f64 = 1.0;
 const DEFAULT_SANDBOX_MEMORY_MB: i64 = 1024;
@@ -190,7 +191,7 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         println!("{}", sandbox_id);
     }
     if is_tty {
-        print_post_create_tip(ctx, &create_result, display_id, name.is_none());
+        print_post_create_tip(&create_result, display_id, name.is_none());
     }
     Ok(())
 }
@@ -203,17 +204,10 @@ fn format_ready_message(name: Option<&str>, sandbox_id: &str) -> String {
 }
 
 fn print_post_create_tip(
-    ctx: &CliContext,
     create_result: &CreateSandboxResult,
     display_id: &str,
     is_ephemeral: bool,
 ) {
-    let (proxy_url, host_header) = post_create_proxy_base(ctx, create_result, display_id);
-    let host_flag = host_header
-        .as_deref()
-        .map(|h| format!(" \\\n     -H \"Host: {}\"", h))
-        .unwrap_or_default();
-
     eprintln!();
     eprintln!("Get started:");
     eprintln!("  tl sbx ssh {display_id}");
@@ -221,6 +215,14 @@ fn print_post_create_tip(
     if is_ephemeral {
         eprintln!("  tl sbx name {display_id} <name>  # make persistent (enables suspend/resume)");
     }
+
+    let Some(proxy_target) = post_create_proxy_base(create_result, display_id) else {
+        eprintln!();
+        eprintln!("Docs: https://docs.tensorlake.ai/sandboxes");
+        return;
+    };
+    let header_flags = proxy_target.header_flags();
+    let proxy_url = proxy_target.proxy_url;
 
     let tips: Vec<(&str, String)> = vec![
         (
@@ -230,30 +232,30 @@ fn print_post_create_tip(
         (
             "run a process via the HTTP API?",
             format!(
-                "  curl -X POST {proxy_url}/api/v1/processes{host_flag} \\\n     -H \"Content-Type: application/json\" \\\n     -d '{{\"command\": \"echo\", \"args\": [\"Hello, World!\"]}}'"
+                "  curl -X POST {proxy_url}/api/v1/processes{header_flags} \\\n     -H \"Content-Type: application/json\" \\\n     -d '{{\"command\": \"echo\", \"args\": [\"Hello, World!\"]}}'"
             ),
         ),
         (
             "run a bash script via the HTTP API?",
             format!(
-                "  curl -X POST {proxy_url}/api/v1/processes{host_flag} \\\n     -H \"Content-Type: application/json\" \\\n     -d '{{\"command\": \"bash\", \"args\": [\"-c\", \"for i in 1 2 3; do echo Line $i; sleep 1; done\"]}}'"
+                "  curl -X POST {proxy_url}/api/v1/processes{header_flags} \\\n     -H \"Content-Type: application/json\" \\\n     -d '{{\"command\": \"bash\", \"args\": [\"-c\", \"for i in 1 2 3; do echo Line $i; sleep 1; done\"]}}'"
             ),
         ),
         (
             "follow process output in real-time?",
             format!(
-                "  # Start a process:\n  curl -X POST {proxy_url}/api/v1/processes{host_flag} \\\n     -H \"Content-Type: application/json\" \\\n     -d '{{\"command\": \"bash\", \"args\": [\"-c\", \"for i in 1 2 3; do echo Line $i; sleep 1; done\"]}}'\n\n  # Then stream its output (replace <pid> with the returned pid):\n  curl {proxy_url}/api/v1/processes/<pid>/output/follow{host_flag}"
+                "  # Start a process:\n  curl -X POST {proxy_url}/api/v1/processes{header_flags} \\\n     -H \"Content-Type: application/json\" \\\n     -d '{{\"command\": \"bash\", \"args\": [\"-c\", \"for i in 1 2 3; do echo Line $i; sleep 1; done\"]}}'\n\n  # Then stream its output (replace <pid> with the returned pid):\n  curl {proxy_url}/api/v1/processes/<pid>/output/follow{header_flags}"
             ),
         ),
         (
             "write files into your sandbox via the HTTP API?",
             format!(
-                "  curl -X PUT \"{proxy_url}/api/v1/files?path=/tmp/hello.txt\"{host_flag} \\\n     -H \"Content-Type: application/octet-stream\" \\\n     -d \"Hello from sandbox!\""
+                "  curl -X PUT \"{proxy_url}/api/v1/files?path=/tmp/hello.txt\"{header_flags} \\\n     -H \"Content-Type: application/octet-stream\" \\\n     -d \"Hello from sandbox!\""
             ),
         ),
         (
             "read files from your sandbox via the HTTP API?",
-            format!("  curl \"{proxy_url}/api/v1/files?path=/tmp/hello.txt\"{host_flag}"),
+            format!("  curl \"{proxy_url}/api/v1/files?path=/tmp/hello.txt\"{header_flags}"),
         ),
     ];
 
@@ -272,50 +274,57 @@ fn print_post_create_tip(
     eprintln!("Docs: https://docs.tensorlake.ai/sandboxes");
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PostCreateProxyTarget {
+    proxy_url: String,
+    host_header: Option<String>,
+    sandbox_id_header: Option<String>,
+}
+
+impl PostCreateProxyTarget {
+    fn header_flags(&self) -> String {
+        let mut flags = String::new();
+        if let Some(host) = self.host_header.as_deref() {
+            flags.push_str(&format!(" \\\n     -H \"Host: {host}\""));
+        }
+        if let Some(sandbox_id) = self.sandbox_id_header.as_deref() {
+            flags.push_str(&format!(
+                " \\\n     -H \"X-Tensorlake-Sandbox-Id: {sandbox_id}\""
+            ));
+        }
+        flags
+    }
+}
+
 fn post_create_proxy_base(
-    ctx: &CliContext,
     create_result: &CreateSandboxResult,
     display_id: &str,
-) -> (String, Option<String>) {
-    if let Some(sandbox_url) = create_result.sandbox_url.clone() {
-        return (sandbox_url, None);
-    }
+) -> Option<PostCreateProxyTarget> {
+    let explicit_proxy_url = super::explicit_proxy_url_override();
+    post_create_proxy_base_with_explicit(create_result, display_id, explicit_proxy_url.as_deref())
+}
 
-    if let Some(sandbox_url) = create_result
-        .ingress_endpoint
+fn post_create_proxy_base_with_explicit(
+    create_result: &CreateSandboxResult,
+    display_id: &str,
+    explicit_proxy_url: Option<&str>,
+) -> Option<PostCreateProxyTarget> {
+    let proxy_url = create_result
+        .sandbox_url
         .as_deref()
-        .and_then(|endpoint| sandbox_url_from_ingress_endpoint(endpoint, &create_result.sandbox_id))
-    {
-        return (sandbox_url, None);
-    }
-
-    let proxy_key = if create_result.sandbox_id == display_id {
+        .or(explicit_proxy_url)?;
+    let has_server_sandbox_url = create_result.sandbox_url.is_some();
+    let proxy_key = if has_server_sandbox_url || create_result.sandbox_id == display_id {
         create_result.sandbox_id.as_str()
     } else {
         display_id
     };
-    sandbox_proxy_base(ctx, proxy_key)
-}
-
-fn sandbox_url_from_ingress_endpoint(ingress_endpoint: &str, sandbox_id: &str) -> Option<String> {
-    let parsed = url::Url::parse(ingress_endpoint).ok()?;
-    let host = parsed.host_str()?;
-    let host = if host.contains(':') && !host.starts_with('[') {
-        format!("[{host}]")
-    } else {
-        host.to_string()
-    };
-    let port = parsed
-        .port()
-        .map(|port| format!(":{port}"))
-        .unwrap_or_default();
-    Some(format!(
-        "{}://{}.{}{}",
-        parsed.scheme(),
-        sandbox_id,
-        host,
-        port
-    ))
+    let target = resolve_sandbox_proxy_target(proxy_url, proxy_key).ok()?;
+    Some(PostCreateProxyTarget {
+        proxy_url: target.base_url,
+        host_header: target.host_override,
+        sandbox_id_header: target.sandbox_id_header,
+    })
 }
 
 fn build_create_request_body(
@@ -380,24 +389,9 @@ fn build_create_request_body(
 #[cfg(test)]
 mod tests {
     use super::{
-        CreateSandboxResult, GpuRequest, build_create_request_body, format_ready_message,
-        parse_file_system_mounts, post_create_proxy_base, sandbox_url_from_ingress_endpoint,
+        CreateSandboxResult, GpuRequest, PostCreateProxyTarget, build_create_request_body,
+        format_ready_message, parse_file_system_mounts, post_create_proxy_base_with_explicit,
     };
-    use crate::auth::context::CliContext;
-    use crate::config::resolver::ResolvedConfig;
-
-    fn test_ctx() -> CliContext {
-        CliContext::from_resolved(ResolvedConfig {
-            api_url: "https://api.tensorlake.ai".to_string(),
-            cloud_url: "https://cloud.tensorlake.ai".to_string(),
-            namespace: "default".to_string(),
-            api_key: None,
-            personal_access_token: None,
-            organization_id: None,
-            project_id: None,
-            debug: false,
-        })
-    }
 
     #[test]
     fn parse_file_system_mounts_builds_wire_objects() {
@@ -579,19 +573,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_url_is_derived_from_returned_ingress_endpoint() {
-        assert_eq!(
-            sandbox_url_from_ingress_endpoint(
-                "https://sandbox.us-east-1.aws.tensorlake.ai",
-                "sbx-123"
-            ),
-            Some("https://sbx-123.sandbox.us-east-1.aws.tensorlake.ai".to_string())
-        );
-    }
-
-    #[test]
     fn post_create_tip_prefers_sandbox_url_from_create_response() {
-        let ctx = test_ctx();
         let create_result = CreateSandboxResult {
             sandbox_id: "sbx-123".to_string(),
             status: Some("running".to_string()),
@@ -600,14 +582,36 @@ mod tests {
         };
 
         assert_eq!(
-            post_create_proxy_base(&ctx, &create_result, "sbx-123"),
-            ("https://returned.example.com".to_string(), None)
+            post_create_proxy_base_with_explicit(&create_result, "sbx-123", None),
+            Some(PostCreateProxyTarget {
+                proxy_url: "https://returned.example.com".to_string(),
+                host_header: None,
+                sandbox_id_header: Some("sbx-123".to_string()),
+            })
         );
     }
 
     #[test]
-    fn post_create_tip_uses_ingress_endpoint_from_create_response() {
-        let ctx = test_ctx();
+    fn post_create_tip_uses_canonical_id_with_server_sandbox_url_for_named_sandbox() {
+        let create_result = CreateSandboxResult {
+            sandbox_id: "sbx-123".to_string(),
+            status: Some("running".to_string()),
+            sandbox_url: Some("https://sbx-123.sandbox.us-east-1.aws.tensorlake.ai".to_string()),
+            ingress_endpoint: Some("https://sandbox.us-east-1.aws.tensorlake.ai".to_string()),
+        };
+
+        assert_eq!(
+            post_create_proxy_base_with_explicit(&create_result, "stable-name", None),
+            Some(PostCreateProxyTarget {
+                proxy_url: "https://sbx-123.sandbox.us-east-1.aws.tensorlake.ai".to_string(),
+                host_header: None,
+                sandbox_id_header: Some("sbx-123".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn post_create_tip_does_not_derive_from_ingress_endpoint() {
         let create_result = CreateSandboxResult {
             sandbox_id: "sbx-123".to_string(),
             status: Some("running".to_string()),
@@ -616,11 +620,31 @@ mod tests {
         };
 
         assert_eq!(
-            post_create_proxy_base(&ctx, &create_result, "sbx-123"),
-            (
-                "https://sbx-123.sandbox.us-east-1.aws.tensorlake.ai".to_string(),
-                None
-            )
+            post_create_proxy_base_with_explicit(&create_result, "sbx-123", None),
+            None
+        );
+    }
+
+    #[test]
+    fn post_create_tip_uses_explicit_override_when_server_url_missing() {
+        let create_result = CreateSandboxResult {
+            sandbox_id: "sbx-123".to_string(),
+            status: Some("running".to_string()),
+            sandbox_url: None,
+            ingress_endpoint: Some("https://sandbox.us-east-1.aws.tensorlake.ai".to_string()),
+        };
+
+        assert_eq!(
+            post_create_proxy_base_with_explicit(
+                &create_result,
+                "sbx-123",
+                Some("http://localhost:9443")
+            ),
+            Some(PostCreateProxyTarget {
+                proxy_url: "http://localhost:9443".to_string(),
+                host_header: Some("sbx-123.local".to_string()),
+                sandbox_id_header: None,
+            })
         );
     }
 }

--- a/crates/cli/src/commands/sbx/describe.rs
+++ b/crates/cli/src/commands/sbx/describe.rs
@@ -243,7 +243,11 @@ fn print_ssh_config_details(item: &serde_json::Value) -> Result<()> {
         .filter(|value| !value.is_empty())
         .unwrap_or("-");
     let name = item.get("name").and_then(|v| v.as_str());
-    let sandbox = native_ssh::ResolvedSandbox::new(id, name);
+    let sandbox_url = item
+        .get("sandbox_url")
+        .or_else(|| item.get("sandboxUrl"))
+        .and_then(|v| v.as_str());
+    let sandbox = native_ssh::ResolvedSandbox::with_sandbox_url(id, name, sandbox_url)?;
     let config = native_ssh::format_ssh_config(&sandbox, None, None)?;
 
     println!("SSH Config:");

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -24,6 +24,10 @@ pub mod tunnel;
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
 use chrono::{DateTime, Local, TimeZone, Utc};
+use tensorlake::sandboxes::{
+    resolve_default_sandbox_proxy_url, resolve_sandbox_proxy_target as resolve_core_proxy_target,
+    select_sandbox_proxy_url,
+};
 use tokio::time::{Duration, Instant};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,6 +37,7 @@ pub struct ResolvedSandboxProxyTarget {
     pub host_override: Option<String>,
     pub routing_hint: Option<String>,
     pub ingress_endpoint: Option<String>,
+    pub sandbox_url: Option<String>,
 }
 
 /// Build the lifecycle API base URL for sandbox CRUD operations.
@@ -153,47 +158,20 @@ pub async fn wait_for_sandbox_status(
     }
 }
 
-/// Build the proxy base URL for a specific sandbox (process/file/PTY operations).
-///
-/// Cloud: returns the apex proxy domain; callers must inject `X-Tensorlake-Sandbox-Id`
-/// via [`with_sandbox_headers`].
-/// Localhost: returns the proxy URL as-is with a `Host` header override.
-pub fn sandbox_proxy_base(ctx: &CliContext, sandbox_id: &str) -> (String, Option<String>) {
-    let proxy_url = resolve_proxy_url(&ctx.api_url);
-    proxy_base_from_url(&proxy_url, sandbox_id)
-}
-
-fn proxy_base_from_url(proxy_url: &str, sandbox_id: &str) -> (String, Option<String>) {
-    if let Ok(parsed) = url::Url::parse(proxy_url) {
-        let host = parsed.host_str().unwrap_or("");
-        if host == "localhost" || host == "127.0.0.1" {
-            // Localhost: keep URL as-is, set Host header to {sandbox_id}.local
-            let host_header = format!("{sandbox_id}.local");
-            return (proxy_url.to_string(), Some(host_header));
-        }
-        // Cloud: use apex domain; sandbox routing is via X-Tensorlake-Sandbox-Id header
-        let port_part = parsed.port().map(|p| format!(":{}", p)).unwrap_or_default();
-        let base_url = format!("{}://{host}{port_part}", parsed.scheme());
-        return (base_url, None);
-    }
-
-    // Fallback
-    (proxy_url.to_string(), None)
-}
-
 pub async fn resolve_sandbox_proxy_target(
     ctx: &CliContext,
     identifier: &str,
 ) -> Result<ResolvedSandboxProxyTarget> {
     if is_localhost(&ctx.api_url) {
-        let proxy_url = resolve_proxy_url(&ctx.api_url);
-        let (proxy_base, host_override) = proxy_base_from_url(&proxy_url, identifier);
+        let proxy_url = resolve_default_sandbox_proxy_url(&ctx.api_url);
+        let target = resolve_core_proxy_target(&proxy_url, identifier)?;
         return Ok(ResolvedSandboxProxyTarget {
             sandbox_id: identifier.to_string(),
-            proxy_base,
-            host_override,
+            proxy_base: target.base_url,
+            host_override: target.host_override,
             routing_hint: None,
             ingress_endpoint: None,
+            sandbox_url: None,
         });
     }
 
@@ -230,21 +208,33 @@ pub async fn resolve_sandbox_proxy_target(
         .map(str::to_string);
     let ingress_endpoint = info
         .get("ingress_endpoint")
+        .or_else(|| info.get("ingressEndpoint"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let sandbox_url = info
+        .get("sandbox_url")
+        .or_else(|| info.get("sandboxUrl"))
         .and_then(|value| value.as_str())
         .filter(|value| !value.is_empty())
         .map(str::to_string);
 
-    let proxy_url = explicit_proxy_url_override()
-        .or_else(|| ingress_endpoint.clone())
-        .unwrap_or_else(|| resolve_proxy_url(&ctx.api_url));
-    let (proxy_base, host_override) = proxy_base_from_url(&proxy_url, &sandbox_id);
+    let proxy_url = select_sandbox_proxy_url(
+        &ctx.api_url,
+        &sandbox_id,
+        sandbox_url.as_deref(),
+        ingress_endpoint.as_deref(),
+        explicit_proxy_url_override().as_deref(),
+    )?;
+    let target = resolve_core_proxy_target(&proxy_url, &sandbox_id)?;
 
     Ok(ResolvedSandboxProxyTarget {
         sandbox_id,
-        proxy_base,
-        host_override,
+        proxy_base: target.base_url,
+        host_override: target.host_override,
         routing_hint,
         ingress_endpoint,
+        sandbox_url,
     })
 }
 
@@ -278,24 +268,6 @@ pub fn resolve_sandbox_lifecycle_url(api_url: &str) -> String {
         let host = parsed.host_str().unwrap_or("");
         if let Some(rest) = host.strip_prefix("api.") {
             return format!("{}://sandbox.{}", parsed.scheme(), rest);
-        }
-    }
-    "https://sandbox.tensorlake.ai".to_string()
-}
-
-/// Resolve the sandbox proxy URL from env or api_url.
-fn resolve_proxy_url(api_url: &str) -> String {
-    if let Some(url) = explicit_proxy_url_override() {
-        return url;
-    }
-    if is_localhost(api_url) {
-        return "http://localhost:9443".to_string();
-    }
-    if let Ok(parsed) = url::Url::parse(api_url) {
-        let host = parsed.host_str().unwrap_or("");
-        if let Some(rest) = host.strip_prefix("api.") {
-            let proxy_host = format!("sandbox.{}", rest);
-            return format!("{}://{}", parsed.scheme(), proxy_host);
         }
     }
     "https://sandbox.tensorlake.ai".to_string()

--- a/crates/cli/src/commands/sbx/native_ssh.rs
+++ b/crates/cli/src/commands/sbx/native_ssh.rs
@@ -1,23 +1,37 @@
 use crate::error::{CliError, Result};
+use tensorlake::sandboxes::sandbox_proxy_hostname;
 
-const SSH_HOSTNAME: &str = "sandbox.tensorlake.ai";
 const DEFAULT_IDENTITY_FILE: &str = "~/.ssh/id_ed25519_tensorlake";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedSandbox {
     sandbox_id: String,
     name: Option<String>,
+    ssh_hostname: String,
 }
 
 impl ResolvedSandbox {
-    pub fn new(sandbox_id: impl Into<String>, name: Option<&str>) -> Self {
-        Self {
+    pub fn with_sandbox_url(
+        sandbox_id: impl Into<String>,
+        name: Option<&str>,
+        sandbox_url: Option<&str>,
+    ) -> Result<Self> {
+        let url = sandbox_url
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                CliError::Other(anyhow::anyhow!(
+                    "server response did not include sandbox_url; refusing to generate SSH config"
+                ))
+            })?;
+        Ok(Self {
             sandbox_id: sandbox_id.into(),
             name: name
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .map(str::to_string),
-        }
+            ssh_hostname: sandbox_proxy_hostname(url)?,
+        })
     }
 }
 
@@ -36,7 +50,7 @@ pub fn format_ssh_config(
 
     let mut lines = vec![
         format!("Host {host_alias}"),
-        format!("    HostName {SSH_HOSTNAME}"),
+        format!("    HostName {}", sandbox.ssh_hostname),
         format!("    User {}", sandbox.sandbox_id),
     ];
 
@@ -89,18 +103,19 @@ mod tests {
 
     #[test]
     fn format_ssh_config_uses_named_alias_and_placeholder_identity_file() {
-        let config = format_ssh_config(
-            &ResolvedSandbox::new("sbx-123", Some("my-sandbox")),
-            None,
-            None,
+        let sandbox = ResolvedSandbox::with_sandbox_url(
+            "sbx-123",
+            Some("my-sandbox"),
+            Some("https://sbx-123.sandbox.gcp-use4.tensorlake.ai"),
         )
-        .expect("config");
+        .expect("sandbox");
+        let config = format_ssh_config(&sandbox, None, None).expect("config");
 
         assert_eq!(
             config,
             concat!(
                 "Host tl-my-sandbox\n",
-                "    HostName sandbox.tensorlake.ai\n",
+                "    HostName sbx-123.sandbox.gcp-use4.tensorlake.ai\n",
                 "    User sbx-123\n",
                 "    # Set this to the private key whose public key you registered with `tl sbx ssh keys add`\n",
                 "    IdentityFile ~/.ssh/id_ed25519_tensorlake\n",
@@ -108,6 +123,31 @@ mod tests {
                 "    ServerAliveInterval 30\n",
                 "    ServerAliveCountMax 3\n"
             )
+        );
+    }
+
+    #[test]
+    fn format_ssh_config_uses_server_sandbox_url_hostname() {
+        let sandbox = ResolvedSandbox::with_sandbox_url(
+            "sbx-123",
+            Some("my-sandbox"),
+            Some("https://sbx-123.sandbox.gcp-use4.tensorlake.ai"),
+        )
+        .expect("sandbox");
+        let config = format_ssh_config(&sandbox, None, None).expect("config");
+
+        assert!(config.contains("    HostName sbx-123.sandbox.gcp-use4.tensorlake.ai\n"));
+    }
+
+    #[test]
+    fn ssh_config_requires_server_sandbox_url() {
+        let error = ResolvedSandbox::with_sandbox_url("sbx-123", None, None).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("server response did not include sandbox_url"),
+            "unexpected error: {error}"
         );
     }
 }

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -25,6 +25,7 @@ use crate::{
             CreateSandboxRequest, CreateSandboxResources, MultipartHint, ProcessInfo,
             RunProcessEvent, SandboxInfo, SignBlobOp, SignBlobRequest, SignBlobTarget,
         },
+        resolve_sandbox_proxy_target, select_sandbox_proxy_url,
     },
 };
 
@@ -527,7 +528,6 @@ where
         })
         .await?;
     let sandbox_id = created.sandbox_id.clone();
-    let routing_hint = created.routing_hint.clone();
 
     let result = async {
         let running_info = wait_for_sandbox_status(
@@ -537,10 +537,18 @@ where
             DEFAULT_SANDBOX_WAIT_TIMEOUT,
         )
         .await?;
+        let sandbox_url = created
+            .sandbox_url
+            .clone()
+            .or_else(|| running_info.sandbox_url.clone());
         let ingress_endpoint = created
             .ingress_endpoint
             .clone()
             .or_else(|| running_info.ingress_endpoint.clone());
+        let routing_hint = created
+            .routing_hint
+            .clone()
+            .or_else(|| running_info.routing_hint.clone());
         emit(SandboxImageBuildEvent::Status(format!(
             "Rootfs builder sandbox {sandbox_id} is running"
         )));
@@ -549,6 +557,7 @@ where
             &ctx,
             &client,
             &sandbox_id,
+            sandbox_url.as_deref(),
             ingress_endpoint.as_deref(),
             routing_hint,
         )?;
@@ -1030,50 +1039,54 @@ fn sandbox_template_builds_path(ctx: &ResolvedBuildContext) -> String {
 fn sandbox_proxy_base(
     api_url: &str,
     sandbox_id: &str,
+    sandbox_url: Option<&str>,
     ingress_endpoint: Option<&str>,
-) -> (String, Option<String>) {
-    let proxy_url = ingress_endpoint
-        .map(str::to_string)
-        .unwrap_or_else(|| resolve_proxy_url(api_url));
-
-    if let Ok(parsed) = url::Url::parse(&proxy_url) {
-        let host = parsed.host_str().unwrap_or("");
-        if host == "localhost" || host == "127.0.0.1" {
-            return (proxy_url, Some(format!("{sandbox_id}.local")));
-        }
-        let port_part = parsed.port().map(|p| format!(":{p}")).unwrap_or_default();
-        let base_url = format!("{}://{host}{port_part}", parsed.scheme());
-        return (base_url, None);
-    }
-
-    (proxy_url, None)
+) -> Result<(String, Option<String>)> {
+    let explicit_proxy_url = explicit_sandbox_proxy_url_override();
+    sandbox_proxy_base_with_explicit(
+        api_url,
+        sandbox_id,
+        sandbox_url,
+        ingress_endpoint,
+        explicit_proxy_url.as_deref(),
+    )
 }
 
-fn resolve_proxy_url(api_url: &str) -> String {
-    if let Ok(url) = std::env::var("TENSORLAKE_SANDBOX_PROXY_URL") {
-        return url;
-    }
-    if is_localhost(api_url) {
-        return "http://localhost:9443".to_string();
-    }
-    if let Ok(parsed) = url::Url::parse(api_url) {
-        let host = parsed.host_str().unwrap_or("");
-        if let Some(rest) = host.strip_prefix("api.") {
-            return format!("{}://sandbox.{}", parsed.scheme(), rest);
-        }
-    }
-    "https://sandbox.tensorlake.ai".to_string()
+fn sandbox_proxy_base_with_explicit(
+    api_url: &str,
+    sandbox_id: &str,
+    sandbox_url: Option<&str>,
+    ingress_endpoint: Option<&str>,
+    explicit_proxy_url: Option<&str>,
+) -> Result<(String, Option<String>)> {
+    let proxy_url = select_sandbox_proxy_url(
+        api_url,
+        sandbox_id,
+        sandbox_url,
+        ingress_endpoint,
+        explicit_proxy_url,
+    )?;
+    let target = resolve_sandbox_proxy_target(&proxy_url, sandbox_id)?;
+    Ok((target.base_url, target.host_override))
+}
+
+fn explicit_sandbox_proxy_url_override() -> Option<String> {
+    std::env::var("TENSORLAKE_SANDBOX_PROXY_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn sandbox_proxy_client(
     ctx: &ResolvedBuildContext,
     client: &Client,
     sandbox_id: &str,
+    sandbox_url: Option<&str>,
     ingress_endpoint: Option<&str>,
     routing_hint: Option<String>,
 ) -> Result<SandboxProxyClient> {
     let (proxy_base, host_override) =
-        sandbox_proxy_base(&ctx.api_url, sandbox_id, ingress_endpoint);
+        sandbox_proxy_base(&ctx.api_url, sandbox_id, sandbox_url, ingress_endpoint)?;
     Ok(
         SandboxProxyClient::new(client.with_base_url(&proxy_base), host_override)
             .with_sandbox_id(Some(sandbox_id.to_string()))
@@ -2794,7 +2807,8 @@ mod tests {
         load_dockerfile_text_plan, logical_dockerfile_lines, normalize_posix,
         parse_df_line_usage_percent, parse_df_max_usage_percent, process_terminal_status,
         rootfs_builder_env, rootfs_builder_executable, rootfs_disk_bytes, rootfs_disk_bytes_to_mb,
-        splice_signed_upload, streaming_process_payload, upload_percent,
+        sandbox_proxy_base_with_explicit, splice_signed_upload, streaming_process_payload,
+        upload_percent,
     };
     use crate::sandboxes::models::ProcessInfo;
     use serde_json::{Value, json};
@@ -2811,6 +2825,21 @@ mod tests {
         assert!(contains_oom_killer_evidence(
             "Killed process 42 (cc1plus), UID 0, total-vm:1234kB"
         ));
+    }
+
+    #[test]
+    fn sandbox_proxy_base_uses_explicit_override_when_server_url_missing() {
+        let (proxy_base, host_override) = sandbox_proxy_base_with_explicit(
+            "https://api.tensorlake.ai",
+            "sbx-123",
+            None,
+            Some("https://sandbox.us-east-1.aws.tensorlake.ai"),
+            Some("http://localhost:9443"),
+        )
+        .unwrap();
+
+        assert_eq!(proxy_base, "http://localhost:9443");
+        assert_eq!(host_override, Some("sbx-123.local".to_string()));
     }
 
     #[test]

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -32,6 +32,9 @@ use models::{
     SignBlobRequest, SnapshotInfo, SnapshotType, UpdateSandboxRequest,
 };
 
+pub const DEFAULT_SANDBOX_PROXY_URL: &str = "https://sandbox.tensorlake.ai";
+pub const SANDBOX_MANAGEMENT_PORT: u16 = 9501;
+
 /// A reference to a sandbox process: either its OS **pid** or a managed-process **name**
 /// given at creation. This is the single place the pid/name path segment is built, reused by
 /// the Rust SDK, the Python/Node bindings, and the CLI.
@@ -119,6 +122,140 @@ pub fn validate_managed_name(name: &str) -> Result<(), SdkError> {
         ));
     }
     Ok(())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SandboxProxyTarget {
+    pub base_url: String,
+    pub host_override: Option<String>,
+    pub sandbox_id_header: Option<String>,
+}
+
+pub fn sandbox_url_from_ingress_endpoint(
+    ingress_endpoint: &str,
+    sandbox_id: &str,
+    port: Option<u16>,
+) -> Result<String, SdkError> {
+    let parsed = reqwest::Url::parse(ingress_endpoint).map_err(|error| {
+        SdkError::ClientError(format!(
+            "invalid ingress endpoint `{ingress_endpoint}`: {error}"
+        ))
+    })?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(SdkError::ClientError(
+            "ingress_endpoint must be an absolute http(s) URL".to_string(),
+        ));
+    }
+    let host = parsed.host_str().ok_or_else(|| {
+        SdkError::ClientError(format!(
+            "ingress endpoint `{ingress_endpoint}` is missing a host"
+        ))
+    })?;
+    let label = match port {
+        Some(port) if port != SANDBOX_MANAGEMENT_PORT => format!("{port}-{sandbox_id}"),
+        _ => sandbox_id.to_string(),
+    };
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+    let port_part = parsed.port().map(|p| format!(":{p}")).unwrap_or_default();
+    Ok(format!("{}://{label}.{host}{port_part}", parsed.scheme()))
+}
+
+pub fn resolve_default_sandbox_proxy_url(api_url: &str) -> String {
+    if let Ok(url) = std::env::var("TENSORLAKE_SANDBOX_PROXY_URL") {
+        let trimmed = url.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
+        }
+    }
+    if is_localhost_api_url(api_url) {
+        return "http://localhost:9443".to_string();
+    }
+    if let Ok(parsed) = reqwest::Url::parse(api_url)
+        && let Some(host) = parsed.host_str()
+        && let Some(rest) = host.strip_prefix("api.")
+    {
+        return format!("{}://sandbox.{rest}", parsed.scheme());
+    }
+    DEFAULT_SANDBOX_PROXY_URL.to_string()
+}
+
+pub fn select_sandbox_proxy_url(
+    _api_url: &str,
+    _sandbox_id: &str,
+    server_sandbox_url: Option<&str>,
+    _server_ingress_endpoint: Option<&str>,
+    explicit_proxy_url: Option<&str>,
+) -> Result<String, SdkError> {
+    if let Some(url) = non_empty(server_sandbox_url) {
+        return Ok(url.to_string());
+    }
+    if let Some(url) = non_empty(explicit_proxy_url) {
+        return Ok(url.to_string());
+    }
+    Err(SdkError::ClientError(
+        "server response did not include sandbox_url; refusing to derive a proxy URL".to_string(),
+    ))
+}
+
+pub fn resolve_sandbox_proxy_target(
+    proxy_url: &str,
+    sandbox_id: &str,
+) -> Result<SandboxProxyTarget, SdkError> {
+    let parsed = reqwest::Url::parse(proxy_url).map_err(|error| {
+        SdkError::ClientError(format!("invalid proxy url `{proxy_url}`: {error}"))
+    })?;
+    let host = parsed.host_str().ok_or_else(|| {
+        SdkError::ClientError(format!("proxy url `{proxy_url}` is missing a host"))
+    })?;
+
+    if host == "localhost" || host == "127.0.0.1" {
+        return Ok(SandboxProxyTarget {
+            base_url: proxy_url.trim_end_matches('/').to_string(),
+            host_override: Some(format!("{sandbox_id}.local")),
+            sandbox_id_header: None,
+        });
+    }
+
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+    let port = parsed.port().map(|p| format!(":{p}")).unwrap_or_default();
+    Ok(SandboxProxyTarget {
+        base_url: format!("{}://{host}{port}", parsed.scheme()),
+        host_override: None,
+        sandbox_id_header: Some(sandbox_id.to_string()),
+    })
+}
+
+pub fn sandbox_proxy_hostname(proxy_url: &str) -> Result<String, SdkError> {
+    let parsed = reqwest::Url::parse(proxy_url).map_err(|error| {
+        SdkError::ClientError(format!("invalid sandbox url `{proxy_url}`: {error}"))
+    })?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(SdkError::ClientError(
+            "sandbox_url must be an absolute http(s) URL".to_string(),
+        ));
+    }
+    parsed.host_str().map(str::to_string).ok_or_else(|| {
+        SdkError::ClientError(format!("sandbox url `{proxy_url}` is missing a host"))
+    })
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn is_localhost_api_url(api_url: &str) -> bool {
+    reqwest::Url::parse(api_url)
+        .ok()
+        .and_then(|url| url.host_str().map(ToString::to_string))
+        .is_some_and(|host| host == "localhost" || host == "127.0.0.1")
 }
 
 /// A client for managing sandbox lifecycle, pool, and snapshot APIs.
@@ -943,7 +1080,10 @@ impl SandboxProxyClient {
 
 #[cfg(test)]
 mod process_ref_tests {
-    use super::{ProcessRef, validate_managed_name};
+    use super::{
+        ProcessRef, resolve_sandbox_proxy_target, sandbox_proxy_hostname,
+        sandbox_url_from_ingress_endpoint, select_sandbox_proxy_url, validate_managed_name,
+    };
 
     #[test]
     fn validate_managed_name_rules() {
@@ -988,5 +1128,89 @@ mod process_ref_tests {
         // Spaces and reserved characters in a name are percent-encoded into one segment.
         assert_eq!(ProcessRef::from("web 1").to_path_segment(), "web%201");
         assert_eq!(ProcessRef::from("a?b").to_path_segment(), "a%3Fb");
+    }
+
+    #[test]
+    fn select_proxy_url_prefers_server_sandbox_url() {
+        let selected = select_sandbox_proxy_url(
+            "https://api.tensorlake.ai",
+            "sbx-1",
+            Some("https://sbx-1.sandbox.gcp-use4.tensorlake.ai"),
+            Some("https://sandbox.us-east-1.aws.tensorlake.ai"),
+            Some("https://override.example.com"),
+        )
+        .unwrap();
+
+        assert_eq!(selected, "https://sbx-1.sandbox.gcp-use4.tensorlake.ai");
+    }
+
+    #[test]
+    fn select_proxy_url_uses_explicit_override_when_server_url_missing() {
+        let selected = select_sandbox_proxy_url(
+            "https://api.tensorlake.ai",
+            "sbx-1",
+            None,
+            Some("https://sandbox.gcp-use4.tensorlake.ai"),
+            Some("https://override.example.com"),
+        )
+        .unwrap();
+
+        assert_eq!(selected, "https://override.example.com");
+    }
+
+    #[test]
+    fn select_proxy_url_errors_without_server_url_or_explicit_override() {
+        let error = select_sandbox_proxy_url(
+            "https://api.tensorlake.ai",
+            "sbx-1",
+            None,
+            Some("https://sandbox.gcp-use4.tensorlake.ai"),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("server response did not include sandbox_url"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn ingress_endpoint_url_builder_preserves_custom_port() {
+        let selected = sandbox_url_from_ingress_endpoint(
+            "https://sandbox.gcp-use4.tensorlake.ai:9443",
+            "sbx-1",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            selected,
+            "https://sbx-1.sandbox.gcp-use4.tensorlake.ai:9443"
+        );
+    }
+
+    #[test]
+    fn proxy_target_preserves_server_sandbox_host() {
+        let target =
+            resolve_sandbox_proxy_target("https://sbx-1.sandbox.gcp-use4.tensorlake.ai", "sbx-1")
+                .unwrap();
+
+        assert_eq!(
+            target.base_url,
+            "https://sbx-1.sandbox.gcp-use4.tensorlake.ai"
+        );
+        assert_eq!(target.host_override, None);
+        assert_eq!(target.sandbox_id_header.as_deref(), Some("sbx-1"));
+    }
+
+    #[test]
+    fn sandbox_proxy_hostname_uses_server_sandbox_url_host() {
+        let hostname =
+            sandbox_proxy_hostname("https://sbx-1.sandbox.gcp-use4.tensorlake.ai").unwrap();
+
+        assert_eq!(hostname, "sbx-1.sandbox.gcp-use4.tensorlake.ai");
     }
 }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -222,6 +222,8 @@ pub struct CreateSandboxResponse {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ingress_endpoint: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub termination_reason: Option<String>,
@@ -265,6 +267,8 @@ pub struct SandboxInfo {
     /// User-provided name. Present only on named (non-ephemeral) sandboxes.
     #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
+    pub routing_hint: Option<String>,
     #[serde(default)]
     pub allow_unauthenticated_access: bool,
     #[serde(default)]
@@ -843,6 +847,25 @@ mod tests {
         assert_eq!(response.source_sandbox_id, "source-1");
         assert_eq!(response.sandboxes[0].sandbox_id, "copy-1");
         assert_eq!(response.sandboxes[0].status, "running");
+    }
+
+    #[test]
+    fn sandbox_info_deserializes_routing_hint_and_sandbox_url() {
+        let json = r#"{
+            "id":"sbx-1",
+            "namespace":"default",
+            "status":"running",
+            "resources":{"cpus":1.0,"memory_mb":512,"ephemeral_disk_mb":1024},
+            "routing_hint":"hint-1",
+            "sandbox_url":"https://sbx-1.sandbox.tensorlake.ai"
+        }"#;
+        let info: SandboxInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.sandbox_id, "sbx-1");
+        assert_eq!(info.routing_hint.as_deref(), Some("hint-1"));
+        assert_eq!(
+            info.sandbox_url.as_deref(),
+            Some("https://sbx-1.sandbox.tensorlake.ai")
+        );
     }
 
     #[test]

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -28,7 +28,9 @@ use tensorlake::sandboxes::models::{
     ArchivedSandboxesPaginationDirection, CreateSandboxRequest, GetSandboxLogsRequest,
     ListArchivedSandboxesParams, SandboxPoolRequest, SnapshotType, UpdateSandboxRequest,
 };
-use tensorlake::sandboxes::{SandboxProxyClient, SandboxesClient};
+use tensorlake::sandboxes::{
+    SandboxProxyClient, SandboxesClient, resolve_sandbox_proxy_target, select_sandbox_proxy_url,
+};
 use tensorlake::{ClientBuilder, error::SdkError};
 
 // ---- Return value objects -------------------------------------------------
@@ -185,36 +187,6 @@ fn is_localhost_api_url(api_url: &str) -> bool {
         .is_some_and(|host| host == "localhost" || host == "127.0.0.1")
 }
 
-/// Resolve the proxy base URL and routing headers for a sandbox connection.
-///
-/// Returns `(base_url, host_override, sandbox_id_header)`:
-/// - localhost: `base_url` is the proxy URL as-is; `host_override` is
-///   `{sandbox_id}.local`; no sandbox-id header.
-/// - cloud: `base_url` is the apex ingress; the sandbox id is sent via the
-///   `X-Tensorlake-Sandbox-Id` header.
-fn resolve_proxy_target(
-    proxy_url: &str,
-    sandbox_id: &str,
-) -> napi::Result<(String, Option<String>, Option<String>)> {
-    let parsed = reqwest::Url::parse(proxy_url)
-        .map_err(|error| usage_error(format!("invalid proxy url `{proxy_url}`: {error}")))?;
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| usage_error(format!("proxy url `{proxy_url}` is missing a host")))?;
-
-    if host == "localhost" || host == "127.0.0.1" {
-        return Ok((
-            proxy_url.trim_end_matches('/').to_string(),
-            Some(format!("{sandbox_id}.local")),
-            None,
-        ));
-    }
-
-    let port = parsed.port().map(|p| format!(":{p}")).unwrap_or_default();
-    let base_url = format!("{}://{host}{port}", parsed.scheme());
-    Ok((base_url, None, Some(sandbox_id.to_string())))
-}
-
 fn resolve_sandbox_lifecycle_url(api_url: &str) -> String {
     if is_localhost_api_url(api_url) {
         return api_url.to_string();
@@ -276,6 +248,7 @@ fn parse_snapshot_type(snapshot_type: Option<String>) -> napi::Result<Option<Sna
 #[napi]
 pub struct NativeSandboxClient {
     client: SandboxesClient,
+    api_url: String,
 }
 
 #[napi]
@@ -326,7 +299,26 @@ impl NativeSandboxClient {
 
         Ok(Self {
             client: sandboxes_client,
+            api_url,
         })
+    }
+
+    #[napi]
+    pub fn select_sandbox_proxy_url(
+        &self,
+        sandbox_id: String,
+        sandbox_url: Option<String>,
+        ingress_endpoint: Option<String>,
+        explicit_proxy_url: Option<String>,
+    ) -> napi::Result<String> {
+        select_sandbox_proxy_url(
+            &self.api_url,
+            &sandbox_id,
+            sandbox_url.as_deref(),
+            ingress_endpoint.as_deref(),
+            explicit_proxy_url.as_deref(),
+        )
+        .map_err(into_napi_error)
     }
 
     /// Create a proxy client for `sandbox_id` that shares this client's
@@ -340,28 +332,28 @@ impl NativeSandboxClient {
         routing_hint: Option<String>,
         request_timeout_sec: Option<f64>,
     ) -> napi::Result<NativeSandboxProxyClient> {
-        let (base_url, host_override, sandbox_id_header) =
-            resolve_proxy_target(&proxy_url, &sandbox_id)?;
+        let target =
+            resolve_sandbox_proxy_target(&proxy_url, &sandbox_id).map_err(into_napi_error)?;
         let shared_client = if let Some(seconds) = request_timeout_sec {
             self.client
                 .http_client()
                 .with_base_url_and_timeout(
-                    &base_url,
+                    &target.base_url,
                     Some(duration_from_seconds("request_timeout_sec", seconds)?),
                 )
                 .map_err(into_napi_error)?
         } else {
             self.client
                 .http_client()
-                .with_base_url_without_timeout(&base_url)
+                .with_base_url_without_timeout(&target.base_url)
                 .map_err(into_napi_error)?
         };
-        let proxy = SandboxProxyClient::new(shared_client, host_override)
-            .with_sandbox_id(sandbox_id_header)
+        let proxy = SandboxProxyClient::new(shared_client, target.host_override)
+            .with_sandbox_id(target.sandbox_id_header)
             .with_routing_hint(routing_hint);
         Ok(NativeSandboxProxyClient {
             client: proxy,
-            base_url,
+            base_url: target.base_url,
         })
     }
 
@@ -731,10 +723,10 @@ impl NativeSandboxProxyClient {
         user_agent: Option<String>,
         request_timeout_sec: Option<f64>,
     ) -> napi::Result<Self> {
-        let (base_url, host_override, sandbox_id_header) =
-            resolve_proxy_target(&proxy_url, &sandbox_id)?;
+        let target =
+            resolve_sandbox_proxy_target(&proxy_url, &sandbox_id).map_err(into_napi_error)?;
 
-        let mut builder = ClientBuilder::new(&base_url);
+        let mut builder = ClientBuilder::new(&target.base_url);
         if let Some(token) = api_key.as_deref() {
             builder = builder.bearer_token(token);
         }
@@ -751,13 +743,13 @@ impl NativeSandboxProxyClient {
         }
 
         let client = builder.build().map_err(into_napi_error)?;
-        let proxy = SandboxProxyClient::new(client, host_override)
-            .with_sandbox_id(sandbox_id_header)
+        let proxy = SandboxProxyClient::new(client, target.host_override)
+            .with_sandbox_id(target.sandbox_id_header)
             .with_routing_hint(routing_hint);
 
         Ok(Self {
             client: proxy,
-            base_url,
+            base_url: target.base_url,
         })
     }
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -33,6 +33,7 @@ use tensorlake::sandboxes::models::{
 };
 use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
+    resolve_sandbox_proxy_target, select_sandbox_proxy_url,
 };
 use tensorlake::{Client, ClientBuilder, error::SdkError};
 use tokio::runtime::Runtime;
@@ -655,6 +656,7 @@ impl CloudApiClient {
 #[pyclass]
 pub struct CloudSandboxClient {
     client: SandboxesClient,
+    api_url: String,
 }
 
 #[pymethods]
@@ -707,11 +709,30 @@ impl CloudSandboxClient {
 
         Ok(Self {
             client: sandboxes_client,
+            api_url,
         })
     }
 
     fn close(&self) {
         // reqwest clients are closed when dropped; this is a no-op for API parity.
+    }
+
+    #[pyo3(signature = (sandbox_id, sandbox_url=None, ingress_endpoint=None, explicit_proxy_url=None))]
+    fn select_sandbox_proxy_url(
+        &self,
+        sandbox_id: String,
+        sandbox_url: Option<String>,
+        ingress_endpoint: Option<String>,
+        explicit_proxy_url: Option<String>,
+    ) -> PyResult<String> {
+        select_sandbox_proxy_url(
+            &self.api_url,
+            &sandbox_id,
+            sandbox_url.as_deref(),
+            ingress_endpoint.as_deref(),
+            explicit_proxy_url.as_deref(),
+        )
+        .map_err(into_sandbox_py_error)
     }
 
     fn create_sandbox(&self, request_json: String) -> PyResult<(String, String)> {
@@ -1495,28 +1516,28 @@ impl CloudSandboxClient {
         routing_hint: Option<String>,
         request_timeout_sec: Option<f64>,
     ) -> PyResult<CloudSandboxProxyClient> {
-        let (base_url, host_override, sandbox_id_header) =
-            resolve_proxy_target(&proxy_url, &sandbox_id)?;
+        let target =
+            resolve_sandbox_proxy_target(&proxy_url, &sandbox_id).map_err(into_sandbox_py_error)?;
         let shared_client = if let Some(seconds) = request_timeout_sec {
             self.client
                 .http_client()
                 .with_base_url_and_timeout(
-                    &base_url,
+                    &target.base_url,
                     Some(duration_from_seconds("request_timeout_sec", seconds)?),
                 )
                 .map_err(into_sandbox_py_error)?
         } else {
             self.client
                 .http_client()
-                .with_base_url_without_timeout(&base_url)
+                .with_base_url_without_timeout(&target.base_url)
                 .map_err(into_sandbox_py_error)?
         };
-        let proxy = SandboxProxyClient::new(shared_client, host_override)
-            .with_sandbox_id(sandbox_id_header)
+        let proxy = SandboxProxyClient::new(shared_client, target.host_override)
+            .with_sandbox_id(target.sandbox_id_header)
             .with_routing_hint(routing_hint);
         Ok(CloudSandboxProxyClient {
             client: proxy,
-            base_url,
+            base_url: target.base_url,
         })
     }
 }
@@ -1557,10 +1578,10 @@ impl CloudSandboxProxyClient {
         user_agent: Option<String>,
         request_timeout_sec: Option<f64>,
     ) -> PyResult<Self> {
-        let (base_url, host_override, sandbox_id_header) =
-            resolve_proxy_target(&proxy_url, &sandbox_id)?;
+        let target =
+            resolve_sandbox_proxy_target(&proxy_url, &sandbox_id).map_err(into_sandbox_py_error)?;
 
-        let mut builder = ClientBuilder::new(&base_url);
+        let mut builder = ClientBuilder::new(&target.base_url);
         if let Some(token) = api_key.as_deref() {
             builder = builder.bearer_token(token);
         }
@@ -1579,13 +1600,13 @@ impl CloudSandboxProxyClient {
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;
-        let sandbox_proxy_client = SandboxProxyClient::new(client, host_override)
-            .with_sandbox_id(sandbox_id_header)
+        let sandbox_proxy_client = SandboxProxyClient::new(client, target.host_override)
+            .with_sandbox_id(target.sandbox_id_header)
             .with_routing_hint(routing_hint);
 
         Ok(Self {
             client: sandbox_proxy_client,
-            base_url,
+            base_url: target.base_url,
         })
     }
 
@@ -2337,10 +2358,10 @@ impl CloudSandboxDesktopClient {
         project_id: Option<String>,
         user_agent: Option<String>,
     ) -> PyResult<Self> {
-        let (base_url, host_override, sandbox_id_header) =
-            resolve_proxy_target(&proxy_url, &sandbox_id)?;
+        let target =
+            resolve_sandbox_proxy_target(&proxy_url, &sandbox_id).map_err(into_sandbox_py_error)?;
 
-        let mut builder = ClientBuilder::new(&base_url);
+        let mut builder = ClientBuilder::new(&target.base_url);
         if let Some(token) = api_key.as_deref() {
             builder = builder.bearer_token(token);
         }
@@ -2356,8 +2377,8 @@ impl CloudSandboxDesktopClient {
         }
 
         let client = builder.build().map_err(into_sandbox_py_error)?;
-        let proxy_client =
-            SandboxProxyClient::new(client, host_override).with_sandbox_id(sandbox_id_header);
+        let proxy_client = SandboxProxyClient::new(client, target.host_override)
+            .with_sandbox_id(target.sandbox_id_header);
         let connect_timeout = duration_from_seconds("connect_timeout_sec", connect_timeout_sec)?;
         let desktop_client = shared_runtime()
             .block_on(RustSandboxDesktopClient::connect(
@@ -3017,44 +3038,6 @@ fn parse_archived_sandboxes_params(
         cursor,
         direction,
     })
-}
-
-/// Resolve the proxy base URL and routing headers for a sandbox connection.
-///
-/// Returns `(base_url, host_override, sandbox_id_header)`:
-/// - localhost: `base_url` = proxy URL as-is; `host_override` = `{sandbox_id}.local`; no sandbox_id header
-/// - cloud: `base_url` = the server-selected ingress endpoint; `sandbox_id_header` = sandbox_id for `X-Tensorlake-Sandbox-Id` header
-fn resolve_proxy_target(
-    proxy_url: &str,
-    sandbox_id: &str,
-) -> PyResult<(String, Option<String>, Option<String>)> {
-    let parsed = reqwest::Url::parse(proxy_url).map_err(|error| {
-        CloudSandboxClientError::new_err((
-            "sdk_usage",
-            Option::<u16>::None,
-            format!("invalid proxy url `{proxy_url}`: {error}"),
-        ))
-    })?;
-    let host = parsed.host_str().ok_or_else(|| {
-        CloudSandboxClientError::new_err((
-            "sdk_usage",
-            Option::<u16>::None,
-            format!("proxy url `{proxy_url}` is missing a host"),
-        ))
-    })?;
-
-    if host == "localhost" || host == "127.0.0.1" {
-        return Ok((
-            proxy_url.trim_end_matches('/').to_string(),
-            Some(format!("{sandbox_id}.local")),
-            None,
-        ));
-    }
-
-    // Cloud: use apex domain with X-Tensorlake-Sandbox-Id header for routing.
-    let port = parsed.port().map(|p| format!(":{p}")).unwrap_or_default();
-    let base_url = format!("{}://{host}{port}", parsed.scheme());
-    Ok((base_url, None, Some(sandbox_id.to_string())))
 }
 
 fn is_localhost_api_url(api_url: &str) -> bool {

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -24,6 +24,7 @@ from .client import (
     _RUST_SANDBOX_CLIENT_AVAILABLE,
     RustCloudSandboxClient,
     _build_gpu_resources,
+    _explicit_proxy_url_override,
     _normalize_log_levels,
     _normalize_user_ports,
     _parse_rust_client_error_fields,
@@ -176,6 +177,11 @@ class AsyncSandboxClient:
         return parsed.hostname in ("localhost", "127.0.0.1")
 
     def _resolve_proxy_url(self) -> str:
+        """Resolve the legacy default proxy URL for direct sandbox handles.
+
+        Normal connect/create flows use the server-returned ``sandbox_url``.
+        ``TENSORLAKE_SANDBOX_PROXY_URL`` remains an explicit override.
+        """
         import os
 
         explicit = os.getenv("TENSORLAKE_SANDBOX_PROXY_URL")
@@ -792,6 +798,12 @@ class AsyncSandboxClient:
         routing_hint: str | None = None,
         request_timeout: float | None = None,
     ) -> "AsyncSandbox":
+        """Connect to a running sandbox for process and file operations.
+
+        When ``proxy_url`` is omitted, the client resolves the sandbox and
+        uses the server-returned ``sandbox_url``. ``proxy_url`` and
+        ``TENSORLAKE_SANDBOX_PROXY_URL`` are explicit overrides.
+        """
         from .async_sandbox import AsyncSandbox
 
         sandbox_identifier = _resolve_sandbox_identifier(
@@ -801,9 +813,14 @@ class AsyncSandboxClient:
         proxy_sandbox_id = sandbox_identifier
         if proxy_url is None:
             info = await self.get(sandbox_identifier)
-            proxy_url = info.ingress_endpoint or self._resolve_proxy_url()
             proxy_sandbox_id = info.sandbox_id
             routing_hint = routing_hint or info.routing_hint
+            proxy_url = self._rust_client.select_sandbox_proxy_url(
+                sandbox_id=proxy_sandbox_id,
+                sandbox_url=info.sandbox_url,
+                ingress_endpoint=info.ingress_endpoint,
+                explicit_proxy_url=_explicit_proxy_url_override(),
+            )
         connect_proxy_kwargs = {
             "proxy_url": proxy_url,
             "sandbox_id": proxy_sandbox_id,
@@ -849,6 +866,11 @@ class AsyncSandboxClient:
         name: str | None = None,
         file_systems: list[FileSystemMount] | None = None,
     ) -> "AsyncSandbox":
+        """Create a sandbox, wait for it to start, and return a connection.
+
+        When ``proxy_url`` is omitted, the connected sandbox uses the
+        server-returned ``sandbox_url``.
+        """
         wait_timeout = (
             request_timeout
             if request_timeout is not None
@@ -882,11 +904,19 @@ class AsyncSandboxClient:
             )
 
         if result.status == SandboxStatus.RUNNING:
+            selected_proxy_url = request_client._rust_client.select_sandbox_proxy_url(
+                sandbox_id=result.sandbox_id,
+                sandbox_url=result.sandbox_url,
+                ingress_endpoint=result.ingress_endpoint,
+                explicit_proxy_url=(
+                    proxy_url
+                    if proxy_url is not None
+                    else _explicit_proxy_url_override()
+                ),
+            )
             sandbox = await request_client.connect(
                 result.sandbox_id,
-                proxy_url=proxy_url
-                or result.ingress_endpoint
-                or self._resolve_proxy_url(),
+                proxy_url=selected_proxy_url,
                 routing_hint=result.routing_hint,
             )
             sandbox._sandbox_id = result.sandbox_id
@@ -897,6 +927,7 @@ class AsyncSandboxClient:
                 sandbox_id=result.sandbox_id,
                 status=result.status,
                 ingress_endpoint=result.ingress_endpoint,
+                sandbox_url=result.sandbox_url,
                 name=result.name or requested_name,
             )
             return sandbox
@@ -922,11 +953,19 @@ class AsyncSandboxClient:
         while asyncio.get_running_loop().time() < deadline:
             info = await request_client.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
+                selected_proxy_url = request_client._rust_client.select_sandbox_proxy_url(
+                    sandbox_id=info.sandbox_id,
+                    sandbox_url=info.sandbox_url,
+                    ingress_endpoint=info.ingress_endpoint,
+                    explicit_proxy_url=(
+                        proxy_url
+                        if proxy_url is not None
+                        else _explicit_proxy_url_override()
+                    ),
+                )
                 sandbox = await request_client.connect(
-                    result.sandbox_id,
-                    proxy_url=proxy_url
-                    or info.ingress_endpoint
-                    or self._resolve_proxy_url(),
+                    info.sandbox_id,
+                    proxy_url=selected_proxy_url,
                     routing_hint=info.routing_hint,
                 )
                 sandbox._sandbox_id = info.sandbox_id

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -953,15 +953,17 @@ class AsyncSandboxClient:
         while asyncio.get_running_loop().time() < deadline:
             info = await request_client.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
-                selected_proxy_url = request_client._rust_client.select_sandbox_proxy_url(
-                    sandbox_id=info.sandbox_id,
-                    sandbox_url=info.sandbox_url,
-                    ingress_endpoint=info.ingress_endpoint,
-                    explicit_proxy_url=(
-                        proxy_url
-                        if proxy_url is not None
-                        else _explicit_proxy_url_override()
-                    ),
+                selected_proxy_url = (
+                    request_client._rust_client.select_sandbox_proxy_url(
+                        sandbox_id=info.sandbox_id,
+                        sandbox_url=info.sandbox_url,
+                        ingress_endpoint=info.ingress_endpoint,
+                        explicit_proxy_url=(
+                            proxy_url
+                            if proxy_url is not None
+                            else _explicit_proxy_url_override()
+                        ),
+                    )
                 )
                 sandbox = await request_client.connect(
                     info.sandbox_id,

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -66,12 +66,16 @@ class AsyncSandbox:
     Use :class:`AsyncSandboxClient` to create or connect, then call methods
     on the returned :class:`AsyncSandbox` to drive the sandbox without
     blocking the event loop.
+
+    Direct construction requires ``proxy_url``. Prefer
+    :meth:`AsyncSandbox.connect` or :class:`AsyncSandboxClient` so the
+    server-returned sandbox URL is used.
     """
 
     def __init__(
         self,
         identifier: str | None = None,
-        proxy_url: str = _defaults.SANDBOX_PROXY_URL,
+        proxy_url: str | None = None,
         api_key: str | None = _defaults.API_KEY,
         organization_id: str | None = None,
         project_id: str | None = None,
@@ -90,6 +94,14 @@ class AsyncSandbox:
             raise SandboxError(
                 "`identifier` is required. `sandbox_id` is accepted as a deprecated alias."
             )
+        if proxy_url is None:
+            if _proxy_rust_client is None:
+                raise SandboxError(
+                    "`proxy_url` is required for direct AsyncSandbox construction; "
+                    "use AsyncSandbox.connect(...) or AsyncSandboxClient.connect(...) to "
+                    "use the server-returned sandbox_url."
+                )
+            proxy_url = _proxy_rust_client.base_url()
 
         self._identifier = sandbox_identifier
         self._sandbox_id: str | None = None

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1550,15 +1550,17 @@ class SandboxClient:
         while time.time() < deadline:
             info = request_client.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
-                selected_proxy_url = request_client._rust_client.select_sandbox_proxy_url(
-                    sandbox_id=info.sandbox_id,
-                    sandbox_url=info.sandbox_url,
-                    ingress_endpoint=info.ingress_endpoint,
-                    explicit_proxy_url=(
-                        proxy_url
-                        if proxy_url is not None
-                        else _explicit_proxy_url_override()
-                    ),
+                selected_proxy_url = (
+                    request_client._rust_client.select_sandbox_proxy_url(
+                        sandbox_id=info.sandbox_id,
+                        sandbox_url=info.sandbox_url,
+                        ingress_endpoint=info.ingress_endpoint,
+                        explicit_proxy_url=(
+                            proxy_url
+                            if proxy_url is not None
+                            else _explicit_proxy_url_override()
+                        ),
+                    )
                 )
                 sandbox = request_client.connect(
                     info.sandbox_id,

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -128,6 +128,14 @@ def _resolve_sandbox_identifier(
     return resolved
 
 
+def _explicit_proxy_url_override() -> str | None:
+    explicit = os.getenv("TENSORLAKE_SANDBOX_PROXY_URL")
+    if explicit is None:
+        return None
+    explicit = explicit.strip()
+    return explicit or None
+
+
 def _raise_as_sandbox_error(e: Exception) -> NoReturn:
     if isinstance(e, SandboxError):
         raise
@@ -359,11 +367,10 @@ class SandboxClient:
         return parsed.hostname in ("localhost", "127.0.0.1")
 
     def _resolve_proxy_url(self) -> str:
-        """Derive the sandbox proxy URL from the API URL.
+        """Resolve the legacy default proxy URL for direct sandbox handles.
 
-        Checks the ``TENSORLAKE_SANDBOX_PROXY_URL`` env var first, then
-        infers the proxy domain from the API URL so that
-        ``api.tensorlake.dev`` → ``sandbox.tensorlake.dev``, etc.
+        Normal connect/create flows use the server-returned ``sandbox_url``.
+        ``TENSORLAKE_SANDBOX_PROXY_URL`` remains an explicit override.
         """
         import os
 
@@ -1333,9 +1340,10 @@ class SandboxClient:
 
         Args:
             identifier: Sandbox ID or name to connect to.
-            proxy_url: Override the sandbox proxy URL. Auto-detected based on
-                api_url when not provided. Can also be set via the
-                TENSORLAKE_SANDBOX_PROXY_URL environment variable.
+            proxy_url: Explicit sandbox proxy URL override. When omitted,
+                the client resolves the sandbox and uses the server-returned
+                ``sandbox_url``. Can also be set via the
+                ``TENSORLAKE_SANDBOX_PROXY_URL`` environment variable.
             sandbox_id: Deprecated alias for ``identifier``.
 
         Returns:
@@ -1353,9 +1361,14 @@ class SandboxClient:
         proxy_sandbox_id = sandbox_identifier
         if proxy_url is None:
             info = self.get(sandbox_identifier)
-            proxy_url = info.ingress_endpoint or self._resolve_proxy_url()
             proxy_sandbox_id = info.sandbox_id
             routing_hint = routing_hint or info.routing_hint
+            proxy_url = self._rust_client.select_sandbox_proxy_url(
+                sandbox_id=proxy_sandbox_id,
+                sandbox_url=info.sandbox_url,
+                ingress_endpoint=info.ingress_endpoint,
+                explicit_proxy_url=_explicit_proxy_url_override(),
+            )
 
         connect_proxy_kwargs = {
             "proxy_url": proxy_url,
@@ -1432,7 +1445,8 @@ class SandboxClient:
                 (e.g. ``["192.168.1.0/24"]``).
             pool_id: Pool ID to use for warm containers (optional)
             snapshot_id: ID of a completed snapshot to restore from
-            proxy_url: Override the sandbox proxy URL
+            proxy_url: Explicit sandbox proxy URL override. When omitted,
+                the connected sandbox uses the server-returned ``sandbox_url``.
             request_timeout: Max seconds to wait for Running status.
                 Defaults to the client request timeout.
             startup_timeout: Deprecated alias for ``request_timeout``.
@@ -1487,11 +1501,19 @@ class SandboxClient:
         # and a short-lived routing hint. Use it immediately to skip an extra poll RTT
         # and let the proxy route the first request without a placement lookup.
         if result.status == SandboxStatus.RUNNING:
+            selected_proxy_url = request_client._rust_client.select_sandbox_proxy_url(
+                sandbox_id=result.sandbox_id,
+                sandbox_url=result.sandbox_url,
+                ingress_endpoint=result.ingress_endpoint,
+                explicit_proxy_url=(
+                    proxy_url
+                    if proxy_url is not None
+                    else _explicit_proxy_url_override()
+                ),
+            )
             sandbox = request_client.connect(
                 result.sandbox_id,
-                proxy_url=proxy_url
-                or result.ingress_endpoint
-                or self._resolve_proxy_url(),
+                proxy_url=selected_proxy_url,
                 routing_hint=result.routing_hint,
             )
             sandbox._sandbox_id = result.sandbox_id
@@ -1502,6 +1524,7 @@ class SandboxClient:
                 sandbox_id=result.sandbox_id,
                 status=result.status,
                 ingress_endpoint=result.ingress_endpoint,
+                sandbox_url=result.sandbox_url,
                 name=result.name or requested_name,
             )
             return sandbox
@@ -1527,11 +1550,19 @@ class SandboxClient:
         while time.time() < deadline:
             info = request_client.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
+                selected_proxy_url = request_client._rust_client.select_sandbox_proxy_url(
+                    sandbox_id=info.sandbox_id,
+                    sandbox_url=info.sandbox_url,
+                    ingress_endpoint=info.ingress_endpoint,
+                    explicit_proxy_url=(
+                        proxy_url
+                        if proxy_url is not None
+                        else _explicit_proxy_url_override()
+                    ),
+                )
                 sandbox = request_client.connect(
-                    result.sandbox_id,
-                    proxy_url=proxy_url
-                    or info.ingress_endpoint
-                    or self._resolve_proxy_url(),
+                    info.sandbox_id,
+                    proxy_url=selected_proxy_url,
                     routing_hint=info.routing_hint,
                 )
                 sandbox._sandbox_id = info.sandbox_id

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -285,6 +285,7 @@ class CreateSandboxResponse(BaseModel):
     reason: str | None = None
     routing_hint: str | None = None
     ingress_endpoint: str | None = None
+    sandbox_url: str | None = None
     name: str | None = None
     termination_reason: str | None = None
     error_details: Any | None = None
@@ -302,6 +303,7 @@ class CopiedSandboxResponse(BaseModel):
     reason: str | None = None
     routing_hint: str | None = None
     ingress_endpoint: str | None = None
+    sandbox_url: str | None = None
     name: str | None = None
     termination_reason: str | None = None
     error_details: Any | None = None
@@ -344,14 +346,14 @@ class SandboxInfo(BaseModel):
     def url_for_port(self, port: int = _SANDBOX_MANAGEMENT_PORT) -> str | None:
         """Return the public URL for the management API or an exposed user port."""
 
+        if port == _SANDBOX_MANAGEMENT_PORT:
+            return self.sandbox_url
         if self.ingress_endpoint is not None:
             return sandbox_url_from_ingress_endpoint(
                 self.ingress_endpoint,
                 self.sandbox_id,
                 port,
             )
-        if port == _SANDBOX_MANAGEMENT_PORT:
-            return self.sandbox_url
         return None
 
 

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -166,6 +166,9 @@ class Sandbox:
     Provides process management, file operations, and I/O streaming
     through the sandbox proxy.
 
+    Direct construction requires ``proxy_url``. Prefer ``Sandbox.connect()``
+    or ``SandboxClient.connect()`` so the server-returned sandbox URL is used.
+
     Can be used as a context manager. If created via
     ``SandboxClient.create_and_connect()``, exiting the context manager
     automatically terminates the sandbox. Otherwise, it only closes the
@@ -175,7 +178,7 @@ class Sandbox:
     def __init__(
         self,
         identifier: str | None = None,
-        proxy_url: str = _defaults.SANDBOX_PROXY_URL,
+        proxy_url: str | None = None,
         api_key: str | None = _defaults.API_KEY,
         organization_id: str | None = None,
         project_id: str | None = None,
@@ -194,6 +197,14 @@ class Sandbox:
             raise SandboxError(
                 "`identifier` is required. `sandbox_id` is accepted as a deprecated alias."
             )
+        if proxy_url is None:
+            if _proxy_rust_client is None:
+                raise SandboxError(
+                    "`proxy_url` is required for direct Sandbox construction; "
+                    "use Sandbox.connect(...) or SandboxClient.connect(...) to use "
+                    "the server-returned sandbox_url."
+                )
+            proxy_url = _proxy_rust_client.base_url()
 
         self._identifier = sandbox_identifier
         self._sandbox_id: str | None = None

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -52,6 +52,22 @@ class _FakeRustClient:
         )
         return _FakeRustProxyClient(proxy_url)
 
+    def select_sandbox_proxy_url(
+        self,
+        *,
+        sandbox_id,
+        sandbox_url=None,
+        ingress_endpoint=None,
+        explicit_proxy_url=None,
+    ):
+        if sandbox_url:
+            return sandbox_url
+        if explicit_proxy_url:
+            return explicit_proxy_url
+        raise RuntimeError(
+            "server response did not include sandbox_url; refusing to derive a proxy URL"
+        )
+
     def create_snapshot(self, sandbox_id, snapshot_type=None):
         self.create_snapshot_calls.append((sandbox_id, snapshot_type))
         return (
@@ -471,7 +487,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         with self.assertRaisesRegex(SandboxError, "Provide only one of"):
             client.connect("stable-name", sandbox_id="sbx-123")
 
-    def test_connect_resolves_ingress_endpoint_when_proxy_url_omitted(self):
+    def test_connect_prefers_server_sandbox_url_when_proxy_url_omitted(self):
         client = SandboxClient(api_url="https://api.tensorlake.ai", api_key="k")
         fake = _FakeRustClient()
         client._rust_client = fake
@@ -483,13 +499,56 @@ class TestSandboxClientRustBackend(unittest.TestCase):
             fake.connect_proxy_calls,
             [
                 {
-                    "proxy_url": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                    "proxy_url": "https://sbx-1.sandbox.tensorlake.ai",
                     "sandbox_id": "sbx-1",
                     "routing_hint": None,
                 }
             ],
         )
         self.assertEqual(sandbox.sandbox_id, "sbx-1")
+
+    def test_connect_uses_env_proxy_override_when_server_url_missing(self):
+        class _NoSandboxUrlRustClient(_FakeRustClient):
+            def get_sandbox_json(self, sandbox_id):
+                self.last_get_sandbox_id = sandbox_id
+                return (
+                    "trace-get-sandbox",
+                    json.dumps(
+                        {
+                            "id": "sbx-1",
+                            "namespace": "default",
+                            "status": "running",
+                            "resources": {
+                                "cpus": 1.0,
+                                "memory_mb": 512,
+                                "ephemeral_disk_mb": 1024,
+                            },
+                        }
+                    ),
+                )
+
+        client = SandboxClient(api_url="https://api.tensorlake.ai", api_key="k")
+        fake = _NoSandboxUrlRustClient()
+        client._rust_client = fake
+
+        with patch.dict(
+            "os.environ",
+            {"TENSORLAKE_SANDBOX_PROXY_URL": "https://override.example.com"},
+        ):
+            sandbox = client.connect("stable-name")
+
+        self.assertEqual(fake.last_get_sandbox_id, "stable-name")
+        self.assertEqual(sandbox.sandbox_id, "sbx-1")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://override.example.com",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": None,
+                }
+            ],
+        )
 
     def test_create_uses_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
@@ -596,7 +655,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         ):
             client.create_and_connect(image="tensorlake/missing-image")
 
-    def test_create_and_connect_uses_ingress_endpoint_from_running_response(self):
+    def test_create_and_connect_uses_sandbox_url_from_running_response(self):
         class _RunningRustClient(_FakeRustClient):
             def create_sandbox(self, request_json):
                 self.create_request_json = request_json
@@ -608,6 +667,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                             "status": "running",
                             "routing_hint": "hint-1",
                             "ingress_endpoint": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                            "sandbox_url": "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
                         }
                     ),
                 )
@@ -623,9 +683,93 @@ class TestSandboxClientRustBackend(unittest.TestCase):
             fake.connect_proxy_calls,
             [
                 {
-                    "proxy_url": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                    "proxy_url": "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
                     "sandbox_id": "sbx-1",
                     "routing_hint": "hint-1",
+                }
+            ],
+        )
+
+    def test_create_and_connect_uses_env_proxy_override_when_server_url_missing(self):
+        class _RunningRustClient(_FakeRustClient):
+            def create_sandbox(self, request_json):
+                self.create_request_json = request_json
+                return (
+                    "trace-create-sandbox",
+                    json.dumps(
+                        {
+                            "sandbox_id": "sbx-1",
+                            "status": "running",
+                        }
+                    ),
+                )
+
+        client = SandboxClient(api_url="https://api.tensorlake.ai", api_key="k")
+        fake = _RunningRustClient()
+        client._rust_client = fake
+
+        with patch.dict(
+            "os.environ",
+            {"TENSORLAKE_SANDBOX_PROXY_URL": "https://override.example.com"},
+        ):
+            sandbox = client.create_and_connect(image="python:3.11")
+
+        self.assertEqual(sandbox.sandbox_id, "sbx-1")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://override.example.com",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": None,
+                }
+            ],
+        )
+
+    def test_create_and_connect_uses_canonical_id_from_polled_running_response(self):
+        class _PollCanonicalRustClient(_FakeRustClient):
+            def create_sandbox(self, request_json):
+                self.create_request_json = request_json
+                return (
+                    "trace-create-sandbox",
+                    json.dumps({"sandbox_id": "sbx-original", "status": "pending"}),
+                )
+
+            def get_sandbox_json(self, sandbox_id):
+                self.last_get_sandbox_id = sandbox_id
+                return (
+                    "trace-get-sandbox",
+                    json.dumps(
+                        {
+                            "id": "sbx-canonical",
+                            "namespace": "default",
+                            "status": "running",
+                            "resources": {
+                                "cpus": 1.0,
+                                "memory_mb": 512,
+                                "ephemeral_disk_mb": 1024,
+                            },
+                            "routing_hint": "hint-2",
+                            "sandbox_url": "https://sbx-canonical.sandbox.tensorlake.ai",
+                        }
+                    ),
+                )
+
+        client = SandboxClient(api_url="https://api.tensorlake.ai", api_key="k")
+        fake = _PollCanonicalRustClient()
+        client._rust_client = fake
+
+        sandbox = client.create_and_connect(image="python:3.11", request_timeout=1)
+
+        self.assertEqual(fake.last_get_sandbox_id, "sbx-original")
+        self.assertEqual(sandbox.sandbox_id, "sbx-canonical")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://sbx-canonical.sandbox.tensorlake.ai",
+                    "sandbox_id": "sbx-canonical",
+                    "routing_hint": "hint-2",
                 }
             ],
         )

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -198,7 +198,24 @@ class _RecordingCreateRustClient:
         self.create_calls += 1
         return (
             "trace-create-sandbox",
-            '{"sandbox_id":"sbx-1","status":"running"}',
+            '{"sandbox_id":"sbx-1","status":"running",'
+            '"sandbox_url":"https://sbx-1.sandbox.tensorlake.ai"}',
+        )
+
+    def select_sandbox_proxy_url(
+        self,
+        *,
+        sandbox_id,
+        sandbox_url=None,
+        ingress_endpoint=None,
+        explicit_proxy_url=None,
+    ):
+        if sandbox_url:
+            return sandbox_url
+        if explicit_proxy_url:
+            return explicit_proxy_url
+        raise RuntimeError(
+            "server response did not include sandbox_url; refusing to derive a proxy URL"
         )
 
     def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):
@@ -755,7 +772,12 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                     ),
                 )
 
-        client = SandboxClient(api_url="https://api.tensorlake.ai", api_key="k")
+        client = SandboxClient(
+            api_url="https://api.tensorlake.ai",
+            api_key="k",
+            request_timeout=1,
+            _internal=True,
+        )
         fake = _PollCanonicalRustClient()
         client._rust_client = fake
 

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -203,7 +203,24 @@ class _RecordingCreateRustClient:
         self.create_calls += 1
         return (
             "trace-create-sandbox",
-            '{"sandbox_id":"sbx-1","status":"running"}',
+            '{"sandbox_id":"sbx-1","status":"running",'
+            '"sandbox_url":"https://sbx-1.sandbox.tensorlake.ai"}',
+        )
+
+    def select_sandbox_proxy_url(
+        self,
+        *,
+        sandbox_id,
+        sandbox_url=None,
+        ingress_endpoint=None,
+        explicit_proxy_url=None,
+    ):
+        if sandbox_url:
+            return sandbox_url
+        if explicit_proxy_url:
+            return explicit_proxy_url
+        raise RuntimeError(
+            "server response did not include sandbox_url; refusing to derive a proxy URL"
         )
 
     def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -46,6 +46,22 @@ class _FakeAsyncRustClient:
         )
         return _FakeAsyncRustProxyClient(proxy_url)
 
+    def select_sandbox_proxy_url(
+        self,
+        *,
+        sandbox_id,
+        sandbox_url=None,
+        ingress_endpoint=None,
+        explicit_proxy_url=None,
+    ):
+        if sandbox_url:
+            return sandbox_url
+        if explicit_proxy_url:
+            return explicit_proxy_url
+        raise RuntimeError(
+            "server response did not include sandbox_url; refusing to derive a proxy URL"
+        )
+
     async def suspend_sandbox_async(self, *, sandbox_id):
         self.suspend_calls.append(sandbox_id)
         return "trace-suspend"
@@ -210,20 +226,22 @@ class _StatusSequenceRustClient(_FakeAsyncRustClient):
     """Returns each status from `statuses` on successive get calls; the last
     status repeats once exhausted."""
 
-    def __init__(self, statuses: list[str]):
+    def __init__(self, statuses: list[str], returned_sandbox_id: str | None = None):
         super().__init__()
         self._statuses = statuses
+        self._returned_sandbox_id = returned_sandbox_id
         self.get_calls = 0
 
     async def get_sandbox_json_async(self, *, sandbox_id) -> tuple[str, str]:
         self.last_get_sandbox_id = sandbox_id
         idx = min(self.get_calls, len(self._statuses) - 1)
         self.get_calls += 1
+        returned_sandbox_id = self._returned_sandbox_id or sandbox_id
         return (
             "trace-get-sandbox",
             json.dumps(
                 {
-                    "id": sandbox_id,
+                    "id": returned_sandbox_id,
                     "namespace": "default",
                     "status": self._statuses[idx],
                     "resources": {
@@ -231,6 +249,8 @@ class _StatusSequenceRustClient(_FakeAsyncRustClient):
                         "memory_mb": 512,
                         "ephemeral_disk_mb": 1024,
                     },
+                    "routing_hint": "hint-2",
+                    "sandbox_url": f"https://{returned_sandbox_id}.sandbox.tensorlake.ai",
                 }
             ),
         )
@@ -523,7 +543,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(SandboxError, "Provide only one of"):
             await client.connect("stable-name", sandbox_id="sbx-123")
 
-    async def test_connect_resolves_ingress_endpoint_when_proxy_url_omitted(self):
+    async def test_connect_prefers_server_sandbox_url_when_proxy_url_omitted(self):
         fake = _FakeAsyncRustClient()
         client = _make_client(fake)
 
@@ -534,13 +554,55 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
             fake.connect_proxy_calls,
             [
                 {
-                    "proxy_url": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                    "proxy_url": "https://sbx-1.sandbox.tensorlake.ai",
                     "sandbox_id": "sbx-1",
                     "routing_hint": None,
                 }
             ],
         )
         self.assertEqual(sandbox.sandbox_id, "sbx-1")
+
+    async def test_connect_uses_env_proxy_override_when_server_url_missing(self):
+        class _NoSandboxUrlRustClient(_FakeAsyncRustClient):
+            async def get_sandbox_json_async(self, *, sandbox_id):
+                self.last_get_sandbox_id = sandbox_id
+                return (
+                    "trace-get-sandbox",
+                    json.dumps(
+                        {
+                            "id": "sbx-1",
+                            "namespace": "default",
+                            "status": "running",
+                            "resources": {
+                                "cpus": 1.0,
+                                "memory_mb": 512,
+                                "ephemeral_disk_mb": 1024,
+                            },
+                        }
+                    ),
+                )
+
+        fake = _NoSandboxUrlRustClient()
+        client = _make_client(fake)
+
+        with patch.dict(
+            "os.environ",
+            {"TENSORLAKE_SANDBOX_PROXY_URL": "https://override.example.com"},
+        ):
+            sandbox = await client.connect("stable-name")
+
+        self.assertEqual(fake.last_get_sandbox_id, "stable-name")
+        self.assertEqual(sandbox.sandbox_id, "sbx-1")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://override.example.com",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": None,
+                }
+            ],
+        )
 
     async def test_create_uses_rust_backend(self):
         fake = _FakeAsyncRustClient()
@@ -598,7 +660,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         ):
             await client.create_and_connect(image="tensorlake/missing-image")
 
-    async def test_create_and_connect_uses_ingress_endpoint_from_running_response(self):
+    async def test_create_and_connect_uses_sandbox_url_from_running_response(self):
         class _RunningRustClient(_FakeAsyncRustClient):
             async def create_sandbox_async(self, *, request_json):
                 self.create_request_json = request_json
@@ -610,6 +672,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
                             "status": "running",
                             "routing_hint": "hint-1",
                             "ingress_endpoint": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                            "sandbox_url": "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
                         }
                     ),
                 )
@@ -624,9 +687,46 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
             fake.connect_proxy_calls,
             [
                 {
-                    "proxy_url": "https://sandbox.us-east-1.aws.tensorlake.ai",
+                    "proxy_url": "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
                     "sandbox_id": "sbx-1",
                     "routing_hint": "hint-1",
+                }
+            ],
+        )
+
+    async def test_create_and_connect_uses_env_proxy_override_when_server_url_missing(
+        self,
+    ):
+        class _RunningRustClient(_FakeAsyncRustClient):
+            async def create_sandbox_async(self, *, request_json):
+                self.create_request_json = request_json
+                return (
+                    "trace-create-sandbox",
+                    json.dumps(
+                        {
+                            "sandbox_id": "sbx-1",
+                            "status": "running",
+                        }
+                    ),
+                )
+
+        fake = _RunningRustClient()
+        client = _make_client(fake)
+
+        with patch.dict(
+            "os.environ",
+            {"TENSORLAKE_SANDBOX_PROXY_URL": "https://override.example.com"},
+        ):
+            sandbox = await client.create_and_connect(image="python:3.11")
+
+        self.assertEqual(sandbox.sandbox_id, "sbx-1")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://override.example.com",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": None,
                 }
             ],
         )
@@ -645,6 +745,29 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(sandbox.sandbox_id, "sbx-1")
             self.assertGreaterEqual(fake.get_calls, 2)
             self.assertEqual(len(fake.connect_proxy_calls), 1)
+
+    async def test_create_and_connect_uses_canonical_id_from_polled_running_response(
+        self,
+    ):
+        fake = _StatusSequenceRustClient(
+            ["running"], returned_sandbox_id="sbx-canonical"
+        )
+        client = _make_client(fake)
+
+        sandbox = await client.create_and_connect(image="python:3.11")
+
+        self.assertEqual(fake.last_get_sandbox_id, "sbx-1")
+        self.assertEqual(sandbox.sandbox_id, "sbx-canonical")
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://sbx-canonical.sandbox.tensorlake.ai",
+                    "sandbox_id": "sbx-canonical",
+                    "routing_hint": "hint-2",
+                }
+            ],
+        )
 
     async def test_list_uses_rust_backend(self):
         client = _make_client()

--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -159,6 +159,10 @@ def _sandbox_info(status=SandboxStatus.RUNNING, **overrides) -> SandboxInfo:
 
 
 class TestSandboxRustBackend(unittest.TestCase):
+    def test_direct_sandbox_requires_proxy_url(self):
+        with self.assertRaisesRegex(SandboxError, "`proxy_url` is required"):
+            Sandbox(sandbox_id="sbx-1", api_key="k")
+
     def test_sandbox_accepts_sandbox_name(self):
         sandbox, _ = _make_sandbox()
         # Rename so the identifier is set from `identifier=` kwarg.

--- a/tests/sandbox/test_sandbox_rust_backend_async.py
+++ b/tests/sandbox/test_sandbox_rust_backend_async.py
@@ -189,6 +189,10 @@ def _sandbox_info(status=SandboxStatus.RUNNING, **overrides) -> SandboxInfo:
 
 
 class TestAsyncSandboxRustBackend(unittest.IsolatedAsyncioTestCase):
+    def test_direct_async_sandbox_requires_proxy_url(self):
+        with self.assertRaisesRegex(SandboxError, "`proxy_url` is required"):
+            AsyncSandbox(sandbox_id="sbx-1", api_key="k")
+
     def test_async_sandbox_accepts_sandbox_name(self):
         sandbox = AsyncSandbox(
             identifier="stable-name",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -39,7 +39,7 @@ import {
 } from "./models.js";
 import { Sandbox } from "./sandbox.js";
 import { nowMs, logSdkTimingEvent, logSdkTiming } from "./sdk-timings.js";
-import { resolveProxyUrl } from "./url.js";
+import { explicitProxyUrlOverride } from "./url.js";
 
 function gpuRequest(
   gpus: number | undefined,
@@ -673,10 +673,9 @@ export class SandboxClient {
     routingHint?: string,
     requestTimeout?: number,
   ): Sandbox {
-    const resolvedProxy = proxyUrl ?? resolveProxyUrl(this.apiUrl);
     return new Sandbox({
       sandboxId: identifier,
-      proxyUrl: resolvedProxy,
+      proxyUrl,
       apiKey: this.apiKey,
       organizationId: this.organizationId,
       projectId: this.projectId,
@@ -724,26 +723,35 @@ export class SandboxClient {
     const requestedName = options?.poolId != null ? null : options?.name ?? null;
 
     const finishConnect = (
+      sandboxId: string,
       routingHint: string | undefined,
       name: string | null | undefined,
       ingressEndpoint: string | undefined,
+      sandboxUrl: string | undefined,
     ) => {
+      const selectedProxyUrl = this.native.selectSandboxProxyUrl(
+        sandboxId,
+        sandboxUrl ?? null,
+        ingressEndpoint ?? null,
+        options?.proxyUrl ?? explicitProxyUrlOverride() ?? null,
+      );
       const sandbox = requestClient.connect(
-        result.sandboxId,
-        options?.proxyUrl ?? ingressEndpoint,
+        sandboxId,
+        selectedProxyUrl,
         routingHint,
         requestTimeout,
       );
       sandbox._setOwner(requestClient);
       sandbox.traceId = result.traceId;
-      sandbox._setLifecycleIdentifier(result.sandboxId);
+      sandbox._setLifecycleIdentifier(sandboxId);
       sandbox._setName(name ?? requestedName);
       logSdkTiming("sandbox.create", "complete", opStart, {
-        sandbox_id: result.sandboxId,
+        sandbox_id: sandboxId,
         status: SandboxStatus.RUNNING,
         server_trace_id: result.traceId,
         routing_hint: routingHint,
         ingress_endpoint: ingressEndpoint,
+        sandbox_url: sandboxUrl,
       });
       return sandbox;
     };
@@ -752,7 +760,13 @@ export class SandboxClient {
     // and a short-lived routing hint. Use it immediately to skip an extra poll RTT
     // and let the proxy route the first request without a placement lookup.
     if (result.status === SandboxStatus.RUNNING) {
-      return finishConnect(result.routingHint, result.name, result.ingressEndpoint);
+      return finishConnect(
+        result.sandboxId,
+        result.routingHint,
+        result.name,
+        result.ingressEndpoint,
+        result.sandboxUrl,
+      );
     }
     if (
       result.status === SandboxStatus.SUSPENDED ||
@@ -787,7 +801,13 @@ export class SandboxClient {
         server_trace_id: info.traceId,
       });
       if (info.status === SandboxStatus.RUNNING) {
-        return finishConnect(info.routingHint, info.name, info.ingressEndpoint);
+        return finishConnect(
+          info.sandboxId,
+          info.routingHint,
+          info.name,
+          info.ingressEndpoint,
+          info.sandboxUrl,
+        );
       }
       if (
         info.status === SandboxStatus.SUSPENDED ||

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -134,6 +134,7 @@ export interface CreateSandboxResponse {
   reason?: string;
   routingHint?: string;
   ingressEndpoint?: string;
+  sandboxUrl?: string;
   name?: string | null;
   terminationReason?: string;
   errorDetails?: unknown;
@@ -153,6 +154,7 @@ export interface CopiedSandboxResponse {
   reason?: string;
   routingHint?: string;
   ingressEndpoint?: string;
+  sandboxUrl?: string;
   name?: string | null;
   terminationReason?: string;
   errorDetails?: unknown;
@@ -563,6 +565,11 @@ export interface SandboxClientOptions {
 
 export interface SandboxOptions {
   sandboxId: string;
+  /**
+   * Explicit sandbox proxy base URL. Direct `new Sandbox(...)` construction
+   * requires this; `Sandbox.connect()` and `SandboxClient.connect()` normally
+   * resolve the server-returned `sandboxUrl`.
+   */
   proxyUrl?: string;
   apiKey?: string;
   organizationId?: string;

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -123,6 +123,12 @@ export interface NativeSandboxClient {
     routingHint?: string | null,
     requestTimeoutSec?: number | null,
   ): NativeSandboxProxyClient;
+  selectSandboxProxyUrl(
+    sandboxId: string,
+    sandboxUrl?: string | null,
+    ingressEndpoint?: string | null,
+    explicitProxyUrl?: string | null,
+  ): string;
 }
 
 interface NativeSandboxClientCtor {

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -3,7 +3,6 @@ import {
   type ConnectDesktopOptions,
   Desktop,
 } from "./desktop.js";
-import * as defaults from "./defaults.js";
 import { SandboxError } from "./errors.js";
 import { type Traced } from "./http.js";
 import {
@@ -54,14 +53,14 @@ import {
   TcpTunnel,
 } from "./tunnel.js";
 import { nowMs, logSdkTimingEvent, sdkTimingPayloadsEnabled, logSdkTiming } from "./sdk-timings.js";
-import { resolveProxyTarget } from "./url.js";
+import { explicitProxyUrlOverride, resolveProxyTarget } from "./url.js";
 import WebSocket, { type RawData } from "ws";
 
 class SandboxProxyConnection {
   baseUrl = "";
   wsHeaders: Record<string, string> = {};
 
-  private nativeProxy: NativeSandboxProxyClient;
+  private nativeProxy: NativeSandboxProxyClient | null = null;
   private resolveProxyInfo?: (
     identifier: string,
   ) => Promise<Traced<SandboxInfo>>;
@@ -73,12 +72,18 @@ class SandboxProxyConnection {
     private readonly options: SandboxOptions,
   ) {
     this.routingHint = options.routingHint;
-    this.nativeProxy = this.configureProxy(
-      options.proxyUrl ?? defaults.SANDBOX_PROXY_URL,
-      options.sandboxId,
-      options.routingHint,
-    );
     this.resolveProxyInfo = options.resolveProxyInfo;
+    if (options.proxyUrl != null) {
+      this.nativeProxy = this.configureProxy(
+        options.proxyUrl,
+        options.sandboxId,
+        options.routingHint,
+      );
+    } else if (this.resolveProxyInfo == null) {
+      throw new SandboxError(
+        "proxyUrl is required for direct Sandbox construction; use Sandbox.connect(...) or SandboxClient.connect(...) to use the server-returned sandbox_url.",
+      );
+    }
   }
 
   async ensureResolved(): Promise<void> {
@@ -102,8 +107,19 @@ class SandboxProxyConnection {
         this.sandbox._setLifecycleIdentifier(info.sandboxId);
         this.sandbox._setName(info.name ?? null);
         this.routingHint = this.routingHint ?? info.routingHint;
-        const proxyUrl =
-          info.ingressEndpoint ?? this.options.proxyUrl ?? defaults.SANDBOX_PROXY_URL;
+        const proxyUrl = this.options.nativeClient?.selectSandboxProxyUrl(
+          info.sandboxId,
+          info.sandboxUrl ?? null,
+          info.ingressEndpoint ?? null,
+          this.options.proxyUrl ?? explicitProxyUrlOverride() ?? null,
+        ) ?? info.sandboxUrl
+          ?? this.options.proxyUrl
+          ?? explicitProxyUrlOverride();
+        if (proxyUrl == null) {
+          throw new SandboxError(
+            "server response did not include sandbox_url; refusing to derive a proxy URL",
+          );
+        }
         this.nativeProxy = this.configureProxy(
           proxyUrl,
           info.sandboxId,
@@ -114,6 +130,7 @@ class SandboxProxyConnection {
           server_trace_id: info.traceId,
           routing_hint: this.routingHint,
           ingress_endpoint: info.ingressEndpoint,
+          sandbox_url: info.sandboxUrl,
         });
       })
       .finally(() => {
@@ -126,6 +143,11 @@ class SandboxProxyConnection {
   /** Await proxy resolution and return the Rust-backed proxy client. */
   async client(): Promise<NativeSandboxProxyClient> {
     await this.ensureResolved();
+    if (this.nativeProxy == null) {
+      throw new SandboxError(
+        "server response did not include sandbox_url; refusing to derive a proxy URL",
+      );
+    }
     return this.nativeProxy;
   }
 

--- a/typescript/src/url.ts
+++ b/typescript/src/url.ts
@@ -15,17 +15,27 @@ export function isLocalhost(apiUrl: string): boolean {
   }
 }
 
+/** Return the explicit sandbox proxy env override, if the user set one. */
+export function explicitProxyUrlOverride(): string | undefined {
+  const explicit = process.env.TENSORLAKE_SANDBOX_PROXY_URL?.trim();
+  return explicit && explicit.length > 0 ? explicit : undefined;
+}
+
 /**
- * Derive the sandbox proxy URL from the API URL.
+ * Resolve the legacy default proxy URL for direct sandbox handles.
  *
- * Priority:
+ * Normal client connect/create flows use the server-returned `sandboxUrl`.
+ * This helper keeps the old direct-handle behavior and treats the env var as
+ * an explicit override.
+ *
+ * Legacy priority:
  * 1. TENSORLAKE_SANDBOX_PROXY_URL env var
  * 2. `http://localhost:9443` for localhost API URLs
  * 3. Transform `api.X` → `sandbox.X`
  * 4. Default fallback
  */
 export function resolveProxyUrl(apiUrl: string): string {
-  const explicit = process.env.TENSORLAKE_SANDBOX_PROXY_URL;
+  const explicit = explicitProxyUrlOverride();
   if (explicit) return explicit;
 
   if (isLocalhost(apiUrl)) return "http://localhost:9443";
@@ -48,7 +58,7 @@ export function resolveProxyUrl(apiUrl: string): string {
  * Resolve the proxy target for a specific sandbox.
  *
  * - Localhost: base URL stays the same, Host header set to `{sandboxId}.local`
- * - Cloud: apex proxy domain with `X-Tensorlake-Sandbox-Id` header
+ * - Cloud: selected proxy domain with `X-Tensorlake-Sandbox-Id` header
  *
  * Returns `{ baseUrl, hostHeader, sandboxIdHeader }`.
  */

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -14,6 +14,7 @@ describe("SandboxClient", () => {
   afterEach(() => {
     clearNativeStub();
     vi.restoreAllMocks();
+    delete process.env.TENSORLAKE_SANDBOX_PROXY_URL;
   });
 
   describe("construction", () => {
@@ -721,7 +722,7 @@ describe("SandboxClient", () => {
   });
 
   describe("createAndConnect", () => {
-    it("uses ingress endpoint from running create response", async () => {
+    it("uses server sandbox URL from running create response", async () => {
       const stub = installNativeStub({
         client: {
           createSandbox: vi.fn(async () => ({
@@ -731,6 +732,7 @@ describe("SandboxClient", () => {
               status: "running",
               routing_hint: "hint-1",
               ingress_endpoint: "https://sandbox.us-east-1.aws.tensorlake.ai",
+              sandbox_url: "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
             }),
           })),
         },
@@ -740,11 +742,75 @@ describe("SandboxClient", () => {
       const sandbox = await client.createAndConnect();
       expect(sandbox.sandboxId).toBe("sbx-1");
       // The proxy is minted from the shared native client via connectProxy with
-      // the ingress endpoint resolved from the create response.
+      // the server-returned sandbox URL from the create response.
       expect(stub.client.connectProxy).toHaveBeenCalledWith(
-        "https://sandbox.us-east-1.aws.tensorlake.ai",
+        "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
         "sbx-1",
         "hint-1",
+        expect.anything(),
+      );
+      sandbox.close();
+      client.close();
+    });
+
+    it("uses canonical sandbox ID from polled running response", async () => {
+      const stub = installNativeStub({
+        client: {
+          createSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({
+              sandbox_id: "sbx-original",
+              status: "pending",
+            }),
+          })),
+          getSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({
+              id: "sbx-canonical",
+              status: "running",
+              routing_hint: "hint-2",
+              sandbox_url: "https://sbx-canonical.sandbox.tensorlake.ai",
+            }),
+          })),
+        },
+      });
+
+      const client = SandboxClient.forCloud({ apiKey: "key" });
+      const sandbox = await client.createAndConnect({ requestTimeout: 1 });
+
+      expect(stub.client.getSandbox).toHaveBeenCalledWith("sbx-original");
+      expect(sandbox.sandboxId).toBe("sbx-canonical");
+      expect(stub.client.connectProxy).toHaveBeenCalledWith(
+        "https://sbx-canonical.sandbox.tensorlake.ai",
+        "sbx-canonical",
+        "hint-2",
+        expect.anything(),
+      );
+      sandbox.close();
+      client.close();
+    });
+
+    it("uses env proxy override when server sandbox URL is missing", async () => {
+      process.env.TENSORLAKE_SANDBOX_PROXY_URL = "https://override.example.com";
+      const stub = installNativeStub({
+        client: {
+          createSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({
+              sandbox_id: "sbx-1",
+              status: "running",
+            }),
+          })),
+        },
+      });
+
+      const client = SandboxClient.forCloud({ apiKey: "key" });
+      const sandbox = await client.createAndConnect();
+
+      expect(stub.client.connectProxy).toHaveBeenCalledWith(
+        "https://override.example.com",
+        "sbx-1",
+        null,
         expect.anything(),
       );
       sandbox.close();
@@ -756,7 +822,11 @@ describe("SandboxClient", () => {
         client: {
           createSandbox: vi.fn(async () => ({
             traceId: "t",
-            json: JSON.stringify({ sandbox_id: "sbx-1", status: "running" }),
+            json: JSON.stringify({
+              sandbox_id: "sbx-1",
+              status: "running",
+              sandbox_url: "https://sbx-1.sandbox.tensorlake.ai",
+            }),
           })),
         },
       });
@@ -776,7 +846,11 @@ describe("SandboxClient", () => {
         client: {
           createSandbox: vi.fn(async () => ({
             traceId: "t",
-            json: JSON.stringify({ sandbox_id: "sbx-1", status: "running" }),
+            json: JSON.stringify({
+              sandbox_id: "sbx-1",
+              status: "running",
+              sandbox_url: "https://sbx-1.sandbox.tensorlake.ai",
+            }),
           })),
         },
       });
@@ -793,7 +867,11 @@ describe("SandboxClient", () => {
         client: {
           createSandbox: vi.fn(async () => ({
             traceId: "t",
-            json: JSON.stringify({ sandbox_id: "sbx-1", status: "running" }),
+            json: JSON.stringify({
+              sandbox_id: "sbx-1",
+              status: "running",
+              sandbox_url: "https://sbx-1.sandbox.tensorlake.ai",
+            }),
           })),
         },
       });
@@ -1137,7 +1215,7 @@ describe("SandboxClient", () => {
       client.close();
     });
 
-    it("resolves ingress endpoint before first proxy request", async () => {
+    it("resolves server sandbox URL before first proxy request", async () => {
       const stub = installNativeStub({
         client: {
           getSandbox: vi.fn(async (id: string) => {
@@ -1148,6 +1226,7 @@ describe("SandboxClient", () => {
                 sandbox_id: "sbx-1",
                 status: "running",
                 ingress_endpoint: "https://sandbox.us-east-1.aws.tensorlake.ai",
+                sandbox_url: "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
                 routing_hint: "hint-1",
               }),
             };
@@ -1163,20 +1242,56 @@ describe("SandboxClient", () => {
 
       const client = SandboxClient.forCloud({ apiKey: "key" });
       const sandbox = client.connect("stable-name");
+      expect(stub.client.connectProxy).not.toHaveBeenCalled();
       const health = await sandbox.health();
 
       expect(health.healthy).toBe(true);
       // The lazy resolver resolves via getSandbox(name) before the first proxy op.
       expect(stub.client.getSandbox).toHaveBeenCalledWith("stable-name");
-      // After resolution the proxy is reconnected with the resolved ingress
-      // endpoint and canonical id.
+      // After resolution the proxy is reconnected with the server-returned
+      // sandbox URL and canonical id.
       expect(stub.client.connectProxy).toHaveBeenLastCalledWith(
-        "https://sandbox.us-east-1.aws.tensorlake.ai",
+        "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
         "sbx-1",
         "hint-1",
         null,
       );
       expect(stub.proxy.health).toHaveBeenCalledOnce();
+      sandbox.close();
+      client.close();
+    });
+
+    it("uses env proxy override when resolved sandbox URL is missing", async () => {
+      process.env.TENSORLAKE_SANDBOX_PROXY_URL = "https://override.example.com";
+      const stub = installNativeStub({
+        client: {
+          getSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({
+              sandbox_id: "sbx-1",
+              status: "running",
+            }),
+          })),
+        },
+        proxy: {
+          health: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({ healthy: true }),
+          })),
+        },
+      });
+
+      const client = SandboxClient.forCloud({ apiKey: "key" });
+      const sandbox = client.connect("stable-name");
+      expect(stub.client.connectProxy).not.toHaveBeenCalled();
+      await sandbox.health();
+
+      expect(stub.client.connectProxy).toHaveBeenLastCalledWith(
+        "https://override.example.com",
+        "sbx-1",
+        null,
+        null,
+      );
       sandbox.close();
       client.close();
     });

--- a/typescript/tests/native-stub.ts
+++ b/typescript/tests/native-stub.ts
@@ -98,6 +98,21 @@ function makeClient(proxy: FakeFns): FakeFns {
     updatePool: vi.fn(tracedJson()),
     deletePool: vi.fn(tracedId()),
     connectProxy: vi.fn(() => proxy as unknown as NativeSandboxProxyClient),
+    selectSandboxProxyUrl: vi.fn(
+      (
+        sandboxId: string,
+        sandboxUrl?: string | null,
+        ingressEndpoint?: string | null,
+        explicitProxyUrl?: string | null,
+      ) =>
+        sandboxUrl ??
+        explicitProxyUrl ??
+        (() => {
+          throw new Error(
+            "server response did not include sandbox_url; refusing to derive a proxy URL",
+          );
+        })(),
+    ),
   };
 }
 

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -25,6 +25,13 @@ describe("Sandbox", () => {
   }
 
   describe("constructor", () => {
+    it("requires an explicit proxyUrl for direct construction", () => {
+      expect(() => new Sandbox({ sandboxId: "sbx-direct" })).toThrow(SandboxError);
+      expect(() => new Sandbox({ sandboxId: "sbx-direct" })).toThrow(
+        /proxyUrl is required/,
+      );
+    });
+
     it("sets sandboxId", () => {
       installNativeStub();
       const sbx = makeSandbox("sbx-abc");


### PR DESCRIPTION
## Summary
- centralize sandbox proxy URL selection in the Rust SDK core
- prefer server-returned `sandbox_url` for proxy traffic and allow only explicit proxy overrides when it is absent
- update Python, TypeScript, native Node/PyO3 bindings, CLI SSH/config tips, and image-builder paths to use the core selector
- preserve `ingress_endpoint` for user-port URL construction, but stop deriving management proxy URLs from it

Server-side companion PR: https://github.com/tensorlakeai/compute-engine-internal/pull/1337

## Tests
- `cargo fmt`
- `git diff --check`
- `python3 -m compileall src/tensorlake/sandbox/client.py src/tensorlake/sandbox/async_client.py tests/sandbox/test_client_rust_backend.py tests/sandbox/test_client_rust_backend_async.py`
- `npm run typecheck`
- `npm test -- --run tests/client.test.ts tests/sandbox.test.ts`
- `cargo test -p tensorlake select_proxy_url`
- `cargo test -p tensorlake sandbox_info_deserializes_routing_hint_and_sandbox_url`
- `cargo test -p tensorlake sandbox_proxy_base_uses_explicit_override_when_server_url_missing`
- `cargo test -p tensorlake-cli ssh_config`
- `cargo test -p tensorlake-cli post_create_tip`

Note: `python3 -m pytest tests/sandbox/test_client_rust_backend.py tests/sandbox/test_client_rust_backend_async.py` was not run because `pytest` is not installed in this environment.