### PR TITLE
Merge API clients: SDK wire types + tl fs sync / promote --merge / tl git merge

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -21,7 +21,8 @@ use tensorlake::artifact_storage::ArtifactStorageClient;
 use tensorlake::artifact_storage::ingest::{PushEvent, PushFile, PushOptions, PushSource};
 use tensorlake::artifact_storage::models::GitCredential;
 use tensorlake::artifact_storage::workspaces::{
-    CreateWorkspaceRequest, PromoteWorkspaceRequest, TreeEntry, WorkspaceInfo,
+    CreateWorkspaceRequest, PromoteOutcome, PromoteWorkspaceRequest, SyncWorkspaceRequest,
+    TreeEntry, WorkspaceInfo,
 };
 
 use crate::auth::context::CliContext;
@@ -930,6 +931,7 @@ pub async fn mount(
                     &CreateWorkspaceRequest {
                         base: base.clone(),
                         shared_target: shared_rw.then(|| base.clone().expect("guarded above")),
+                        ..Default::default()
                     },
                 )
                 .await?
@@ -1350,6 +1352,7 @@ pub async fn promote(
     path: &Path,
     branch: &str,
     full_history: bool,
+    merge: bool,
     message: Option<&str>,
 ) -> Result<()> {
     let (mountpoint, state_dir) = state_dir_for(path)?;
@@ -1375,7 +1378,9 @@ pub async fn promote(
         branch: branch.to_string(),
         expect_oid: None,
         full_history,
+        mode: merge.then(|| "merge".to_string()),
         message: message.map(str::to_string),
+        ..Default::default()
     };
     // A squash promote reads the snapshot's commit-index row, which materializes asynchronously
     // after the snapshot publishes; a promote issued right behind a snapshot can land in that
@@ -1395,7 +1400,25 @@ pub async fn promote(
                 )
                 .await
             {
-                Ok(resp) => break resp.into_inner(),
+                Ok(resp) => match resp.into_inner() {
+                    PromoteOutcome::Promoted(resp) => break resp,
+                    PromoteOutcome::Conflicted(report) => {
+                        eprintln!(
+                            "{} promote to {branch} conflicts on {} path(s); nothing was published:",
+                            style("error:").red(),
+                            report.conflicts.len(),
+                        );
+                        for c in &report.conflicts {
+                            eprintln!("  {:<14} {}", style(&c.kind).yellow(), c.path);
+                        }
+                        return Err(CliError::usage(format!(
+                            "pull {branch} into the workspace, resolve, and promote again:\n  tl fs sync {}\n  # fix the conflict markers, then\n  tl fs snapshot {} && tl fs promote {} {branch} --merge",
+                            path.display(),
+                            path.display(),
+                            path.display(),
+                        )));
+                    }
+                },
                 Err(tensorlake::error::SdkError::ServerError { status, message })
                     if status.as_u16() == 425 && std::time::Instant::now() < deadline =>
                 {
@@ -1411,12 +1434,140 @@ pub async fn promote(
         short_id(&state.workspace_id),
         resp.ref_name,
         resp.commit,
-        if resp.squashed {
+        if resp.fast_forwarded {
+            " (fast-forward)"
+        } else if resp.merged {
+            " (merge)"
+        } else if resp.squashed {
             " (squashed)"
         } else {
             " (full history)"
         },
     );
+    Ok(())
+}
+
+/// Sync: pull the target branch into a behind workspace — one server-side rebase-style merge
+/// commit on the target head; the mount's lower layer then advances to it. Under the default
+/// materialize policy conflicts land as diff3 markers in the workspace files; resolve them and
+/// snapshot. Local overlay changes would shadow synced content (markers included), so a dirty
+/// mount must snapshot first.
+pub async fn sync(
+    ctx: &CliContext,
+    path: &Path,
+    target: Option<&str>,
+    fail_on_conflict: bool,
+    message: Option<&str>,
+) -> Result<()> {
+    let (mountpoint, state_dir) = state_dir_for(path)?;
+    let state = daemon::load_mount_state(&state_dir)?;
+    if state.read_only() {
+        return Err(CliError::usage(format!(
+            "this is a read-only mount following {}; it syncs automatically",
+            state.follow_ref.as_deref().unwrap_or("the branch"),
+        )));
+    }
+    let session = FsSession::open(ctx, Some(&state.repo)).await?;
+    heartbeat(&session, &state).await?;
+    let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
+    if !upserts.is_empty() || !deletes.is_empty() {
+        return Err(CliError::usage(format!(
+            "{} local change(s) not in any snapshot would shadow synced content. Run `tl fs snapshot {}` first.",
+            upserts.len() + deletes.len(),
+            path.display(),
+        )));
+    }
+    let (user, token) = session.creds();
+    let request = SyncWorkspaceRequest {
+        target: target.map(str::to_string),
+        policy: fail_on_conflict.then(|| "fail".to_string()),
+        message: message.map(str::to_string),
+        ..Default::default()
+    };
+    // Same 425 contract as promote: a sync issued right behind a snapshot can catch the
+    // commit index still materializing.
+    let resp = {
+        let deadline = std::time::Instant::now() + TOO_EARLY_DEADLINE;
+        loop {
+            match session
+                .client
+                .workspace_sync(
+                    &session.project_id,
+                    &state.repo,
+                    user,
+                    token,
+                    &state.workspace_id,
+                    &request,
+                )
+                .await
+            {
+                Ok(resp) => break resp.into_inner(),
+                Err(tensorlake::error::SdkError::ServerError { status, .. })
+                    if status.as_u16() == 425 && std::time::Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    };
+    if resp.up_to_date {
+        println!(
+            "Already up to date with {}.",
+            &resp.target_head[..resp.target_head.len().min(12)]
+        );
+        return Ok(());
+    }
+    if !resp.clean && fail_on_conflict {
+        eprintln!(
+            "{} sync conflicts on {} path(s); the workspace is unchanged:",
+            style("error:").red(),
+            resp.conflicts.len(),
+        );
+        for c in &resp.conflicts {
+            eprintln!("  {:<14} {}", style(&c.kind).yellow(), c.path);
+        }
+        return Err(CliError::usage(
+            "rerun without --fail-on-conflict to materialize the conflicts as diff3 markers",
+        ));
+    }
+    // The workspace ref moved server-side; swap the mount's lower layer now instead of
+    // waiting out the follow poll, then make sure the kernel drops stale views of the
+    // conflicted paths (their content changed to marker text behind its back).
+    daemon::control(&state_dir, "refresh").await?;
+    if !resp.conflicts.is_empty() {
+        let mut changed = std::collections::BTreeSet::new();
+        let mut expect = std::collections::BTreeMap::new();
+        for c in &resp.conflicts {
+            changed.insert(c.path.clone());
+            expect.insert(c.path.clone(), PathExpect::Present);
+        }
+        converge_kernel_view(Path::new(&mountpoint), &changed, &expect);
+    }
+    println!(
+        "Synced with {} ({} path(s) pulled){}.",
+        &resp.target_head[..resp.target_head.len().min(12)],
+        resp.changed_paths,
+        if resp.fast_forwarded {
+            "; workspace fast-forwarded"
+        } else {
+            ""
+        },
+    );
+    if !resp.conflicts.is_empty() {
+        println!(
+            "{} {} conflict(s) materialized as diff3 markers:",
+            style("note:").yellow(),
+            resp.conflicts.len(),
+        );
+        for c in &resp.conflicts {
+            println!("  {:<14} {}", style(&c.kind).yellow(), c.path);
+        }
+        println!(
+            "Resolve the markers, then `tl fs snapshot {}`.",
+            path.display()
+        );
+    }
     Ok(())
 }
 

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use comfy_table::Cell;
 use console::style;
 use tensorlake::artifact_storage::ArtifactStorageClient;
+use tensorlake::artifact_storage::merge::MergeRequest;
 use tensorlake::artifact_storage::models::{
     ListBranchesResponse, ListOperationsResponse, ListRefsResponse, ListReposResponse,
 };
@@ -364,6 +365,166 @@ pub async fn list_operations(
         return Ok(());
     }
     print_operations_table(&response);
+    Ok(())
+}
+
+/// Server-side three-way merge of `theirs` into `ours` (gsvc merge design §9.3). Preflight
+/// never writes; commit mode CAS-advances the `ours` branch. A `fail`-policy conflict prints
+/// the report and exits non-zero — nothing was published.
+#[allow(clippy::too_many_arguments)]
+pub async fn merge(
+    ctx: &CliContext,
+    repo: &str,
+    ours: &str,
+    theirs: &str,
+    preflight: bool,
+    deep: bool,
+    materialize: bool,
+    message: Option<&str>,
+    base: Option<&str>,
+    output_json: bool,
+) -> Result<()> {
+    let project_id = project_id(ctx)?;
+    let client = artifact_storage_client(ctx)?;
+    let cred = client
+        .mint_token_for_repo(&project_id, Some(repo))
+        .await
+        .map_err(map_sdk_error)?
+        .into_inner();
+    let request = MergeRequest {
+        ours: ours.to_string(),
+        theirs: theirs.to_string(),
+        base: base.map(str::to_string),
+        deep,
+        mode: (!preflight).then(|| "commit".to_string()),
+        policy: materialize.then(|| "materialize".to_string()),
+        message: message.map(str::to_string),
+        ..Default::default()
+    };
+    let report = client
+        .repo_merge(&project_id, repo, &cred.git_username, &cred.token, &request)
+        .await
+        .map_err(map_sdk_error)?
+        .into_inner();
+    if output_json {
+        print_json(&report)?;
+        // A fail-policy conflict published nothing; the exit code says so even in JSON mode.
+        if !preflight && report.commit.is_none() && !report.clean {
+            return Err(CliError::usage("merge conflicts; nothing was published"));
+        }
+        return Ok(());
+    }
+    let short = |oid: &str| oid[..oid.len().min(12)].to_string();
+    if let Some(b) = &report.merge_base {
+        print_field("merge base", &short(b));
+    } else {
+        print_field("merge base", "none (unrelated histories)");
+    }
+    print_field("changed paths", &report.changed_paths.to_string());
+    if !report.conflicts.is_empty() {
+        println!(
+            "{} {} conflict(s):",
+            style("conflicts:").dim(),
+            report.conflicts.len()
+        );
+        for c in &report.conflicts {
+            println!(
+                "  {:<14} {}{}",
+                style(&c.kind).yellow(),
+                c.path,
+                if c.potential { " (potential)" } else { "" },
+            );
+        }
+        if report.conflicts.iter().any(|c| c.potential) {
+            println!("  (run with --deep for exact content-merge answers)");
+        }
+    }
+    if preflight {
+        if report.already_merged {
+            println!("{theirs} is already merged into {ours}; a merge would change nothing.");
+        } else if report.clean {
+            println!(
+                "Clean merge{}.",
+                if report.fast_forward {
+                    " (fast-forward)"
+                } else {
+                    ""
+                }
+            );
+        }
+        return Ok(());
+    }
+    match report.commit {
+        Some(commit) => {
+            println!(
+                "Merged {theirs} into {ours} at {}{}",
+                short(&commit),
+                if report.fast_forwarded {
+                    " (fast-forward)"
+                } else if !report.clean {
+                    " (conflicts materialized as diff3 markers)"
+                } else {
+                    ""
+                },
+            );
+            Ok(())
+        }
+        None if report.already_merged => {
+            println!("{theirs} is already merged into {ours}; nothing to do.");
+            Ok(())
+        }
+        None => Err(CliError::usage(format!(
+            "merge conflicts; nothing was published. Rerun with --materialize to land the conflicts as diff3 markers, or resolve on a workspace forked from {ours}.",
+        ))),
+    }
+}
+
+/// The structured conflict record of a materialize-policy merge commit.
+pub async fn commit_conflicts(
+    ctx: &CliContext,
+    repo: &str,
+    commit: &str,
+    output_json: bool,
+) -> Result<()> {
+    let project_id = project_id(ctx)?;
+    let client = artifact_storage_client(ctx)?;
+    let cred = client
+        .mint_token_for_repo(&project_id, Some(repo))
+        .await
+        .map_err(map_sdk_error)?
+        .into_inner();
+    let record = client
+        .commit_conflicts(&project_id, repo, &cred.git_username, &cred.token, commit)
+        .await
+        .map_err(map_sdk_error)?
+        .into_inner();
+    let Some(record) = record else {
+        println!("no conflict record: {commit} merged cleanly (or is unknown here)");
+        return Ok(());
+    };
+    if output_json {
+        return print_json(&record);
+    }
+    let short = |oid: &str| oid[..oid.len().min(12)].to_string();
+    print_field("ours", &short(&record.ours_commit));
+    print_field("theirs", &short(&record.theirs_commit));
+    if let Some(base) = &record.base_commit {
+        print_field("base", &short(base));
+    }
+    println!(
+        "{} {} path(s):",
+        style("conflicts:").dim(),
+        record.paths.len()
+    );
+    for p in &record.paths {
+        println!("  {:<14} {}", style(&p.kind).yellow(), p.path);
+    }
+    if record.truncated_paths > 0 {
+        println!(
+            "  … and {} more (record truncated; the commit's marker content is complete)",
+            record.truncated_paths
+        );
+    }
     Ok(())
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -299,7 +299,30 @@ enum FsCommands {
         #[arg(long)]
         full_history: bool,
 
+        /// Merge onto a moved target (two-parent merge commit); conflicts are reported
+        /// and nothing is published
+        #[arg(long, conflicts_with = "full_history")]
+        merge: bool,
+
         /// Commit message for the squashed promote
+        #[arg(short, long)]
+        message: Option<String>,
+    },
+
+    /// Pull the target branch into the workspace (server-side rebase-style merge)
+    Sync {
+        /// A mounted directory
+        path: PathBuf,
+
+        /// Branch to pull from (default: the branch the workspace was created from)
+        #[arg(long)]
+        target: Option<String>,
+
+        /// Fail on conflicts instead of materializing diff3 markers into the workspace
+        #[arg(long)]
+        fail_on_conflict: bool,
+
+        /// Commit message for the sync merge commit
         #[arg(short, long)]
         message: Option<String>,
     },
@@ -429,6 +452,43 @@ enum GitCommands {
         /// Force-with-lease: require the branch to currently equal this commit oid
         #[arg(long)]
         expect_oid: Option<String>,
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Server-side three-way merge of one branch (or commit) into another
+    Merge {
+        /// Repo name
+        repo: String,
+        /// Target branch the merge lands on (ours)
+        ours: String,
+        /// Branch or commit to merge in (theirs)
+        theirs: String,
+        /// Report what the merge would do without publishing anything
+        #[arg(long)]
+        preflight: bool,
+        /// Preflight: run the text merges for exact conflict answers instead of potential ones
+        #[arg(long)]
+        deep: bool,
+        /// Land conflicts as diff3 markers plus a structured conflict record instead of failing
+        #[arg(long, conflicts_with = "preflight")]
+        materialize: bool,
+        /// Merge commit message
+        #[arg(short, long)]
+        message: Option<String>,
+        /// Merge base override (commit hex)
+        #[arg(long)]
+        base: Option<String>,
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show the structured conflict record of a materialized merge commit
+    Conflicts {
+        /// Repo name
+        repo: String,
+        /// Merge commit oid (hex)
+        commit: String,
         /// Output JSON
         #[arg(long)]
         json: bool,
@@ -2166,6 +2226,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
     match &subcmd {
         FsCommands::Snapshot { path, .. }
         | FsCommands::Promote { path, .. }
+        | FsCommands::Sync { path, .. }
         | FsCommands::Status { path, .. }
         | FsCommands::Restore { path, .. }
         | FsCommands::Diff { path, .. }
@@ -2201,8 +2262,27 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             path,
             branch,
             full_history,
+            merge,
             message,
-        } => commands::fs::promote(ctx, &path, &branch, full_history, message.as_deref()).await,
+        } => {
+            commands::fs::promote(ctx, &path, &branch, full_history, merge, message.as_deref())
+                .await
+        }
+        FsCommands::Sync {
+            path,
+            target,
+            fail_on_conflict,
+            message,
+        } => {
+            commands::fs::sync(
+                ctx,
+                &path,
+                target.as_deref(),
+                fail_on_conflict,
+                message.as_deref(),
+            )
+            .await
+        }
         FsCommands::Status { path, json } => commands::fs::status(ctx, &path, json).await,
         FsCommands::Restore { path, version } => commands::fs::restore(ctx, &path, &version).await,
         FsCommands::Diff { path, a, b } => {
@@ -2278,6 +2358,34 @@ async fn run_git_command(ctx: &CliContext, subcmd: GitCommands) -> error::Result
             expect_oid,
             json,
         } => commands::git::push(ctx, &repo, &branch, &message, expect_oid, json).await,
+        GitCommands::Merge {
+            repo,
+            ours,
+            theirs,
+            preflight,
+            deep,
+            materialize,
+            message,
+            base,
+            json,
+        } => {
+            commands::git::merge(
+                ctx,
+                &repo,
+                &ours,
+                &theirs,
+                preflight,
+                deep,
+                materialize,
+                message.as_deref(),
+                base.as_deref(),
+                json,
+            )
+            .await
+        }
+        GitCommands::Conflicts { repo, commit, json } => {
+            commands::git::commit_conflicts(ctx, &repo, &commit, json).await
+        }
         GitCommands::CommitStatus { repo, job_id } => {
             commands::git::commit_status(ctx, &repo, &job_id).await
         }

--- a/crates/cloud-sdk/src/artifact_storage/merge.rs
+++ b/crates/cloud-sdk/src/artifact_storage/merge.rs
@@ -1,0 +1,290 @@
+//! Server-side three-way merge client (gsvc `docs/merge-design.md` §9.3).
+//!
+//! `POST /repos/{repo}/merge` computes a jj-style three-way tree merge entirely server-side:
+//! `preflight` mode is a pure reader returning the conflict report; `commit` mode mints the
+//! merged tree plus a two-parent merge commit and CAS-advances the `ours` branch. A conflicted
+//! commit under the default `fail` policy publishes nothing and the report rides a `409`;
+//! `materialize` publishes diff3 marker content plus a structured conflict record readable at
+//! `GET /repos/{repo}/commits/{oid}/conflicts`. Wire types here duplicate the gsvc-server
+//! shapes (same rule as the ingest shapes).
+
+use reqwest::{Method, StatusCode};
+use serde::{Deserialize, Serialize};
+
+use crate::Traced;
+use crate::error::SdkError;
+
+use super::ArtifactStorageClient;
+use super::ingest::expect_json;
+
+/// Commit author/committer identity for server-minted commits.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Signature {
+    pub name: String,
+    pub email: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct MergeRequest {
+    /// The side the merge lands on. Any commitish for preflight; a branch for commit mode
+    /// (its ref is what the merge commit CAS-advances).
+    pub ours: String,
+    /// The side being merged in.
+    pub theirs: String,
+    /// Explicit merge base override; omitted = walk the commit graph for the best common
+    /// ancestor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
+    /// Preflight only: run the text merges for same-file collisions instead of reporting them
+    /// as potential conflicts. Commit mode always runs them.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub deep: bool,
+    /// `"preflight"` (default) or `"commit"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    /// Commit mode: `"fail"` (default — conflicts publish nothing) or `"materialize"`
+    /// (conflicts publish marker content plus the structured conflict record).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy: Option<String>,
+    /// Commit mode: merge commit message; default `Merge {theirs} into {branch}`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<Signature>,
+}
+
+/// One side's entry at a conflicted path; `None` on the wire = the side is absent.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct MergeEntry {
+    /// Raw git mode (`0o100644`, `0o100755`, `0o120000`, `0o40000` for directories).
+    pub mode: u32,
+    pub oid: String,
+}
+
+/// One conflicted path with its jj-shaped term list (`ours`, negative `base`, `theirs`).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct MergeConflict {
+    pub path: String,
+    /// `content` | `delete_modify` | `add_add` | `kind_mismatch` | `mode` | `too_large`.
+    pub kind: String,
+    /// Shallow preflight only: the sides collide on content but the texts were not merged —
+    /// a deep preflight (or commit mode) may still resolve them cleanly.
+    #[serde(default)]
+    pub potential: bool,
+    pub ours: Option<MergeEntry>,
+    pub base: Option<MergeEntry>,
+    pub theirs: Option<MergeEntry>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct MergeStats {
+    pub trees_read: u64,
+    pub entries_compared: u64,
+    pub blobs_merged: u64,
+    pub wall_ms: f64,
+}
+
+/// The merge report: preflight result, commit-mode success body, and the `409` body when a
+/// `fail`-policy merge (or merge-mode promote) hit conflicts and published nothing.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MergeReport {
+    /// Resolved `ours` commit (hex).
+    pub ours: String,
+    /// Resolved `theirs` commit (hex).
+    pub theirs: String,
+    /// `None` = unrelated histories (the report then treats every path as added on both
+    /// sides).
+    pub merge_base: Option<String>,
+    pub clean: bool,
+    /// `ours` is an ancestor of `theirs`: the merge is a ref advance, no new commit needed.
+    pub fast_forward: bool,
+    /// `theirs` is already reachable from `ours`: nothing to do.
+    pub already_merged: bool,
+    pub changed_paths: u64,
+    pub conflicts: Vec<MergeConflict>,
+    pub stats: MergeStats,
+    /// Commit mode only: the published merge commit (`theirs` itself for a fast-forward).
+    #[serde(default)]
+    pub commit: Option<String>,
+    /// Commit mode only: the ref advanced to `theirs` with no new commit object.
+    #[serde(default)]
+    pub fast_forwarded: bool,
+}
+
+/// One term of a recorded conflict; index order is `[ours, base, theirs]`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ConflictTerm {
+    pub mode: u32,
+    pub oid: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ConflictPath {
+    pub path: String,
+    pub kind: String,
+    /// `[ours, base, theirs]`; `None` = the side is absent.
+    pub terms: Vec<Option<ConflictTerm>>,
+}
+
+/// The structured conflict record of a `materialize`-policy merge commit.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MergeConflictRecord {
+    pub version: u32,
+    pub ours_commit: String,
+    pub theirs_commit: String,
+    pub base_commit: Option<String>,
+    pub paths: Vec<ConflictPath>,
+    /// Conflicted paths dropped to bound the stored record; the commit's marker content
+    /// remains complete.
+    #[serde(default)]
+    pub truncated_paths: u32,
+}
+
+/// Decode a response whose `409` body may be a structured merge report (`fail`-policy
+/// conflicts publish nothing and return the report). A `409` that isn't a report (e.g. a
+/// concurrent ref move) stays a `ServerError`.
+pub(super) async fn expect_json_or_conflict<T, R>(
+    resp: reqwest::Response,
+) -> Result<Result<T, R>, SdkError>
+where
+    T: serde::de::DeserializeOwned,
+    R: serde::de::DeserializeOwned,
+{
+    let status = resp.status();
+    if status == StatusCode::CONFLICT {
+        let message = resp.text().await.unwrap_or_default();
+        if let Ok(report) = serde_json::from_str::<R>(&message) {
+            return Ok(Err(report));
+        }
+        return Err(SdkError::ServerError { status, message });
+    }
+    if !status.is_success() {
+        let message = resp.text().await.unwrap_or_default();
+        return Err(SdkError::ServerError { status, message });
+    }
+    resp.json::<T>()
+        .await
+        .map(Ok)
+        .map_err(|e| SdkError::ClientError(format!("bad response body: {e}")))
+}
+
+impl ArtifactStorageClient {
+    /// Server-side three-way merge between two commitishes. Preflight (the default mode) never
+    /// writes; commit mode CAS-advances the `ours` branch. A `fail`-policy conflict returns
+    /// `Ok` with `clean: false`, `commit: None`, and the conflict list (the server's `409`
+    /// report body).
+    pub async fn repo_merge(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        request: &MergeRequest,
+    ) -> Result<Traced<MergeReport>, SdkError> {
+        let (req, trace_id) = self.git_request(
+            Method::POST,
+            project_id,
+            repo,
+            Some("merge"),
+            git_username,
+            git_token,
+        )?;
+        let report =
+            expect_json_or_conflict::<MergeReport, MergeReport>(req.json(request).send().await?)
+                .await?
+                .unwrap_or_else(|report| report);
+        Ok(Traced::new(trace_id, report))
+    }
+
+    /// The structured conflict record of a `materialize`-policy merge commit. `Ok(None)` =
+    /// the commit merged cleanly (or the server doesn't know it).
+    pub async fn commit_conflicts(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        commit: &str,
+    ) -> Result<Traced<Option<MergeConflictRecord>>, SdkError> {
+        let (req, trace_id) = self.git_request(
+            Method::GET,
+            project_id,
+            repo,
+            Some(&format!("commits/{commit}/conflicts")),
+            git_username,
+            git_token,
+        )?;
+        let resp = req.send().await?;
+        if resp.status() == StatusCode::NOT_FOUND {
+            return Ok(Traced::new(trace_id, None));
+        }
+        let record = expect_json(resp).await?;
+        Ok(Traced::new(trace_id, Some(record)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The gsvc-server merge report shape (both the 200 body and the fail-policy 409 body)
+    /// decodes with every field the server serializes.
+    #[test]
+    fn merge_report_decodes_server_shape() {
+        let body = r#"{
+            "ours": "aaaa", "theirs": "bbbb", "merge_base": "cccc",
+            "clean": false, "fast_forward": false, "already_merged": false,
+            "changed_paths": 3,
+            "conflicts": [{
+                "path": "src/main.rs", "kind": "content", "potential": true,
+                "ours": {"mode": 33188, "oid": "o1"}, "base": null,
+                "theirs": {"mode": 33188, "oid": "t1"}
+            }],
+            "stats": {"trees_read": 10, "entries_compared": 100, "blobs_merged": 1, "wall_ms": 2.5},
+            "commit": null, "fast_forwarded": false
+        }"#;
+        let report: MergeReport = serde_json::from_str(body).unwrap();
+        assert!(!report.clean);
+        assert_eq!(report.merge_base.as_deref(), Some("cccc"));
+        assert_eq!(report.conflicts.len(), 1);
+        let c = &report.conflicts[0];
+        assert_eq!(c.kind, "content");
+        assert!(c.potential);
+        assert!(c.base.is_none());
+        assert_eq!(c.theirs.as_ref().unwrap().oid, "t1");
+        assert_eq!(report.stats.blobs_merged, 1);
+        assert!(report.commit.is_none());
+    }
+
+    /// Optional request fields stay off the wire so older servers never see unknown keys.
+    #[test]
+    fn merge_request_skips_defaults() {
+        let req = MergeRequest {
+            ours: "refs/heads/main".into(),
+            theirs: "dev".into(),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({"ours": "refs/heads/main", "theirs": "dev"})
+        );
+    }
+
+    /// The conflict-record terms ride as `[ours, base, theirs]` with `null` for absent sides.
+    #[test]
+    fn conflict_record_decodes_terms() {
+        let body = r#"{
+            "version": 1, "ours_commit": "aa", "theirs_commit": "bb", "base_commit": null,
+            "paths": [{"path": "f", "kind": "delete_modify",
+                       "terms": [null, {"mode": 33188, "oid": "b1"}, {"mode": 33188, "oid": "t1"}]}],
+            "truncated_paths": 0
+        }"#;
+        let record: MergeConflictRecord = serde_json::from_str(body).unwrap();
+        assert_eq!(record.paths.len(), 1);
+        let terms = &record.paths[0].terms;
+        assert_eq!(terms.len(), 3);
+        assert!(terms[0].is_none());
+        assert_eq!(terms[2].as_ref().unwrap().oid, "t1");
+    }
+}

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 pub mod ingest;
+pub mod merge;
 pub mod models;
 pub mod workspaces;
 

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -14,6 +14,7 @@ use crate::Traced;
 use crate::error::SdkError;
 
 use super::ingest::expect_json;
+use super::merge::{MergeConflict, MergeReport, MergeStats, Signature, expect_json_or_conflict};
 use super::{ArtifactStorageClient, decode_empty};
 
 /// One workspace joined across its identity record, ref, and lease rows.
@@ -48,6 +49,10 @@ pub struct CreateWorkspaceRequest {
     /// Shared-rw mode: reconcile every snapshot into this branch (short name) in server order.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shared_target: Option<String>,
+    /// Shared-rw conflict handling: `"materialize"` (default — three-way merge, diff3 markers
+    /// on conflicts) or `"lww"` (legacy last-writer-wins overwrite).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconcile_policy: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -67,16 +72,87 @@ pub struct PromoteWorkspaceRequest {
     /// Land the full checkpoint chain instead of the default squash.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub full_history: bool,
+    /// `"squash"` (default) | `"full_history"` | `"merge"`. Takes precedence over the legacy
+    /// `full_history` flag. `merge` lands a two-parent merge commit when the target moved
+    /// since the workspace forked; conflicts come back as `PromoteOutcome::Conflicted`
+    /// (`fail` policy — the workspace is the resolution surface).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<Signature>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PromoteWorkspaceResponse {
     pub commit: String,
     pub ref_name: String,
     pub created: bool,
     pub squashed: bool,
+    /// Merge-mode promote landed a merge (or found nothing to do).
+    #[serde(default)]
+    pub merged: bool,
+    /// Merge mode advanced the ref to the workspace tip with no new commit object.
+    #[serde(default)]
+    pub fast_forwarded: bool,
+}
+
+/// A merge-mode promote either lands or reports why it can't — conflicts are a normal outcome,
+/// not a transport error (the server's `409` report body).
+#[derive(Clone, Debug)]
+pub enum PromoteOutcome {
+    Promoted(PromoteWorkspaceResponse),
+    /// `fail`-policy conflicts: nothing was published; the target branch and the workspace are
+    /// both untouched. Sync the workspace, resolve, and promote again.
+    Conflicted(MergeReport),
+}
+
+/// Ref-level promote preflight: did the target move since the workspace forked?
+/// (Tree-level conflict prediction is `repo_merge` in preflight mode.)
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PromotePreflight {
+    pub target_ref: String,
+    /// Absent when the target branch does not exist yet.
+    pub target_head: Option<String>,
+    pub workspace_base: String,
+    pub workspace_head: String,
+    pub moved: bool,
+    pub fast_forward: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct SyncWorkspaceRequest {
+    /// Branch to pull from (short name). Defaults to the workspace's shared-rw target, else
+    /// the ref it was created from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// `"materialize"` (default — conflicts land as diff3 markers in the workspace, with the
+    /// commit's structured conflict record) or `"fail"` (a conflicted sync changes nothing and
+    /// returns the report).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<Signature>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SyncWorkspaceResponse {
+    /// The workspace ref after the sync (unchanged when `up_to_date`, or when a
+    /// `fail`-policy sync hit conflicts).
+    pub workspace_head: String,
+    pub target_head: String,
+    /// The workspace's fork point after the sync.
+    pub base: String,
+    pub clean: bool,
+    pub up_to_date: bool,
+    /// The workspace had no snapshots: its ref moved to the target head with no new commit.
+    pub fast_forwarded: bool,
+    pub changed_paths: u64,
+    pub conflicts: Vec<MergeConflict>,
+    pub stats: MergeStats,
 }
 
 /// One ref's head and movement generation — the poll target for branch/workspace following.
@@ -188,7 +264,10 @@ impl ArtifactStorageClient {
         Ok(Traced::new(trace_id, hb))
     }
 
-    /// CAS-advance a real branch to the workspace's snapshot (squash by default).
+    /// CAS-advance a real branch to the workspace's snapshot (squash by default). Merge mode
+    /// (`mode: "merge"`) lands a two-parent merge commit when the target moved; its conflicts
+    /// are returned as `PromoteOutcome::Conflicted`, not an error. A plain `409` (concurrent
+    /// ref move) still surfaces as `SdkError::ServerError`.
     pub async fn workspace_promote(
         &self,
         project_id: &str,
@@ -197,7 +276,7 @@ impl ArtifactStorageClient {
         git_token: &str,
         workspace_id: &str,
         request: &PromoteWorkspaceRequest,
-    ) -> Result<Traced<PromoteWorkspaceResponse>, SdkError> {
+    ) -> Result<Traced<PromoteOutcome>, SdkError> {
         let (req, trace_id) = self.git_request(
             Method::POST,
             project_id,
@@ -206,7 +285,70 @@ impl ArtifactStorageClient {
             git_username,
             git_token,
         )?;
-        let resp = expect_json(req.json(request).send().await?).await?;
+        let outcome = expect_json_or_conflict::<PromoteWorkspaceResponse, MergeReport>(
+            req.json(request).send().await?,
+        )
+        .await?
+        .map(PromoteOutcome::Promoted)
+        .unwrap_or_else(PromoteOutcome::Conflicted);
+        Ok(Traced::new(trace_id, outcome))
+    }
+
+    /// Ref-level promote preflight: whether `target` moved since the workspace forked, and
+    /// whether a promote would fast-forward.
+    pub async fn workspace_promote_preflight(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        workspace_id: &str,
+        target: &str,
+    ) -> Result<Traced<PromotePreflight>, SdkError> {
+        let suffix = format!(
+            "workspaces/{workspace_id}/promote/preflight?target={}",
+            url::form_urlencoded::byte_serialize(target.as_bytes()).collect::<String>()
+        );
+        let (req, trace_id) = self.git_request(
+            Method::GET,
+            project_id,
+            repo,
+            Some(&suffix),
+            git_username,
+            git_token,
+        )?;
+        let preflight = expect_json(req.send().await?).await?;
+        Ok(Traced::new(trace_id, preflight))
+    }
+
+    /// Pull the target branch into a behind workspace, rebase-style: one merge commit on the
+    /// target head, workspace history kept linear, the pre-sync chain preserved under a
+    /// presync ref. Under the default `materialize` policy conflicts land as diff3 markers in
+    /// the workspace; under `fail` a conflicted sync changes nothing and the returned report
+    /// has `clean: false` with `workspace_head` untouched. Snapshot uncommitted mount changes
+    /// before syncing.
+    pub async fn workspace_sync(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        workspace_id: &str,
+        request: &SyncWorkspaceRequest,
+    ) -> Result<Traced<SyncWorkspaceResponse>, SdkError> {
+        let (req, trace_id) = self.git_request(
+            Method::POST,
+            project_id,
+            repo,
+            Some(&format!("workspaces/{workspace_id}/sync")),
+            git_username,
+            git_token,
+        )?;
+        let resp = expect_json_or_conflict::<SyncWorkspaceResponse, SyncWorkspaceResponse>(
+            req.json(request).send().await?,
+        )
+        .await?
+        .unwrap_or_else(|conflicted| conflicted);
         Ok(Traced::new(trace_id, resp))
     }
 
@@ -320,5 +462,40 @@ impl ArtifactStorageClient {
         }
         let bytes = resp.bytes().await?.to_vec();
         Ok(Traced::new(trace_id, bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Promote responses from servers that predate merge mode decode with the new fields
+    /// defaulting to false.
+    #[test]
+    fn promote_response_tolerates_old_servers() {
+        let body = r#"{"commit": "aa", "ref_name": "refs/heads/main", "created": false, "squashed": true}"#;
+        let resp: PromoteWorkspaceResponse = serde_json::from_str(body).unwrap();
+        assert!(resp.squashed);
+        assert!(!resp.merged);
+        assert!(!resp.fast_forwarded);
+    }
+
+    /// The sync response decodes the full server shape, conflicts included.
+    #[test]
+    fn sync_response_decodes_server_shape() {
+        let body = r#"{
+            "workspace_head": "ws1", "target_head": "t1", "base": "t1",
+            "clean": false, "up_to_date": false, "fast_forwarded": false,
+            "changed_paths": 2,
+            "conflicts": [{"path": "f", "kind": "content", "potential": false,
+                           "ours": {"mode": 33188, "oid": "o"}, "base": {"mode": 33188, "oid": "b"},
+                           "theirs": {"mode": 33188, "oid": "t"}}],
+            "stats": {"trees_read": 4, "entries_compared": 9, "blobs_merged": 1, "wall_ms": 0.7}
+        }"#;
+        let resp: SyncWorkspaceResponse = serde_json::from_str(body).unwrap();
+        assert!(!resp.clean);
+        assert_eq!(resp.base, "t1");
+        assert_eq!(resp.conflicts.len(), 1);
+        assert_eq!(resp.conflicts[0].kind, "content");
     }
 }


### PR DESCRIPTION
Companion PR to the gsvc server-side merge stack (`docs/merge-design.md` in artifact_storage, PRs 1–4 + workspace sync): duplicates the merge wire shapes into the cloud SDK (per the wire-type rule) and gives the CLI the complete merge workflow.

## cloud-sdk

- New `artifact_storage::merge` module: `MergeRequest` / `MergeReport` / `MergeConflict` / `MergeStats` / `MergeConflictRecord` / `Signature`, with `repo_merge()` (`POST /repos/{repo}/merge`) and `commit_conflicts()` (`GET /commits/{oid}/conflicts`, 404 → `None`).
- Shared `expect_json_or_conflict` helper: a 409 whose body is the structured conflict report parses as data (fail-policy conflicts publish nothing and ride the 409); a plain-text 409 (concurrent ref move) stays a `ServerError`.
- `PromoteWorkspaceRequest` gains `mode` (`"squash" | "full_history" | "merge"`) and `author`; the response gains `merged` / `fast_forwarded` with serde defaults so pre-merge servers still decode. `workspace_promote()` now returns `PromoteOutcome::Promoted | Conflicted(MergeReport)`.
- New `workspace_sync()` (`POST .../workspaces/{id}/sync`) and `workspace_promote_preflight()` (parity with the dashboard).
- `CreateWorkspaceRequest` gains `reconcile_policy` (`"materialize" | "lww"`).

## CLI

- `tl fs promote --merge` — two-parent merge commit onto a moved target; on conflict prints the per-path report plus the resolution recipe (`tl fs sync` → fix markers → snapshot → re-promote).
- `tl fs sync` — the missing step of the resolution loop: server-side rebase-style pull of the target branch into the workspace. Refuses on a dirty overlay (local changes would shadow synced markers), polls out the 425 index-lag window, then refreshes the mount's lower layer immediately and converges the kernel view of conflicted paths so diff3 markers appear at once. `--fail-on-conflict` for the strict variant.
- `tl git merge <repo> <ours> <theirs>` (`--preflight`, `--deep`, `--materialize`, `--base`, `--json`) — plumbing over `POST /merge`; fail-policy conflicts exit non-zero having published nothing.
- `tl git conflicts <repo> <commit>` — the structured conflict record of a materialized merge.

## Testing

- 5 new serde tests pin the wire shapes to the exact JSON the server emits (from `origin/merge-atomicity-pr9` in artifact_storage); promote decoding is tested against pre-merge server responses. Full SDK suite: 125 passed.
- Builds verified: default features, `--no-default-features`, and a type-check with the real gsvc-mount/gsvc-codec sources swapped in (`just build-cli-full` path).

## Notes

- Only merge preflight (PR 1) is on artifact_storage `main` today; commit mode / sync / merge-mode promote need the `merge-atomicity-pr9` stack deployed. The CLI degrades to plain server errors against older servers.
- Version bump (`python .github/scripts/bump_version.py`) deliberately left to the release maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)