### PR TITLE
Path-addressed fs commands resolve their scope from the mount state

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -662,6 +662,27 @@ fn state_dir_for(path: &Path) -> Result<(String, PathBuf)> {
     Ok((mountpoint, PathBuf::from(state_dir)))
 }
 
+/// Path-addressed commands (snapshot/promote/status/restore/diff/unmount) know their scope
+/// from the mount they operate on; seed the auth context from the mount state so they work
+/// from any working directory. Without this, running `tl fs snapshot` from a CWD with no
+/// `.tensorlake/config.toml` up-tree dropped into the interactive init flow — which, run from
+/// inside the mount, wrote its config INTO the workspace and the snapshot sealed it.
+pub fn hydrate_scope_from_mount(ctx: &mut CliContext, path: &Path) {
+    if ctx.effective_project_id().is_some() {
+        return;
+    }
+    let Ok((_, state_dir)) = state_dir_for(path) else {
+        return;
+    };
+    let Ok(state) = daemon::load_mount_state(&state_dir) else {
+        return;
+    };
+    ctx.project_id = Some(state.project_id);
+    if ctx.organization_id.is_none() {
+        ctx.organization_id = state.organization_id;
+    }
+}
+
 #[cfg(unix)]
 fn daemon_alive(pid: i32) -> bool {
     unsafe { libc::kill(pid, 0) == 0 }
@@ -911,6 +932,7 @@ pub async fn mount(
         &state_dir,
         &MountState {
             project_id: session.project_id.clone(),
+            organization_id: ctx.effective_organization_id(),
             repo: repo.clone(),
             workspace_id: ws.id.clone(),
             ref_name: ws.ref_name.clone(),
@@ -1222,9 +1244,14 @@ pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> R
         .chain(deletes.iter().cloned())
         .collect();
     revalidate_paths(Path::new(&mountpoint), &sealed);
+    // Small files skip chunk negotiation (token-only commits), so uploads can exceed the
+    // negotiated chunk count — clamp so the summary never reads "3 of 0 chunks".
     println!(
         "Snapshot {} ({} file(s), {} of {} chunks uploaded)",
-        report.commit, report.files, report.chunks_uploaded, report.chunks_total,
+        report.commit,
+        report.files,
+        report.chunks_uploaded,
+        report.chunks_total.max(report.chunks_uploaded),
     );
     Ok(())
 }

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -47,6 +47,10 @@ type InvalSink = Arc<dyn Fn(Vec<OverlayInval>) + Send + Sync>;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MountState {
     pub project_id: String,
+    /// Scope for platform token minting with a PAT. Absent in state files written before
+    /// path-addressed commands resolved their scope from the mount instead of the CWD.
+    #[serde(default)]
+    pub organization_id: Option<String>,
     pub repo: String,
     pub workspace_id: String,
     pub ref_name: String,

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -612,7 +612,9 @@ pub async fn push(
             })
         );
     } else {
-        let deduped = report.chunks_total - report.chunks_uploaded;
+        // Small files skip chunk negotiation, so uploads can exceed the negotiated count;
+        // saturate instead of panicking on the subtraction.
+        let deduped = report.chunks_total.saturating_sub(report.chunks_uploaded);
         println!(
             "{} {} -> {} ({} files, {} of {} chunks uploaded, {} deduplicated, {} bytes on the wire)",
             console::style("pushed").green().bold(),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2164,6 +2164,18 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
         }
         other => other,
     };
+    // Path-addressed commands carry their scope in the mount state; resolve it from there so
+    // they work from any CWD instead of triggering the interactive init flow (which, run from
+    // inside a mount, would write .tensorlake/config.toml into the workspace).
+    match &subcmd {
+        FsCommands::Snapshot { path, .. }
+        | FsCommands::Promote { path, .. }
+        | FsCommands::Status { path, .. }
+        | FsCommands::Restore { path, .. }
+        | FsCommands::Diff { path, .. }
+        | FsCommands::Unmount { path, .. } => commands::fs::hydrate_scope_from_mount(ctx, path),
+        _ => {}
+    }
     ensure_auth_and_project(ctx).await?;
     let result = match subcmd {
         FsCommands::Setup { .. } => unreachable!("handled before the auth guard"),


### PR DESCRIPTION
Org/project resolution walks up from the CWD looking for `.tensorlake/config.toml`, so `tl fs snapshot <path>` run from a directory with no config up-tree — e.g. from inside the mount itself — dropped into the interactive init flow. Worse, that flow then wrote its `config.toml` INTO the mounted workspace, and the snapshot sealed it into the file system.

The mount already knows its scope: `MountState` gains `organization_id` (serde default, so old state files load), and `snapshot`/`promote`/`status`/`restore`/`diff`/`unmount` hydrate the auth context from the mount state before the auth guard runs. They now work from any CWD without prompting; `mount`/`ls`/`rm` (which need a project before any mount exists) keep the existing resolution.

Also clamps the "N of M chunks uploaded" summaries: small files skip chunk negotiation (token-only commits), so uploads can exceed the negotiated count — snapshot printed "3 of 0 chunks", and `tl git push`'s dedup subtraction could panic on u64 underflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)