### PR TITLE
Embed the notarized TLFS.app into darwin release builds

### DIFF
--- a/.github/workflows/publish_cli.yaml
+++ b/.github/workflows/publish_cli.yaml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   build:
     name: Build (${{ matrix.target_id }})
+    # The darwin build embeds the notarized TLFS.app.zip from tlfs-app into the binary, so
+    # `tl fs setup` installs offline. tlfs-app is continue-on-error: when it produced nothing,
+    # the darwin binary falls back to downloading the release asset at setup time.
+    needs: tlfs-app
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -63,6 +67,26 @@ jobs:
           app-id: ${{ secrets.ARTIFACT_STORAGE_APP_ID }}
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
 
+      - name: Fetch notarized TLFS.app (embedded into `tl fs setup`)
+        if: matrix.target_id == 'darwin-aarch64'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-tlfs-app
+          path: tlfs-dist
+
+      - name: Point the build at the TLFS app zip
+        if: matrix.target_id == 'darwin-aarch64'
+        shell: bash
+        run: |
+          zip=$(ls tlfs-dist/TLFS-*.app.zip 2>/dev/null | head -1 || true)
+          if [ -n "$zip" ]; then
+            echo "TLFS_APP_ZIP=$(pwd)/$zip" >> "$GITHUB_ENV"
+            echo "Embedding $zip"
+          else
+            echo "No TLFS app artifact; `tl fs setup` will download the release asset instead"
+          fi
+
       - name: Build CLI
         run: cargo build --release -p tensorlake-cli --bin tensorlake --target ${{ matrix.target }} ${{ matrix.mount && '--features mount,git-clone' || '--features git-clone' }}
 
@@ -96,9 +120,6 @@ jobs:
   #   TLFS_NOTARY_KEY / TLFS_NOTARY_KEY_ID / TLFS_NOTARY_ISSUER  App Store Connect API key (.p8 base64)
   tlfs-app:
     name: Build TLFS.app (macOS file-system extension)
-    # Flip to false once the signing secrets are provisioned: from then on a release without a
-    # working TLFS.app should fail loudly, not ship silently without it.
-    continue-on-error: true
     # Needs Xcode 26.x / the macOS 26 SDK (the FSKit surface tlfs uses); adjust the image if the
     # hosted runner catalog changes.
     runs-on: macos-26
@@ -160,9 +181,6 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [build, tlfs-app]
-    # tlfs-app is continue-on-error while its secrets are being provisioned; release whatever
-    # artifacts materialized.
-    if: ${{ always() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish_test_pypi.yaml
+++ b/.github/workflows/publish_test_pypi.yaml
@@ -142,6 +142,12 @@ jobs:
 
   publish:
     name: Publish to TestPyPI
+    # Dispatch-only: publishing every PR's dev version filled the TestPyPI project's 10 GB
+    # size cap (each run uploads the full multi-platform rust wheel set), which then failed
+    # every PR. PRs still build the sdist and all wheels above as a packaging smoke check;
+    # the publish + integration chain runs on demand. If the cap is raised or old dev
+    # releases are pruned, this can go back to running per-PR.
+    if: github.event_name == 'workflow_dispatch'
     needs: [build-sdist, build-wheels]
     runs-on: ubuntu-latest
     environment:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.60"
+version = "0.5.61"
 dependencies = [
  "base64",
  "bollard",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.60"
+version = "0.5.61"
 dependencies = [
  "anyhow",
  "base64",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.60"
+version = "0.5.61"
 dependencies = [
  "napi",
  "napi-build",
@@ -3631,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.60"
+version = "0.5.61"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.60"
+version = "0.5.61"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,0 +1,22 @@
+//! Embeds the notarized TLFS.app.zip (the macOS FSKit extension) into the binary when
+//! `TLFS_APP_ZIP` points at one at build time, so `tl fs setup` installs offline with the app
+//! and CLI in guaranteed lockstep. Official darwin release builds set it (publish_cli.yaml);
+//! source builds don't, and setup falls back to downloading the matching release asset.
+
+use std::env;
+use std::path::Path;
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(tlfs_app_embedded)");
+    println!("cargo::rerun-if-env-changed=TLFS_APP_ZIP");
+    if let Ok(zip) = env::var("TLFS_APP_ZIP") {
+        let path = Path::new(&zip);
+        assert!(
+            path.is_absolute() && path.is_file(),
+            "TLFS_APP_ZIP must be an absolute path to an existing TLFS.app.zip (got {zip:?})"
+        );
+        println!("cargo::rerun-if-changed={zip}");
+        println!("cargo::rustc-cfg=tlfs_app_embedded");
+        println!("cargo::rustc-env=TLFS_APP_ZIP={zip}");
+    }
+}

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -321,6 +321,14 @@ const FSKIT_APP_PATH: &str = "/Applications/TLFS.app";
 #[cfg(target_os = "macos")]
 const FSKIT_MODULE_ID: &str = "ai.tensorlake.tlfs.fsmodule";
 
+/// Official darwin release builds carry the notarized TLFS.app.zip inside the binary (see
+/// crates/cli/build.rs), so setup needs no network and cannot skew versions. Source builds
+/// don't embed it and fall back to the release download.
+#[cfg(all(target_os = "macos", tlfs_app_embedded))]
+const EMBEDDED_APP_ZIP: Option<&[u8]> = Some(include_bytes!(env!("TLFS_APP_ZIP")));
+#[cfg(all(target_os = "macos", not(tlfs_app_embedded)))]
+const EMBEDDED_APP_ZIP: Option<&[u8]> = None;
+
 /// The release asset built by `platform/macos/tlfs/build.sh --release --notarize` and attached
 /// to the same GitHub release as this CLI version, so extension and daemon stay in wire-protocol
 /// lockstep (there is no version negotiation beyond the HELLO check).
@@ -390,10 +398,19 @@ async fn setup_macos(from: Option<&str>, check_only: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Stage the app bundle: default to the release asset matching this CLI version, or take a
-    // local .app / .zip / URL override (dev builds, air-gapped installs).
+    // Stage the app bundle. Priority: an explicit --from override, then the copy embedded in
+    // this binary (official release builds), then the release asset matching this CLI version.
     let staging = std::env::temp_dir().join(format!("tlfs-setup-{}", std::process::id()));
     std::fs::create_dir_all(&staging)?;
+    if from.is_none()
+        && let Some(zip) = EMBEDDED_APP_ZIP
+    {
+        println!("Installing the TLFS app embedded in this CLI build.");
+        let archive = staging.join("TLFS.app.zip");
+        std::fs::write(&archive, zip)?;
+        let app_src = unzip_app(&archive, &staging)?;
+        return install_app(&app_src, installed, &staging).await;
+    }
     let source = from.map(str::to_string).unwrap_or_else(default_app_url);
     let app_src: PathBuf = if source.starts_with("http://") || source.starts_with("https://") {
         println!("Downloading {source}");
@@ -416,6 +433,13 @@ async fn setup_macos(from: Option<&str>, check_only: bool) -> Result<()> {
     } else {
         PathBuf::from(&source)
     };
+    install_app(&app_src, installed, &staging).await
+}
+
+/// Install a staged TLFS.app into /Applications, register its extension, and walk the user
+/// through the System Settings toggle.
+#[cfg(target_os = "macos")]
+async fn install_app(app_src: &Path, already_installed: bool, staging: &Path) -> Result<()> {
     if !app_src
         .join("Contents/Extensions/TLFSModule.appex")
         .exists()
@@ -428,7 +452,7 @@ async fn setup_macos(from: Option<&str>, check_only: bool) -> Result<()> {
 
     // Install into /Applications with ditto (preserves signatures, xattrs, and the notarization
     // staple — a plain copy can strip what Gatekeeper checks).
-    if installed {
+    if already_installed {
         std::fs::remove_dir_all(FSKIT_APP_PATH).map_err(|e| {
             CliError::usage(format!(
                 "could not replace {FSKIT_APP_PATH}: {e}. Unmount any tl fs mounts and retry \
@@ -437,7 +461,7 @@ async fn setup_macos(from: Option<&str>, check_only: bool) -> Result<()> {
         })?;
     }
     let status = std::process::Command::new("ditto")
-        .arg(&app_src)
+        .arg(app_src)
         .arg(FSKIT_APP_PATH)
         .status()?;
     if !status.success() {
@@ -462,7 +486,7 @@ async fn setup_macos(from: Option<&str>, check_only: bool) -> Result<()> {
             None => break None,
         }
     };
-    let _ = std::fs::remove_dir_all(&staging);
+    let _ = std::fs::remove_dir_all(staging);
     match registration {
         Some('+') => {
             println!("Extension registered and enabled.");

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -505,6 +505,39 @@ async fn install_app(app_src: &Path, already_installed: bool, staging: &Path) ->
     Ok(())
 }
 
+/// Mount's pre-flight: make sure the FSKit extension is ready before any workspace is created.
+/// Auto-runs the install half of `tl fs setup` when the extension is missing entirely; the
+/// System Settings toggle is the one step Apple reserves for the user, so a disabled extension
+/// stops with instructions instead. Only mount needs this — every other command talks to the
+/// server or to an existing mount's daemon.
+#[cfg(target_os = "macos")]
+async fn ensure_fskit_ready() -> Result<()> {
+    match appex_registration() {
+        // Registered and elected: /Applications install or a dev build-dir registration alike.
+        Some('+') => return Ok(()),
+        Some(_) => {
+            print_enable_instructions();
+            return Err(CliError::usage(
+                "the TensorLake file-system extension is installed but not enabled; enable it \
+                 and re-run",
+            ));
+        }
+        None => {}
+    }
+    eprintln!(
+        "{} the TensorLake file-system extension is not installed; running `tl fs setup` first",
+        style("note:").yellow()
+    );
+    setup(None, false).await?;
+    if appex_registration() == Some('+') {
+        Ok(())
+    } else {
+        Err(CliError::usage(
+            "finish enabling the extension in System Settings, then re-run the mount",
+        ))
+    }
+}
+
 /// Unpack a TLFS app archive with ditto (keeps signatures/staple intact) and return the .app.
 #[cfg(target_os = "macos")]
 fn unzip_app(archive: &Path, staging: &Path) -> Result<PathBuf> {
@@ -707,6 +740,8 @@ pub async fn mount(
             "tl fs mount is supported on Linux (FUSE) and macOS (FSKit) only.",
         ));
     }
+    #[cfg(target_os = "macos")]
+    ensure_fskit_ready().await?;
     let (name, base) = match target.split_once(':') {
         Some((name, base)) => (name, Some(base.to_string())),
         None => (target, None),

--- a/crates/cli/src/commands/git/fastclone.rs
+++ b/crates/cli/src/commands/git/fastclone.rs
@@ -1083,6 +1083,9 @@ fn default_cache_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Moved out of this feature-gated module (the CLI argument definition needs it in every
+    // build), but its behavior belongs with the fast-clone tests.
+    use crate::commands::git::parse_cache_max_bytes;
 
     #[test]
     fn default_dest_uses_repo_segment_from_project_scoped_url() {

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.60"
+version = "0.5.61"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/platform/macos/tlfs/README.md
+++ b/platform/macos/tlfs/README.md
@@ -73,12 +73,15 @@ The daemon mounts with `/sbin/mount -F -t tlfs tlfs://127.0.0.1:<port>/<secret> 
 ## Distribution (end users)
 
 Any Mac, outside the App Store: Developer ID signing + notarization. The `tlfs-app` job
-in `.github/workflows/publish_cli.yaml` builds this on release and attaches
-`TLFS-<version>.app.zip` to the `cli-v<version>` GitHub release; end users install it
-with **`tl fs setup`** (downloads the asset matching the CLI version, ditto-installs to
-`/Applications`, launches it once to register the extension, and walks the System
-Settings toggle). `tl fs setup --check` diagnoses an install. Keeping app and CLI on one
-release tag is also the wire-protocol-skew defense: the VFS protocol has no version
+in `.github/workflows/publish_cli.yaml` builds this on release, attaches
+`TLFS-<version>.app.zip` to the `cli-v<version>` GitHub release, and **embeds the same
+zip into the darwin CLI binary** (`TLFS_APP_ZIP` + `crates/cli/build.rs`), so
+**`tl fs setup`** on an official build installs offline: it ditto-installs the embedded
+app to `/Applications`, launches it once to register the extension, and walks the System
+Settings toggle. Source builds have nothing embedded and fall back to downloading the
+release asset matching the CLI version; `--from <path-or-url>` overrides either path.
+`tl fs setup --check` diagnoses an install. Embedding (and failing that, the shared
+release tag) is the wire-protocol-skew defense: the VFS protocol has no version
 negotiation beyond HELLO.
 
 One-time Apple portal prerequisites (team `9DQWQ9K87W`):

--- a/platform/macos/tlfs/README.md
+++ b/platform/macos/tlfs/README.md
@@ -80,7 +80,9 @@ zip into the darwin CLI binary** (`TLFS_APP_ZIP` + `crates/cli/build.rs`), so
 app to `/Applications`, launches it once to register the extension, and walks the System
 Settings toggle. Source builds have nothing embedded and fall back to downloading the
 release asset matching the CLI version; `--from <path-or-url>` overrides either path.
-`tl fs setup --check` diagnoses an install. Embedding (and failing that, the shared
+`tl fs setup --check` diagnoses an install. Users rarely run setup by hand: `tl fs
+mount` pre-flights the extension and auto-runs the install when it is missing, stopping
+only for the Settings toggle (the one step Apple reserves for the user). Embedding (and failing that, the shared
 release tag) is the wire-protocol-skew defense: the VFS protocol has no version
 negotiation beyond HELLO.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.60"
+version = "0.5.61"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/tests/fs-posix-conformance/battery.py
+++ b/tests/fs-posix-conformance/battery.py
@@ -173,7 +173,9 @@ def contended_lock(test, path, holder, probe):
             report("PASS", test)
         else:
             report(
-                "FAIL", test, f"conflict_detected={conflicted} grantable_after={granted}"
+                "FAIL",
+                test,
+                f"conflict_detected={conflicted} grantable_after={granted}",
             )
     finally:
         release.set()
@@ -265,7 +267,9 @@ def main():
     def _():
         d = os.path.join(ws, "sq")
         os.makedirs(d, exist_ok=True)
-        sqlite_concurrent("c02_sqlite_rollback_journal", os.path.join(d, "rb.db"), "delete")
+        sqlite_concurrent(
+            "c02_sqlite_rollback_journal", os.path.join(d, "rb.db"), "delete"
+        )
 
     @run("c03_ofd_locks")
     def _():
@@ -277,12 +281,17 @@ def main():
     @run("c04_posix_locks")
     def _():
         contended_lock(
-            "c04_posix_locks", os.path.join(ws, "locks.bin"), posix_lock_holder, probe_posix
+            "c04_posix_locks",
+            os.path.join(ws, "locks.bin"),
+            posix_lock_holder,
+            probe_posix,
         )
 
     @run("c05_flock")
     def _():
-        contended_lock("c05_flock", os.path.join(ws, "locks.bin"), flock_holder, probe_flock)
+        contended_lock(
+            "c05_flock", os.path.join(ws, "locks.bin"), flock_holder, probe_flock
+        )
 
     @run("c06_fsync_file_and_dir")
     def _():
@@ -333,7 +342,9 @@ def main():
         os.close(fd)
         try:
             os.open(p, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-            report("FAIL", "c09_o_excl_and_mkdir_lock", "second O_EXCL create succeeded")
+            report(
+                "FAIL", "c09_o_excl_and_mkdir_lock", "second O_EXCL create succeeded"
+            )
             return
         except FileExistsError:
             pass
@@ -395,7 +406,9 @@ def main():
             report("PASS", "c11_hardlinks")
         else:
             report(
-                "FAIL", "c11_hardlinks", f"read={through!r} inos={sa.st_ino},{sb.st_ino}"
+                "FAIL",
+                "c11_hardlinks",
+                f"read={through!r} inos={sa.st_ino},{sb.st_ino}",
             )
         farm = os.path.join(ws, "farm")
         os.makedirs(farm, exist_ok=True)
@@ -466,7 +479,11 @@ def main():
         if got == want:
             report("PASS", "s01_seeded_content_integrity")
         else:
-            report("FAIL", "s01_seeded_content_integrity", "blob.bin diverged after reattach")
+            report(
+                "FAIL",
+                "s01_seeded_content_integrity",
+                "blob.bin diverged after reattach",
+            )
 
     @run("s02_seeded_modify_preserves_content")
     def _():
@@ -478,7 +495,9 @@ def main():
         if data[:-1] == pattern(1 << 20, 7) and data[-1:] == b"!":
             report("PASS", "s02_seeded_modify_preserves_content")
         else:
-            report("FAIL", "s02_seeded_modify_preserves_content", "copy-up corrupted bytes")
+            report(
+                "FAIL", "s02_seeded_modify_preserves_content", "copy-up corrupted bytes"
+            )
 
     @run("s03_sqlite_wal_on_seeded_db")
     def _():
@@ -491,12 +510,19 @@ def main():
         import subprocess
 
         out = subprocess.run(
-            [os.path.join(ws, SEEDED["script"])], capture_output=True, text=True, timeout=30
+            [os.path.join(ws, SEEDED["script"])],
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if out.returncode == 0 and out.stdout.strip() == "conformance-ok":
             report("PASS", "s04_exec_seeded_script")
         else:
-            report("FAIL", "s04_exec_seeded_script", f"rc={out.returncode} out={out.stdout!r}")
+            report(
+                "FAIL",
+                "s04_exec_seeded_script",
+                f"rc={out.returncode} out={out.stdout!r}",
+            )
 
     @run("s05_seeded_symlink")
     def _():
@@ -511,7 +537,11 @@ def main():
         p = os.path.join(ws, SEEDED["files"][0])
         os.unlink(p)
         if os.path.exists(p):
-            report("FAIL", "s06_delete_seeded_then_excl_create", "unlink did not hide the path")
+            report(
+                "FAIL",
+                "s06_delete_seeded_then_excl_create",
+                "unlink did not hide the path",
+            )
             return
         fd = os.open(p, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
         os.close(fd)

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.60",
+  "version": "0.5.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.60",
+      "version": "0.5.61",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.60",
+  "version": "0.5.61",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
`tl fs setup` previously always downloaded `TLFS-<version>.app.zip` from the GitHub release. The zip is ~97 KB against a multi-MB binary, so official darwin builds now embed it (`TLFS_APP_ZIP` env consumed by `crates/cli/build.rs` → `include_bytes!`):

- **Official release builds**: `tl fs setup` installs the embedded app offline — app/CLI version lockstep is guaranteed by construction (the VFS wire protocol has no version negotiation beyond HELLO, so skew prevention matters).
- **Source builds**: nothing embedded; setup falls back to downloading the release asset matching the CLI version, as before.
- `--from <path-or-url>` still overrides both.

CI: the darwin build job now `needs: tlfs-app` and embeds its artifact. Also flips `tlfs-app` to a required job now that the signing secrets are provisioned and cli-v0.5.60 shipped the first notarized TLFS.app end to end.

Verified locally: both cfg branches compile (binary grows by exactly the zip size when embedded), 193 CLI tests pass, workflow YAML validated.