### PR TITLE
Refresh sandbox proxy routing after resume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-codec"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "base64",
  "bollard",
@@ -3349,7 +3349,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "anyhow",
  "base64",
@@ -3396,7 +3396,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "napi",
  "napi-build",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.58"
+version = "0.5.59"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.58"
+version = "0.5.59"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/resume.rs
+++ b/crates/cli/src/commands/sbx/resume.rs
@@ -1,6 +1,7 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
-    DEFAULT_SANDBOX_WAIT_TIMEOUT, sandbox_endpoint, wait_for_sandbox_status,
+    DEFAULT_SANDBOX_WAIT_TIMEOUT, ResolvedSandboxProxyTarget, resolve_sandbox_proxy_target,
+    sandbox_endpoint, wait_for_sandbox_status,
 };
 use crate::error::{CliError, Result};
 
@@ -38,8 +39,42 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, wait: bool) -> Result<()> {
 
     if is_tty {
         eprintln!("Sandbox {} is running.", sandbox_id);
+        if wait {
+            if let Ok(target) = resolve_sandbox_proxy_target(ctx, sandbox_id).await {
+                eprintln!("{}", format_post_resume_url_line(&target));
+            }
+        }
     } else {
         println!("{sandbox_id}");
     }
     Ok(())
+}
+
+fn format_post_resume_url_line(target: &ResolvedSandboxProxyTarget) -> String {
+    format!(
+        "URL:             {}",
+        target.sandbox_url.as_deref().unwrap_or(&target.proxy_base)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn post_resume_tip_prefers_sandbox_url() {
+        let target = ResolvedSandboxProxyTarget {
+            sandbox_id: "sbx-123".to_string(),
+            proxy_base: "https://proxy.example.com".to_string(),
+            host_override: None,
+            routing_hint: Some("hint-1".to_string()),
+            ingress_endpoint: Some("https://ingress.example.com".to_string()),
+            sandbox_url: Some("https://returned.example.com".to_string()),
+        };
+
+        assert_eq!(
+            format_post_resume_url_line(&target),
+            "URL:             https://returned.example.com"
+        );
+    }
 }

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.58"
+version = "0.5.59"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.58"
+version = "0.5.59"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -797,6 +797,7 @@ class AsyncSandboxClient:
         sandbox_id: str | None = None,
         routing_hint: str | None = None,
         request_timeout: float | None = None,
+        _routing_info: object | None = None,
     ) -> "AsyncSandbox":
         """Connect to a running sandbox for process and file operations.
 
@@ -810,19 +811,34 @@ class AsyncSandboxClient:
             identifier, sandbox_id, parameter_name="identifier"
         )
         info: Traced[SandboxInfo] | None = None
+        routing_info = _routing_info
+        cached_info: SandboxInfo | None = None
         proxy_sandbox_id = sandbox_identifier
-        if proxy_url is None:
+        explicit_proxy_url = (
+            proxy_url if proxy_url is not None else _explicit_proxy_url_override()
+        )
+        selected_proxy_url = explicit_proxy_url
+        if routing_info is None and proxy_url is None:
             info = await self.get(sandbox_identifier)
-            proxy_sandbox_id = info.sandbox_id
-            routing_hint = routing_hint or info.routing_hint
-            proxy_url = self._rust_client.select_sandbox_proxy_url(
+            routing_info = info.value
+            cached_info = info.value
+        if routing_info is not None:
+            proxy_sandbox_id = routing_info.sandbox_id
+            routing_hint = routing_hint or routing_info.routing_hint
+            if isinstance(routing_info, SandboxInfo):
+                cached_info = routing_info
+            selected_proxy_url = self._rust_client.select_sandbox_proxy_url(
                 sandbox_id=proxy_sandbox_id,
-                sandbox_url=info.sandbox_url,
-                ingress_endpoint=info.ingress_endpoint,
-                explicit_proxy_url=_explicit_proxy_url_override(),
+                sandbox_url=routing_info.sandbox_url,
+                ingress_endpoint=routing_info.ingress_endpoint,
+                explicit_proxy_url=explicit_proxy_url,
+            )
+        if selected_proxy_url is None:
+            raise SandboxError(
+                "server response did not include sandbox_url; refusing to derive a proxy URL"
             )
         connect_proxy_kwargs = {
-            "proxy_url": proxy_url,
+            "proxy_url": selected_proxy_url,
             "sandbox_id": proxy_sandbox_id,
             "routing_hint": routing_hint,
         }
@@ -831,18 +847,22 @@ class AsyncSandboxClient:
         proxy_rust_client = self._rust_client.connect_proxy(**connect_proxy_kwargs)
         sandbox = AsyncSandbox(
             identifier=proxy_sandbox_id,
-            proxy_url=proxy_url,
+            proxy_url=selected_proxy_url,
             api_key=self._api_key,
             organization_id=self._organization_id,
             project_id=self._project_id,
             routing_hint=routing_hint,
+            request_timeout=request_timeout,
             _proxy_rust_client=proxy_rust_client,
+            _explicit_proxy_url=explicit_proxy_url,
         )
         sandbox._lifecycle_client = self
         if info is not None:
             sandbox._sandbox_id = info.sandbox_id
-            sandbox._cached_info = info.value
             sandbox._trace_id = info.trace_id
+        if cached_info is not None:
+            sandbox._sandbox_id = cached_info.sandbox_id
+            sandbox._cached_info = cached_info
         return sandbox
 
     async def create_and_connect(
@@ -904,20 +924,12 @@ class AsyncSandboxClient:
             )
 
         if result.status == SandboxStatus.RUNNING:
-            selected_proxy_url = request_client._rust_client.select_sandbox_proxy_url(
-                sandbox_id=result.sandbox_id,
-                sandbox_url=result.sandbox_url,
-                ingress_endpoint=result.ingress_endpoint,
-                explicit_proxy_url=(
-                    proxy_url
-                    if proxy_url is not None
-                    else _explicit_proxy_url_override()
-                ),
-            )
             sandbox = await request_client.connect(
                 result.sandbox_id,
-                proxy_url=selected_proxy_url,
+                proxy_url=proxy_url,
                 routing_hint=result.routing_hint,
+                request_timeout=wait_timeout,
+                _routing_info=result,
             )
             sandbox._sandbox_id = result.sandbox_id
             sandbox._owns_sandbox = True
@@ -953,22 +965,12 @@ class AsyncSandboxClient:
         while asyncio.get_running_loop().time() < deadline:
             info = await request_client.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
-                selected_proxy_url = (
-                    request_client._rust_client.select_sandbox_proxy_url(
-                        sandbox_id=info.sandbox_id,
-                        sandbox_url=info.sandbox_url,
-                        ingress_endpoint=info.ingress_endpoint,
-                        explicit_proxy_url=(
-                            proxy_url
-                            if proxy_url is not None
-                            else _explicit_proxy_url_override()
-                        ),
-                    )
-                )
                 sandbox = await request_client.connect(
                     info.sandbox_id,
-                    proxy_url=selected_proxy_url,
+                    proxy_url=proxy_url,
                     routing_hint=info.routing_hint,
+                    request_timeout=wait_timeout,
+                    _routing_info=info.value,
                 )
                 sandbox._sandbox_id = info.sandbox_id
                 sandbox._cached_info = info.value

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -7,6 +7,7 @@ asyncio event loop instead of blocking a worker thread.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from collections.abc import Mapping
@@ -84,6 +85,7 @@ class AsyncSandbox:
         routing_hint: str | None = None,
         request_timeout: float | None = None,
         _proxy_rust_client: object | None = None,
+        _explicit_proxy_url: str | None = None,
     ) -> None:
         if identifier and sandbox_id and identifier != sandbox_id:
             raise SandboxError(
@@ -114,21 +116,8 @@ class AsyncSandbox:
         self._organization_id = organization_id
         self._project_id = project_id
         self._request_timeout = request_timeout
-        parsed_proxy = urlparse(proxy_url)
-        self._host_header = None
-        if parsed_proxy.hostname in ("localhost", "127.0.0.1"):
-            self._host_header = f"{sandbox_identifier}.local"
-        self._proxy_headers: dict[str, str] = {}
-        if api_key:
-            self._proxy_headers["Authorization"] = f"Bearer {api_key}"
-        if organization_id:
-            self._proxy_headers["X-Forwarded-Organization-Id"] = organization_id
-        if project_id:
-            self._proxy_headers["X-Forwarded-Project-Id"] = project_id
-        if self._host_header:
-            self._proxy_headers["Host"] = self._host_header
-        else:
-            self._proxy_headers["X-Tensorlake-Sandbox-Id"] = sandbox_identifier
+        self._explicit_proxy_url = _explicit_proxy_url
+        self._set_proxy_transport(proxy_url, sandbox_identifier)
 
         if _proxy_rust_client is not None:
             self._rust_client = _proxy_rust_client
@@ -155,6 +144,94 @@ class AsyncSandbox:
                 self._base_url = self._rust_client.base_url()
             except Exception as e:
                 _raise_as_sandbox_error(e)
+
+    def _set_proxy_transport(self, proxy_url: str, sandbox_identifier: str) -> None:
+        self._proxy_url = proxy_url
+        parsed_proxy = urlparse(proxy_url)
+        self._host_header = None
+        if parsed_proxy.hostname in ("localhost", "127.0.0.1"):
+            self._host_header = f"{sandbox_identifier}.local"
+        self._proxy_headers = {}
+        if self._api_key:
+            self._proxy_headers["Authorization"] = f"Bearer {self._api_key}"
+        if self._organization_id:
+            self._proxy_headers["X-Forwarded-Organization-Id"] = self._organization_id
+        if self._project_id:
+            self._proxy_headers["X-Forwarded-Project-Id"] = self._project_id
+        if self._host_header:
+            self._proxy_headers["Host"] = self._host_header
+        else:
+            self._proxy_headers["X-Tensorlake-Sandbox-Id"] = sandbox_identifier
+
+    def _rebind_proxy(self, info: SandboxInfo) -> None:
+        self._require_lifecycle_client("refresh proxy routing")
+        if info.status != SandboxStatus.RUNNING:
+            raise SandboxError(
+                f"Sandbox {info.sandbox_id!r} is {info.status.value}; cannot refresh proxy routing"
+            )
+        if info.sandbox_url is None and self._explicit_proxy_url is None:
+            raise SandboxError(
+                f"Sandbox {info.sandbox_id!r} did not include proxy routing information"
+            )
+
+        proxy_url = self._lifecycle_client._rust_client.select_sandbox_proxy_url(
+            sandbox_id=info.sandbox_id,
+            sandbox_url=info.sandbox_url,
+            ingress_endpoint=info.ingress_endpoint,
+            explicit_proxy_url=self._explicit_proxy_url,
+        )
+        connect_proxy_kwargs = {
+            "proxy_url": proxy_url,
+            "sandbox_id": info.sandbox_id,
+            "routing_hint": info.routing_hint,
+        }
+        if self._request_timeout is not None:
+            connect_proxy_kwargs["request_timeout_sec"] = self._request_timeout
+        try:
+            new_rust_client = self._lifecycle_client._rust_client.connect_proxy(
+                **connect_proxy_kwargs
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+        self._rust_client = new_rust_client
+        self._base_url = self._rust_client.base_url()
+        self._set_proxy_transport(proxy_url, info.sandbox_id)
+        self._cached_info = info
+        self._sandbox_id = info.sandbox_id
+
+    async def _fresh_running_info_for_rebind(
+        self,
+        deadline: float,
+        poll_interval: float,
+    ) -> SandboxInfo:
+        self._require_lifecycle_client("refresh proxy routing")
+        identifier = self._lifecycle_identifier()
+        loop = asyncio.get_running_loop()
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                break
+            try:
+                info = (
+                    await asyncio.wait_for(
+                        self._lifecycle_client.get(identifier), timeout=remaining
+                    )
+                ).value
+            except asyncio.TimeoutError:
+                break
+            if info.status == SandboxStatus.RUNNING and (
+                info.sandbox_url is not None or self._explicit_proxy_url is not None
+            ):
+                return info
+            if info.status == SandboxStatus.TERMINATED:
+                raise SandboxError(
+                    f"Sandbox {identifier!r} terminated while refreshing proxy routing"
+                )
+            await asyncio.sleep(min(poll_interval, max(0.0, deadline - loop.time())))
+        raise SandboxError(
+            f"Sandbox {identifier!r} did not provide refreshed proxy routing within timeout"
+        )
 
     # --- Class-level factory methods ---
 
@@ -291,13 +368,31 @@ class AsyncSandbox:
         timeout: float = 300,
         poll_interval: float = 1.0,
     ) -> None:
+        """Resume this sandbox.
+
+        By default waits until the sandbox is ``Running`` and refreshes this
+        handle's cached proxy routing. Rare transient proxy errors may still
+        occur immediately after resume.
+
+        Passing ``wait=False`` is fire-and-return and does not refresh cached
+        proxy routing on this handle. Use the default ``wait=True`` for
+        immediate follow-up operations; if using ``wait=False``, wait until the
+        sandbox is running and reconnect to get fresh routing before issuing
+        process/file/PTY operations.
+        """
         self._require_lifecycle_client("resume")
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        remaining = max(0.0, deadline - loop.time())
         await self._lifecycle_client.resume(
             self._lifecycle_identifier(),
             wait=wait,
-            timeout=timeout,
+            timeout=remaining,
             poll_interval=poll_interval,
         )
+        if wait:
+            info = await self._fresh_running_info_for_rebind(deadline, poll_interval)
+            self._rebind_proxy(info)
 
     async def attach_file_system(
         self,

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1335,6 +1335,7 @@ class SandboxClient:
         sandbox_id: str | None = None,
         routing_hint: str | None = None,
         request_timeout: float | None = None,
+        _routing_info: object | None = None,
     ) -> "Sandbox":
         """Connect to a running sandbox for process and file operations.
 
@@ -1358,20 +1359,35 @@ class SandboxClient:
         )
 
         info: Traced[SandboxInfo] | None = None
+        routing_info = _routing_info
+        cached_info: SandboxInfo | None = None
         proxy_sandbox_id = sandbox_identifier
-        if proxy_url is None:
+        explicit_proxy_url = (
+            proxy_url if proxy_url is not None else _explicit_proxy_url_override()
+        )
+        selected_proxy_url = explicit_proxy_url
+        if routing_info is None and proxy_url is None:
             info = self.get(sandbox_identifier)
-            proxy_sandbox_id = info.sandbox_id
-            routing_hint = routing_hint or info.routing_hint
-            proxy_url = self._rust_client.select_sandbox_proxy_url(
+            routing_info = info.value
+            cached_info = info.value
+        if routing_info is not None:
+            proxy_sandbox_id = routing_info.sandbox_id
+            routing_hint = routing_hint or routing_info.routing_hint
+            if isinstance(routing_info, SandboxInfo):
+                cached_info = routing_info
+            selected_proxy_url = self._rust_client.select_sandbox_proxy_url(
                 sandbox_id=proxy_sandbox_id,
-                sandbox_url=info.sandbox_url,
-                ingress_endpoint=info.ingress_endpoint,
-                explicit_proxy_url=_explicit_proxy_url_override(),
+                sandbox_url=routing_info.sandbox_url,
+                ingress_endpoint=routing_info.ingress_endpoint,
+                explicit_proxy_url=explicit_proxy_url,
+            )
+        if selected_proxy_url is None:
+            raise SandboxError(
+                "server response did not include sandbox_url; refusing to derive a proxy URL"
             )
 
         connect_proxy_kwargs = {
-            "proxy_url": proxy_url,
+            "proxy_url": selected_proxy_url,
             "sandbox_id": proxy_sandbox_id,
             "routing_hint": routing_hint,
         }
@@ -1381,18 +1397,22 @@ class SandboxClient:
 
         sandbox = Sandbox(
             identifier=proxy_sandbox_id,
-            proxy_url=proxy_url,
+            proxy_url=selected_proxy_url,
             api_key=self._api_key,
             organization_id=self._organization_id,
             project_id=self._project_id,
             routing_hint=routing_hint,
+            request_timeout=request_timeout,
             _proxy_rust_client=proxy_rust_client,
+            _explicit_proxy_url=explicit_proxy_url,
         )
         sandbox._lifecycle_client = self
         if info is not None:
             sandbox._sandbox_id = info.sandbox_id
-            sandbox._cached_info = info.value
             sandbox._trace_id = info.trace_id
+        if cached_info is not None:
+            sandbox._sandbox_id = cached_info.sandbox_id
+            sandbox._cached_info = cached_info
         return sandbox
 
     def create_and_connect(
@@ -1501,20 +1521,12 @@ class SandboxClient:
         # and a short-lived routing hint. Use it immediately to skip an extra poll RTT
         # and let the proxy route the first request without a placement lookup.
         if result.status == SandboxStatus.RUNNING:
-            selected_proxy_url = request_client._rust_client.select_sandbox_proxy_url(
-                sandbox_id=result.sandbox_id,
-                sandbox_url=result.sandbox_url,
-                ingress_endpoint=result.ingress_endpoint,
-                explicit_proxy_url=(
-                    proxy_url
-                    if proxy_url is not None
-                    else _explicit_proxy_url_override()
-                ),
-            )
             sandbox = request_client.connect(
                 result.sandbox_id,
-                proxy_url=selected_proxy_url,
+                proxy_url=proxy_url,
                 routing_hint=result.routing_hint,
+                request_timeout=wait_timeout,
+                _routing_info=result,
             )
             sandbox._sandbox_id = result.sandbox_id
             sandbox._owns_sandbox = True
@@ -1550,22 +1562,12 @@ class SandboxClient:
         while time.time() < deadline:
             info = request_client.get(result.sandbox_id)
             if info.status == SandboxStatus.RUNNING:
-                selected_proxy_url = (
-                    request_client._rust_client.select_sandbox_proxy_url(
-                        sandbox_id=info.sandbox_id,
-                        sandbox_url=info.sandbox_url,
-                        ingress_endpoint=info.ingress_endpoint,
-                        explicit_proxy_url=(
-                            proxy_url
-                            if proxy_url is not None
-                            else _explicit_proxy_url_override()
-                        ),
-                    )
-                )
                 sandbox = request_client.connect(
                     info.sandbox_id,
-                    proxy_url=selected_proxy_url,
+                    proxy_url=proxy_url,
                     routing_hint=info.routing_hint,
+                    request_timeout=wait_timeout,
+                    _routing_info=info.value,
                 )
                 sandbox._sandbox_id = info.sandbox_id
                 sandbox._cached_info = info.value

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -187,6 +187,7 @@ class Sandbox:
         routing_hint: str | None = None,
         request_timeout: float | None = None,
         _proxy_rust_client: object | None = None,
+        _explicit_proxy_url: str | None = None,
     ):
         if identifier and sandbox_id and identifier != sandbox_id:
             raise SandboxError(
@@ -217,21 +218,8 @@ class Sandbox:
         self._organization_id = organization_id
         self._project_id = project_id
         self._request_timeout = request_timeout
-        parsed_proxy = urlparse(proxy_url)
-        self._host_header = None
-        if parsed_proxy.hostname in ("localhost", "127.0.0.1"):
-            self._host_header = f"{sandbox_identifier}.local"
-        self._proxy_headers: dict[str, str] = {}
-        if api_key:
-            self._proxy_headers["Authorization"] = f"Bearer {api_key}"
-        if organization_id:
-            self._proxy_headers["X-Forwarded-Organization-Id"] = organization_id
-        if project_id:
-            self._proxy_headers["X-Forwarded-Project-Id"] = project_id
-        if self._host_header:
-            self._proxy_headers["Host"] = self._host_header
-        else:
-            self._proxy_headers["X-Tensorlake-Sandbox-Id"] = sandbox_identifier
+        self._explicit_proxy_url = _explicit_proxy_url
+        self._set_proxy_transport(proxy_url, sandbox_identifier)
 
         if _proxy_rust_client is not None:
             self._rust_client = _proxy_rust_client
@@ -258,6 +246,89 @@ class Sandbox:
                 self._base_url = self._rust_client.base_url()
             except Exception as e:
                 _raise_as_sandbox_error(e)
+
+    def _set_proxy_transport(self, proxy_url: str, sandbox_identifier: str) -> None:
+        self._proxy_url = proxy_url
+        parsed_proxy = urlparse(proxy_url)
+        self._host_header = None
+        if parsed_proxy.hostname in ("localhost", "127.0.0.1"):
+            self._host_header = f"{sandbox_identifier}.local"
+        self._proxy_headers = {}
+        if self._api_key:
+            self._proxy_headers["Authorization"] = f"Bearer {self._api_key}"
+        if self._organization_id:
+            self._proxy_headers["X-Forwarded-Organization-Id"] = self._organization_id
+        if self._project_id:
+            self._proxy_headers["X-Forwarded-Project-Id"] = self._project_id
+        if self._host_header:
+            self._proxy_headers["Host"] = self._host_header
+        else:
+            self._proxy_headers["X-Tensorlake-Sandbox-Id"] = sandbox_identifier
+
+    def _rebind_proxy(self, info: SandboxInfo) -> None:
+        self._require_lifecycle_client("refresh proxy routing")
+        if info.status != SandboxStatus.RUNNING:
+            raise SandboxError(
+                f"Sandbox {info.sandbox_id!r} is {info.status.value}; cannot refresh proxy routing"
+            )
+        if info.sandbox_url is None and self._explicit_proxy_url is None:
+            raise SandboxError(
+                f"Sandbox {info.sandbox_id!r} did not include proxy routing information"
+            )
+
+        proxy_url = self._lifecycle_client._rust_client.select_sandbox_proxy_url(
+            sandbox_id=info.sandbox_id,
+            sandbox_url=info.sandbox_url,
+            ingress_endpoint=info.ingress_endpoint,
+            explicit_proxy_url=self._explicit_proxy_url,
+        )
+        connect_proxy_kwargs = {
+            "proxy_url": proxy_url,
+            "sandbox_id": info.sandbox_id,
+            "routing_hint": info.routing_hint,
+        }
+        if self._request_timeout is not None:
+            connect_proxy_kwargs["request_timeout_sec"] = self._request_timeout
+        try:
+            new_rust_client = self._lifecycle_client._rust_client.connect_proxy(
+                **connect_proxy_kwargs
+            )
+        except Exception as e:
+            _raise_as_sandbox_error(e)
+
+        self._rust_client = new_rust_client
+        self._base_url = self._rust_client.base_url()
+        self._set_proxy_transport(proxy_url, info.sandbox_id)
+        self._cached_info = info
+        self._sandbox_id = info.sandbox_id
+
+    def _fresh_running_info_for_rebind(
+        self,
+        deadline: float,
+        poll_interval: float,
+    ) -> SandboxInfo:
+        self._require_lifecycle_client("refresh proxy routing")
+        identifier = self._lifecycle_identifier()
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            request_client = self._lifecycle_client._with_request_timeout(
+                min(remaining, self._lifecycle_client._request_timeout)
+            )
+            info = request_client.get(identifier).value
+            if info.status == SandboxStatus.RUNNING and (
+                info.sandbox_url is not None or self._explicit_proxy_url is not None
+            ):
+                return info
+            if info.status == SandboxStatus.TERMINATED:
+                raise SandboxError(
+                    f"Sandbox {identifier!r} terminated while refreshing proxy routing"
+                )
+            time.sleep(min(poll_interval, max(0.0, deadline - time.monotonic())))
+        raise SandboxError(
+            f"Sandbox {identifier!r} did not provide refreshed proxy routing within timeout"
+        )
 
     # --- Class-level factory methods ---
 
@@ -580,9 +651,15 @@ class Sandbox:
     ) -> None:
         """Resume this sandbox.
 
-        By default blocks until the sandbox is ``Running`` and routable.
-        Pass ``wait=False`` for fire-and-return. No-op (no error) if the
-        sandbox is already Running.
+        By default blocks until the sandbox is ``Running`` and refreshes this
+        handle's cached proxy routing. Rare transient proxy errors may still
+        occur immediately after resume.
+
+        Pass ``wait=False`` for fire-and-return. In that mode this handle's
+        cached proxy routing is not refreshed; use the default ``wait=True``
+        for immediate follow-up operations. If you intentionally use
+        ``wait=False``, wait until the sandbox is running and reconnect to get
+        fresh routing before issuing process/file/PTY operations.
 
         Args:
             wait: If True (default), poll until Running.
@@ -594,9 +671,17 @@ class Sandbox:
                 or terminates unexpectedly.
         """
         self._require_lifecycle_client("resume")
+        deadline = time.monotonic() + timeout
+        remaining = max(0.0, deadline - time.monotonic())
         self._lifecycle_client.resume(
-            self.sandbox_id, wait=wait, timeout=timeout, poll_interval=poll_interval
+            self._lifecycle_identifier(),
+            wait=wait,
+            timeout=remaining,
+            poll_interval=poll_interval,
         )
+        if wait:
+            info = self._fresh_running_info_for_rebind(deadline, poll_interval)
+            self._rebind_proxy(info)
 
     def attach_file_system(
         self,

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -42,14 +42,17 @@ class _FakeRustClient:
     def resume_sandbox(self, sandbox_id):
         self.resume_calls.append(sandbox_id)
 
-    def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):
-        self.connect_proxy_calls.append(
-            {
-                "proxy_url": proxy_url,
-                "sandbox_id": sandbox_id,
-                "routing_hint": routing_hint,
-            }
-        )
+    def connect_proxy(
+        self, *, proxy_url, sandbox_id, routing_hint=None, request_timeout_sec=None
+    ):
+        call = {
+            "proxy_url": proxy_url,
+            "sandbox_id": sandbox_id,
+            "routing_hint": routing_hint,
+        }
+        if request_timeout_sec is not None:
+            call["request_timeout_sec"] = request_timeout_sec
+        self.connect_proxy_calls.append(call)
         return _FakeRustProxyClient(proxy_url)
 
     def select_sandbox_proxy_url(
@@ -218,12 +221,40 @@ class _RecordingCreateRustClient:
             "server response did not include sandbox_url; refusing to derive a proxy URL"
         )
 
-    def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):
+    def connect_proxy(
+        self, *, proxy_url, sandbox_id, routing_hint=None, request_timeout_sec=None
+    ):
         return _FakeProxyClient()
 
     def delete_sandbox(self, *, sandbox_id):
         self.delete_calls.append(sandbox_id)
         return "trace-delete"
+
+
+def _sandbox_info_json(
+    sandbox_id: str,
+    *,
+    status: str = "running",
+    sandbox_url: str | None = None,
+    routing_hint: str | None = None,
+) -> str:
+    payload = {
+        "id": sandbox_id,
+        "namespace": "default",
+        "status": status,
+        "resources": {
+            "cpus": 1.0,
+            "memory_mb": 512,
+            "ephemeral_disk_mb": 1024,
+        },
+        "allow_unauthenticated_access": False,
+        "exposed_ports": [],
+    }
+    if sandbox_url is not None:
+        payload["sandbox_url"] = sandbox_url
+    if routing_hint is not None:
+        payload["routing_hint"] = routing_hint
+    return json.dumps(payload)
 
 
 class TestSandboxClientRustBackend(unittest.TestCase):
@@ -703,6 +734,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                     "proxy_url": "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
                     "sandbox_id": "sbx-1",
                     "routing_hint": "hint-1",
+                    "request_timeout_sec": 300.0,
                 }
             ],
         )
@@ -739,6 +771,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                     "proxy_url": "https://override.example.com",
                     "sandbox_id": "sbx-1",
                     "routing_hint": None,
+                    "request_timeout_sec": 300.0,
                 }
             ],
         )
@@ -792,6 +825,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                     "proxy_url": "https://sbx-canonical.sandbox.tensorlake.ai",
                     "sandbox_id": "sbx-canonical",
                     "routing_hint": "hint-2",
+                    "request_timeout_sec": 1,
                 }
             ],
         )
@@ -916,6 +950,159 @@ class TestSandboxClientRustBackend(unittest.TestCase):
 
         self.assertEqual(fake.resume_calls, ["my-env"])
         self.assertEqual(fake.suspend_calls, [])
+
+    def test_handle_resume_wait_rebinds_proxy_from_fresh_info(self):
+        class _ResumeRoutingRustClient(_FakeRustClient):
+            def __init__(self):
+                super().__init__()
+                self._responses = [
+                    _sandbox_info_json(
+                        "sbx-1",
+                        sandbox_url="https://old.sandbox.tensorlake.ai",
+                        routing_hint="old-hint",
+                    ),
+                    _sandbox_info_json(
+                        "sbx-1",
+                        sandbox_url="https://new.sandbox.tensorlake.ai",
+                        routing_hint="new-hint",
+                    ),
+                    _sandbox_info_json(
+                        "sbx-1",
+                        sandbox_url="https://new.sandbox.tensorlake.ai",
+                        routing_hint="new-hint",
+                    ),
+                ]
+
+            def get_sandbox_json(self, sandbox_id):
+                self.last_get_sandbox_id = sandbox_id
+                idx = min(len(self.connect_proxy_calls), len(self._responses) - 1)
+                if self.resume_calls:
+                    idx = min(2, len(self._responses) - 1)
+                return ("trace-get-sandbox", self._responses[idx])
+
+        client = SandboxClient(
+            api_url="http://localhost:8900",
+            api_key="k",
+            request_timeout=9.0,
+            _internal=True,
+        )
+        fake = _ResumeRoutingRustClient()
+        client._rust_client = fake
+        clamped_timeouts = []
+        client._with_request_timeout = lambda request_timeout: (
+            clamped_timeouts.append(request_timeout) or client
+        )
+        sandbox = client.connect("stable-name", request_timeout=7.0)
+
+        sandbox.resume(wait=True, timeout=2.0, poll_interval=0.01)
+
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://old.sandbox.tensorlake.ai",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": "old-hint",
+                    "request_timeout_sec": 7.0,
+                },
+                {
+                    "proxy_url": "https://new.sandbox.tensorlake.ai",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": "new-hint",
+                    "request_timeout_sec": 7.0,
+                },
+            ],
+        )
+        self.assertEqual(sandbox._proxy_url, "https://new.sandbox.tensorlake.ai")
+        self.assertEqual(sandbox._base_url, "https://new.sandbox.tensorlake.ai")
+        self.assertEqual(sandbox._sandbox_id, "sbx-1")
+        self.assertEqual(sandbox._cached_info.routing_hint, "new-hint")
+        self.assertTrue(clamped_timeouts)
+        self.assertLessEqual(clamped_timeouts[-1], 2.0)
+
+    def test_handle_resume_wait_false_does_not_rebind_proxy(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+        sandbox = client.connect("stable-name")
+
+        sandbox.resume(wait=False)
+
+        self.assertEqual(len(fake.connect_proxy_calls), 1)
+        self.assertEqual(fake.resume_calls, ["sbx-1"])
+
+    def test_handle_resume_requires_routing_info_without_explicit_proxy(self):
+        class _MissingRoutingRustClient(_FakeRustClient):
+            def __init__(self):
+                super().__init__()
+                self._calls = 0
+
+            def get_sandbox_json(self, sandbox_id):
+                self._calls += 1
+                if self._calls == 1:
+                    return (
+                        "trace-get-sandbox",
+                        _sandbox_info_json(
+                            "sbx-1",
+                            sandbox_url="https://old.sandbox.tensorlake.ai",
+                            routing_hint="old-hint",
+                        ),
+                    )
+                return ("trace-get-sandbox", _sandbox_info_json("sbx-1"))
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _MissingRoutingRustClient()
+        client._rust_client = fake
+        client._with_request_timeout = lambda request_timeout: client
+        sandbox = client.connect("stable-name")
+
+        with self.assertRaisesRegex(SandboxError, "refreshed proxy routing"):
+            sandbox.resume(wait=True, timeout=0.02, poll_interval=0.01)
+
+        self.assertEqual(len(fake.connect_proxy_calls), 1)
+
+    def test_handle_resume_rebind_failure_leaves_existing_proxy_intact(self):
+        class _FailingRebindRustClient(_FakeRustClient):
+            def __init__(self):
+                super().__init__()
+                self._calls = 0
+
+            def get_sandbox_json(self, sandbox_id):
+                self._calls += 1
+                if self._calls == 1:
+                    return (
+                        "trace-get-sandbox",
+                        _sandbox_info_json(
+                            "sbx-1",
+                            sandbox_url="https://old.sandbox.tensorlake.ai",
+                            routing_hint="old-hint",
+                        ),
+                    )
+                return (
+                    "trace-get-sandbox",
+                    _sandbox_info_json(
+                        "sbx-1",
+                        sandbox_url="https://new.sandbox.tensorlake.ai",
+                        routing_hint="new-hint",
+                    ),
+                )
+
+            def connect_proxy(self, **kwargs):
+                if self.connect_proxy_calls:
+                    raise RuntimeError("boom")
+                return super().connect_proxy(**kwargs)
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FailingRebindRustClient()
+        client._rust_client = fake
+        client._with_request_timeout = lambda request_timeout: client
+        sandbox = client.connect("stable-name")
+
+        with self.assertRaisesRegex(SandboxError, "boom"):
+            sandbox.resume(wait=True, timeout=2.0, poll_interval=0.01)
+
+        self.assertEqual(sandbox._proxy_url, "https://old.sandbox.tensorlake.ai")
+        self.assertEqual(sandbox._base_url, "https://old.sandbox.tensorlake.ai")
 
     def test_suspend_maps_404_to_sandbox_not_found(self):
         class FakeRustError(Exception):

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import unittest
 from unittest.mock import patch
@@ -36,14 +37,17 @@ class _FakeAsyncRustClient:
     def close(self):
         return None
 
-    def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):
-        self.connect_proxy_calls.append(
-            {
-                "proxy_url": proxy_url,
-                "sandbox_id": sandbox_id,
-                "routing_hint": routing_hint,
-            }
-        )
+    def connect_proxy(
+        self, *, proxy_url, sandbox_id, routing_hint=None, request_timeout_sec=None
+    ):
+        call = {
+            "proxy_url": proxy_url,
+            "sandbox_id": sandbox_id,
+            "routing_hint": routing_hint,
+        }
+        if request_timeout_sec is not None:
+            call["request_timeout_sec"] = request_timeout_sec
+        self.connect_proxy_calls.append(call)
         return _FakeAsyncRustProxyClient(proxy_url)
 
     def select_sandbox_proxy_url(
@@ -223,12 +227,40 @@ class _RecordingCreateRustClient:
             "server response did not include sandbox_url; refusing to derive a proxy URL"
         )
 
-    def connect_proxy(self, *, proxy_url, sandbox_id, routing_hint=None):
+    def connect_proxy(
+        self, *, proxy_url, sandbox_id, routing_hint=None, request_timeout_sec=None
+    ):
         return _FakeProxyClient()
 
     async def delete_sandbox_async(self, *, sandbox_id):
         self.delete_calls.append(sandbox_id)
         return "trace-delete"
+
+
+def _sandbox_info_json(
+    sandbox_id: str,
+    *,
+    status: str = "running",
+    sandbox_url: str | None = None,
+    routing_hint: str | None = None,
+) -> str:
+    payload = {
+        "id": sandbox_id,
+        "namespace": "default",
+        "status": status,
+        "resources": {
+            "cpus": 1.0,
+            "memory_mb": 512,
+            "ephemeral_disk_mb": 1024,
+        },
+        "allow_unauthenticated_access": False,
+        "exposed_ports": [],
+    }
+    if sandbox_url is not None:
+        payload["sandbox_url"] = sandbox_url
+    if routing_hint is not None:
+        payload["routing_hint"] = routing_hint
+    return json.dumps(payload)
 
 
 def _make_client(fake: object | None = None) -> AsyncSandboxClient:
@@ -707,6 +739,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
                     "proxy_url": "https://sbx-1.sandbox.gcp-use4.tensorlake.ai",
                     "sandbox_id": "sbx-1",
                     "routing_hint": "hint-1",
+                    "request_timeout_sec": 300.0,
                 }
             ],
         )
@@ -744,6 +777,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
                     "proxy_url": "https://override.example.com",
                     "sandbox_id": "sbx-1",
                     "routing_hint": None,
+                    "request_timeout_sec": 300.0,
                 }
             ],
         )
@@ -782,6 +816,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
                     "proxy_url": "https://sbx-canonical.sandbox.tensorlake.ai",
                     "sandbox_id": "sbx-canonical",
                     "routing_hint": "hint-2",
+                    "request_timeout_sec": 300.0,
                 }
             ],
         )
@@ -898,6 +933,175 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(fake.resume_calls, ["my-env"])
         self.assertEqual(fake.suspend_calls, [])
+
+    async def test_handle_resume_wait_rebinds_proxy_from_fresh_info(self):
+        class _ResumeRoutingRustClient(_FakeAsyncRustClient):
+            def __init__(self):
+                super().__init__()
+                self._calls = 0
+
+            async def get_sandbox_json_async(self, *, sandbox_id):
+                self._calls += 1
+                if self._calls == 1:
+                    return (
+                        "trace-get-sandbox",
+                        _sandbox_info_json(
+                            "sbx-1",
+                            sandbox_url="https://old.sandbox.tensorlake.ai",
+                            routing_hint="old-hint",
+                        ),
+                    )
+                return (
+                    "trace-get-sandbox",
+                    _sandbox_info_json(
+                        "sbx-1",
+                        sandbox_url="https://new.sandbox.tensorlake.ai",
+                        routing_hint="new-hint",
+                    ),
+                )
+
+        fake = _ResumeRoutingRustClient()
+        client = _make_client(fake)
+        sandbox = await client.connect("stable-name", request_timeout=7.0)
+
+        await sandbox.resume(wait=True, timeout=2.0, poll_interval=0.01)
+
+        self.assertEqual(
+            fake.connect_proxy_calls,
+            [
+                {
+                    "proxy_url": "https://old.sandbox.tensorlake.ai",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": "old-hint",
+                    "request_timeout_sec": 7.0,
+                },
+                {
+                    "proxy_url": "https://new.sandbox.tensorlake.ai",
+                    "sandbox_id": "sbx-1",
+                    "routing_hint": "new-hint",
+                    "request_timeout_sec": 7.0,
+                },
+            ],
+        )
+        self.assertEqual(sandbox._proxy_url, "https://new.sandbox.tensorlake.ai")
+        self.assertEqual(sandbox._base_url, "https://new.sandbox.tensorlake.ai")
+        self.assertEqual(sandbox._sandbox_id, "sbx-1")
+        self.assertEqual(sandbox._cached_info.routing_hint, "new-hint")
+
+    async def test_handle_resume_wait_false_does_not_rebind_proxy(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+        sandbox = await client.connect("stable-name")
+
+        await sandbox.resume(wait=False)
+
+        self.assertEqual(len(fake.connect_proxy_calls), 1)
+        self.assertEqual(fake.resume_calls, ["sbx-1"])
+
+    async def test_handle_resume_requires_routing_info_without_explicit_proxy(self):
+        class _MissingRoutingRustClient(_FakeAsyncRustClient):
+            def __init__(self):
+                super().__init__()
+                self._calls = 0
+
+            async def get_sandbox_json_async(self, *, sandbox_id):
+                self._calls += 1
+                if self._calls == 1:
+                    return (
+                        "trace-get-sandbox",
+                        _sandbox_info_json(
+                            "sbx-1",
+                            sandbox_url="https://old.sandbox.tensorlake.ai",
+                            routing_hint="old-hint",
+                        ),
+                    )
+                return ("trace-get-sandbox", _sandbox_info_json("sbx-1"))
+
+        fake = _MissingRoutingRustClient()
+        client = _make_client(fake)
+        sandbox = await client.connect("stable-name")
+
+        with self.assertRaisesRegex(SandboxError, "refreshed proxy routing"):
+            await sandbox.resume(wait=True, timeout=0.02, poll_interval=0.01)
+
+        self.assertEqual(len(fake.connect_proxy_calls), 1)
+
+    async def test_handle_resume_timeout_raises_sandbox_error(self):
+        class _SlowRefreshRustClient(_FakeAsyncRustClient):
+            def __init__(self):
+                super().__init__()
+                self._calls = 0
+
+            async def get_sandbox_json_async(self, *, sandbox_id):
+                self._calls += 1
+                if self._calls == 1:
+                    return (
+                        "trace-get-sandbox",
+                        _sandbox_info_json(
+                            "sbx-1",
+                            sandbox_url="https://old.sandbox.tensorlake.ai",
+                            routing_hint="old-hint",
+                        ),
+                    )
+                await asyncio.sleep(0.2)
+                return (
+                    "trace-get-sandbox",
+                    _sandbox_info_json(
+                        "sbx-1",
+                        sandbox_url="https://new.sandbox.tensorlake.ai",
+                        routing_hint="new-hint",
+                    ),
+                )
+
+        fake = _SlowRefreshRustClient()
+        client = _make_client(fake)
+        sandbox = await client.connect("stable-name")
+
+        with self.assertRaisesRegex(SandboxError, "refreshed proxy routing"):
+            await sandbox.resume(wait=True, timeout=0.01, poll_interval=0.01)
+
+        self.assertEqual(len(fake.connect_proxy_calls), 1)
+
+    async def test_handle_resume_rebind_failure_leaves_existing_proxy_intact(self):
+        class _FailingRebindRustClient(_FakeAsyncRustClient):
+            def __init__(self):
+                super().__init__()
+                self._calls = 0
+
+            async def get_sandbox_json_async(self, *, sandbox_id):
+                self._calls += 1
+                if self._calls == 1:
+                    return (
+                        "trace-get-sandbox",
+                        _sandbox_info_json(
+                            "sbx-1",
+                            sandbox_url="https://old.sandbox.tensorlake.ai",
+                            routing_hint="old-hint",
+                        ),
+                    )
+                return (
+                    "trace-get-sandbox",
+                    _sandbox_info_json(
+                        "sbx-1",
+                        sandbox_url="https://new.sandbox.tensorlake.ai",
+                        routing_hint="new-hint",
+                    ),
+                )
+
+            def connect_proxy(self, **kwargs):
+                if self.connect_proxy_calls:
+                    raise RuntimeError("boom")
+                return super().connect_proxy(**kwargs)
+
+        fake = _FailingRebindRustClient()
+        client = _make_client(fake)
+        sandbox = await client.connect("stable-name")
+
+        with self.assertRaisesRegex(SandboxError, "boom"):
+            await sandbox.resume(wait=True, timeout=2.0, poll_interval=0.01)
+
+        self.assertEqual(sandbox._proxy_url, "https://old.sandbox.tensorlake.ai")
+        self.assertEqual(sandbox._base_url, "https://old.sandbox.tensorlake.ai")
 
     async def test_suspend_polls_until_suspended(self):
         fake = _StatusSequenceRustClient(["running", "suspended"])

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.58",
+  "version": "0.5.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.58",
+      "version": "0.5.59",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.58",
+  "version": "0.5.59",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -672,17 +672,21 @@ export class SandboxClient {
     proxyUrl?: string,
     routingHint?: string,
     requestTimeout?: number,
+    explicitProxyUrl?: string,
   ): Sandbox {
+    const explicitProxyUrlProvided = arguments.length >= 5;
+    const resolvedExplicitProxyUrl = explicitProxyUrlProvided
+      ? explicitProxyUrl ?? undefined
+      : proxyUrl ?? explicitProxyUrlOverride() ?? undefined;
     return new Sandbox({
       sandboxId: identifier,
       proxyUrl,
+      explicitProxyUrl: resolvedExplicitProxyUrl,
       apiKey: this.apiKey,
       organizationId: this.organizationId,
       projectId: this.projectId,
       routingHint,
-      resolveProxyInfo: proxyUrl == null
-        ? async (currentIdentifier) => this.get(currentIdentifier)
-        : undefined,
+      resolveProxyInfo: async (currentIdentifier) => this.get(currentIdentifier),
       requestTimeout,
       nativeClient: this.native,
     });
@@ -729,17 +733,19 @@ export class SandboxClient {
       ingressEndpoint: string | undefined,
       sandboxUrl: string | undefined,
     ) => {
+      const explicitProxyUrl = options?.proxyUrl ?? explicitProxyUrlOverride() ?? undefined;
       const selectedProxyUrl = this.native.selectSandboxProxyUrl(
         sandboxId,
         sandboxUrl ?? null,
         ingressEndpoint ?? null,
-        options?.proxyUrl ?? explicitProxyUrlOverride() ?? null,
+        explicitProxyUrl ?? null,
       );
       const sandbox = requestClient.connect(
         sandboxId,
         selectedProxyUrl,
         routingHint,
         requestTimeout,
+        explicitProxyUrl,
       );
       sandbox._setOwner(requestClient);
       sandbox.traceId = result.traceId;

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -571,6 +571,8 @@ export interface SandboxOptions {
    * resolve the server-returned `sandboxUrl`.
    */
   proxyUrl?: string;
+  /** @internal Real caller/env proxy override, distinct from an internally selected proxyUrl. */
+  explicitProxyUrl?: string;
   apiKey?: string;
   organizationId?: string;
   projectId?: string;

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -66,12 +66,17 @@ class SandboxProxyConnection {
   ) => Promise<Traced<SandboxInfo>>;
   private resolvePromise: Promise<void> | null = null;
   private routingHint?: string;
+  private readonly optionRoutingHint?: string;
+  private readonly explicitProxyUrl?: string;
+  private resolveGeneration = 0;
 
   constructor(
     private readonly sandbox: Sandbox,
     private readonly options: SandboxOptions,
   ) {
     this.routingHint = options.routingHint;
+    this.optionRoutingHint = options.routingHint;
+    this.explicitProxyUrl = options.explicitProxyUrl ?? explicitProxyUrlOverride() ?? undefined;
     this.resolveProxyInfo = options.resolveProxyInfo;
     if (options.proxyUrl != null) {
       this.nativeProxy = this.configureProxy(
@@ -87,6 +92,9 @@ class SandboxProxyConnection {
   }
 
   async ensureResolved(): Promise<void> {
+    if (this.nativeProxy != null) {
+      return;
+    }
     if (this.resolveProxyInfo == null) {
       return;
     }
@@ -100,21 +108,23 @@ class SandboxProxyConnection {
       sandbox_id: identifier,
     });
 
+    const generation = this.resolveGeneration;
     this.resolvePromise = this.resolveProxyInfo(identifier)
       .then((info) => {
-        this.resolveProxyInfo = undefined;
+        if (generation !== this.resolveGeneration) {
+          return;
+        }
         this.sandbox.traceId = info.traceId;
         this.sandbox._setLifecycleIdentifier(info.sandboxId);
         this.sandbox._setName(info.name ?? null);
-        this.routingHint = this.routingHint ?? info.routingHint;
+        this.routingHint = info.routingHint ?? this.optionRoutingHint;
         const proxyUrl = this.options.nativeClient?.selectSandboxProxyUrl(
           info.sandboxId,
           info.sandboxUrl ?? null,
           info.ingressEndpoint ?? null,
-          this.options.proxyUrl ?? explicitProxyUrlOverride() ?? null,
+          this.explicitProxyUrl ?? null,
         ) ?? info.sandboxUrl
-          ?? this.options.proxyUrl
-          ?? explicitProxyUrlOverride();
+          ?? this.explicitProxyUrl;
         if (proxyUrl == null) {
           throw new SandboxError(
             "server response did not include sandbox_url; refusing to derive a proxy URL",
@@ -140,6 +150,40 @@ class SandboxProxyConnection {
     return this.resolvePromise;
   }
 
+  hasExplicitProxyUrl(): boolean {
+    return this.explicitProxyUrl != null;
+  }
+
+  refreshFromInfo(info: Traced<SandboxInfo>): void {
+    const routingHint = info.routingHint ?? this.optionRoutingHint;
+    const proxyUrl = this.options.nativeClient?.selectSandboxProxyUrl(
+      info.sandboxId,
+      info.sandboxUrl ?? null,
+      info.ingressEndpoint ?? null,
+      this.explicitProxyUrl ?? null,
+    ) ?? info.sandboxUrl
+      ?? this.explicitProxyUrl;
+    if (proxyUrl == null) {
+      throw new SandboxError(
+        "server response did not include sandbox_url; refusing to derive a proxy URL",
+      );
+    }
+    const state = this.buildProxyState(
+      proxyUrl,
+      info.sandboxId,
+      routingHint,
+    );
+    this.resolveGeneration += 1;
+    this.resolvePromise = null;
+    this.routingHint = routingHint;
+    this.nativeProxy = state.nativeProxy;
+    this.baseUrl = state.baseUrl;
+    this.wsHeaders = state.wsHeaders;
+    this.sandbox.traceId = info.traceId;
+    this.sandbox._setLifecycleIdentifier(info.sandboxId);
+    this.sandbox._setName(info.name ?? null);
+  }
+
   /** Await proxy resolution and return the Rust-backed proxy client. */
   async client(): Promise<NativeSandboxProxyClient> {
     await this.ensureResolved();
@@ -161,51 +205,68 @@ class SandboxProxyConnection {
     sandboxId: string,
     routingHint?: string,
   ): NativeSandboxProxyClient {
+    const state = this.buildProxyState(proxyUrl, sandboxId, routingHint);
+    this.baseUrl = state.baseUrl;
+    this.wsHeaders = state.wsHeaders;
+    return state.nativeProxy;
+  }
+
+  private buildProxyState(
+    proxyUrl: string,
+    sandboxId: string,
+    routingHint?: string,
+  ): {
+    nativeProxy: NativeSandboxProxyClient;
+    baseUrl: string;
+    wsHeaders: Record<string, string>;
+  } {
     // `baseUrl`/`wsHeaders` are still computed here for the WebSocket consumers
     // (PTY, tunnel, desktop), which do not flow through the native HTTP client.
     const { baseUrl, hostHeader, sandboxIdHeader } = resolveProxyTarget(
       proxyUrl,
       sandboxId,
     );
-    this.baseUrl = baseUrl;
-    this.wsHeaders = {};
+    const wsHeaders: Record<string, string> = {};
     if (this.options.apiKey) {
-      this.wsHeaders.Authorization = `Bearer ${this.options.apiKey}`;
+      wsHeaders.Authorization = `Bearer ${this.options.apiKey}`;
     }
     if (this.options.organizationId) {
-      this.wsHeaders["X-Forwarded-Organization-Id"] = this.options.organizationId;
+      wsHeaders["X-Forwarded-Organization-Id"] = this.options.organizationId;
     }
     if (this.options.projectId) {
-      this.wsHeaders["X-Forwarded-Project-Id"] = this.options.projectId;
+      wsHeaders["X-Forwarded-Project-Id"] = this.options.projectId;
     }
     if (hostHeader) {
-      this.wsHeaders.Host = hostHeader;
+      wsHeaders.Host = hostHeader;
     }
     if (sandboxIdHeader) {
-      this.wsHeaders["X-Tensorlake-Sandbox-Id"] = sandboxIdHeader;
+      wsHeaders["X-Tensorlake-Sandbox-Id"] = sandboxIdHeader;
     }
 
     // Prefer minting from the shared lifecycle client so the proxy reuses its
     // connection pool; fall back to a standalone client when none was wired.
+    let nativeProxy: NativeSandboxProxyClient;
     if (this.options.nativeClient) {
-      return this.options.nativeClient.connectProxy(
+      nativeProxy = this.options.nativeClient.connectProxy(
         proxyUrl,
         sandboxId,
         routingHint ?? null,
         this.proxyRequestTimeoutSec(),
       );
+    } else {
+      const binding = loadNativeSandboxBinding();
+      nativeProxy = new binding.NativeSandboxProxyClient(
+        proxyUrl,
+        sandboxId,
+        this.options.apiKey ?? null,
+        this.options.organizationId ?? null,
+        this.options.projectId ?? null,
+        routingHint ?? null,
+        null,
+        this.proxyRequestTimeoutSec(),
+      );
     }
-    const binding = loadNativeSandboxBinding();
-    return new binding.NativeSandboxProxyClient(
-      proxyUrl,
-      sandboxId,
-      this.options.apiKey ?? null,
-      this.options.organizationId ?? null,
-      this.options.projectId ?? null,
-      routingHint ?? null,
-      null,
-      this.proxyRequestTimeoutSec(),
-    );
+    return { nativeProxy, baseUrl, wsHeaders };
   }
 
   private proxyRequestTimeoutSec(): number | null {
@@ -231,6 +292,10 @@ function processUserPayload(
     throw new SandboxError("process user must not be empty");
   }
   return user;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const PTY_OP_DATA = 0x00;
@@ -670,12 +735,46 @@ export class Sandbox {
   /**
    * Resume this sandbox.
    *
-   * By default blocks until the sandbox is `Running` and routable. Pass
-   * `{ wait: false }` for fire-and-return.
+   * By default blocks until the sandbox is `Running` and refreshes this
+   * handle's cached proxy routing. Rare transient proxy errors may still occur
+   * immediately after resume.
+   *
+   * Pass `{ wait: false }` for fire-and-return. That mode does not refresh
+   * cached proxy routing on this handle; use the default wait behavior for
+   * immediate follow-up operations, or wait until the sandbox is running and
+   * reconnect before issuing process/file/PTY operations.
    */
   async resume(options?: SuspendResumeOptions): Promise<void> {
     const client = this.requireLifecycleClient("resume");
-    await client.resume(this.lifecycleIdentifier, options);
+    const wait = options?.wait !== false;
+    const timeout = options?.timeout ?? 300;
+    const pollInterval = options?.pollInterval ?? 1;
+    const deadline = Date.now() + timeout * 1000;
+    await client.resume(this.lifecycleIdentifier, {
+      ...options,
+      timeout: Math.max(0, (deadline - Date.now()) / 1000),
+    });
+    if (!wait) return;
+
+    while (Date.now() < deadline) {
+      const info = await client.get(this.lifecycleIdentifier);
+      if (
+        info.status === SandboxStatus.RUNNING &&
+        (info.sandboxUrl != null || this.proxy.hasExplicitProxyUrl())
+      ) {
+        this.proxy.refreshFromInfo(info);
+        return;
+      }
+      if (info.status === SandboxStatus.TERMINATED) {
+        throw new SandboxError(
+          `Sandbox ${this.lifecycleIdentifier} terminated while refreshing proxy routing`,
+        );
+      }
+      await sleep(Math.min(pollInterval * 1000, Math.max(0, deadline - Date.now())));
+    }
+    throw new SandboxError(
+      `Sandbox ${this.lifecycleIdentifier} did not provide refreshed proxy routing within ${timeout}s`,
+    );
   }
 
   /** Live-copy this running sandbox. */

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -15,6 +15,7 @@ describe("Sandbox", () => {
     vi.restoreAllMocks();
     delete process.env.TENSORLAKE_SDK_TIMINGS;
     delete process.env.TENSORLAKE_SDK_TIMING_PAYLOADS;
+    delete process.env.TENSORLAKE_SANDBOX_PROXY_URL;
   });
 
   function makeSandbox(id = "sbx-test"): Sandbox {
@@ -96,6 +97,289 @@ describe("Sandbox", () => {
       expect(response.sourceSandboxId).toBe("sbx-abc");
       expect(response.sandboxes[0].sandboxId).toBe("copy-1");
       expect(stub.client.copySandbox).toHaveBeenCalled();
+      sbx.close();
+    });
+  });
+
+  describe("resume", () => {
+    function sandboxInfo(overrides: Record<string, unknown> = {}) {
+      return JSON.stringify({
+        id: "sbx-1",
+        namespace: "default",
+        status: "running",
+        resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
+        sandbox_url: "https://old.sandbox.tensorlake.ai",
+        routing_hint: "old-hint",
+        ...overrides,
+      });
+    }
+
+    it("refreshes proxy routing after blocking resume", async () => {
+      const responses = [
+        sandboxInfo(),
+        sandboxInfo({
+          sandbox_url: "https://new.sandbox.tensorlake.ai",
+          routing_hint: "new-hint",
+        }),
+        sandboxInfo({
+          sandbox_url: "https://new.sandbox.tensorlake.ai",
+          routing_hint: "new-hint",
+        }),
+      ];
+      const stub = installNativeStub({
+        client: {
+          getSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: responses.shift()!,
+          })),
+          resumeSandbox: vi.fn(async () => "t"),
+        },
+        proxy: {
+          health: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({ healthy: true }),
+          })),
+        },
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "stable-name",
+        apiKey: "key",
+        apiUrl: "https://api.tensorlake.ai",
+        requestTimeout: 7,
+      });
+      await sbx.health();
+      await sbx.resume({ timeout: 2, pollInterval: 0.01 });
+
+      expect(stub.client.connectProxy).toHaveBeenNthCalledWith(
+        1,
+        "https://old.sandbox.tensorlake.ai",
+        "sbx-1",
+        "old-hint",
+        7,
+      );
+      expect(stub.client.connectProxy).toHaveBeenNthCalledWith(
+        2,
+        "https://new.sandbox.tensorlake.ai",
+        "sbx-1",
+        "new-hint",
+        7,
+      );
+      sbx.close();
+    });
+
+    it("does not refresh proxy routing for wait=false", async () => {
+      const stub = installNativeStub({
+        client: {
+          getSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: sandboxInfo(),
+          })),
+          resumeSandbox: vi.fn(async () => "t"),
+        },
+        proxy: {
+          health: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({ healthy: true }),
+          })),
+        },
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "stable-name",
+        apiKey: "key",
+        apiUrl: "https://api.tensorlake.ai",
+      });
+      await sbx.health();
+      await sbx.resume({ wait: false });
+
+      expect(stub.client.connectProxy).toHaveBeenCalledOnce();
+      expect(stub.client.resumeSandbox).toHaveBeenCalledWith("sbx-1");
+      sbx.close();
+    });
+
+    it("keeps caller proxyUrl as the explicit override across resume rebind", async () => {
+      const stub = installNativeStub({
+        client: {
+          getSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: sandboxInfo({
+              sandbox_url: "https://server-after-resume.tensorlake.ai",
+              routing_hint: "new-hint",
+            }),
+          })),
+          resumeSandbox: vi.fn(async () => "t"),
+          selectSandboxProxyUrl: vi.fn(
+            (
+              _sandboxId: string,
+              sandboxUrl?: string | null,
+              _ingressEndpoint?: string | null,
+              explicitProxyUrl?: string | null,
+            ) => explicitProxyUrl ?? sandboxUrl ?? "",
+          ),
+        },
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-1",
+        proxyUrl: "https://caller-proxy.example.com",
+        apiKey: "key",
+        apiUrl: "https://api.tensorlake.ai",
+        requestTimeout: 7,
+      });
+
+      await sbx.resume({ timeout: 2, pollInterval: 0.01 });
+
+      expect(stub.client.selectSandboxProxyUrl).toHaveBeenCalledWith(
+        "sbx-1",
+        "https://server-after-resume.tensorlake.ai",
+        null,
+        "https://caller-proxy.example.com",
+      );
+      expect(stub.client.connectProxy).toHaveBeenNthCalledWith(
+        2,
+        "https://caller-proxy.example.com",
+        "sbx-1",
+        "new-hint",
+        7,
+      );
+      sbx.close();
+    });
+
+    it("keeps the connect-time env proxy override across resume rebind", async () => {
+      process.env.TENSORLAKE_SANDBOX_PROXY_URL = "https://initial-env.example.com";
+      const responses = [
+        sandboxInfo({
+          sandbox_url: undefined,
+          routing_hint: "old-hint",
+        }),
+        sandboxInfo({
+          sandbox_url: undefined,
+          routing_hint: "new-hint",
+        }),
+        sandboxInfo({
+          sandbox_url: undefined,
+          routing_hint: "new-hint",
+        }),
+      ];
+      const stub = installNativeStub({
+        client: {
+          getSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: responses.shift()!,
+          })),
+          resumeSandbox: vi.fn(async () => "t"),
+          selectSandboxProxyUrl: vi.fn(
+            (
+              _sandboxId: string,
+              sandboxUrl?: string | null,
+              _ingressEndpoint?: string | null,
+              explicitProxyUrl?: string | null,
+            ) => explicitProxyUrl ?? sandboxUrl ?? "",
+          ),
+        },
+        proxy: {
+          health: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({ healthy: true }),
+          })),
+        },
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "stable-name",
+        apiKey: "key",
+        apiUrl: "https://api.tensorlake.ai",
+        requestTimeout: 7,
+      });
+      await sbx.health();
+      process.env.TENSORLAKE_SANDBOX_PROXY_URL = "https://later-env.example.com";
+
+      await sbx.resume({ timeout: 2, pollInterval: 0.01 });
+
+      expect(stub.client.selectSandboxProxyUrl).toHaveBeenNthCalledWith(
+        1,
+        "sbx-1",
+        null,
+        null,
+        "https://initial-env.example.com",
+      );
+      expect(stub.client.selectSandboxProxyUrl).toHaveBeenNthCalledWith(
+        2,
+        "sbx-1",
+        null,
+        null,
+        "https://initial-env.example.com",
+      );
+      expect(stub.client.connectProxy).toHaveBeenNthCalledWith(
+        2,
+        "https://initial-env.example.com",
+        "sbx-1",
+        "new-hint",
+        7,
+      );
+      sbx.close();
+    });
+
+    it("does not treat create-time server URL as an explicit resume override", async () => {
+      const stub = installNativeStub({
+        client: {
+          createSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({
+              sandbox_id: "sbx-1",
+              status: "running",
+              sandbox_url: "https://old.sandbox.tensorlake.ai",
+              routing_hint: "old-hint",
+            }),
+          })),
+          getSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: sandboxInfo({
+              sandbox_url: "https://new.sandbox.tensorlake.ai",
+              routing_hint: "new-hint",
+            }),
+          })),
+          resumeSandbox: vi.fn(async () => "t"),
+          selectSandboxProxyUrl: vi.fn(
+            (
+              _sandboxId: string,
+              sandboxUrl?: string | null,
+              _ingressEndpoint?: string | null,
+              explicitProxyUrl?: string | null,
+            ) => explicitProxyUrl ?? sandboxUrl ?? "",
+          ),
+        },
+      });
+
+      const sbx = await Sandbox.create({
+        apiKey: "key",
+        apiUrl: "https://api.tensorlake.ai",
+        requestTimeout: 7,
+      });
+      await sbx.resume({ timeout: 2, pollInterval: 0.01 });
+
+      expect(stub.client.selectSandboxProxyUrl).toHaveBeenNthCalledWith(
+        1,
+        "sbx-1",
+        "https://old.sandbox.tensorlake.ai",
+        null,
+        null,
+      );
+      expect(stub.client.selectSandboxProxyUrl).toHaveBeenNthCalledWith(
+        2,
+        "sbx-1",
+        "https://new.sandbox.tensorlake.ai",
+        null,
+        null,
+      );
+      expect(stub.client.connectProxy).toHaveBeenNthCalledWith(
+        2,
+        "https://new.sandbox.tensorlake.ai",
+        "sbx-1",
+        "new-hint",
+        7,
+      );
       sbx.close();
     });
   });


### PR DESCRIPTION
## Summary
- refresh Python and TypeScript sandbox proxy clients after blocking `resume()` by fetching fresh `SandboxInfo` and eagerly rebuilding routing state
- keep `wait=false` fire-and-return, document that it does not refresh cached routing, and preserve explicit proxy overrides as resolved-once values
- add a best-effort TTY-only CLI post-resume URL tip while keeping non-TTY output script-safe
- bump release metadata and locks to `0.5.59` across Python, TypeScript, Rust, and CLI packages

## Details
- guard post-resume rebinding on `RUNNING` plus `sandbox_url` unless an explicit override is present
- build replacement proxy clients before swapping handle state so failed rebinds leave the old proxy intact
- keep resume timeout behavior bounded by the original deadline, including sync post-resume refresh and async timeout typing
- protect TypeScript lazy proxy resolution from clobbering eagerly refreshed post-resume routing

## Verification
- `poetry run python tests/sandbox/test_client_rust_backend.py`
- `poetry run python tests/sandbox/test_client_rust_backend_async.py`
- `npm test -- --run tests/sandbox.test.ts tests/client.test.ts`
- `cargo fmt --check`
- `cargo test -p tensorlake-cli`
- `git diff --check`