### PR TITLE
[codex] Bump SDK and CLI versions to 0.5.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-codec"
-version = "0.5.57"
+version = "0.5.58"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.57"
+version = "0.5.58"
 dependencies = [
  "base64",
  "bollard",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.57"
+version = "0.5.58"
 dependencies = [
  "anyhow",
  "base64",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.57"
+version = "0.5.58"
 dependencies = [
  "napi",
  "napi-build",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.57"
+version = "0.5.58"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.57"
+version = "0.5.58"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.57"
+version = "0.5.58"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.57"
+version = "0.5.58"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.57",
+  "version": "0.5.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.57",
+      "version": "0.5.58",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.57",
+  "version": "0.5.58",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Bumps the Tensorlake SDK and CLI package metadata from 0.5.57 to 0.5.58 in lockstep across Python, Rust, TypeScript, and lockfiles.

## Why

origin/main contains the dataplane/sandbox proxy routing change after the cli-v0.5.57 tag, but the release metadata still reported 0.5.57. This prepares the next patch release so the SDKs and CLI pick up that change.

## Validation

- Confirmed no stale 0.5.57 remains in the release metadata files
- Ran cargo metadata --locked --format-version 1 --no-deps
- Checked Python, Rust, TypeScript package and lockfile versions all report 0.5.58