### PR TITLE
Fast, honest, wedge-proof unmounts

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1034,10 +1034,31 @@ pub async fn unmount(ctx: &CliContext, path: &Path, delete: bool) -> Result<()> 
     let (mountpoint, state_dir) = state_dir_for(path)?;
     let state = daemon::load_mount_state(&state_dir)?;
     let pid = daemon::daemon_pid(&state_dir);
-    let _ = daemon::control(&state_dir, "shutdown").await;
+    // The daemon replies to `shutdown` only once the kernel released the volume, so this call
+    // covers the slow phase (FSKit teardown on macOS takes seconds); spin so it doesn't look
+    // hung. A busy volume answers ok:false — surface it and leave the mount fully intact.
+    let bar = indicatif::ProgressBar::new_spinner();
+    bar.enable_steady_tick(std::time::Duration::from_millis(120));
+    bar.set_message(format!(
+        "unmounting {mountpoint} (waiting for the kernel to release the volume)..."
+    ));
+    if let Err(e) = daemon::control(&state_dir, "shutdown").await {
+        // A dead daemon is not an obstacle — the mount is already gone; clean up local state.
+        // Anything else (EBUSY, most likely) means the volume is still live and serving.
+        let message = e.to_string();
+        if !message.contains("mount daemon is not running") {
+            bar.finish_and_clear();
+            return Err(CliError::usage(format!(
+                "could not unmount {mountpoint}: {message}\nThe volume stays mounted and \
+                 usable. Close whatever is using it (shells cd'd inside, editors holding \
+                 files), then re-run: tl fs unmount {mountpoint}"
+            )));
+        }
+    }
     // Wait for the daemon to actually exit before tearing down its state dir: the shutdown op
     // races the process exit, and deleting upper/control state under a live daemon is how
-    // daemons leak (and how a reattach ends up sharing a state dir with a zombie).
+    // daemons leak (and how a reattach ends up sharing a state dir with a zombie). The kernel
+    // already let go by the time shutdown answered, so this is quick.
     if let Some(pid) = pid {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
         while unsafe { libc::kill(pid, 0) } == 0 {
@@ -1050,6 +1071,7 @@ pub async fn unmount(ctx: &CliContext, path: &Path, delete: bool) -> Result<()> 
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
     }
+    bar.finish_and_clear();
     if delete {
         let session = FsSession::open(ctx, Some(&state.repo)).await?;
         let (user, token) = session.creds();

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -349,14 +349,24 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                             Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
                         },
                         "shutdown" => {
-                            let resp = serde_json::json!({ "ok": true });
-                            let mut stream = reader.into_inner();
-                            let _ = stream.write_all(format!("{resp}\n").as_bytes()).await;
-                            unmount(&mountpoint);
-                            // Exit outright: session-wait is not guaranteed to return after an
-                            // external unmount (observed leaked daemons on Linux), and the
-                            // daemon's one job is over. The reply above already flushed.
-                            std::process::exit(0);
+                            // Unmount BEFORE replying: the reply is the CLI's signal that the
+                            // kernel released the volume (the slow phase on macOS — fskitd
+                            // teardown). A busy volume (a shell cd'd inside) keeps the daemon
+                            // serving — exiting with the volume still attached is how zombie
+                            // mounts are born.
+                            if unmount(&mountpoint).await {
+                                let resp = serde_json::json!({ "ok": true });
+                                let mut stream = reader.into_inner();
+                                let _ = stream.write_all(format!("{resp}\n").as_bytes()).await;
+                                // Exit outright: session-wait is not guaranteed to return after
+                                // an external unmount (observed leaked daemons on Linux), and
+                                // the daemon's one job is over. The reply above already flushed.
+                                std::process::exit(0);
+                            }
+                            serde_json::json!({
+                                "ok": false,
+                                "error": "the volume is busy (something is still using it)",
+                            })
                         }
                         other => {
                             serde_json::json!({ "ok": false, "error": format!("unknown op {other:?}") })
@@ -449,10 +459,16 @@ async fn attach(overlay: Arc<OverlayFs>, mountpoint: &Path) -> Result<(Attached,
         .await
         .map_err(|e| CliError::usage(format!("vfs server: {e}")))?;
     let url = format!("tlfs://127.0.0.1:{}/{}", server.port, server.secret);
+    // nobrowse asks for MNT_DONTBROWSE: no Finder sidebar entry, no mds indexing crawl (the
+    // classic macOS unmount-delayer), no .DS_Store turds in workspaces. Advisory for now —
+    // fskitd on 26.5 accepts but does not apply it (mount table shows no nobrowse; measured) —
+    // kept so the behavior arrives for free when FSKit honors it.
     let status = tokio::process::Command::new("/sbin/mount")
         .arg("-F")
         .arg("-t")
         .arg("tlfs")
+        .arg("-o")
+        .arg("nobrowse")
         .arg(&url)
         .arg(mountpoint)
         .status()
@@ -474,31 +490,82 @@ async fn attach(overlay: Arc<OverlayFs>, mountpoint: &Path) -> Result<(Attached,
 
 #[cfg(target_os = "macos")]
 fn is_mounted(mountpoint: &Path) -> bool {
+    // Read the kernel's mount table with MNT_NOWAIT instead of statfs(mountpoint): statfs
+    // calls into the filesystem and BLOCKS (uninterruptibly) while an unmount of it is in
+    // flight — the exact moment this question gets asked. Measured: a busy-volume unmount
+    // wedged the daemon in statfs for 50 minutes. getfsstat with MNT_NOWAIT only copies
+    // cached table entries and never touches the fs.
     use std::os::unix::ffi::OsStrExt;
-    let Ok(c_path) = std::ffi::CString::new(mountpoint.as_os_str().as_bytes()) else {
-        return false;
-    };
-    let mut sfs: libc::statfs = unsafe { std::mem::zeroed() };
-    if unsafe { libc::statfs(c_path.as_ptr(), &mut sfs) } != 0 {
+    let want = mountpoint.as_os_str().as_bytes();
+    let count = unsafe { libc::getfsstat(std::ptr::null_mut(), 0, libc::MNT_NOWAIT) };
+    if count <= 0 {
         return false;
     }
-    let fstype = unsafe { std::ffi::CStr::from_ptr(sfs.f_fstypename.as_ptr()) };
-    fstype.to_string_lossy() == "tlfs"
+    // Room for a few mounts appearing between the two calls; the kernel truncates to fit.
+    let capacity = count as usize + 8;
+    let mut stats: Vec<libc::statfs> = Vec::with_capacity(capacity);
+    let bufsize = (capacity * std::mem::size_of::<libc::statfs>()) as libc::c_int;
+    let written = unsafe { libc::getfsstat(stats.as_mut_ptr(), bufsize, libc::MNT_NOWAIT) };
+    if written <= 0 {
+        return false;
+    }
+    unsafe { stats.set_len(written as usize) };
+    stats.iter().any(|sfs| {
+        let name = unsafe { std::ffi::CStr::from_ptr(sfs.f_mntonname.as_ptr()) };
+        let fstype = unsafe { std::ffi::CStr::from_ptr(sfs.f_fstypename.as_ptr()) };
+        fstype.to_bytes() == b"tlfs" && name.to_bytes() == want
+    })
 }
 
-/// Ask the kernel to unmount; the daemon then observes the detach and exits.
+/// Ask the kernel to unmount, bounded. A busy volume (a shell cd'd inside) makes umount(8)
+/// fail with EBUSY; on macOS/FSKit a teardown can also wedge in-kernel, so the wait is capped
+/// and the mount table (never the filesystem itself — see is_mounted) is the arbiter on every
+/// non-success path. Returns whether the volume is actually detached.
 #[cfg(unix)]
-fn unmount(mountpoint: &Path) {
+async fn unmount(mountpoint: &Path) -> bool {
     #[cfg(target_os = "linux")]
-    let status = std::process::Command::new("fusermount")
-        .arg("-u")
-        .arg(mountpoint)
-        .status();
+    let mut cmd = {
+        let mut cmd = tokio::process::Command::new("fusermount");
+        cmd.arg("-u");
+        cmd
+    };
     #[cfg(not(target_os = "linux"))]
-    let status = std::process::Command::new("umount")
-        .arg(mountpoint)
-        .status();
-    if let Err(e) = status {
-        tracing::warn!("unmount of {} failed: {e}", mountpoint.display());
+    let mut cmd = tokio::process::Command::new("umount");
+    cmd.arg(mountpoint)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            tracing::warn!("unmount of {} failed to spawn: {e}", mountpoint.display());
+            return !still_mounted(mountpoint);
+        }
+    };
+    match tokio::time::timeout(Duration::from_secs(10), child.wait()).await {
+        Ok(Ok(status)) if status.success() => true,
+        // Fast failure (EBUSY) — or, on timeout, a wedged teardown whose child is deliberately
+        // left running (killing it would not abort an in-flight detach anyway).
+        _ => !still_mounted(mountpoint),
+    }
+}
+
+/// Whether the kernel still shows a live mount at `mountpoint`.
+#[cfg(unix)]
+fn still_mounted(mountpoint: &Path) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        is_mounted(mountpoint)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let path = mountpoint.to_string_lossy();
+        std::fs::read_to_string("/proc/self/mounts")
+            .map(|mounts| {
+                mounts
+                    .lines()
+                    .any(|line| line.split_whitespace().nth(1) == Some(path.as_ref()))
+            })
+            .unwrap_or(false)
     }
 }


### PR DESCRIPTION
Unmount used to feel hung and could wedge for real. Measured on macOS 26.5 (FSKit) and fixed at three layers:

- **Slow + silent**: the daemon replied to `shutdown` before unmounting, so the CLI's post-shutdown wait silently covered the whole FSKit teardown. It now unmounts first and replies with the outcome, and the CLI shows a spinner over that round trip. Clean unmounts measure ~1.3s and are visibly alive.
- **Busy volumes orphaned the mount**: umount(8) fails EBUSY when something holds the volume (a shell cd'd inside), and the old daemon exited anyway — leaving a zombie kernel mount with a dead backend (the `rmdir`-hangs case). The daemon now stays alive and answers "volume is busy"; the CLI reports it (bounded, ~10s worst case) and the mount stays fully usable. For a genuinely wedged teardown the umount child is deliberately left running — killing it cannot abort an in-flight detach.
- **The 50-minute wedge**: still-mounted checks used `statfs(mountpoint)`, which calls into the filesystem and blocks *uninterruptibly* while that filesystem's unmount is in flight — measured wedging the daemon for 50 minutes in state U. They now read the mount table via `getfsstat(MNT_NOWAIT)`, which never touches the fs.

Also mounts with `-o nobrowse` (advisory: fskitd on 26.5 accepts but does not yet apply MNT_DONTBROWSE; kept so Finder/Spotlight exclusion arrives free when it does).

Verified end-to-end on a live workspace: clean unmount 1.3s with spinner; busy unmount errors at ~10s with the volume left serving reads; re-run after the holder exits unmounts cleanly; daemon-dead unmount cleans local state in <1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)