### PR TITLE
Linux unmount uses fusermount3; failed daemon startups explain themselves

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -949,14 +949,17 @@ pub async fn mount(
         return daemon::run(ctx, &state_dir).await;
     }
 
-    // Detach the daemon and wait for its control socket to answer.
+    // Detach the daemon and wait for its control socket to answer. Its stderr lands in the
+    // state dir so a daemon that dies on startup (no /dev/fuse access, missing fusermount3,
+    // FSKit extension disabled) explains itself instead of just never answering.
     let exe = std::env::current_exe()?;
+    let daemon_log = state_dir.join("daemon.log");
     std::process::Command::new(exe)
         .args(["fs", "daemon", "--state-dir"])
         .arg(&state_dir)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::fs::File::create(&daemon_log)?)
         .spawn()?;
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
     loop {
@@ -1017,10 +1020,24 @@ pub async fn mount(
                         .delete_workspace(&session.project_id, &repo, user, token, &ws.id)
                         .await;
                 }
+                // The daemon's own last words are the diagnosis; read them before the state
+                // dir (and the log with it) goes away.
+                let last_words = std::fs::read_to_string(&daemon_log)
+                    .ok()
+                    .map(|log| {
+                        let mut tail: Vec<&str> =
+                            log.lines().filter(|l| !l.trim().is_empty()).collect();
+                        tail = tail.split_off(tail.len().saturating_sub(5));
+                        tail.join("\n  ")
+                    })
+                    .filter(|tail| !tail.is_empty())
+                    .map(|tail| format!(" Daemon log:\n  {tail}\n"))
+                    .unwrap_or_default();
                 let _ = std::fs::remove_dir_all(&state_dir);
                 return Err(CliError::usage(format!(
-                    "mount daemon did not come up: {e}. Linux builds need /dev/fuse; macOS needs the \
-                     TensorLake FSKit extension enabled."
+                    "mount daemon did not come up: {e}.{last_words}\nLinux needs /dev/fuse \
+                     accessible (mode 666) and the fuse3 package (fusermount3 + /etc/mtab); \
+                     macOS needs the TensorLake file-system extension (tl fs setup)."
                 )));
             }
         }

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -538,6 +538,54 @@ async fn ensure_fskit_ready() -> Result<()> {
     }
 }
 
+/// Mount's pre-flight on Linux: unprivileged FUSE needs /dev/fuse to be openable plus the
+/// setuid fusermount3 helper (fuse3 package) — mount(2) itself needs CAP_SYS_ADMIN regardless
+/// of device permissions. Checking up front turns "mount daemon did not come up" into the
+/// exact missing piece, and heads off the `sudo tl fs mount` reflex: a root mount is visible
+/// ONLY to root (FUSE denies other users without allow_other), with state and credentials
+/// under /root.
+#[cfg(target_os = "linux")]
+fn ensure_fuse_ready() -> Result<()> {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!(
+            "{} mounting as root: the volume will be accessible ONLY to root (FUSE default), \
+             and mount state lands in root's home. Prefer unprivileged mounts — they work \
+             wherever /dev/fuse is mode 666 and the fuse3 package is installed.",
+            style("warning:").yellow()
+        );
+        return Ok(());
+    }
+    if let Err(e) = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/fuse")
+    {
+        return Err(CliError::usage(format!(
+            "cannot open /dev/fuse ({e}); unprivileged mounts need it read/write. Fix:\n  \
+             sudo chmod 666 /dev/fuse\n(the fuse3 package's udev rule persists this on most \
+             distros; on minimal images add a tmpfiles.d entry: z /dev/fuse 0666 - - -)"
+        )));
+    }
+    let helper_on_path = |name: &str| {
+        std::env::var_os("PATH")
+            .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join(name).is_file()))
+    };
+    if !helper_on_path("fusermount3") && !helper_on_path("fusermount") {
+        return Err(CliError::usage(
+            "fusermount3 not found; unprivileged FUSE mounts go through the setuid helper from \
+             the fuse3 package. Fix:\n  sudo apt-get install fuse3",
+        ));
+    }
+    if !Path::new("/etc/mtab").exists() {
+        eprintln!(
+            "{} /etc/mtab is missing; fusermount3 will refuse to unmount later. Fix:\n  \
+             sudo ln -s /proc/self/mounts /etc/mtab",
+            style("warning:").yellow()
+        );
+    }
+    Ok(())
+}
+
 /// Unpack a TLFS app archive with ditto (keeps signatures/staple intact) and return the .app.
 #[cfg(target_os = "macos")]
 fn unzip_app(archive: &Path, staging: &Path) -> Result<PathBuf> {
@@ -763,6 +811,8 @@ pub async fn mount(
     }
     #[cfg(target_os = "macos")]
     ensure_fskit_ready().await?;
+    #[cfg(target_os = "linux")]
+    ensure_fuse_ready()?;
     let (name, base) = match target.split_once(':') {
         Some((name, base)) => (name, Some(base.to_string())),
         None => (target, None),

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -523,24 +523,31 @@ fn is_mounted(mountpoint: &Path) -> bool {
 /// non-success path. Returns whether the volume is actually detached.
 #[cfg(unix)]
 async fn unmount(mountpoint: &Path) -> bool {
+    // fuse3 systems ship only `fusermount3`, fuse2 systems only `fusermount` — try in that
+    // order (measured: Ubuntu 24.04's fuse3 has no `fusermount` compat name, and the old
+    // single-name spawn failed instantly, misreporting a free volume as busy).
     #[cfg(target_os = "linux")]
-    let mut cmd = {
-        let mut cmd = tokio::process::Command::new("fusermount");
-        cmd.arg("-u");
-        cmd
-    };
+    let unmounters: &[(&str, &[&str])] = &[("fusermount3", &["-u"]), ("fusermount", &["-u"])];
     #[cfg(not(target_os = "linux"))]
-    let mut cmd = tokio::process::Command::new("umount");
-    cmd.arg(mountpoint)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
-    let mut child = match cmd.spawn() {
-        Ok(child) => child,
-        Err(e) => {
-            tracing::warn!("unmount of {} failed to spawn: {e}", mountpoint.display());
-            return !still_mounted(mountpoint);
+    let unmounters: &[(&str, &[&str])] = &[("umount", &[])];
+    let mut child = None;
+    for (helper, args) in unmounters {
+        let mut cmd = tokio::process::Command::new(helper);
+        cmd.args(*args)
+            .arg(mountpoint)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        match cmd.spawn() {
+            Ok(spawned) => {
+                child = Some(spawned);
+                break;
+            }
+            Err(e) => tracing::warn!("could not spawn {helper}: {e}"),
         }
+    }
+    let Some(mut child) = child else {
+        return !still_mounted(mountpoint);
     };
     match tokio::time::timeout(Duration::from_secs(10), child.wait()).await {
         Ok(Ok(status)) if status.success() => true,


### PR DESCRIPTION
Found by testing `tl fs` end-to-end in a tensorlake sandbox (Ubuntu 24.04):

- **fusermount3**: fuse3 systems ship only `fusermount3` (no `fusermount` compat name). The daemon's unmount spawned `fusermount`, failed instantly, and misreported a free volume as busy. It now tries `fusermount3` then `fusermount`.
- **Daemon startup diagnostics**: a daemon that dies on startup (EACCES on `/dev/fuse`, missing fusermount3, disabled FSKit extension) produced only "mount daemon did not come up". Its stderr now lands in `<state-dir>/daemon.log`, the mount error quotes the last lines, and the hint names the actual Linux requirements (mode-666 `/dev/fuse`, fuse3 package, `/etc/mtab`).

Verified in the sandbox after fixing its image gaps by hand: mount → write → snapshot → unmount all pass (unmount 0.1s).

Note for the sandbox base image (separate repo): it needs `/dev/fuse` mode 666 (ships 600 root:root today), the `fuse3` package, and the standard `/etc/mtab -> /proc/self/mounts` symlink for `tl fs mount` to work out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)