### PR TITLE
feat(documentai): support BytesIO uploads

### DIFF
--- a/src/tensorlake/documentai/_files.py
+++ b/src/tensorlake/documentai/_files.py
@@ -4,6 +4,7 @@ File-management helpers (upload, list, delete).
 
 from __future__ import annotations
 
+from io import BytesIO
 from pathlib import Path
 from typing import Optional, Union
 
@@ -14,6 +15,8 @@ from ._utils import _drop_none
 from .common import PaginatedResult
 from .files import FileInfo, FileUploader
 from .models import PaginationDirection, Region
+
+UploadSource = Union[str, Path, BytesIO]
 
 
 class _FilesMixin(_BaseClient):
@@ -102,21 +105,21 @@ class _FilesMixin(_BaseClient):
         resp = await self._arequest("GET", "files", params=params)
         return PaginatedResult[FileInfo].model_validate(resp.json())
 
-    def upload(self, path: Union[str, Path]) -> str:
+    def upload(self, path: UploadSource) -> str:
         """
         Upload a file to Tensorlake.
 
         Args:
-            file_path: Path to the file to upload
+            file_path: Path to the file to upload, or an in-memory BytesIO buffer.
         """
         return self._uploader.upload_file(path)
 
     @exponential_backoff(max_retries=10, initial_delay_seconds=2)
-    async def upload_async(self, path: Union[str, Path]) -> str:
+    async def upload_async(self, path: UploadSource) -> str:
         """
         Upload a file to Tensorlake asynchronously.
         Args:
-            file_path: Path to the file to upload
+            file_path: Path to the file to upload, or an in-memory BytesIO buffer.
         """
         return await self._uploader.upload_file_async(path)
 

--- a/src/tensorlake/documentai/files.py
+++ b/src/tensorlake/documentai/files.py
@@ -4,6 +4,7 @@ This module contains the FileUploader class, which is used to upload files to th
 
 import asyncio
 import json
+from io import BytesIO
 from pathlib import Path
 from typing import Optional, Union
 
@@ -11,6 +12,8 @@ from pydantic import BaseModel, Field
 
 from .common import get_doc_ai_base_url
 from .models import Region
+
+UploadSource = Union[str, Path, BytesIO]
 
 try:
     from tensorlake._cloud_sdk import CloudDocumentAIClient as RustCloudDocumentAIClient
@@ -64,12 +67,14 @@ class FileUploader:
             api_key=self.api_key,
         )
 
-    def upload_file(self, file_path: Union[str, Path]) -> str:
+    def upload_file(self, file_path: UploadSource) -> str:
         """
         Upload a file to Tensorlake.
 
         Args:
-            file_path: Path to the file to upload
+            file_path: Path to the file to upload, or an in-memory BytesIO buffer.
+                BytesIO uploads use the buffer's ``name`` attribute as the file
+                name when present, otherwise ``upload.bin``.
 
         Returns:
             File ID of the uploaded file. This ID can be used to reference the file in other API calls.
@@ -78,6 +83,11 @@ class FileUploader:
         Raises:
             FileNotFoundError: If the file doesn't exist
         """
+        if isinstance(file_path, BytesIO):
+            return self._upload_content(
+                file_name=self._bytes_io_file_name(file_path),
+                content=file_path.getvalue(),
+            )
 
         if isinstance(file_path, str):
             if file_path.startswith("http://") or file_path.startswith("https://"):
@@ -89,9 +99,11 @@ class FileUploader:
         if not path.exists():
             raise FileNotFoundError(f"File not found: {path}")
 
+        return self._upload_content(file_name=path.name, content=path.read_bytes())
+
+    def _upload_content(self, file_name: str, content: bytes) -> str:
         response_json = self._rust_client.upload_file_json(
-            file_name=path.name,
-            content=path.read_bytes(),
+            file_name=file_name, content=content
         )
         payload = json.loads(response_json)
         status_code = int(payload.get("status_code", 500))
@@ -106,12 +118,21 @@ class FileUploader:
         except Exception as e:
             raise RuntimeError(f"Invalid upload response payload: {body}") from e
 
-    async def upload_file_async(self, path: Union[str, Path]) -> str:
+    @staticmethod
+    def _bytes_io_file_name(file_obj: BytesIO) -> str:
+        name = getattr(file_obj, "name", None)
+        if isinstance(name, (str, Path)):
+            file_name = Path(name).name
+            if file_name:
+                return file_name
+        return "upload.bin"
+
+    async def upload_file_async(self, path: UploadSource) -> str:
         """
         Upload a file to Tensorlake asynchronously.
 
         Args:
-            file_path: Path to the file to upload
+            file_path: Path to the file to upload, or an in-memory BytesIO buffer.
 
         Returns:
             File ID of the uploaded file. This ID can be used to reference the file in other API calls.

--- a/tests/document_ai/test_rust_backend.py
+++ b/tests/document_ai/test_rust_backend.py
@@ -1,3 +1,4 @@
+import io
 import json
 import tempfile
 import unittest
@@ -125,6 +126,30 @@ class TestDocumentAIRustBackend(unittest.TestCase):
         self.assertEqual(file_id, "tensorlake-123")
         self.assertEqual(len(fake.uploads), 1)
         self.assertEqual(fake.uploads[0][0], tmp_path.name)
+
+    def test_upload_accepts_bytes_io(self):
+        doc_ai = DocumentAI(api_key="k", server_url="http://localhost:8900")
+        fake = _FakeRustDocumentAIClient()
+        doc_ai._uploader._rust_client = fake
+        buffer = io.BytesIO(b"hello from memory")
+        buffer.name = "/tmp/report.txt"
+        buffer.seek(5)
+
+        file_id = doc_ai.upload(path=buffer)
+
+        self.assertEqual(file_id, "tensorlake-123")
+        self.assertEqual(fake.uploads, [("report.txt", b"hello from memory")])
+        self.assertEqual(buffer.tell(), 5)
+
+    def test_upload_accepts_unnamed_bytes_io(self):
+        doc_ai = DocumentAI(api_key="k", server_url="http://localhost:8900")
+        fake = _FakeRustDocumentAIClient()
+        doc_ai._uploader._rust_client = fake
+
+        file_id = doc_ai.upload(path=io.BytesIO(b"nameless"))
+
+        self.assertEqual(file_id, "tensorlake-123")
+        self.assertEqual(fake.uploads, [("upload.bin", b"nameless")])
 
     def test_unauthorized_maps_to_document_ai_error(self):
         doc_ai = DocumentAI(api_key="k", server_url="http://localhost:8900")


### PR DESCRIPTION
## Summary
Fixes #274.

- accept in-memory `io.BytesIO` buffers in DocumentAI `upload` / `upload_async`
- preserve the current buffer position by reading with `getvalue()`
- use the `BytesIO.name` basename when present, otherwise `upload.bin`
- reuse the existing Rust upload response handling through a shared helper
- add fake-Rust tests for named and unnamed `BytesIO` uploads

## Testing
- `python -m py_compile src\tensorlake\documentai\files.py src\tensorlake\documentai\_files.py tests\document_ai\test_rust_backend.py`
- local smoke script for named/unnamed `BytesIO` upload behavior
- `PYTHONPATH=src python -m unittest tests.document_ai.test_rust_backend` (does not run successfully in this checkout because the package is not installed, so top-level import fails with `PackageNotFoundError: No package metadata was found for tensorlake` before test collection)