### PR TITLE
Add repository SDK APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,8 +3520,9 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.61"
+version = "0.5.62"
 dependencies = [
+ "anyhow",
  "base64",
  "bollard",
  "bytes",
@@ -3529,11 +3530,13 @@ dependencies = [
  "data-encoding",
  "derive_builder",
  "des",
+ "dirs",
  "docker-credentials-config",
  "eventsource-stream",
  "fastcdc",
  "flate2",
  "futures",
+ "gsvc-codec",
  "hex",
  "ignore",
  "pin-project-lite",
@@ -3566,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.61"
+version = "0.5.62"
 dependencies = [
  "anyhow",
  "base64",
@@ -3586,10 +3589,10 @@ dependencies = [
  "fuser",
  "futures",
  "gethostname",
- "gsvc-codec",
  "gsvc-mount",
  "hex",
  "http-body-util",
+ "ignore",
  "indicatif",
  "libc",
  "minijinja",
@@ -3617,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.61"
+version = "0.5.62"
 dependencies = [
  "napi",
  "napi-build",
@@ -3631,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.61"
+version = "0.5.62"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.61"
+version = "0.5.62"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,7 @@ mount = ["dep:gsvc-mount", "dep:libc", "dep:fuser"]
 # placeholder + ephemeral-vendor arrangement as `mount` (see crates/VENDORED_FROM): off by
 # default so this public crate builds with no access to the artifact_storage repo. Official
 # binaries enable it via `just build-cli-full` locally or the vendor-private-crates CI action.
-git-clone = ["dep:gsvc-codec"]
+git-clone = ["tensorlake/git-clone"]
 
 [[bin]]
 name = "tl"
@@ -66,12 +66,12 @@ hex = { workspace = true }
 rand = { workspace = true }
 shlex = { workspace = true }
 rustpython-parser = "0.3"
-gsvc-codec = { workspace = true, optional = true }
 gsvc-mount = { workspace = true, optional = true }
 libc = { version = "0.2", optional = true }
 tracing = { workspace = true }
 flate2 = { workspace = true }
 sha1 = { workspace = true }
+ignore = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -11,12 +11,15 @@
 //! `restore` refills the overlay from any snapshot. FUSE is the only mount path — Linux builds
 //! carry it unconditionally, macOS requires macFUSE and the `macfuse` build feature.
 
-use std::path::{Path, PathBuf};
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use comfy_table::Cell;
 use console::style;
 use futures::StreamExt;
+use ignore::Match;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use tensorlake::artifact_storage::ArtifactStorageClient;
 use tensorlake::artifact_storage::ingest::{PushEvent, PushFile, PushOptions, PushSource};
 use tensorlake::artifact_storage::models::GitCredential;
@@ -1182,8 +1185,90 @@ pub async fn unmount(ctx: &CliContext, path: &Path, delete: bool) -> Result<()> 
 /// Overlay upserts as `(repo path, upper file, git mode)`.
 type OverlayUpserts = Vec<(String, PathBuf, u32)>;
 
+struct SnapshotIgnore {
+    mount_root: PathBuf,
+    ignored_names: Vec<String>,
+    gitignores: HashMap<PathBuf, Gitignore>,
+}
+
+impl SnapshotIgnore {
+    fn new(mount_root: &Path) -> Self {
+        Self {
+            mount_root: mount_root.to_path_buf(),
+            ignored_names: local::ignored_names(mount_root),
+            gitignores: HashMap::new(),
+        }
+    }
+
+    fn matcher_for(&mut self, rel_dir: &Path) -> Result<&Gitignore> {
+        if !self.gitignores.contains_key(rel_dir) {
+            let abs_dir = self.mount_root.join(rel_dir);
+            let mut builder = GitignoreBuilder::new(&abs_dir);
+            let gitignore = abs_dir.join(".gitignore");
+            if gitignore.is_file()
+                && let Some(err) = builder.add(&gitignore)
+            {
+                return Err(CliError::usage(format!(
+                    "failed to read {}: {err}",
+                    gitignore.display()
+                )));
+            }
+            let matcher = builder.build().map_err(|err| {
+                CliError::usage(format!("failed to parse {}: {err}", gitignore.display()))
+            })?;
+            self.gitignores.insert(rel_dir.to_path_buf(), matcher);
+        }
+        Ok(self.gitignores.get(rel_dir).expect("matcher inserted"))
+    }
+
+    fn is_ignored(&mut self, rel: &str, is_dir: bool) -> Result<bool> {
+        let rel_path = Path::new(rel);
+        for component in rel_path.components() {
+            let Component::Normal(name) = component else {
+                continue;
+            };
+            let name = name.to_string_lossy();
+            if self.ignored_names.iter().any(|ignored| ignored == &*name)
+                || local::is_metadata_turd(&name)
+            {
+                return Ok(true);
+            }
+        }
+
+        let abs = self.mount_root.join(rel_path);
+        let mut ignored = false;
+        for dir in gitignore_dirs_for(rel_path) {
+            match self
+                .matcher_for(&dir)?
+                .matched_path_or_any_parents(&abs, is_dir)
+            {
+                Match::Ignore(_) => ignored = true,
+                Match::Whitelist(_) => ignored = false,
+                Match::None => {}
+            }
+        }
+        Ok(ignored)
+    }
+}
+
+fn gitignore_dirs_for(rel: &Path) -> Vec<PathBuf> {
+    let mut dirs = vec![PathBuf::new()];
+    let Some(parent) = rel.parent() else {
+        return dirs;
+    };
+
+    let mut current = PathBuf::new();
+    for component in parent.components() {
+        if let Component::Normal(name) = component {
+            current.push(name);
+            dirs.push(current.clone());
+        }
+    }
+    dirs
+}
+
 fn enumerate_overlay(state_dir: &Path, mount_root: &Path) -> Result<(OverlayUpserts, Vec<String>)> {
-    let ignored = local::ignored_names(mount_root);
+    let mut ignored = SnapshotIgnore::new(mount_root);
     let mut upserts = Vec::new();
     let mut deletes = Vec::new();
     let upper = state_dir.join("upper");
@@ -1192,17 +1277,13 @@ fn enumerate_overlay(state_dir: &Path, mount_root: &Path) -> Result<(OverlayUpse
     fn walk(
         root: &Path,
         dir: &Path,
-        ignored: &[String],
+        ignored: &mut SnapshotIgnore,
         out: &mut dyn FnMut(String, PathBuf, &std::fs::Metadata),
     ) -> Result<()> {
         let Ok(read) = std::fs::read_dir(dir) else {
             return Ok(());
         };
         for entry in read.flatten() {
-            let name = entry.file_name().to_string_lossy().into_owned();
-            if ignored.contains(&name) || local::is_metadata_turd(&name) {
-                continue;
-            }
             let abs = entry.path();
             let meta = std::fs::symlink_metadata(&abs)?;
             let rel = abs
@@ -1212,6 +1293,9 @@ fn enumerate_overlay(state_dir: &Path, mount_root: &Path) -> Result<(OverlayUpse
                 .map(|c| c.as_os_str().to_string_lossy())
                 .collect::<Vec<_>>()
                 .join("/");
+            if ignored.is_ignored(&rel, meta.is_dir())? {
+                continue;
+            }
             if meta.file_type().is_symlink() || meta.is_file() {
                 out(rel, abs, &meta);
             } else if meta.is_dir() {
@@ -1221,7 +1305,7 @@ fn enumerate_overlay(state_dir: &Path, mount_root: &Path) -> Result<(OverlayUpse
         Ok(())
     }
 
-    walk(&upper, &upper, &ignored, &mut |rel, abs, meta| {
+    walk(&upper, &upper, &mut ignored, &mut |rel, abs, meta| {
         #[cfg(unix)]
         let exec = {
             use std::os::unix::fs::PermissionsExt;
@@ -1239,7 +1323,7 @@ fn enumerate_overlay(state_dir: &Path, mount_root: &Path) -> Result<(OverlayUpse
         };
         upserts.push((rel, abs, mode));
     })?;
-    walk(&wh, &wh, &ignored, &mut |rel, _abs, _meta| {
+    walk(&wh, &wh, &mut ignored, &mut |rel, _abs, _meta| {
         deletes.push(rel);
     })?;
     // A whiteout under a path that upper re-created is already shadowed; don't double-send.
@@ -2158,6 +2242,8 @@ fn age_display(created_at_secs: u64) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn registry_document_parses_as_table() {
         // toml 0.9 rejects top-level documents through Value::from_str; the registry must
@@ -2168,5 +2254,28 @@ mod tests {
             table.get("/Users/u/work").and_then(|v| v.as_str()),
             Some("/Users/u/.local/share/tensorlake/mounts/abc")
         );
+    }
+
+    #[test]
+    fn snapshot_enumeration_honors_gitignore_for_upserts_and_deletes() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        let upper = state.path().join("upper");
+        let wh = state.path().join("wh");
+        std::fs::create_dir_all(&upper).unwrap();
+        std::fs::create_dir_all(&wh).unwrap();
+
+        std::fs::write(mount.path().join(".gitignore"), "*.tmp\nignored/\n").unwrap();
+        std::fs::write(upper.join("keep.txt"), "keep").unwrap();
+        std::fs::write(upper.join("drop.tmp"), "ignored").unwrap();
+        std::fs::create_dir_all(upper.join("ignored")).unwrap();
+        std::fs::write(upper.join("ignored/file.txt"), "ignored").unwrap();
+        std::fs::write(wh.join("drop.tmp"), "").unwrap();
+
+        let (upserts, deletes) = enumerate_overlay(state.path(), mount.path()).unwrap();
+
+        let upsert_paths: Vec<_> = upserts.iter().map(|(path, _, _)| path.as_str()).collect();
+        assert_eq!(upsert_paths, vec!["keep.txt"]);
+        assert!(deletes.is_empty());
     }
 }

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -13,9 +13,6 @@ use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
 use crate::output::table::new_table;
 
-#[cfg(feature = "git-clone")]
-pub(crate) mod fastclone;
-
 /// Parse a human cache-size argument (`512MB`, `2GiB`, `1073741824`, ...). Lives here — not in
 /// the feature-gated fast-clone module — because the CLI argument definition needs it even in
 /// builds without the fast-clone engine.
@@ -187,6 +184,7 @@ pub async fn restore_repo(ctx: &CliContext, repo: &str) -> Result<()> {
 /// Accept either a bare repo name or a full clone URL (as printed by `tl git url`), matching how
 /// `git clone` itself treats its argument. A URL's last non-empty path segment (with any `.git`
 /// suffix stripped) is used as the repo name.
+#[cfg(any(feature = "git-clone", test))]
 fn normalize_repo_arg(repo: &str) -> String {
     let Ok(url) = reqwest::Url::parse(repo) else {
         return repo.to_string();
@@ -223,6 +221,54 @@ pub async fn clone_repo(
 }
 
 #[cfg(feature = "git-clone")]
+fn new_fastclone_spinner(message: &str) -> Option<indicatif::ProgressBar> {
+    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+        return None;
+    }
+    let pb = indicatif::ProgressBar::new_spinner();
+    pb.set_style(
+        indicatif::ProgressStyle::default_spinner()
+            .template("{spinner} {msg}")
+            .unwrap(),
+    );
+    pb.set_message(message.to_string());
+    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+    Some(pb)
+}
+
+#[cfg(feature = "git-clone")]
+fn fastclone_byte_progress_style() -> indicatif::ProgressStyle {
+    indicatif::ProgressStyle::with_template(
+        "{spinner} {bytes}/{total_bytes} ({bytes_per_sec}, eta {eta}) {msg}",
+    )
+    .unwrap()
+}
+
+#[cfg(feature = "git-clone")]
+fn fastclone_progress(
+    spinner: Option<indicatif::ProgressBar>,
+) -> Option<tensorlake::artifact_storage::fastclone::FastCloneProgress> {
+    let pb = spinner?;
+    Some(std::sync::Arc::new(move |ev| {
+        use tensorlake::artifact_storage::fastclone::FastCloneEvent;
+        match ev {
+            FastCloneEvent::FetchingManifest => pb.set_message("fetching clone manifest"),
+            FastCloneEvent::DownloadPlan { bytes } => {
+                pb.set_style(fastclone_byte_progress_style());
+                pb.set_length(bytes);
+                pb.set_position(0);
+                pb.set_message("fetching pack artifacts");
+            }
+            FastCloneEvent::DownloadedBytes { bytes } => pb.inc(bytes),
+            FastCloneEvent::InstallingObjects { dest } => {
+                pb.finish_and_clear();
+                eprintln!("installing objects into {}", dest.display());
+            }
+        }
+    }))
+}
+
+#[cfg(feature = "git-clone")]
 pub async fn clone_repo(
     ctx: &CliContext,
     repo: &str,
@@ -231,22 +277,24 @@ pub async fn clone_repo(
     cache_max_bytes: Option<u64>,
     no_checkout: bool,
 ) -> Result<()> {
+    use tensorlake::artifact_storage::fastclone;
+
     let repo = &normalize_repo_arg(repo);
     let project_id = project_id(ctx)?;
     let client = artifact_storage_client(ctx)?;
     let repo_url = client.git_repo_url(&project_id, repo);
 
-    let spinner = fastclone::new_spinner(&format!("minting git credential for {repo}"));
+    let spinner = new_fastclone_spinner(&format!("minting git credential for {repo}"));
     let credential = client
-        .mint_token_for_repo(&project_id, Some(repo))
+        .git_credential_for_repo(&project_id, repo)
         .await
-        .map_err(map_sdk_error)?
-        .into_inner();
+        .map_err(map_sdk_error)?;
     if let Some(pb) = &spinner {
         pb.set_message("fetching clone manifest");
     }
 
     let dest = dest.unwrap_or_else(|| fastclone::default_dest_from_url(&repo_url));
+    let progress = fastclone_progress(spinner.clone());
     let opts = fastclone::FastCloneOptions {
         repo_url: repo_url.clone(),
         dest,
@@ -257,9 +305,12 @@ pub async fn clone_repo(
             password: Some(credential.token),
         }),
         checkout: !no_checkout,
-        progress: spinner,
+        progress,
     };
     let stats = fastclone::fast_clone(opts).await?;
+    if let Some(pb) = spinner {
+        pb.finish_and_clear();
+    }
     println!(
         "{}",
         fastclone::format_fast_clone_stats(&format!("cloned {repo}"), &stats)
@@ -310,40 +361,29 @@ pub async fn list_refs(ctx: &CliContext, repo: &str, output_json: bool) -> Resul
 pub async fn status(ctx: &CliContext, repo: &str, output_json: bool) -> Result<()> {
     let project_id = project_id(ctx)?;
     let client = artifact_storage_client(ctx)?;
-    let branches = client
-        .list_branches(&project_id, repo)
+    let info = client
+        .repo_info(&project_id, repo)
         .await
         .map_err(map_sdk_error)?
         .into_inner();
-    let refs = client
-        .list_refs(&project_id, repo)
-        .await
-        .map_err(map_sdk_error)?
-        .into_inner();
-    let remote_url = client.git_repo_url(&project_id, repo);
 
     if output_json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
-                "repo": repo,
-                "url": remote_url,
-                "branches": branches.branches,
-                "refs": refs.refs,
-            }))?
-        );
+        println!("{}", serde_json::to_string_pretty(&info)?);
         return Ok(());
     }
 
-    println!("repo: {repo}");
-    println!("url: {remote_url}");
-    println!("branches: {}", branches.branches.len());
-    if branches.branches.is_empty() {
+    println!("repo: {}", info.repo);
+    println!("url: {}", info.url);
+    println!("branches: {}", info.branches.len());
+    if info.branches.is_empty() {
         println!("no branches found");
     } else {
-        print_branches_table(&branches);
+        print_branches_table(&ListBranchesResponse {
+            repo: info.repo.clone(),
+            branches: info.branches.clone(),
+        });
     }
-    println!("refs: {}", refs.refs.len());
+    println!("refs: {}", info.refs.len());
     Ok(())
 }
 
@@ -663,21 +703,14 @@ pub async fn push(
     let root = current_git_worktree_root()?;
     let project_id = project_id(ctx)?;
     let client = artifact_storage_client(ctx)?;
-    let credential = push_credential(&client, &project_id, repo).await?;
-
-    // Collect files from the worktree root; repo paths are relative to that root and normalized to
-    // forward slashes.
-    let mut files = Vec::new();
-    collect_push_files(&root, &root, &mut files)?;
-    if files.is_empty() {
-        return Err(crate::error::CliError::Usage(
-            "no files found under the current Git worktree".to_string(),
-        ));
-    }
+    let credential = client
+        .git_credential_for_repo(&project_id, repo)
+        .await
+        .map_err(map_sdk_error)?;
 
     let bar = indicatif::ProgressBar::new_spinner();
     bar.enable_steady_tick(std::time::Duration::from_millis(120));
-    bar.set_message(format!("hashing {} files...", files.len()));
+    bar.set_message("hashing worktree files...");
     let bar_for_events = bar.clone();
     let opts = PushOptions {
         branch: branch.to_string(),
@@ -743,12 +776,12 @@ pub async fn push(
         ..Default::default()
     };
     let report = client
-        .push_files(
+        .push_worktree(
             &project_id,
             repo,
             &credential.git_username,
             &credential.token,
-            files,
+            &root,
             opts,
         )
         .await?
@@ -826,70 +859,15 @@ fn git_worktree_root_from(cwd: &std::path::Path) -> Result<std::path::PathBuf> {
     Ok(std::path::PathBuf::from(root))
 }
 
-fn collect_push_files(
-    root: &std::path::Path,
-    path: &std::path::Path,
-    out: &mut Vec<tensorlake::artifact_storage::ingest::PushFile>,
-) -> Result<()> {
-    use tensorlake::artifact_storage::ingest::{PushFile, PushSource};
-    let meta = std::fs::metadata(path)?;
-    if meta.is_dir() {
-        let mut entries: Vec<_> = std::fs::read_dir(path)?.collect::<std::io::Result<_>>()?;
-        entries.sort_by_key(|e| e.file_name());
-        for entry in entries {
-            let name = entry.file_name();
-            // Never traverse into VCS metadata.
-            if name == ".git" {
-                continue;
-            }
-            collect_push_files(root, &entry.path(), out)?;
-        }
-        return Ok(());
-    }
-    let repo_path = repo_path_for(root, path);
-    if repo_path.is_empty() {
-        return Ok(());
-    }
-    out.push(PushFile {
-        mode: None,
-        delete: false,
-        repo_path,
-        source: PushSource::Path(path.to_path_buf()),
-    });
-    Ok(())
-}
-
-/// Git credential for pushes and job polls. Same dev affordance as `tl fs`
-/// (FsSession::open): a pre-provisioned `TENSORLAKE_GIT_TOKEN` skips platform minting, e.g.
-/// against a local artifact-storage server in open-auth mode.
-async fn push_credential(
-    client: &tensorlake::artifact_storage::ArtifactStorageClient,
-    project_id: &str,
-    repo: &str,
-) -> Result<tensorlake::artifact_storage::models::GitCredential> {
-    if let Ok(token) = std::env::var("TENSORLAKE_GIT_TOKEN") {
-        return Ok(tensorlake::artifact_storage::models::GitCredential {
-            token,
-            token_type: "bearer".to_string(),
-            expires_at: String::new(),
-            git_username: std::env::var("TENSORLAKE_GIT_USERNAME")
-                .unwrap_or_else(|_| "t".to_string()),
-            repo_pattern: "*".to_string(),
-            scopes: Vec::new(),
-        });
-    }
-    Ok(client
-        .mint_token_for_repo(project_id, Some(repo))
-        .await?
-        .into_inner())
-}
-
 /// `tl git commit-status --repo <repo> <job-id>` — the out-of-band view of a detached commit
 /// job's state machine, from any terminal or process.
 pub async fn commit_status(ctx: &CliContext, repo: &str, job_id: &str) -> Result<()> {
     let project_id = project_id(ctx)?;
     let client = artifact_storage_client(ctx)?;
-    let credential = push_credential(&client, &project_id, repo).await?;
+    let credential = client
+        .git_credential_for_repo(&project_id, repo)
+        .await
+        .map_err(map_sdk_error)?;
     let job = client
         .commit_job_status(
             &project_id,
@@ -900,31 +878,36 @@ pub async fn commit_status(ctx: &CliContext, repo: &str, job_id: &str) -> Result
         )
         .await?
         .into_inner();
-    let state = job["state"].as_str().unwrap_or("?");
+    let state = job.state.as_str();
     match state {
         "committed" => println!(
             "{} {} -> {}",
             console::style("committed").green().bold(),
-            job["commit"].as_str().unwrap_or("?"),
-            job["ref_name"].as_str().unwrap_or("?"),
+            job.commit.as_deref().unwrap_or("?"),
+            job.ref_name.as_deref().unwrap_or("?"),
         ),
         "failed" => println!(
             "{} {} ({}){}",
             console::style("failed").red().bold(),
-            job["error"]["message"].as_str().unwrap_or("?"),
-            job["error"]["kind"].as_str().unwrap_or("?"),
-            if job["error"]["retryable"].as_bool().unwrap_or(false) {
+            job.error
+                .as_ref()
+                .map(|err| err.message.as_str())
+                .unwrap_or("?"),
+            job.error
+                .as_ref()
+                .map(|err| err.kind.as_str())
+                .unwrap_or("?"),
+            if job.error.as_ref().map(|err| err.retryable).unwrap_or(false) {
                 " — safe to re-push: uploaded chunks are deduplicated"
             } else {
                 ""
             },
         ),
         _ => {
-            let phase = job["phase"].as_str().unwrap_or(state);
-            if let (Some(done), Some(total)) = (
-                job["read_back"]["done"].as_u64(),
-                job["read_back"]["total"].as_u64(),
-            ) {
+            let phase = job.phase.as_deref().unwrap_or(state);
+            if let Some(read_back) = job.read_back {
+                let done = read_back.done;
+                let total = read_back.total;
                 let pct = if total > 0 { done * 100 / total } else { 0 };
                 println!(
                     "{} {phase}: {done}/{total} chunks ({pct}%)",
@@ -938,46 +921,9 @@ pub async fn commit_status(ctx: &CliContext, repo: &str, job_id: &str) -> Result
     Ok(())
 }
 
-/// Repo path for a file under the worktree root, built from normal components only. Pushing `.`
-/// used to yield `./arch/boot.c` — the server rejects `.`/`..`/empty components at commit time,
-/// after every chunk was already uploaded, so this must be clean by construction.
-fn repo_path_for(root: &std::path::Path, path: &std::path::Path) -> String {
-    path.strip_prefix(root)
-        .unwrap_or(path)
-        .components()
-        .filter_map(|c| match c {
-            std::path::Component::Normal(part) => Some(part.to_string_lossy()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("/")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn repo_paths_from_dot_have_no_dot_components() {
-        let root = std::path::Path::new(".");
-        assert_eq!(
-            repo_path_for(root, std::path::Path::new("./.clang-format")),
-            ".clang-format"
-        );
-        assert_eq!(
-            repo_path_for(root, std::path::Path::new("./arch/boot.c")),
-            "arch/boot.c"
-        );
-    }
-
-    #[test]
-    fn repo_paths_from_absolute_root_are_root_relative() {
-        let root = std::path::Path::new("/tmp/somedir");
-        assert_eq!(
-            repo_path_for(root, std::path::Path::new("/tmp/somedir/a/b.txt")),
-            "a/b.txt"
-        );
-    }
 
     #[test]
     fn git_worktree_root_rejects_non_git_dir() {

--- a/crates/cloud-sdk/Cargo.toml
+++ b/crates/cloud-sdk/Cargo.toml
@@ -10,16 +10,19 @@ homepage = "https://tensorlake.ai"
 documentation = "https://docs.rs/tensorlake"
 
 [dependencies]
+anyhow = { workspace = true }
 fastcdc = { workspace = true }
 bytes = { workspace = true }
 base64 = { workspace = true }
 bollard = { workspace = true }
 chrono = { workspace = true }
+dirs = { workspace = true }
 docker-credentials-config = { workspace = true }
 utoipa = { workspace = true, optional = true }
 derive_builder = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
+gsvc-codec = { workspace = true, optional = true }
 hex = { workspace = true }
 ignore = { workspace = true }
 pin-project-lite = { workspace = true }
@@ -59,5 +62,6 @@ zip = "0.6"
 too_many_arguments = "allow"
 
 [features]
+git-clone = ["dep:gsvc-codec"]
 integration-tests = []
 openapi = ["utoipa"]

--- a/crates/cloud-sdk/src/artifact_storage/fastclone.rs
+++ b/crates/cloud-sdk/src/artifact_storage/fastclone.rs
@@ -23,12 +23,12 @@ use std::fs;
 use std::io::{Read as _, Seek as _, SeekFrom, Write as _};
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 use flate2::Compression;
 use gsvc_codec::{BlobOidHasher, IdxV2, Oid};
-use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
@@ -103,28 +103,19 @@ pub struct FastCloneOptions {
     /// Basic-auth credential for the gsvc origin, e.g. from a minted git token.
     pub credential: Option<BasicAuth>,
     pub checkout: bool,
-    /// Spinner already shown by the caller (e.g. while minting a credential); reused and
-    /// switched to a byte progress bar once the manifest's artifact sizes are known.
-    pub progress: Option<ProgressBar>,
+    /// Optional progress sink. Rendering (spinner, logs, bars) is the caller's concern.
+    pub progress: Option<FastCloneProgress>,
 }
 
-/// A spinner for indeterminate-length work (auth, manifest fetch), or `None` when stderr isn't a
-/// TTY. `fast_clone` converts it into a byte progress bar once download sizes are known.
-pub fn new_spinner(message: &str) -> Option<ProgressBar> {
-    if !std::io::IsTerminal::is_terminal(&std::io::stderr()) {
-        return None;
-    }
-    let pb = ProgressBar::new_spinner();
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"])
-            .template("{spinner} {msg}")
-            .unwrap(),
-    );
-    pb.set_message(message.to_string());
-    pb.enable_steady_tick(std::time::Duration::from_millis(80));
-    Some(pb)
+#[derive(Clone, Debug)]
+pub enum FastCloneEvent {
+    FetchingManifest,
+    DownloadPlan { bytes: u64 },
+    DownloadedBytes { bytes: u64 },
+    InstallingObjects { dest: PathBuf },
 }
+
+pub type FastCloneProgress = Arc<dyn Fn(FastCloneEvent) + Send + Sync>;
 
 #[derive(Clone, Debug, Default)]
 pub struct FastCloneStats {
@@ -151,19 +142,16 @@ struct HttpCtx {
     client: reqwest::Client,
     origin: Url,
     auth: Option<BasicAuth>,
-    progress: Option<ProgressBar>,
+    progress: Option<FastCloneProgress>,
 }
 
-fn byte_progress_style() -> ProgressStyle {
-    ProgressStyle::with_template(
-        "{spinner} {bytes}/{total_bytes} ({bytes_per_sec}, eta {eta}) {msg}",
-    )
-    .unwrap()
-    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"])
+fn emit(ctx: &HttpCtx, event: FastCloneEvent) {
+    if let Some(progress) = &ctx.progress {
+        progress(event);
+    }
 }
 
-/// Run a fast clone into `opts.dest`. `opts.progress`, if set, is shown while resolving the
-/// manifest and then converted into a byte progress bar once download sizes are known.
+/// Run a fast clone into `opts.dest`.
 pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
     ensure_clone_target_available(&opts.dest)?;
     let mut clean_base = Url::parse(&opts.repo_url)
@@ -175,13 +163,14 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         let path = format!("{}/", clean_base.path());
         clean_base.set_path(&path);
     }
-    let mut ctx = HttpCtx {
+    let ctx = HttpCtx {
         client: reqwest::Client::builder().build()?,
         origin: clean_base.clone(),
         auth: opts.credential.clone(),
         progress: opts.progress,
     };
     let manifest_url = clean_base.join("fast/clone-manifest")?;
+    emit(&ctx, FastCloneEvent::FetchingManifest);
     let manifest: FastCloneManifest = get_json(&ctx, manifest_url).await?;
     if manifest.version != 1 {
         bail!(
@@ -200,18 +189,7 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         .map(|p| p.pack_bytes + p.idx_bytes)
         .sum::<u64>()
         + manifest.large_blobs.iter().map(|b| b.bytes).sum::<u64>();
-    if let Some(pb) = &ctx.progress {
-        pb.set_style(byte_progress_style());
-        pb.set_length(total_bytes);
-        pb.set_position(0);
-        pb.set_message("fetching pack artifacts");
-    } else if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
-        let pb = ProgressBar::new(total_bytes);
-        pb.set_style(byte_progress_style());
-        pb.set_message("fetching pack artifacts");
-        pb.enable_steady_tick(std::time::Duration::from_millis(80));
-        ctx.progress = Some(pb);
-    }
+    emit(&ctx, FastCloneEvent::DownloadPlan { bytes: total_bytes });
 
     let mut stats = FastCloneStats {
         packs: manifest.packs.len(),
@@ -262,10 +240,12 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         }
     }
 
-    if let Some(pb) = ctx.progress.take() {
-        pb.finish_and_clear();
-    }
-    eprintln!("installing objects into {}", opts.dest.display());
+    emit(
+        &ctx,
+        FastCloneEvent::InstallingObjects {
+            dest: opts.dest.clone(),
+        },
+    );
 
     run_git_outside(&mut stats, &["init", "-q", opts.dest.to_str().unwrap()])?;
     let git_dir = opts.dest.join(".git");
@@ -380,9 +360,12 @@ where
         match file_size(path)? {
             Some(size) if size == expected_bytes => match validate(path) {
                 Ok(()) => {
-                    if let Some(pb) = &ctx.progress {
-                        pb.inc(expected_bytes);
-                    }
+                    emit(
+                        ctx,
+                        FastCloneEvent::DownloadedBytes {
+                            bytes: expected_bytes,
+                        },
+                    );
                     return Ok(false);
                 }
                 Err(_) => {
@@ -413,9 +396,12 @@ where
                     let _ = fs::remove_file(path);
                     fs::rename(&tmp, path)
                         .with_context(|| format!("commit cache artifact {}", path.display()))?;
-                    if let Some(pb) = &ctx.progress {
-                        pb.inc(expected_bytes);
-                    }
+                    emit(
+                        ctx,
+                        FastCloneEvent::DownloadedBytes {
+                            bytes: expected_bytes,
+                        },
+                    );
                     return Ok(true);
                 }
                 Err(_) => {
@@ -463,9 +449,12 @@ where
     let mut written = resume_from;
     while let Some(chunk) = resp.chunk().await? {
         written += chunk.len() as u64;
-        if let Some(pb) = &ctx.progress {
-            pb.inc(chunk.len() as u64);
-        }
+        emit(
+            ctx,
+            FastCloneEvent::DownloadedBytes {
+                bytes: chunk.len() as u64,
+            },
+        );
         out.write_all(&chunk).await?;
     }
     out.flush().await?;
@@ -502,9 +491,12 @@ async fn ensure_loose_blob_cached(
     if path.exists() {
         match validate_loose_blob_cache(path, oid, expected_bytes) {
             Ok(()) => {
-                if let Some(pb) = &ctx.progress {
-                    pb.inc(expected_bytes);
-                }
+                emit(
+                    ctx,
+                    FastCloneEvent::DownloadedBytes {
+                        bytes: expected_bytes,
+                    },
+                );
                 return Ok(false);
             }
             Err(_) => {
@@ -538,9 +530,12 @@ async fn ensure_loose_blob_cached(
     let mut written = 0u64;
     while let Some(chunk) = resp.chunk().await? {
         written += chunk.len() as u64;
-        if let Some(pb) = &ctx.progress {
-            pb.inc(chunk.len() as u64);
-        }
+        emit(
+            ctx,
+            FastCloneEvent::DownloadedBytes {
+                bytes: chunk.len() as u64,
+            },
+        );
         hasher.update(&chunk);
         enc.write_all(&chunk)?;
     }
@@ -1083,9 +1078,6 @@ fn default_cache_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // Moved out of this feature-gated module (the CLI argument definition needs it in every
-    // build), but its behavior belongs with the fast-clone tests.
-    use crate::commands::git::parse_cache_max_bytes;
 
     #[test]
     fn default_dest_uses_repo_segment_from_project_scoped_url() {
@@ -1097,16 +1089,6 @@ mod tests {
             default_dest_from_url("https://git.example.com/demo/myrepo.git"),
             PathBuf::from("myrepo")
         );
-    }
-
-    #[test]
-    fn parse_cache_max_bytes_accepts_suffixes() {
-        assert_eq!(parse_cache_max_bytes("512").unwrap(), 512);
-        assert_eq!(
-            parse_cache_max_bytes("2GiB").unwrap(),
-            2 * 1024 * 1024 * 1024
-        );
-        assert_eq!(parse_cache_max_bytes("10 mb").unwrap(), 10 * 1024 * 1024);
     }
 
     #[test]

--- a/crates/cloud-sdk/src/artifact_storage/fastclone.rs
+++ b/crates/cloud-sdk/src/artifact_storage/fastclone.rs
@@ -93,7 +93,7 @@ pub struct FastCloneBlob {
     pub path: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct FastCloneOptions {
     /// Clean https(s) repo URL, no embedded credentials (e.g. from `repo_url()`).
     pub repo_url: String,
@@ -105,6 +105,20 @@ pub struct FastCloneOptions {
     pub checkout: bool,
     /// Optional progress sink. Rendering (spinner, logs, bars) is the caller's concern.
     pub progress: Option<FastCloneProgress>,
+}
+
+impl std::fmt::Debug for FastCloneOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FastCloneOptions")
+            .field("repo_url", &self.repo_url)
+            .field("dest", &self.dest)
+            .field("cache_dir", &self.cache_dir)
+            .field("cache_max_bytes", &self.cache_max_bytes)
+            .field("credential", &self.credential)
+            .field("checkout", &self.checkout)
+            .field("progress", &self.progress.as_ref().map(|_| "<callback>"))
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -23,9 +23,10 @@
 //! would make the replayed offset conflict).
 
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
+use ignore::WalkBuilder;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -134,7 +135,7 @@ impl Default for PushOptions {
 }
 
 /// Outcome of a push.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct PushReport {
     pub commit: String,
     pub tree: String,
@@ -224,45 +225,45 @@ struct StagedRegisterWire {
     entries: Vec<StagedEntryWire>,
 }
 
-#[derive(Deserialize)]
-struct CommitJobReadBackWire {
-    done: u64,
-    total: u64,
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CommitJobReadBack {
+    pub done: u64,
+    pub total: u64,
 }
 
-#[derive(Default, Deserialize)]
-struct CommitJobErrorWire {
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct CommitJobError {
     #[serde(default)]
-    kind: String,
+    pub kind: String,
     #[serde(default)]
-    message: String,
+    pub message: String,
     #[serde(default)]
-    retryable: bool,
+    pub retryable: bool,
 }
 
 /// A commit job's state machine as rendered by the server (submission response and polls).
 /// This is the only commit protocol: both the branch-commit and workspace-snapshot endpoints
 /// answer it, and success embeds the commit fields at the top level.
-#[derive(Deserialize)]
-struct CommitJobWire {
-    job_id: String,
-    state: String,
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CommitJobStatus {
+    pub job_id: String,
+    pub state: String,
     #[serde(default)]
-    phase: Option<String>,
+    pub phase: Option<String>,
     #[serde(default)]
-    read_back: Option<CommitJobReadBackWire>,
+    pub read_back: Option<CommitJobReadBack>,
     #[serde(default)]
-    commit: Option<String>,
+    pub commit: Option<String>,
     #[serde(default)]
-    tree: Option<String>,
+    pub tree: Option<String>,
     #[serde(default)]
-    ref_name: Option<String>,
+    pub ref_name: Option<String>,
     #[serde(default)]
-    parent: Option<String>,
+    pub parent: Option<String>,
     #[serde(default)]
-    created: Option<bool>,
+    pub created: Option<bool>,
     #[serde(default)]
-    error: Option<CommitJobErrorWire>,
+    pub error: Option<CommitJobError>,
 }
 
 /// zstd level for staged chunk frames — the server stores frames verbatim, so this matches its
@@ -349,7 +350,7 @@ fn chunk_source(
             ));
         }
     };
-    let reader: Box<dyn Read> = match source {
+    let reader: Box<dyn Read + Send> = match source {
         PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
         PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
         PushSource::KnownOid(_) => unreachable!("guarded above"),
@@ -504,7 +505,128 @@ fn dedup_needed_chunks(
         .collect()
 }
 
+fn collect_worktree_files(root: &Path, out: &mut Vec<PushFile>) -> Result<(), SdkError> {
+    let mut walker = WalkBuilder::new(root);
+    walker
+        // Git tracks dotfiles by default; only ignore patterns should exclude them.
+        .hidden(false)
+        // `git add` does not read ripgrep-style `.ignore` files.
+        .ignore(false)
+        // Keep snapshot roots self-contained instead of reading parent `.gitignore` files.
+        .parents(false)
+        // Honor Git's ignore sources, including `.gitignore` in roots that are not full repos.
+        .require_git(false)
+        .git_ignore(true)
+        .git_exclude(true)
+        .git_global(true)
+        .follow_links(false)
+        .sort_by_file_path(|a, b| a.cmp(b))
+        .filter_entry(|entry| entry.file_name() != ".git");
+
+    for entry in walker.build() {
+        let entry = entry.map_err(|err| SdkError::ClientError(err.to_string()))?;
+        let path = entry.path();
+        let meta = std::fs::symlink_metadata(path)?;
+        if meta.is_dir() {
+            continue;
+        }
+
+        let repo_path = repo_path_for_worktree(root, path);
+        if repo_path.is_empty() {
+            continue;
+        }
+
+        let file_type = meta.file_type();
+        if file_type.is_symlink() {
+            let target = std::fs::read_link(path)?;
+            out.push(PushFile {
+                repo_path,
+                source: PushSource::Bytes(symlink_target_bytes(&target)),
+                mode: Some(0o120000),
+                delete: false,
+            });
+        } else if file_type.is_file() {
+            out.push(PushFile {
+                repo_path,
+                source: PushSource::Path(path.to_path_buf()),
+                mode: Some(regular_file_mode(&meta)),
+                delete: false,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn regular_file_mode(meta: &std::fs::Metadata) -> u32 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if meta.permissions().mode() & 0o111 != 0 {
+            0o100755
+        } else {
+            0o100644
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = meta;
+        0o100644
+    }
+}
+
+fn symlink_target_bytes(target: &Path) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        target.as_os_str().as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        target.to_string_lossy().into_owned().into_bytes()
+    }
+}
+
+/// Repo path for a file under a worktree root, using forward slashes and only normal path
+/// components. This keeps `.` and `..` out of server commit payloads.
+fn repo_path_for_worktree(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .filter_map(|c| match c {
+            Component::Normal(part) => Some(part.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 impl ArtifactStorageClient {
+    /// Push every Git-visible file under `root` as one commit. `.git` is skipped, `.gitignore`
+    /// rules are honored, repository paths are rooted at `root`, and regular-file executable bits
+    /// plus symlinks are preserved.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn push_worktree(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        root: impl AsRef<Path>,
+        opts: PushOptions,
+    ) -> Result<Traced<PushReport>, SdkError> {
+        let root = root.as_ref();
+        let mut files = Vec::new();
+        collect_worktree_files(root, &mut files)?;
+        if files.is_empty() {
+            return Err(SdkError::ClientError(
+                "no files found under the Git worktree".to_string(),
+            ));
+        }
+        self.push_files(project_id, repo, git_username, git_token, files, opts)
+            .await
+    }
+
     /// Push a set of files as one commit, transferring only chunks the server lacks. Safe to
     /// retry wholesale on any failure: completed work is discovered, not redone.
     #[allow(clippy::too_many_arguments)]
@@ -778,7 +900,7 @@ impl ArtifactStorageClient {
                         body.extend_from_slice(&total.to_be_bytes());
                         body.extend_from_slice(&(file.chunks.len() as u32).to_be_bytes());
                         body.extend_from_slice(token.as_bytes());
-                        let mut reader: Box<dyn Read> = match &file.source {
+                        let mut reader: Box<dyn Read + Send> = match &file.source {
                             PushSource::Path(p) => {
                                 Box::new(std::fs::File::open(p).map_err(io_err)?)
                             }
@@ -849,7 +971,7 @@ impl ArtifactStorageClient {
                 let batch_bytes = opts.upload_batch_bytes;
                 async move {
                     let total: u64 = file.chunks.iter().map(|(_, s)| *s as u64).sum();
-                    let mut reader: Box<dyn Read> = match &file.source {
+                    let mut reader: Box<dyn Read + Send> = match &file.source {
                         PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
                         PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
                         PushSource::KnownOid(_) => unreachable!("known-oid files are not tokened"),
@@ -959,7 +1081,7 @@ impl ArtifactStorageClient {
                 if file.chunks.is_empty() {
                     continue; // deletes and known-oid references carry no bytes
                 }
-                let mut reader: Box<dyn Read> = match &file.source {
+                let mut reader: Box<dyn Read + Send> = match &file.source {
                     PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
                     PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
                     PushSource::KnownOid(_) => unreachable!("no chunks to upload"),
@@ -1058,7 +1180,7 @@ impl ArtifactStorageClient {
                 if file.chunks.is_empty() {
                     continue; // deletes and known-oid references carry no bytes
                 }
-                let mut reader: Box<dyn Read> = match &file.source {
+                let mut reader: Box<dyn Read + Send> = match &file.source {
                     PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
                     PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
                     PushSource::KnownOid(_) => unreachable!("no chunks to upload"),
@@ -1192,7 +1314,7 @@ impl ArtifactStorageClient {
                 .send()
                 .await?;
             let accepted = submit.status().as_u16() == 202;
-            let job: CommitJobWire = expect_json(submit).await?;
+            let job: CommitJobStatus = expect_json(submit).await?;
             Ok((accepted, job, trace_id))
         })
         .await?;
@@ -1337,7 +1459,7 @@ impl ArtifactStorageClient {
         git_username: &str,
         git_token: &str,
         job_id: &str,
-    ) -> Result<Traced<serde_json::Value>, SdkError> {
+    ) -> Result<Traced<CommitJobStatus>, SdkError> {
         let (req, trace_id) = self.git_request(
             Method::GET,
             project_id,
@@ -1683,6 +1805,95 @@ mod tests {
             !need.contains(&h(2)),
             "chunks only a tokened file carries ride the tokened stream"
         );
+    }
+
+    #[test]
+    fn worktree_repo_paths_from_dot_have_no_dot_components() {
+        let root = std::path::Path::new(".");
+        assert_eq!(
+            repo_path_for_worktree(root, std::path::Path::new("./.clang-format")),
+            ".clang-format"
+        );
+        assert_eq!(
+            repo_path_for_worktree(root, std::path::Path::new("./arch/boot.c")),
+            "arch/boot.c"
+        );
+    }
+
+    #[test]
+    fn worktree_repo_paths_from_absolute_root_are_root_relative() {
+        let root = std::path::Path::new("/tmp/somedir");
+        assert_eq!(
+            repo_path_for_worktree(root, std::path::Path::new("/tmp/somedir/a/b.txt")),
+            "a/b.txt"
+        );
+    }
+
+    #[test]
+    fn collect_worktree_files_skips_git_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "a").unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        std::fs::write(dir.path().join(".git").join("config"), "ignored").unwrap();
+
+        let mut files = Vec::new();
+        collect_worktree_files(dir.path(), &mut files).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].repo_path, "a.txt");
+    }
+
+    #[test]
+    fn collect_worktree_files_honors_gitignore_without_git_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".gitignore"), "ignored.bin\n").unwrap();
+        std::fs::write(dir.path().join("ignored.bin"), "ignored").unwrap();
+        std::fs::write(dir.path().join("kept.tensorlake-test"), "kept").unwrap();
+
+        let mut files = Vec::new();
+        collect_worktree_files(dir.path(), &mut files).unwrap();
+
+        let paths: Vec<_> = files.iter().map(|file| file.repo_path.as_str()).collect();
+        assert_eq!(paths, vec![".gitignore", "kept.tensorlake-test"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_worktree_files_preserves_executable_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("script.sh");
+        std::fs::write(&script, "#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut files = Vec::new();
+        collect_worktree_files(dir.path(), &mut files).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].repo_path, "script.sh");
+        assert_eq!(files[0].mode, Some(0o100755));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn collect_worktree_files_preserves_symlink_mode_and_target() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("target.txt"), "target").unwrap();
+        std::os::unix::fs::symlink("target.txt", dir.path().join("link.txt")).unwrap();
+
+        let mut files = Vec::new();
+        collect_worktree_files(dir.path(), &mut files).unwrap();
+
+        let link = files
+            .iter()
+            .find(|file| file.repo_path == "link.txt")
+            .expect("symlink should be collected");
+        assert_eq!(link.mode, Some(0o120000));
+        match &link.source {
+            PushSource::Bytes(bytes) => assert_eq!(bytes, b"target.txt"),
+            other => panic!("expected symlink bytes, got {other:?}"),
+        }
     }
 
     /// The commit wire shape for a known-oid file: `oid` set, no chunks, no content.

--- a/crates/cloud-sdk/src/artifact_storage/merge.rs
+++ b/crates/cloud-sdk/src/artifact_storage/merge.rs
@@ -169,6 +169,24 @@ where
 }
 
 impl ArtifactStorageClient {
+    /// Credential-aware wrapper for server-side repository merge.
+    pub async fn merge_repo(
+        &self,
+        project_id: &str,
+        repo: &str,
+        request: &MergeRequest,
+    ) -> Result<Traced<MergeReport>, SdkError> {
+        let credential = self.git_credential_for_repo(project_id, repo).await?;
+        self.repo_merge(
+            project_id,
+            repo,
+            &credential.git_username,
+            &credential.token,
+            request,
+        )
+        .await
+    }
+
     /// Server-side three-way merge between two commitishes. Preflight (the default mode) never
     /// writes; commit mode CAS-advances the `ours` branch. A `fail`-policy conflict returns
     /// `Ok` with `clean: false`, `commit: None`, and the conflict list (the server's `409`
@@ -194,6 +212,25 @@ impl ArtifactStorageClient {
                 .await?
                 .unwrap_or_else(|report| report);
         Ok(Traced::new(trace_id, report))
+    }
+
+    /// The structured conflict record of a `materialize`-policy merge commit. `Ok(None)` =
+    /// the commit merged cleanly (or the server doesn't know it).
+    pub async fn get_commit_conflicts(
+        &self,
+        project_id: &str,
+        repo: &str,
+        commit: &str,
+    ) -> Result<Traced<Option<MergeConflictRecord>>, SdkError> {
+        let credential = self.git_credential_for_repo(project_id, repo).await?;
+        self.commit_conflicts(
+            project_id,
+            repo,
+            &credential.git_username,
+            &credential.token,
+            commit,
+        )
+        .await
     }
 
     /// The structured conflict record of a `materialize`-policy merge commit. `Ok(None)` =

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -6,6 +6,8 @@ use crate::{
     error::SdkError,
 };
 
+#[cfg(feature = "git-clone")]
+pub mod fastclone;
 pub mod ingest;
 pub mod merge;
 pub mod models;
@@ -13,7 +15,7 @@ pub mod workspaces;
 
 use models::{
     CreateRepoRequest, GitCredential, ListBranchesResponse, ListOperationsResponse,
-    ListRefsResponse, ListReposResponse, MintGitTokenRequest,
+    ListRefsResponse, ListReposResponse, MintGitTokenRequest, RepoInfo,
 };
 
 #[derive(Clone)]
@@ -69,13 +71,55 @@ impl ArtifactStorageClient {
         self.api_client.execute_json(req).await
     }
 
+    pub fn git_credential_from_env() -> Option<GitCredential> {
+        std::env::var("TENSORLAKE_GIT_TOKEN")
+            .ok()
+            .map(|token| GitCredential {
+                token,
+                token_type: "bearer".to_string(),
+                expires_at: String::new(),
+                git_username: std::env::var("TENSORLAKE_GIT_USERNAME")
+                    .unwrap_or_else(|_| "t".to_string()),
+                repo_pattern: "*".to_string(),
+                scopes: Vec::new(),
+            })
+    }
+
+    /// Resolve the Git credential used by repository helpers.
+    ///
+    /// `TENSORLAKE_GIT_TOKEN` is honored first for local artifact-storage development; otherwise
+    /// the SDK mints a short-lived token scoped to `repo`.
+    pub async fn git_credential_for_repo(
+        &self,
+        project_id: &str,
+        repo: &str,
+    ) -> Result<GitCredential, SdkError> {
+        if let Some(credential) = Self::git_credential_from_env() {
+            return Ok(credential);
+        }
+        Ok(self
+            .mint_token_for_repo(project_id, Some(repo))
+            .await?
+            .into_inner())
+    }
+
+    pub async fn git_credential_for_project(
+        &self,
+        project_id: &str,
+    ) -> Result<GitCredential, SdkError> {
+        if let Some(credential) = Self::git_credential_from_env() {
+            return Ok(credential);
+        }
+        Ok(self.mint_token(project_id).await?.into_inner())
+    }
+
     pub async fn create_repo(
         &self,
         project_id: &str,
         repo: &str,
         default_branch: Option<&str>,
     ) -> Result<Traced<()>, SdkError> {
-        let credential = self.mint_token(project_id).await?;
+        let credential = self.git_credential_for_project(project_id).await?;
         self.create_repo_with_credential(
             project_id,
             repo,
@@ -115,7 +159,7 @@ impl ArtifactStorageClient {
         repo: &str,
         base_repo: &str,
     ) -> Result<Traced<()>, SdkError> {
-        let credential = self.mint_token(project_id).await?;
+        let credential = self.git_credential_for_project(project_id).await?;
         self.fork_repo_with_credential(
             project_id,
             repo,
@@ -148,7 +192,7 @@ impl ArtifactStorageClient {
     }
 
     pub async fn delete_repo(&self, project_id: &str, repo: &str) -> Result<Traced<()>, SdkError> {
-        let credential = self.mint_token(project_id).await?;
+        let credential = self.git_credential_for_repo(project_id, repo).await?;
         self.delete_repo_with_credential(
             project_id,
             repo,
@@ -191,7 +235,7 @@ impl ArtifactStorageClient {
         repo: &str,
         status: &str,
     ) -> Result<Traced<()>, SdkError> {
-        let credential = self.mint_token(project_id).await?;
+        let credential = self.git_credential_for_repo(project_id, repo).await?;
         self.set_repo_status_with_credential(
             project_id,
             repo,
@@ -227,7 +271,7 @@ impl ArtifactStorageClient {
         &self,
         project_id: &str,
     ) -> Result<Traced<ListReposResponse>, SdkError> {
-        let credential = self.mint_token(project_id).await?;
+        let credential = self.git_credential_for_project(project_id).await?;
         self.list_repos_with_credential(project_id, &credential.git_username, &credential.token)
             .await
     }
@@ -253,7 +297,7 @@ impl ArtifactStorageClient {
         project_id: &str,
         repo: &str,
     ) -> Result<Traced<ListRefsResponse>, SdkError> {
-        let credential = self.mint_token_for_repo(project_id, Some(repo)).await?;
+        let credential = self.git_credential_for_repo(project_id, repo).await?;
         self.list_refs_with_credential(
             project_id,
             repo,
@@ -282,12 +326,48 @@ impl ArtifactStorageClient {
         decode_json(response, trace_id).await
     }
 
+    pub async fn repo_info(
+        &self,
+        project_id: &str,
+        repo: &str,
+    ) -> Result<Traced<RepoInfo>, SdkError> {
+        let credential = self.git_credential_for_repo(project_id, repo).await?;
+        let branches = self
+            .list_branches_with_credential(
+                project_id,
+                repo,
+                &credential.git_username,
+                &credential.token,
+            )
+            .await?;
+        let refs = self
+            .list_refs_with_credential(
+                project_id,
+                repo,
+                &credential.git_username,
+                &credential.token,
+            )
+            .await?;
+        let trace_id = refs.trace_id.clone();
+        let branches = branches.into_inner();
+        let refs = refs.into_inner();
+        Ok(Traced::new(
+            trace_id,
+            RepoInfo {
+                repo: repo.to_string(),
+                url: self.git_repo_url(project_id, repo),
+                branches: branches.branches,
+                refs: refs.refs,
+            },
+        ))
+    }
+
     pub async fn list_branches(
         &self,
         project_id: &str,
         repo: &str,
     ) -> Result<Traced<ListBranchesResponse>, SdkError> {
-        let credential = self.mint_token_for_repo(project_id, Some(repo)).await?;
+        let credential = self.git_credential_for_repo(project_id, repo).await?;
         self.list_branches_with_credential(
             project_id,
             repo,
@@ -322,7 +402,7 @@ impl ArtifactStorageClient {
         repo: &str,
         branch: &str,
     ) -> Result<Traced<()>, SdkError> {
-        let credential = self.mint_token_for_repo(project_id, Some(repo)).await?;
+        let credential = self.git_credential_for_repo(project_id, repo).await?;
         self.delete_branch_with_credential(
             project_id,
             repo,
@@ -371,6 +451,21 @@ impl ArtifactStorageClient {
         )?;
         let response = request.send().await?;
         decode_json(response, trace_id).await
+    }
+
+    pub async fn list_operations(
+        &self,
+        project_id: &str,
+        repo: &str,
+    ) -> Result<Traced<ListOperationsResponse>, SdkError> {
+        let credential = self.git_credential_for_repo(project_id, repo).await?;
+        self.list_operations_with_credential(
+            project_id,
+            repo,
+            &credential.git_username,
+            &credential.token,
+        )
+        .await
     }
 
     fn git_request(

--- a/crates/cloud-sdk/src/artifact_storage/models.rs
+++ b/crates/cloud-sdk/src/artifact_storage/models.rs
@@ -71,6 +71,14 @@ pub struct ListBranchesResponse {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RepoInfo {
+    pub repo: String,
+    pub url: String,
+    pub branches: Vec<Branch>,
+    pub refs: Vec<GitRef>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OperationRef {
     pub name: String,
     pub old: Option<String>,

--- a/crates/gsvc-codec/Cargo.toml
+++ b/crates/gsvc-codec/Cargo.toml
@@ -2,8 +2,8 @@
 #
 # The real crate lives in the private artifact_storage repo and is no longer vendored into this
 # public tree. This placeholder exists solely so the public repo *resolves* the optional
-# `gsvc-codec` dependency of `tensorlake-cli` without any access to that repo. Its `src/lib.rs`
-# is a `compile_error!` and is never compiled by a valid build:
+# `gsvc-codec` dependency of the Rust SDK's `git-clone` feature without any access to that repo.
+# Its `src/lib.rs` is a `compile_error!` and is never compiled by a valid build:
 #   * default / `cargo build --workspace` builds — the `git-clone` feature is off, so the
 #     optional dependency is not activated (and the crate is `exclude`d from the workspace, so
 #     `--workspace` does not build it either);

--- a/crates/gsvc-codec/src/lib.rs
+++ b/crates/gsvc-codec/src/lib.rs
@@ -1,9 +1,9 @@
 //! Resolution-only placeholder for the private `gsvc-codec` packfile codec.
 //!
 //! The real crate is not vendored into this public repository (it used to be; it is not
-//! anymore). This file exists only so the optional `gsvc-codec` dependency of `tensorlake-cli`
-//! resolves without access to the private artifact_storage repo. It is never compiled by a
-//! valid build — see this crate's `Cargo.toml`.
+//! anymore). This file exists only so the optional `gsvc-codec` dependency of the Rust SDK's
+//! `git-clone` feature resolves without access to the private artifact_storage repo. It is never
+//! compiled by a valid build — see this crate's `Cargo.toml`.
 //!
 //! If you are reading this because the build failed: you enabled `--features git-clone` without
 //! the real source in place. Build the official binary via the justfile recipe instead:

--- a/crates/rust-cloud-sdk-node/src/lib.rs
+++ b/crates/rust-cloud-sdk-node/src/lib.rs
@@ -8,6 +8,7 @@
 
 #![deny(clippy::all)]
 
+mod repositories;
 mod sandbox;
 
 use std::path::PathBuf;

--- a/crates/rust-cloud-sdk-node/src/repositories.rs
+++ b/crates/rust-cloud-sdk-node/src/repositories.rs
@@ -1,0 +1,410 @@
+//! napi-rs bindings for Tensorlake Artifact Storage Git repositories.
+
+use std::path::PathBuf;
+
+use napi_derive::napi;
+use tensorlake::artifact_storage::ArtifactStorageClient;
+use tensorlake::artifact_storage::ingest::PushOptions;
+use tensorlake::artifact_storage::merge::MergeRequest;
+use tensorlake::{ClientBuilder, error::SdkError};
+
+use crate::sandbox::{TracedJson, duration_from_seconds, into_napi_error, usage_error, with_retry};
+
+#[napi]
+pub struct NativeRepositoryClient {
+    client: ArtifactStorageClient,
+    project_id: Option<String>,
+}
+
+#[napi]
+impl NativeRepositoryClient {
+    #[napi(constructor)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        api_url: String,
+        api_key: Option<String>,
+        organization_id: Option<String>,
+        project_id: Option<String>,
+        user_agent: Option<String>,
+        request_timeout_sec: Option<f64>,
+    ) -> napi::Result<Self> {
+        let mut builder = ClientBuilder::new(&api_url);
+        if let Some(token) = api_key.as_deref() {
+            builder = builder.bearer_token(token);
+        }
+        if let (Some(org_id), Some(project_id)) =
+            (organization_id.as_deref(), project_id.as_deref())
+        {
+            builder = builder.scope(org_id, project_id);
+        }
+        if let Some(ua) = user_agent.as_deref() {
+            builder = builder.user_agent(ua);
+        }
+        if let Some(seconds) = request_timeout_sec {
+            builder = builder.timeout(duration_from_seconds("request_timeout_sec", seconds)?);
+        }
+
+        let api_client = builder.build().map_err(into_napi_error)?;
+        let client = ArtifactStorageClient::new(
+            api_client,
+            tensorlake::resolve_artifact_storage_url(&api_url),
+        )
+        .map_err(into_napi_error)?;
+        Ok(Self { client, project_id })
+    }
+
+    fn project_id(&self) -> napi::Result<&str> {
+        self.project_id
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| usage_error("Repository operations require projectId".to_string()))
+    }
+
+    #[napi]
+    pub fn git_repo_url(&self, repo: String) -> napi::Result<String> {
+        Ok(self.client.git_repo_url(self.project_id()?, &repo))
+    }
+
+    #[napi]
+    pub async fn create_repo(
+        &self,
+        repo: String,
+        default_branch: Option<String>,
+    ) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let default_branch = default_branch.clone();
+            async move {
+                let traced = client
+                    .create_repo(&project_id, &repo, default_branch.as_deref())
+                    .await?;
+                let url = client.git_repo_url(&project_id, &repo);
+                let json = serde_json::to_string(&serde_json::json!({
+                    "repo": repo,
+                    "url": url,
+                }))?;
+                Ok(TracedJson {
+                    trace_id: traced.trace_id,
+                    json,
+                })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn list_repos(&self) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            async move {
+                let traced = client.list_repos(&project_id).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn delete_repo(&self, repo: String) -> napi::Result<String> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                client
+                    .delete_repo(&project_id, &repo)
+                    .await
+                    .map(|t| t.trace_id)
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn fork_repo(&self, repo: String, base_repo: String) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let base_repo = base_repo.clone();
+            async move {
+                let traced = client.fork_repo(&project_id, &repo, &base_repo).await?;
+                let url = client.git_repo_url(&project_id, &repo);
+                let json = serde_json::to_string(&serde_json::json!({
+                    "repo": repo,
+                    "url": url,
+                    "base_repo": base_repo,
+                }))?;
+                Ok(TracedJson {
+                    trace_id: traced.trace_id,
+                    json,
+                })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn archive_repo(&self, repo: String) -> napi::Result<String> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                client
+                    .archive_repo(&project_id, &repo)
+                    .await
+                    .map(|t| t.trace_id)
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn restore_repo(&self, repo: String) -> napi::Result<String> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                client
+                    .restore_repo(&project_id, &repo)
+                    .await
+                    .map(|t| t.trace_id)
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn repo_info(&self, repo: String) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let traced = client.repo_info(&project_id, &repo).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn list_branches(&self, repo: String) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let traced = client.list_branches(&project_id, &repo).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn list_refs(&self, repo: String) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let traced = client.list_refs(&project_id, &repo).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn delete_branch(&self, repo: String, branch: String) -> napi::Result<String> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let branch = branch.clone();
+            async move {
+                client
+                    .delete_branch(&project_id, &repo, &branch)
+                    .await
+                    .map(|t| t.trace_id)
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn list_operations(&self, repo: String) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let traced = client.list_operations(&project_id, &repo).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn git_credential(&self, repo: Option<String>) -> napi::Result<String> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let credential = match repo.as_deref() {
+                    Some(repo) => client.git_credential_for_repo(&project_id, repo).await?,
+                    None => client.git_credential_for_project(&project_id).await?,
+                };
+                serde_json::to_string(&credential).map_err(SdkError::from)
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn commit_status(&self, repo: String, job_id: String) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let job_id = job_id.clone();
+            async move {
+                let credential = client.git_credential_for_repo(&project_id, &repo).await?;
+                let traced = client
+                    .commit_job_status(
+                        &project_id,
+                        &repo,
+                        &credential.git_username,
+                        &credential.token,
+                        &job_id,
+                    )
+                    .await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn push_worktree(
+        &self,
+        repo: String,
+        root: String,
+        branch: String,
+        message: String,
+        expect_oid: Option<String>,
+    ) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let root = root.clone();
+            let branch = branch.clone();
+            let message = message.clone();
+            let expect_oid = expect_oid.clone();
+            async move {
+                let credential = client.git_credential_for_repo(&project_id, &repo).await?;
+                let opts = PushOptions {
+                    branch,
+                    message,
+                    expect_oid,
+                    ..Default::default()
+                };
+                let traced = client
+                    .push_worktree(
+                        &project_id,
+                        &repo,
+                        &credential.git_username,
+                        &credential.token,
+                        PathBuf::from(root),
+                        opts,
+                    )
+                    .await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn merge_repo(
+        &self,
+        repo: String,
+        ours: String,
+        theirs: String,
+        preflight: bool,
+        deep: bool,
+        materialize: bool,
+        message: Option<String>,
+        base: Option<String>,
+    ) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let ours = ours.clone();
+            let theirs = theirs.clone();
+            let message = message.clone();
+            let base = base.clone();
+            async move {
+                let request = MergeRequest {
+                    ours,
+                    theirs,
+                    base,
+                    deep,
+                    mode: (!preflight).then(|| "commit".to_string()),
+                    policy: materialize.then(|| "materialize".to_string()),
+                    message,
+                    ..Default::default()
+                };
+                let traced = client.merge_repo(&project_id, &repo, &request).await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    #[napi]
+    pub async fn commit_conflicts(&self, repo: String, commit: String) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let commit = commit.clone();
+            async move {
+                let traced = client
+                    .get_commit_conflicts(&project_id, &repo, &commit)
+                    .await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+}

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -70,7 +70,7 @@ fn make_napi_error(category: &str, status: Option<u16>, message: String) -> napi
 
 /// Map an [`SdkError`] to a structured napi error. Mirrors the Python binding's
 /// `into_sandbox_py_error` so both SDKs classify failures identically.
-fn into_napi_error(error: SdkError) -> napi::Error {
+pub(crate) fn into_napi_error(error: SdkError) -> napi::Error {
     match error {
         SdkError::Authentication(message) => make_napi_error("sdk_usage", Some(401), message),
         SdkError::Authorization(message) => make_napi_error("sdk_usage", Some(403), message),
@@ -99,7 +99,7 @@ fn into_napi_error(error: SdkError) -> napi::Error {
     }
 }
 
-fn usage_error(message: String) -> napi::Error {
+pub(crate) fn usage_error(message: String) -> napi::Error {
     make_napi_error("sdk_usage", None, message)
 }
 
@@ -153,7 +153,11 @@ where
 }
 
 /// Run `op` with bounded retries, mapping any terminal error to a napi error.
-async fn with_retry<C, T, F, Fut>(client: C, max_retries: usize, op: F) -> napi::Result<T>
+pub(crate) async fn with_retry<C, T, F, Fut>(
+    client: C,
+    max_retries: usize,
+    op: F,
+) -> napi::Result<T>
 where
     C: Clone,
     F: Fn(C) -> Fut,
@@ -166,7 +170,7 @@ where
 
 // ---- Misc helpers (ported from the Python binding) ------------------------
 
-fn duration_from_seconds(name: &str, seconds: f64) -> napi::Result<Duration> {
+pub(crate) fn duration_from_seconds(name: &str, seconds: f64) -> napi::Result<Duration> {
     if !seconds.is_finite() || seconds <= 0.0 {
         return Err(usage_error(format!(
             "{name} must be a positive finite number"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.61"
+version = "0.5.62"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -20,6 +20,9 @@ use reqwest::Method;
 use reqwest::multipart::{Form, Part};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use tensorlake::artifact_storage::ArtifactStorageClient;
+use tensorlake::artifact_storage::ingest::PushOptions;
+use tensorlake::artifact_storage::merge::MergeRequest;
 use tensorlake::document_ai::DocumentAiClient;
 use tensorlake::file_systems::FileSystemsClient;
 use tensorlake::file_systems::models::CreateFileSystemRequest;
@@ -259,6 +262,382 @@ impl CloudApiClient {
                 let file_systems = FileSystemsClient::new(client, organization_id, project_id);
                 file_systems.delete(&file_system_id).await?;
                 Ok(())
+            }
+        })
+    }
+
+    fn git_repo_url(&self, project_id: String, repo: String) -> PyResult<String> {
+        let client = self.artifact_storage_client().map_err(into_py_error)?;
+        Ok(client.git_repo_url(&project_id, &repo))
+    }
+
+    #[pyo3(signature = (project_id, repo, default_branch=None))]
+    fn create_git_repo(
+        &self,
+        project_id: String,
+        repo: String,
+        default_branch: Option<String>,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let default_branch = default_branch.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client
+                    .create_repo(&project_id, &repo, default_branch.as_deref())
+                    .await?;
+                let url = client.git_repo_url(&project_id, &repo);
+                let response = serde_json::json!({
+                    "repo": repo,
+                    "url": url,
+                });
+                let mut value = serde_json::to_value(response).map_err(SdkError::from)?;
+                if let Some(obj) = value.as_object_mut() {
+                    obj.insert(
+                        "trace_id".to_string(),
+                        serde_json::Value::String(traced.trace_id),
+                    );
+                }
+                serde_json::to_string(&value).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn list_git_repos(&self, project_id: String) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client.list_repos(&project_id).await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn delete_git_repo(&self, project_id: String, repo: String) -> PyResult<()> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                client.delete_repo(&project_id, &repo).await?;
+                Ok(())
+            }
+        })
+    }
+
+    fn fork_git_repo(
+        &self,
+        project_id: String,
+        repo: String,
+        base_repo: String,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let base_repo = base_repo.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client.fork_repo(&project_id, &repo, &base_repo).await?;
+                let url = client.git_repo_url(&project_id, &repo);
+                let response = serde_json::json!({
+                    "repo": repo,
+                    "url": url,
+                    "base_repo": base_repo,
+                    "trace_id": traced.trace_id,
+                });
+                serde_json::to_string(&response).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn archive_git_repo(&self, project_id: String, repo: String) -> PyResult<()> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                client.archive_repo(&project_id, &repo).await?;
+                Ok(())
+            }
+        })
+    }
+
+    fn restore_git_repo(&self, project_id: String, repo: String) -> PyResult<()> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                client.restore_repo(&project_id, &repo).await?;
+                Ok(())
+            }
+        })
+    }
+
+    fn git_repo_info(&self, project_id: String, repo: String) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client.repo_info(&project_id, &repo).await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn list_git_branches(&self, project_id: String, repo: String) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client.list_branches(&project_id, &repo).await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn list_git_refs(&self, project_id: String, repo: String) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client.list_refs(&project_id, &repo).await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn delete_git_branch(&self, project_id: String, repo: String, branch: String) -> PyResult<()> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let branch = branch.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                client.delete_branch(&project_id, &repo, &branch).await?;
+                Ok(())
+            }
+        })
+    }
+
+    fn list_git_operations(&self, project_id: String, repo: String) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client.list_operations(&project_id, &repo).await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    #[pyo3(signature = (project_id, repo=None))]
+    fn git_credential(&self, project_id: String, repo: Option<String>) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let credential = match repo.as_deref() {
+                    Some(repo) => client.git_credential_for_repo(&project_id, repo).await?,
+                    None => client.git_credential_for_project(&project_id).await?,
+                };
+                serde_json::to_string(&credential).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn git_commit_status(
+        &self,
+        project_id: String,
+        repo: String,
+        job_id: String,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let job_id = job_id.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let credential = client.git_credential_for_repo(&project_id, &repo).await?;
+                let traced = client
+                    .commit_job_status(
+                        &project_id,
+                        &repo,
+                        &credential.git_username,
+                        &credential.token,
+                        &job_id,
+                    )
+                    .await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn push_git_worktree(
+        &self,
+        project_id: String,
+        repo: String,
+        root: String,
+        branch: String,
+        message: String,
+        expect_oid: Option<String>,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let root = root.clone();
+            let branch = branch.clone();
+            let message = message.clone();
+            let expect_oid = expect_oid.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let credential = client.git_credential_for_repo(&project_id, &repo).await?;
+                let opts = PushOptions {
+                    branch,
+                    message,
+                    expect_oid,
+                    ..Default::default()
+                };
+                let traced = client
+                    .push_worktree(
+                        &project_id,
+                        &repo,
+                        &credential.git_username,
+                        &credential.token,
+                        PathBuf::from(root),
+                        opts,
+                    )
+                    .await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    #[pyo3(signature = (project_id, repo, ours, theirs, preflight=false, deep=false, materialize=false, message=None, base=None))]
+    fn merge_git_repo(
+        &self,
+        project_id: String,
+        repo: String,
+        ours: String,
+        theirs: String,
+        preflight: bool,
+        deep: bool,
+        materialize: bool,
+        message: Option<String>,
+        base: Option<String>,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let ours = ours.clone();
+            let theirs = theirs.clone();
+            let message = message.clone();
+            let base = base.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let request = MergeRequest {
+                    ours,
+                    theirs,
+                    base,
+                    deep,
+                    mode: (!preflight).then(|| "commit".to_string()),
+                    policy: materialize.then(|| "materialize".to_string()),
+                    message,
+                    ..Default::default()
+                };
+                let traced = client.merge_repo(&project_id, &repo, &request).await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn git_commit_conflicts(
+        &self,
+        project_id: String,
+        repo: String,
+        commit: String,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let repo = repo.clone();
+            let commit = commit.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client
+                    .get_commit_conflicts(&project_id, &repo, &commit)
+                    .await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
             }
         })
     }
@@ -2619,6 +2998,13 @@ where
 }
 
 impl CloudApiClient {
+    fn artifact_storage_client(&self) -> Result<ArtifactStorageClient, SdkError> {
+        ArtifactStorageClient::new(
+            self.client.clone(),
+            tensorlake::resolve_artifact_storage_url(&self.api_url),
+        )
+    }
+
     fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
         F: FnMut(Client) -> Fut,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.61"
+version = "0.5.62"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/__init__.py
+++ b/src/tensorlake/__init__.py
@@ -12,6 +12,7 @@ from tensorlake.sandbox import (
     delete_file_system,
     list_file_systems,
 )
+from tensorlake.repositories import RepositoryClient
 
 __all__ = [
     "Image",
@@ -24,4 +25,5 @@ __all__ = [
     "create_file_system",
     "list_file_systems",
     "delete_file_system",
+    "RepositoryClient",
 ]

--- a/src/tensorlake/__init__.py
+++ b/src/tensorlake/__init__.py
@@ -5,6 +5,7 @@ from tensorlake.image import (
     import_sandbox_image,
     list_sandbox_images,
 )
+from tensorlake.repositories import RepositoryClient
 from tensorlake.sandbox import (
     FileSystem,
     FileSystemMount,
@@ -12,7 +13,6 @@ from tensorlake.sandbox import (
     delete_file_system,
     list_file_systems,
 )
-from tensorlake.repositories import RepositoryClient
 
 __all__ = [
     "Image",

--- a/src/tensorlake/cloud_client.py
+++ b/src/tensorlake/cloud_client.py
@@ -240,3 +240,153 @@ class CloudClient:
             )
         except Exception as e:
             _raise_as_tensorlake_error(e)
+
+    # -- Git repository operations --
+
+    def git_repo_url(self, project_id: str, repo: str) -> str:
+        try:
+            return self._client.git_repo_url(project_id, repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def create_git_repo(
+        self,
+        project_id: str,
+        repo: str,
+        default_branch: str | None = None,
+    ) -> str:
+        try:
+            return self._client.create_git_repo(project_id, repo, default_branch)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def list_git_repos(self, project_id: str) -> str:
+        try:
+            return self._client.list_git_repos(project_id)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def delete_git_repo(self, project_id: str, repo: str) -> None:
+        try:
+            self._client.delete_git_repo(project_id, repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def fork_git_repo(self, project_id: str, repo: str, base_repo: str) -> str:
+        try:
+            return self._client.fork_git_repo(project_id, repo, base_repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def archive_git_repo(self, project_id: str, repo: str) -> None:
+        try:
+            self._client.archive_git_repo(project_id, repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def restore_git_repo(self, project_id: str, repo: str) -> None:
+        try:
+            self._client.restore_git_repo(project_id, repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def git_repo_info(self, project_id: str, repo: str) -> str:
+        try:
+            return self._client.git_repo_info(project_id, repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def list_git_branches(self, project_id: str, repo: str) -> str:
+        try:
+            return self._client.list_git_branches(project_id, repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def list_git_refs(self, project_id: str, repo: str) -> str:
+        try:
+            return self._client.list_git_refs(project_id, repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def delete_git_branch(self, project_id: str, repo: str, branch: str) -> None:
+        try:
+            self._client.delete_git_branch(project_id, repo, branch)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def list_git_operations(self, project_id: str, repo: str) -> str:
+        try:
+            return self._client.list_git_operations(project_id, repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def git_credential(self, project_id: str, repo: str | None = None) -> str:
+        try:
+            return self._client.git_credential(project_id, repo)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def git_commit_status(self, project_id: str, repo: str, job_id: str) -> str:
+        try:
+            return self._client.git_commit_status(project_id, repo, job_id)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def push_git_worktree(
+        self,
+        project_id: str,
+        repo: str,
+        root: str,
+        branch: str,
+        message: str,
+        expect_oid: str | None = None,
+    ) -> str:
+        try:
+            return self._client.push_git_worktree(
+                project_id,
+                repo,
+                root,
+                branch,
+                message,
+                expect_oid,
+            )
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def merge_git_repo(
+        self,
+        project_id: str,
+        repo: str,
+        ours: str,
+        theirs: str,
+        preflight: bool = False,
+        deep: bool = False,
+        materialize: bool = False,
+        message: str | None = None,
+        base: str | None = None,
+    ) -> str:
+        try:
+            return self._client.merge_git_repo(
+                project_id,
+                repo,
+                ours,
+                theirs,
+                preflight,
+                deep,
+                materialize,
+                message,
+                base,
+            )
+        except Exception as e:
+            _raise_as_tensorlake_error(e)
+
+    def git_commit_conflicts(
+        self,
+        project_id: str,
+        repo: str,
+        commit: str,
+    ) -> str:
+        try:
+            return self._client.git_commit_conflicts(project_id, repo, commit)
+        except Exception as e:
+            _raise_as_tensorlake_error(e)

--- a/src/tensorlake/image/utils.py
+++ b/src/tensorlake/image/utils.py
@@ -4,7 +4,10 @@ from typing import List
 from ._dockerfile import image_has_workdir, render_op_line
 from .image import Image
 
-_SDK_VERSION: str = importlib.metadata.version("tensorlake")
+try:
+    _SDK_VERSION: str = importlib.metadata.version("tensorlake")
+except importlib.metadata.PackageNotFoundError:
+    _SDK_VERSION = "unknown"
 
 
 def dockerfile_content(img: Image, extra_env_vars: List[tuple] | None = None) -> str:

--- a/src/tensorlake/repositories.py
+++ b/src/tensorlake/repositories.py
@@ -1,0 +1,408 @@
+"""Git repository APIs backed by the Rust cloud SDK."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from tensorlake.cloud_client import CloudClient
+
+
+class RepositoryError(RuntimeError):
+    """Raised when repository SDK configuration or operations fail."""
+
+
+@dataclass(frozen=True)
+class _EnvContext:
+    api_url: str
+    api_key: str | None
+    personal_access_token: str | None
+    organization_id: str | None
+    project_id: str | None
+    namespace: str
+
+
+class _Model(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class Repository(_Model):
+    name: str
+    full_name: str = Field(alias="full_name")
+    default_branch: str = Field(alias="default_branch")
+    status: str
+
+
+class RepositoryHandle(_Model):
+    repo: str
+    url: str
+    trace_id: str | None = Field(default=None, alias="trace_id")
+    base_repo: str | None = Field(default=None, alias="base_repo")
+
+
+class GitRef(_Model):
+    name: str
+    oid: str
+
+
+class Branch(_Model):
+    name: str
+    ref_name: str = Field(alias="ref_name")
+    oid: str
+
+
+class RepositoryInfo(_Model):
+    repo: str
+    url: str
+    branches: list[Branch]
+    refs: list[GitRef]
+
+
+class GitCredential(_Model):
+    token: str
+    token_type: str = Field(alias="tokenType")
+    expires_at: str = Field(alias="expiresAt")
+    git_username: str = Field(alias="gitUsername")
+    repo_pattern: str = Field(alias="repoPattern")
+    scopes: list[str]
+
+
+class CommitJobReadBack(_Model):
+    done: int
+    total: int
+
+
+class CommitJobError(_Model):
+    kind: str = ""
+    message: str = ""
+    retryable: bool = False
+
+
+class CommitJobStatus(_Model):
+    job_id: str = Field(alias="job_id")
+    state: str
+    phase: str | None = None
+    read_back: CommitJobReadBack | None = Field(default=None, alias="read_back")
+    commit: str | None = None
+    tree: str | None = None
+    ref_name: str | None = Field(default=None, alias="ref_name")
+    parent: str | None = None
+    created: bool | None = None
+    error: CommitJobError | None = None
+
+
+class PushReport(_Model):
+    commit: str
+    tree: str
+    ref_name: str = Field(alias="ref_name")
+    created: bool
+    files: int
+    bytes_total: int = Field(alias="bytes_total")
+    chunks_total: int = Field(alias="chunks_total")
+    chunks_uploaded: int = Field(alias="chunks_uploaded")
+    bytes_uploaded: int = Field(alias="bytes_uploaded")
+    file_blob_oids: list[tuple[str, str]] = Field(alias="file_blob_oids")
+
+
+class MergeEntry(_Model):
+    mode: int
+    oid: str
+
+
+class MergeConflict(_Model):
+    path: str
+    kind: str
+    potential: bool = False
+    ours: MergeEntry | None = None
+    base: MergeEntry | None = None
+    theirs: MergeEntry | None = None
+
+
+class MergeStats(_Model):
+    trees_read: int = Field(alias="trees_read")
+    entries_compared: int = Field(alias="entries_compared")
+    blobs_merged: int = Field(alias="blobs_merged")
+    wall_ms: float = Field(alias="wall_ms")
+
+
+class MergeReport(_Model):
+    ours: str
+    theirs: str
+    merge_base: str | None = Field(default=None, alias="merge_base")
+    clean: bool
+    fast_forward: bool = Field(alias="fast_forward")
+    already_merged: bool = Field(alias="already_merged")
+    changed_paths: int = Field(alias="changed_paths")
+    conflicts: list[MergeConflict]
+    stats: MergeStats
+    commit: str | None = None
+    fast_forwarded: bool = Field(default=False, alias="fast_forwarded")
+
+
+class ConflictTerm(_Model):
+    mode: int
+    oid: str
+
+
+class ConflictPath(_Model):
+    path: str
+    kind: str
+    terms: list[ConflictTerm | None]
+
+
+class MergeConflictRecord(_Model):
+    version: int
+    ours_commit: str = Field(alias="ours_commit")
+    theirs_commit: str = Field(alias="theirs_commit")
+    base_commit: str | None = Field(default=None, alias="base_commit")
+    paths: list[ConflictPath]
+    truncated_paths: int = Field(default=0, alias="truncated_paths")
+
+
+class OperationRef(_Model):
+    name: str
+    old: str | None = None
+    new: str | None = None
+
+
+class Operation(_Model):
+    op_id: str = Field(alias="op_id")
+    repo: str
+    network: str | None = None
+    parent_op_id: str | None = Field(default=None, alias="parent_op_id")
+    actor: str
+    at_secs: int = Field(alias="at_secs")
+    kind: str
+    result: str
+    refs: list[OperationRef]
+    pack_ids: list[str] = Field(alias="pack_ids")
+    old_pack_ids: list[str] = Field(alias="old_pack_ids")
+    related_repo: str | None = Field(default=None, alias="related_repo")
+    status: str | None = None
+    old_pack_count: int = Field(alias="old_pack_count")
+    object_count: int = Field(alias="object_count")
+    pack_bytes: int = Field(alias="pack_bytes")
+
+
+def _load_json(raw: str) -> Any:
+    return json.loads(raw) if raw else {}
+
+
+def _non_empty_env(name: str) -> str | None:
+    value = os.environ.get(name)
+    return value or None
+
+
+def _build_context_from_env() -> _EnvContext:
+    return _EnvContext(
+        api_url=_non_empty_env("TENSORLAKE_API_URL") or "https://api.tensorlake.ai",
+        api_key=_non_empty_env("TENSORLAKE_API_KEY"),
+        personal_access_token=_non_empty_env("TENSORLAKE_PAT"),
+        organization_id=_non_empty_env("TENSORLAKE_ORGANIZATION_ID"),
+        project_id=_non_empty_env("TENSORLAKE_PROJECT_ID"),
+        namespace=_non_empty_env("INDEXIFY_NAMESPACE") or "default",
+    )
+
+
+def _extract_project_id(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+
+    for key in ("project_id", "projectId"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    project = payload.get("project")
+    if isinstance(project, str) and project:
+        return project
+    if isinstance(project, dict):
+        for key in ("id", "project_id", "projectId"):
+            value = project.get(key)
+            if isinstance(value, str) and value:
+                return value
+
+    for key in ("scope", "api_key", "apiKey", "key"):
+        found = _extract_project_id(payload.get(key))
+        if found:
+            return found
+
+    projects = payload.get("projects")
+    if isinstance(projects, list) and len(projects) == 1:
+        return _extract_project_id(projects[0])
+
+    return None
+
+
+class RepositoryClient:
+    """Client for Tensorlake Git repositories."""
+
+    def __init__(
+        self,
+        api_url: str | None = None,
+        api_key: str | None = None,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+    ):
+        ctx = _build_context_from_env()
+        token = api_key or ctx.api_key
+        if not token:
+            if ctx.personal_access_token:
+                raise RepositoryError(
+                    "Repository SDKs require TENSORLAKE_API_KEY. "
+                    "Personal access tokens are CLI-only."
+                )
+            raise RepositoryError(
+                "Missing TENSORLAKE_API_KEY credentials."
+            )
+
+        self._client = CloudClient(
+            api_url=api_url or ctx.api_url,
+            api_key=token,
+            organization_id=None,
+            project_id=None,
+            namespace=ctx.namespace,
+        )
+        self.project_id = project_id or ctx.project_id or self._project_id_from_api_key()
+
+    def _project_id_from_api_key(self) -> str:
+        payload = _load_json(self._client.introspect_api_key_json())
+        project_id = _extract_project_id(payload)
+        if not project_id:
+            raise RepositoryError("Repository API key did not include project context.")
+        return project_id
+
+    @classmethod
+    def from_env(cls) -> "RepositoryClient":
+        return cls()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "RepositoryClient":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    def url(self, repo: str) -> str:
+        return self._client.git_repo_url(self.project_id, repo)
+
+    def create(
+        self,
+        repo: str,
+        default_branch: str | None = None,
+    ) -> RepositoryHandle:
+        raw = self._client.create_git_repo(self.project_id, repo, default_branch)
+        return RepositoryHandle.model_validate(_load_json(raw))
+
+    def list(self) -> list[Repository]:
+        raw = self._client.list_git_repos(self.project_id)
+        payload = _load_json(raw)
+        return [Repository.model_validate(item) for item in payload.get("repos", [])]
+
+    def delete(self, repo: str) -> None:
+        self._client.delete_git_repo(self.project_id, repo)
+
+    def fork(self, repo: str, base_repo: str) -> RepositoryHandle:
+        raw = self._client.fork_git_repo(self.project_id, repo, base_repo)
+        return RepositoryHandle.model_validate(_load_json(raw))
+
+    def archive(self, repo: str) -> None:
+        self._client.archive_git_repo(self.project_id, repo)
+
+    def restore(self, repo: str) -> None:
+        self._client.restore_git_repo(self.project_id, repo)
+
+    def info(self, repo: str) -> RepositoryInfo:
+        raw = self._client.git_repo_info(self.project_id, repo)
+        return RepositoryInfo.model_validate(_load_json(raw))
+
+    def branches(self, repo: str) -> list[Branch]:
+        raw = self._client.list_git_branches(self.project_id, repo)
+        payload = _load_json(raw)
+        return [Branch.model_validate(item) for item in payload.get("branches", [])]
+
+    def refs(self, repo: str) -> list[GitRef]:
+        raw = self._client.list_git_refs(self.project_id, repo)
+        payload = _load_json(raw)
+        return [GitRef.model_validate(item) for item in payload.get("refs", [])]
+
+    def delete_branch(self, repo: str, branch: str) -> None:
+        self._client.delete_git_branch(self.project_id, repo, branch)
+
+    def operations(self, repo: str) -> list[Operation]:
+        raw = self._client.list_git_operations(self.project_id, repo)
+        payload = _load_json(raw)
+        return [Operation.model_validate(item) for item in payload.get("operations", [])]
+
+    def credential(self, repo: str | None = None) -> GitCredential:
+        raw = self._client.git_credential(self.project_id, repo)
+        return GitCredential.model_validate(_load_json(raw))
+
+    def commit_status(self, repo: str, job_id: str) -> CommitJobStatus:
+        raw = self._client.git_commit_status(self.project_id, repo, job_id)
+        return CommitJobStatus.model_validate(_load_json(raw))
+
+    def push_worktree(
+        self,
+        repo: str,
+        root: str | Path = ".",
+        branch: str = "main",
+        message: str = "Update repository",
+        expect_oid: str | None = None,
+    ) -> PushReport:
+        raw = self._client.push_git_worktree(
+            self.project_id,
+            repo,
+            str(root),
+            branch,
+            message,
+            expect_oid,
+        )
+        return PushReport.model_validate(_load_json(raw))
+
+    def merge(
+        self,
+        repo: str,
+        ours: str,
+        theirs: str,
+        *,
+        preflight: bool = False,
+        deep: bool = False,
+        materialize: bool = False,
+        message: str | None = None,
+        base: str | None = None,
+    ) -> MergeReport:
+        raw = self._client.merge_git_repo(
+            self.project_id,
+            repo,
+            ours,
+            theirs,
+            preflight,
+            deep,
+            materialize,
+            message,
+            base,
+        )
+        return MergeReport.model_validate(_load_json(raw))
+
+    def commit_conflicts(
+        self,
+        repo: str,
+        commit: str,
+    ) -> MergeConflictRecord | None:
+        raw = self._client.git_commit_conflicts(self.project_id, repo, commit)
+        payload = _load_json(raw)
+        if payload is None:
+            return None
+        return MergeConflictRecord.model_validate(payload)
+
+
+def client_from_env() -> RepositoryClient:
+    return RepositoryClient.from_env()

--- a/src/tensorlake/repositories.py
+++ b/src/tensorlake/repositories.py
@@ -257,9 +257,7 @@ class RepositoryClient:
                     "Repository SDKs require TENSORLAKE_API_KEY. "
                     "Personal access tokens are CLI-only."
                 )
-            raise RepositoryError(
-                "Missing TENSORLAKE_API_KEY credentials."
-            )
+            raise RepositoryError("Missing TENSORLAKE_API_KEY credentials.")
 
         self._client = CloudClient(
             api_url=api_url or ctx.api_url,
@@ -268,7 +266,9 @@ class RepositoryClient:
             project_id=None,
             namespace=ctx.namespace,
         )
-        self.project_id = project_id or ctx.project_id or self._project_id_from_api_key()
+        self.project_id = (
+            project_id or ctx.project_id or self._project_id_from_api_key()
+        )
 
     def _project_id_from_api_key(self) -> str:
         payload = _load_json(self._client.introspect_api_key_json())
@@ -339,7 +339,9 @@ class RepositoryClient:
     def operations(self, repo: str) -> list[Operation]:
         raw = self._client.list_git_operations(self.project_id, repo)
         payload = _load_json(raw)
-        return [Operation.model_validate(item) for item in payload.get("operations", [])]
+        return [
+            Operation.model_validate(item) for item in payload.get("operations", [])
+        ]
 
     def credential(self, repo: str | None = None) -> GitCredential:
         raw = self._client.git_credential(self.project_id, repo)

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,0 +1,356 @@
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from tensorlake.repositories import RepositoryClient, RepositoryError
+
+
+class _FakeCloudClient:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.closed = False
+        self.calls = []
+        _FakeCloudClient.instances.append(self)
+
+    def close(self):
+        self.closed = True
+
+    def introspect_api_key_json(self):
+        self.calls.append(("introspect",))
+        return json.dumps({"project_id": "project-from-key"})
+
+    def git_repo_url(self, project_id, repo):
+        self.calls.append(("url", project_id, repo))
+        return f"https://git.tensorlake.ai/{project_id}/{repo}"
+
+    def create_git_repo(self, project_id, repo, default_branch):
+        self.calls.append(("create", project_id, repo, default_branch))
+        return json.dumps(
+            {
+                "repo": repo,
+                "url": f"https://git.tensorlake.ai/{project_id}/{repo}",
+                "trace_id": "tr-create",
+            }
+        )
+
+    def list_git_repos(self, project_id):
+        self.calls.append(("list", project_id))
+        return json.dumps(
+            {
+                "project": project_id,
+                "repos": [
+                    {
+                        "name": "linux",
+                        "full_name": f"{project_id}/linux",
+                        "default_branch": "main",
+                        "status": "active",
+                    }
+                ],
+            }
+        )
+
+    def git_repo_info(self, project_id, repo):
+        self.calls.append(("info", project_id, repo))
+        return json.dumps(
+            {
+                "repo": repo,
+                "url": f"https://git.tensorlake.ai/{project_id}/{repo}",
+                "branches": [
+                    {"name": "main", "ref_name": "refs/heads/main", "oid": "abc"}
+                ],
+                "refs": [{"name": "HEAD", "oid": "abc"}],
+            }
+        )
+
+    def git_credential(self, project_id, repo):
+        self.calls.append(("credential", project_id, repo))
+        return json.dumps(
+            {
+                "token": "tok",
+                "tokenType": "bearer",
+                "expiresAt": "",
+                "gitUsername": "t",
+                "repoPattern": repo or "*",
+                "scopes": [],
+            }
+        )
+
+    def push_git_worktree(
+        self,
+        project_id,
+        repo,
+        root,
+        branch,
+        message,
+        expect_oid,
+    ):
+        self.calls.append(("push", project_id, repo, root, branch, message, expect_oid))
+        return json.dumps(
+            {
+                "commit": "def",
+                "tree": "tree",
+                "ref_name": f"refs/heads/{branch}",
+                "created": False,
+                "files": 1,
+                "bytes_total": 12,
+                "chunks_total": 1,
+                "chunks_uploaded": 1,
+                "bytes_uploaded": 12,
+                "file_blob_oids": [["README.md", "oid"]],
+            }
+        )
+
+    def merge_git_repo(
+        self,
+        project_id,
+        repo,
+        ours,
+        theirs,
+        preflight,
+        deep,
+        materialize,
+        message,
+        base,
+    ):
+        self.calls.append(
+            (
+                "merge",
+                project_id,
+                repo,
+                ours,
+                theirs,
+                preflight,
+                deep,
+                materialize,
+                message,
+                base,
+            )
+        )
+        return json.dumps(
+            {
+                "ours": "ours-oid",
+                "theirs": "theirs-oid",
+                "merge_base": "base-oid",
+                "clean": False,
+                "fast_forward": False,
+                "already_merged": False,
+                "changed_paths": 2,
+                "conflicts": [
+                    {
+                        "path": "src/main.rs",
+                        "kind": "content",
+                        "potential": True,
+                        "ours": {"mode": 33188, "oid": "ours-blob"},
+                        "base": None,
+                        "theirs": {"mode": 33188, "oid": "theirs-blob"},
+                    }
+                ],
+                "stats": {
+                    "trees_read": 3,
+                    "entries_compared": 4,
+                    "blobs_merged": 1,
+                    "wall_ms": 2.5,
+                },
+                "commit": None,
+                "fast_forwarded": False,
+            }
+        )
+
+    def git_commit_conflicts(self, project_id, repo, commit):
+        self.calls.append(("commit_conflicts", project_id, repo, commit))
+        if commit == "clean-oid":
+            return "null"
+        return json.dumps(
+            {
+                "version": 1,
+                "ours_commit": "ours-oid",
+                "theirs_commit": "theirs-oid",
+                "base_commit": None,
+                "paths": [
+                    {
+                        "path": "src/main.rs",
+                        "kind": "content",
+                        "terms": [None, {"mode": 33188, "oid": "base-blob"}, None],
+                    }
+                ],
+                "truncated_paths": 0,
+            }
+        )
+
+
+class TestRepositoryClient(unittest.TestCase):
+    def setUp(self):
+        _FakeCloudClient.instances = []
+        self._env = patch.dict(
+            os.environ,
+            {
+                "TENSORLAKE_API_KEY": "k",
+                "TENSORLAKE_PROJECT_ID": "project-1",
+                "TENSORLAKE_ORGANIZATION_ID": "org-1",
+            },
+            clear=False,
+        )
+        self._env.start()
+        self._client_patch = patch("tensorlake.repositories.CloudClient", _FakeCloudClient)
+        self._client_patch.start()
+
+    def tearDown(self):
+        self._client_patch.stop()
+        self._env.stop()
+
+    def test_create_repository(self):
+        client = RepositoryClient()
+        created = client.create("linux", default_branch="main")
+
+        fake = _FakeCloudClient.instances[-1]
+        self.assertEqual(
+            fake.calls,
+            [("create", "project-1", "linux", "main")],
+        )
+        self.assertEqual(created.repo, "linux")
+        self.assertEqual(created.trace_id, "tr-create")
+
+    def test_list_repositories(self):
+        client = RepositoryClient()
+        repos = client.list()
+
+        self.assertEqual(repos[0].name, "linux")
+        self.assertEqual(repos[0].full_name, "project-1/linux")
+        self.assertEqual(repos[0].default_branch, "main")
+
+    def test_info_and_credential(self):
+        client = RepositoryClient()
+
+        info = client.info("linux")
+        credential = client.credential("linux")
+
+        self.assertEqual(info.branches[0].ref_name, "refs/heads/main")
+        self.assertEqual(info.refs[0].name, "HEAD")
+        self.assertEqual(credential.git_username, "t")
+        self.assertEqual(credential.repo_pattern, "linux")
+
+    def test_push_worktree(self):
+        client = RepositoryClient()
+        report = client.push_worktree(
+            "linux",
+            root="/tmp/linux",
+            branch="feature",
+            message="sync",
+            expect_oid="abc",
+        )
+
+        fake = _FakeCloudClient.instances[-1]
+        self.assertEqual(
+            fake.calls,
+            [("push", "project-1", "linux", "/tmp/linux", "feature", "sync", "abc")],
+        )
+        self.assertEqual(report.ref_name, "refs/heads/feature")
+        self.assertEqual(report.bytes_uploaded, 12)
+
+    def test_merge(self):
+        client = RepositoryClient()
+        report = client.merge(
+            "linux",
+            "main",
+            "feature",
+            preflight=True,
+            deep=True,
+            message="merge feature",
+            base="base-oid",
+        )
+
+        fake = _FakeCloudClient.instances[-1]
+        self.assertEqual(
+            fake.calls,
+            [
+                (
+                    "merge",
+                    "project-1",
+                    "linux",
+                    "main",
+                    "feature",
+                    True,
+                    True,
+                    False,
+                    "merge feature",
+                    "base-oid",
+                )
+            ],
+        )
+        self.assertEqual(report.merge_base, "base-oid")
+        self.assertEqual(report.changed_paths, 2)
+        self.assertTrue(report.conflicts[0].potential)
+        self.assertIsNone(report.conflicts[0].base)
+        self.assertEqual(report.stats.entries_compared, 4)
+
+    def test_commit_conflicts(self):
+        client = RepositoryClient()
+        record = client.commit_conflicts("linux", "merge-oid")
+        clean = client.commit_conflicts("linux", "clean-oid")
+
+        fake = _FakeCloudClient.instances[-1]
+        self.assertEqual(
+            fake.calls,
+            [
+                ("commit_conflicts", "project-1", "linux", "merge-oid"),
+                ("commit_conflicts", "project-1", "linux", "clean-oid"),
+            ],
+        )
+        self.assertIsNotNone(record)
+        assert record is not None
+        self.assertEqual(record.ours_commit, "ours-oid")
+        self.assertIsNone(record.base_commit)
+        self.assertIsNone(record.paths[0].terms[0])
+        self.assertEqual(record.paths[0].terms[1].oid, "base-blob")
+        self.assertIsNone(clean)
+
+    def test_derives_project_context_from_api_key(self):
+        with patch.dict(os.environ, {"TENSORLAKE_PROJECT_ID": ""}, clear=False):
+            client = RepositoryClient()
+            created = client.create("linux")
+
+        fake = _FakeCloudClient.instances[-1]
+        self.assertEqual(
+            fake.calls,
+            [("introspect",), ("create", "project-from-key", "linux", None)],
+        )
+        self.assertEqual(created.url, "https://git.tensorlake.ai/project-from-key/linux")
+
+    def test_rejects_pat_without_api_key(self):
+        with patch.dict(
+            os.environ,
+            {
+                "TENSORLAKE_API_KEY": "",
+                "TENSORLAKE_PAT": "pat",
+                "TENSORLAKE_PROJECT_ID": "",
+            },
+            clear=False,
+        ):
+            with self.assertRaisesRegex(
+                RepositoryError,
+                "Personal access tokens are CLI-only",
+            ):
+                RepositoryClient()
+
+    def test_requires_api_key(self):
+        with patch.dict(
+            os.environ,
+            {
+                "TENSORLAKE_API_KEY": "",
+                "TENSORLAKE_PAT": "",
+                "TENSORLAKE_PROJECT_ID": "",
+            },
+            clear=False,
+        ):
+            with self.assertRaisesRegex(
+                RepositoryError,
+                "Missing TENSORLAKE_API_KEY",
+            ):
+                RepositoryClient()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -194,7 +194,9 @@ class TestRepositoryClient(unittest.TestCase):
             clear=False,
         )
         self._env.start()
-        self._client_patch = patch("tensorlake.repositories.CloudClient", _FakeCloudClient)
+        self._client_patch = patch(
+            "tensorlake.repositories.CloudClient", _FakeCloudClient
+        )
         self._client_patch.start()
 
     def tearDown(self):
@@ -317,7 +319,9 @@ class TestRepositoryClient(unittest.TestCase):
             fake.calls,
             [("introspect",), ("create", "project-from-key", "linux", None)],
         )
-        self.assertEqual(created.url, "https://git.tensorlake.ai/project-from-key/linux")
+        self.assertEqual(
+            created.url, "https://git.tensorlake.ai/project-from-key/linux"
+        )
 
     def test_rejects_pat_without_api_key(self):
         with patch.dict(

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.61",
+  "version": "0.5.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.61",
+      "version": "0.5.62",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.61",
+  "version": "0.5.62",
   "description": "TensorLake SDK and CLI for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -6,6 +6,7 @@ export { Desktop } from "./desktop.js";
 export { TcpTunnel } from "./tunnel.js";
 export { CloudClient } from "./cloud-client.js";
 export { APIClient } from "./api-client.js";
+export { RepositoryClient } from "./repositories.js";
 export {
   createSandboxImage,
   importSandboxImage,
@@ -167,3 +168,28 @@ export type {
   ImageBuildOperation,
   ImageBuildOperationType as ImageBuildOperationTypeValue,
 } from "./image.js";
+
+export type {
+  Branch,
+  CommitJobError,
+  CommitJobReadBack,
+  CommitJobStatus,
+  ConflictPath,
+  ConflictTerm,
+  GitCredential,
+  GitRef,
+  GitRepository,
+  MergeConflict,
+  MergeConflictRecord,
+  MergeEntry,
+  MergeOptions,
+  MergeReport,
+  MergeStats,
+  Operation,
+  OperationRef,
+  PushReport,
+  PushWorktreeOptions,
+  RepositoryClientOptions,
+  RepositoryHandle,
+  RepositoryInfo,
+} from "./repositories.js";

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -131,6 +131,41 @@ export interface NativeSandboxClient {
   ): string;
 }
 
+export interface NativeRepositoryClient {
+  gitRepoUrl(repo: string): string;
+  createRepo(repo: string, defaultBranch?: string | null): Promise<TracedJson>;
+  listRepos(): Promise<TracedJson>;
+  deleteRepo(repo: string): Promise<string>;
+  forkRepo(repo: string, baseRepo: string): Promise<TracedJson>;
+  archiveRepo(repo: string): Promise<string>;
+  restoreRepo(repo: string): Promise<string>;
+  repoInfo(repo: string): Promise<TracedJson>;
+  listBranches(repo: string): Promise<TracedJson>;
+  listRefs(repo: string): Promise<TracedJson>;
+  deleteBranch(repo: string, branch: string): Promise<string>;
+  listOperations(repo: string): Promise<TracedJson>;
+  gitCredential(repo?: string | null): Promise<string>;
+  commitStatus(repo: string, jobId: string): Promise<TracedJson>;
+  pushWorktree(
+    repo: string,
+    root: string,
+    branch: string,
+    message: string,
+    expectOid?: string | null,
+  ): Promise<TracedJson>;
+  mergeRepo(
+    repo: string,
+    ours: string,
+    theirs: string,
+    preflight: boolean,
+    deep: boolean,
+    materialize: boolean,
+    message?: string | null,
+    base?: string | null,
+  ): Promise<TracedJson>;
+  commitConflicts(repo: string, commit: string): Promise<TracedJson>;
+}
+
 interface NativeSandboxClientCtor {
   new (
     apiUrl: string,
@@ -141,6 +176,17 @@ interface NativeSandboxClientCtor {
     userAgent?: string | null,
     requestTimeoutSec?: number | null,
   ): NativeSandboxClient;
+}
+
+interface NativeRepositoryClientCtor {
+  new (
+    apiUrl: string,
+    apiKey?: string | null,
+    organizationId?: string | null,
+    projectId?: string | null,
+    userAgent?: string | null,
+    requestTimeoutSec?: number | null,
+  ): NativeRepositoryClient;
 }
 
 interface NativeSandboxProxyClientCtor {
@@ -159,6 +205,7 @@ interface NativeSandboxProxyClientCtor {
 export interface NativeSandboxBinding {
   NativeSandboxClient: NativeSandboxClientCtor;
   NativeSandboxProxyClient: NativeSandboxProxyClientCtor;
+  NativeRepositoryClient?: NativeRepositoryClientCtor;
   /** Validate a managed-process name; throws on failure. Single source-of-truth rule in Rust. */
   validateManagedName: (name: string) => void;
 }

--- a/typescript/src/repositories.ts
+++ b/typescript/src/repositories.ts
@@ -1,0 +1,457 @@
+import * as defaults from "./defaults.js";
+import { CloudClient } from "./cloud-client.js";
+import { SandboxError } from "./errors.js";
+import type { Traced } from "./http.js";
+import {
+  callNative,
+  loadNativeSandboxBinding,
+  type NativeRepositoryClient,
+} from "./native-sandbox.js";
+import { fromSnakeKeys } from "./models.js";
+import { buildContextFromEnv } from "./sandbox-image.js";
+
+export interface RepositoryClientOptions {
+  apiUrl?: string;
+  apiKey?: string;
+  organizationId?: string;
+  projectId?: string;
+  requestTimeout?: number;
+  timeoutMs?: number;
+}
+
+export interface GitRepository {
+  name: string;
+  fullName: string;
+  defaultBranch: string;
+  status: string;
+}
+
+export interface RepositoryHandle {
+  repo: string;
+  url: string;
+  baseRepo?: string;
+}
+
+export interface GitRef {
+  name: string;
+  oid: string;
+}
+
+export interface Branch {
+  name: string;
+  refName: string;
+  oid: string;
+}
+
+export interface RepositoryInfo {
+  repo: string;
+  url: string;
+  branches: Branch[];
+  refs: GitRef[];
+}
+
+export interface GitCredential {
+  token: string;
+  tokenType: string;
+  expiresAt: string;
+  gitUsername: string;
+  repoPattern: string;
+  scopes: string[];
+}
+
+export interface CommitJobReadBack {
+  done: number;
+  total: number;
+}
+
+export interface CommitJobError {
+  kind: string;
+  message: string;
+  retryable: boolean;
+}
+
+export interface CommitJobStatus {
+  jobId: string;
+  state: string;
+  phase?: string;
+  readBack?: CommitJobReadBack;
+  commit?: string;
+  tree?: string;
+  refName?: string;
+  parent?: string;
+  created?: boolean;
+  error?: CommitJobError;
+}
+
+export interface PushReport {
+  commit: string;
+  tree: string;
+  refName: string;
+  created: boolean;
+  files: number;
+  bytesTotal: number;
+  chunksTotal: number;
+  chunksUploaded: number;
+  bytesUploaded: number;
+  fileBlobOids: Array<[string, string]>;
+}
+
+export interface PushWorktreeOptions {
+  path?: string;
+  branch?: string;
+  message?: string;
+  expectOid?: string;
+}
+
+export interface MergeEntry {
+  mode: number;
+  oid: string;
+}
+
+export interface MergeConflict {
+  path: string;
+  kind: string;
+  potential: boolean;
+  ours?: MergeEntry;
+  base?: MergeEntry;
+  theirs?: MergeEntry;
+}
+
+export interface MergeStats {
+  treesRead: number;
+  entriesCompared: number;
+  blobsMerged: number;
+  wallMs: number;
+}
+
+export interface MergeReport {
+  ours: string;
+  theirs: string;
+  mergeBase?: string;
+  clean: boolean;
+  fastForward: boolean;
+  alreadyMerged: boolean;
+  changedPaths: number;
+  conflicts: MergeConflict[];
+  stats: MergeStats;
+  commit?: string;
+  fastForwarded: boolean;
+}
+
+export interface MergeOptions {
+  preflight?: boolean;
+  deep?: boolean;
+  materialize?: boolean;
+  message?: string;
+  base?: string;
+}
+
+export interface ConflictTerm {
+  mode: number;
+  oid: string;
+}
+
+export interface ConflictPath {
+  path: string;
+  kind: string;
+  terms: Array<ConflictTerm | null>;
+}
+
+export interface MergeConflictRecord {
+  version: number;
+  oursCommit: string;
+  theirsCommit: string;
+  baseCommit?: string;
+  paths: ConflictPath[];
+  truncatedPaths: number;
+}
+
+export interface OperationRef {
+  name: string;
+  old?: string;
+  new?: string;
+}
+
+export interface Operation {
+  opId: string;
+  repo: string;
+  network?: string;
+  parentOpId?: string;
+  actor: string;
+  atSecs: number;
+  kind: string;
+  result: string;
+  refs: OperationRef[];
+  packIds: string[];
+  oldPackIds: string[];
+  relatedRepo?: string;
+  status?: string;
+  oldPackCount: number;
+  objectCount: number;
+  packBytes: number;
+}
+
+export class RepositoryClient {
+  private readonly native: NativeRepositoryClient;
+  private readonly requestTimeoutMs: number;
+
+  constructor(options?: RepositoryClientOptions) {
+    this.requestTimeoutMs = resolveRequestTimeoutMs(options);
+    const binding = loadNativeSandboxBinding();
+    if (typeof binding.NativeRepositoryClient !== "function") {
+      throw new SandboxError(
+        "native binding does not export the repository client; rebuild with 'npm run build:native'",
+      );
+    }
+    this.native = new binding.NativeRepositoryClient(
+      options?.apiUrl ?? defaults.API_URL,
+      options?.apiKey ?? defaults.API_KEY ?? null,
+      options?.organizationId ?? null,
+      options?.projectId ?? null,
+      null,
+      this.requestTimeoutMs / 1000,
+    );
+  }
+
+  static forCloud(options?: RepositoryClientOptions): RepositoryClient {
+    return new RepositoryClient({
+      apiUrl: options?.apiUrl ?? "https://api.tensorlake.ai",
+      apiKey: options?.apiKey,
+      organizationId: options?.organizationId,
+      projectId: options?.projectId,
+      requestTimeout: options?.requestTimeout,
+      timeoutMs: options?.timeoutMs,
+    });
+  }
+
+  static async fromEnv(): Promise<RepositoryClient> {
+    const context = buildContextFromEnv();
+    if (!context.apiKey) {
+      if (context.personalAccessToken) {
+        throw new SandboxError(
+          "Repository SDKs require TENSORLAKE_API_KEY. Personal access tokens are CLI-only.",
+        );
+      }
+      throw new SandboxError("Missing TENSORLAKE_API_KEY credentials.");
+    }
+    return new RepositoryClient({
+      apiUrl: context.apiUrl,
+      apiKey: context.apiKey,
+      projectId: context.projectId ?? await projectIdFromApiKey(context.apiUrl, context.apiKey),
+    });
+  }
+
+  close(): void {
+    // The native client releases its connection pool on GC; nothing to do.
+  }
+
+  url(repo: string): string {
+    return this.native.gitRepoUrl(repo);
+  }
+
+  async create(
+    repo: string,
+    options?: { defaultBranch?: string },
+  ): Promise<Traced<RepositoryHandle>> {
+    return this.tracedJson<RepositoryHandle>(() =>
+      this.native.createRepo(repo, options?.defaultBranch ?? null),
+    );
+  }
+
+  async list(): Promise<Traced<GitRepository[]>> {
+    const { traceId, json } = await callNative(() => this.native.listRepos());
+    const parsed = fromSnakeKeys(JSON.parse(json)) as { repos?: GitRepository[] };
+    return Object.assign(parsed.repos ?? [], { traceId });
+  }
+
+  async delete(repo: string): Promise<void> {
+    await callNative(() => this.native.deleteRepo(repo));
+  }
+
+  async fork(repo: string, baseRepo: string): Promise<Traced<RepositoryHandle>> {
+    return this.tracedJson<RepositoryHandle>(() =>
+      this.native.forkRepo(repo, baseRepo),
+    );
+  }
+
+  async archive(repo: string): Promise<void> {
+    await callNative(() => this.native.archiveRepo(repo));
+  }
+
+  async restore(repo: string): Promise<void> {
+    await callNative(() => this.native.restoreRepo(repo));
+  }
+
+  async info(repo: string): Promise<Traced<RepositoryInfo>> {
+    return this.tracedJson<RepositoryInfo>(() => this.native.repoInfo(repo));
+  }
+
+  async branches(repo: string): Promise<Traced<Branch[]>> {
+    const { traceId, json } = await callNative(() => this.native.listBranches(repo));
+    const parsed = fromSnakeKeys(JSON.parse(json)) as { branches?: Branch[] };
+    return Object.assign(parsed.branches ?? [], { traceId });
+  }
+
+  async refs(repo: string): Promise<Traced<GitRef[]>> {
+    const { traceId, json } = await callNative(() => this.native.listRefs(repo));
+    const parsed = fromSnakeKeys(JSON.parse(json)) as { refs?: GitRef[] };
+    return Object.assign(parsed.refs ?? [], { traceId });
+  }
+
+  async deleteBranch(repo: string, branch: string): Promise<void> {
+    await callNative(() => this.native.deleteBranch(repo, branch));
+  }
+
+  async operations(repo: string): Promise<Traced<Operation[]>> {
+    const { traceId, json } = await callNative(() => this.native.listOperations(repo));
+    const parsed = fromSnakeKeys(JSON.parse(json)) as { operations?: Operation[] };
+    return Object.assign(parsed.operations ?? [], { traceId });
+  }
+
+  async credential(repo?: string): Promise<GitCredential> {
+    const json = await callNative(() => this.native.gitCredential(repo ?? null));
+    return JSON.parse(json) as GitCredential;
+  }
+
+  async commitStatus(repo: string, jobId: string): Promise<Traced<CommitJobStatus>> {
+    return this.tracedJson<CommitJobStatus>(() =>
+      this.native.commitStatus(repo, jobId),
+    );
+  }
+
+  async pushWorktree(
+    repo: string,
+    options?: PushWorktreeOptions,
+  ): Promise<Traced<PushReport>> {
+    return this.tracedJson<PushReport>(() =>
+      this.native.pushWorktree(
+        repo,
+        options?.path ?? process.cwd(),
+        options?.branch ?? "main",
+        options?.message ?? "Update repository",
+        options?.expectOid ?? null,
+      ),
+    );
+  }
+
+  async merge(
+    repo: string,
+    ours: string,
+    theirs: string,
+    options?: MergeOptions,
+  ): Promise<Traced<MergeReport>> {
+    return this.tracedJson<MergeReport>(() =>
+      this.native.mergeRepo(
+        repo,
+        ours,
+        theirs,
+        options?.preflight ?? false,
+        options?.deep ?? false,
+        options?.materialize ?? false,
+        options?.message ?? null,
+        options?.base ?? null,
+      ),
+    );
+  }
+
+  async commitConflicts(
+    repo: string,
+    commit: string,
+  ): Promise<Traced<MergeConflictRecord> | null> {
+    const { traceId, json } = await callNative(() =>
+      this.native.commitConflicts(repo, commit),
+    );
+    const parsed = JSON.parse(json) as unknown;
+    if (parsed == null) {
+      return null;
+    }
+    return Object.assign(fromSnakeKeys(parsed) as MergeConflictRecord, { traceId });
+  }
+
+  private async tracedJson<T extends object>(
+    fn: () => Promise<{ traceId: string; json: string }>,
+  ): Promise<Traced<T>> {
+    const { traceId, json } = await callNative(fn);
+    return Object.assign(fromSnakeKeys(JSON.parse(json)) as T, { traceId });
+  }
+}
+
+function resolveRequestTimeoutMs(
+  options?: { requestTimeout?: number; timeoutMs?: number },
+): number {
+  if (options?.requestTimeout != null) {
+    return secondsToMillis(options.requestTimeout);
+  }
+  if (options?.timeoutMs != null) {
+    validateTimeoutMs(options.timeoutMs);
+    return options.timeoutMs;
+  }
+  return defaults.DEFAULT_HTTP_TIMEOUT_MS;
+}
+
+function secondsToMillis(seconds: number): number {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new SandboxError("requestTimeout must be a positive number of seconds");
+  }
+  return Math.ceil(seconds * 1000);
+}
+
+function validateTimeoutMs(timeoutMs: number): void {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new SandboxError("timeoutMs must be a positive number of milliseconds");
+  }
+}
+
+async function projectIdFromApiKey(apiUrl: string, apiKey: string): Promise<string> {
+  const client = new CloudClient({ apiUrl, apiKey });
+  try {
+    const projectId = extractProjectId(await client.introspectApiKey());
+    if (!projectId) {
+      throw new SandboxError("Repository API key did not include project context.");
+    }
+    return projectId;
+  } finally {
+    client.close();
+  }
+}
+
+function extractProjectId(value: unknown): string | undefined {
+  if (value == null || typeof value !== "object") {
+    return undefined;
+  }
+  const object = value as Record<string, unknown>;
+  for (const key of ["projectId", "project_id"]) {
+    const candidate = object[key];
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate;
+    }
+  }
+
+  const project = object.project;
+  if (typeof project === "string" && project.length > 0) {
+    return project;
+  }
+  if (project != null && typeof project === "object") {
+    const projectObject = project as Record<string, unknown>;
+    for (const key of ["id", "projectId", "project_id"]) {
+      const candidate = projectObject[key];
+      if (typeof candidate === "string" && candidate.length > 0) {
+        return candidate;
+      }
+    }
+  }
+
+  for (const key of ["scope", "apiKey", "api_key", "key"]) {
+    const nested = extractProjectId(object[key]);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  const projects = object.projects;
+  if (Array.isArray(projects) && projects.length === 1) {
+    return extractProjectId(projects[0]);
+  }
+
+  return undefined;
+}

--- a/typescript/tests/native-stub.ts
+++ b/typescript/tests/native-stub.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import {
   __setNativeSandboxBindingForTest,
+  type NativeRepositoryClient,
   type NativeSandboxBinding,
   type NativeSandboxClient,
   type NativeSandboxProxyClient,
@@ -33,10 +34,14 @@ export interface NativeStub {
   client: FakeFns;
   /** Fake `NativeSandboxProxyClient` (process/file/stream ops). */
   proxy: FakeFns;
+  /** Fake `NativeRepositoryClient`. */
+  repository: FakeFns;
   /** Args the `NativeSandboxClient` constructor was last called with. */
   clientCtorArgs: unknown[];
   /** Args the `NativeSandboxProxyClient` constructor was last called with. */
   proxyCtorArgs: unknown[];
+  /** Args the `NativeRepositoryClient` constructor was last called with. */
+  repositoryCtorArgs: unknown[];
 }
 
 const tracedJson = (json = "{}") => async () => ({ traceId: "t", json });
@@ -116,6 +121,35 @@ function makeClient(proxy: FakeFns): FakeFns {
   };
 }
 
+function makeRepository(): FakeFns {
+  return {
+    gitRepoUrl: vi.fn((repo: string) => `https://git.tensorlake.ai/project_1/${repo}`),
+    createRepo: vi.fn(tracedJson()),
+    listRepos: vi.fn(tracedJson('{"project":"project_1","repos":[]}')),
+    deleteRepo: vi.fn(tracedId()),
+    forkRepo: vi.fn(tracedJson()),
+    archiveRepo: vi.fn(tracedId()),
+    restoreRepo: vi.fn(tracedId()),
+    repoInfo: vi.fn(tracedJson()),
+    listBranches: vi.fn(tracedJson('{"repo":"repo","branches":[]}')),
+    listRefs: vi.fn(tracedJson('{"repo":"repo","refs":[]}')),
+    deleteBranch: vi.fn(tracedId()),
+    listOperations: vi.fn(tracedJson('{"repo":"repo","operations":[]}')),
+    gitCredential: vi.fn(async () => JSON.stringify({
+      token: "tok",
+      tokenType: "bearer",
+      expiresAt: "",
+      gitUsername: "t",
+      repoPattern: "*",
+      scopes: [],
+    })),
+    commitStatus: vi.fn(tracedJson()),
+    pushWorktree: vi.fn(tracedJson()),
+    mergeRepo: vi.fn(tracedJson()),
+    commitConflicts: vi.fn(tracedJson("null")),
+  };
+}
+
 /**
  * Install a fake native binding. Pass `overrides.client` / `overrides.proxy`
  * to replace specific method implementations (e.g. assert on args or return
@@ -124,17 +158,22 @@ function makeClient(proxy: FakeFns): FakeFns {
 export function installNativeStub(overrides?: {
   client?: Record<string, unknown>;
   proxy?: Record<string, unknown>;
+  repository?: Record<string, unknown>;
 }): NativeStub {
   const proxy = makeProxy();
   const client = makeClient(proxy);
+  const repository = makeRepository();
   Object.assign(proxy, overrides?.proxy ?? {});
   Object.assign(client, overrides?.client ?? {});
+  Object.assign(repository, overrides?.repository ?? {});
 
   const stub: NativeStub = {
     client,
     proxy,
+    repository,
     clientCtorArgs: [],
     proxyCtorArgs: [],
+    repositoryCtorArgs: [],
   };
 
   const binding: NativeSandboxBinding = {
@@ -159,6 +198,12 @@ export function installNativeStub(overrides?: {
         return proxy as unknown as NativeSandboxProxyClient;
       }
     } as unknown as NativeSandboxBinding["NativeSandboxProxyClient"],
+    NativeRepositoryClient: class {
+      constructor(...args: unknown[]) {
+        stub.repositoryCtorArgs = args;
+        return repository as unknown as NativeRepositoryClient;
+      }
+    } as unknown as NonNullable<NativeSandboxBinding["NativeRepositoryClient"]>,
   };
   __setNativeSandboxBindingForTest(binding);
   return stub;

--- a/typescript/tests/repositories.test.ts
+++ b/typescript/tests/repositories.test.ts
@@ -1,0 +1,366 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RepositoryClient } from "../src/repositories.js";
+import { clearNativeStub, installNativeStub } from "./native-stub.js";
+
+const repositoryEnvKeys = [
+  "TENSORLAKE_API_URL",
+  "TENSORLAKE_API_KEY",
+  "TENSORLAKE_PAT",
+  "TENSORLAKE_PROJECT_ID",
+] as const;
+
+function saveRepositoryEnv(): Record<string, string | undefined> {
+  return Object.fromEntries(
+    repositoryEnvKeys.map((key) => [key, process.env[key]]),
+  );
+}
+
+function restoreRepositoryEnv(saved: Record<string, string | undefined>): void {
+  for (const key of repositoryEnvKeys) {
+    const value = saved[key];
+    if (value == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe("RepositoryClient", () => {
+  afterEach(() => {
+    clearNativeStub();
+    vi.restoreAllMocks();
+  });
+
+  it("constructs the native client with project context", () => {
+    const stub = installNativeStub();
+    const client = new RepositoryClient({
+      apiUrl: "http://localhost:8900",
+      apiKey: "k",
+      organizationId: "org-1",
+      projectId: "project-1",
+    });
+
+    expect(stub.repositoryCtorArgs).toEqual([
+      "http://localhost:8900",
+      "k",
+      "org-1",
+      "project-1",
+      null,
+      300,
+    ]);
+    client.close();
+  });
+
+  it("constructs from env with API key project context", async () => {
+    const saved = saveRepositoryEnv();
+    try {
+      process.env.TENSORLAKE_API_URL = "http://localhost:8900";
+      process.env.TENSORLAKE_API_KEY = "k";
+      process.env.TENSORLAKE_PROJECT_ID = "project-1";
+      delete process.env.TENSORLAKE_PAT;
+
+      const stub = installNativeStub();
+      const client = await RepositoryClient.fromEnv();
+
+      expect(stub.repositoryCtorArgs).toEqual([
+        "http://localhost:8900",
+        "k",
+        null,
+        "project-1",
+        null,
+        300,
+      ]);
+      client.close();
+    } finally {
+      restoreRepositoryEnv(saved);
+    }
+  });
+
+  it("rejects PAT-only env credentials", async () => {
+    const saved = saveRepositoryEnv();
+    try {
+      process.env.TENSORLAKE_API_KEY = "";
+      process.env.TENSORLAKE_PAT = "pat";
+      process.env.TENSORLAKE_PROJECT_ID = "";
+
+      await expect(RepositoryClient.fromEnv()).rejects.toThrow(
+        "Personal access tokens are CLI-only",
+      );
+    } finally {
+      restoreRepositoryEnv(saved);
+    }
+  });
+
+  it("creates repositories and returns the clone URL", async () => {
+    const createRepo = vi.fn(async (repo: string, defaultBranch: string | null) => {
+      expect(repo).toBe("linux");
+      expect(defaultBranch).toBe("main");
+      return {
+        traceId: "tr-create",
+        json: JSON.stringify({
+          repo: "linux",
+          url: "https://git.tensorlake.ai/project-1/linux",
+        }),
+      };
+    });
+    installNativeStub({ repository: { createRepo } });
+
+    const client = new RepositoryClient({ apiKey: "k", projectId: "project-1" });
+    const created = await client.create("linux", { defaultBranch: "main" });
+
+    expect(created.repo).toBe("linux");
+    expect(created.url).toBe("https://git.tensorlake.ai/project-1/linux");
+    expect(created.traceId).toBe("tr-create");
+    expect(createRepo).toHaveBeenCalledOnce();
+  });
+
+  it("lists repositories as camel-cased models", async () => {
+    installNativeStub({
+      repository: {
+        listRepos: vi.fn(async () => ({
+          traceId: "tr-list",
+          json: JSON.stringify({
+            project: "project-1",
+            repos: [
+              {
+                name: "linux",
+                full_name: "project-1/linux",
+                default_branch: "main",
+                status: "active",
+              },
+            ],
+          }),
+        })),
+      },
+    });
+
+    const client = new RepositoryClient({ apiKey: "k", projectId: "project-1" });
+    const repos = await client.list();
+
+    expect(repos.traceId).toBe("tr-list");
+    expect(repos).toHaveLength(1);
+    expect(repos[0].defaultBranch).toBe("main");
+    expect(repos[0].fullName).toBe("project-1/linux");
+  });
+
+  it("returns repository info with branches and refs", async () => {
+    installNativeStub({
+      repository: {
+        repoInfo: vi.fn(async () => ({
+          traceId: "tr-info",
+          json: JSON.stringify({
+            repo: "linux",
+            url: "https://git.tensorlake.ai/project-1/linux",
+            branches: [{ name: "main", ref_name: "refs/heads/main", oid: "abc" }],
+            refs: [{ name: "HEAD", oid: "abc" }],
+          }),
+        })),
+      },
+    });
+
+    const client = new RepositoryClient({ apiKey: "k", projectId: "project-1" });
+    const info = await client.info("linux");
+
+    expect(info.traceId).toBe("tr-info");
+    expect(info.branches[0].refName).toBe("refs/heads/main");
+    expect(info.refs[0].name).toBe("HEAD");
+  });
+
+  it("gets git credentials", async () => {
+    const gitCredential = vi.fn(async (repo: string | null) => {
+      expect(repo).toBe("linux");
+      return JSON.stringify({
+        token: "tok",
+        tokenType: "bearer",
+        expiresAt: "2026-07-08T00:00:00Z",
+        gitUsername: "t",
+        repoPattern: "linux",
+        scopes: ["git:read"],
+      });
+    });
+    installNativeStub({ repository: { gitCredential } });
+
+    const client = new RepositoryClient({ apiKey: "k", projectId: "project-1" });
+    const credential = await client.credential("linux");
+
+    expect(credential.gitUsername).toBe("t");
+    expect(credential.tokenType).toBe("bearer");
+    expect(credential.expiresAt).toBe("2026-07-08T00:00:00Z");
+    expect(credential.scopes).toEqual(["git:read"]);
+  });
+
+  it("pushes a local worktree through the native core", async () => {
+    const pushWorktree = vi.fn(
+      async (
+        repo: string,
+        root: string,
+        branch: string,
+        message: string,
+        expectOid: string | null,
+      ) => {
+        expect([repo, root, branch, message, expectOid]).toEqual([
+          "linux",
+          "/tmp/linux",
+          "feature",
+          "sync",
+          "abc",
+        ]);
+        return {
+          traceId: "tr-push",
+          json: JSON.stringify({
+            commit: "def",
+            tree: "tree",
+            ref_name: "refs/heads/feature",
+            created: false,
+            files: 2,
+            bytes_total: 12,
+            chunks_total: 1,
+            chunks_uploaded: 1,
+            bytes_uploaded: 12,
+            file_blob_oids: [["README.md", "oid"]],
+          }),
+        };
+      },
+    );
+    installNativeStub({ repository: { pushWorktree } });
+
+    const client = new RepositoryClient({ apiKey: "k", projectId: "project-1" });
+    const report = await client.pushWorktree("linux", {
+      path: "/tmp/linux",
+      branch: "feature",
+      message: "sync",
+      expectOid: "abc",
+    });
+
+    expect(report.traceId).toBe("tr-push");
+    expect(report.refName).toBe("refs/heads/feature");
+    expect(report.bytesUploaded).toBe(12);
+  });
+
+  it("merges branches through the native core", async () => {
+    const mergeRepo = vi.fn(
+      async (
+        repo: string,
+        ours: string,
+        theirs: string,
+        preflight: boolean,
+        deep: boolean,
+        materialize: boolean,
+        message: string | null,
+        base: string | null,
+      ) => {
+        expect([
+          repo,
+          ours,
+          theirs,
+          preflight,
+          deep,
+          materialize,
+          message,
+          base,
+        ]).toEqual([
+          "linux",
+          "main",
+          "feature",
+          true,
+          true,
+          false,
+          "merge feature",
+          "base-oid",
+        ]);
+        return {
+          traceId: "tr-merge",
+          json: JSON.stringify({
+            ours: "ours-oid",
+            theirs: "theirs-oid",
+            merge_base: "base-oid",
+            clean: false,
+            fast_forward: false,
+            already_merged: false,
+            changed_paths: 2,
+            conflicts: [
+              {
+                path: "src/main.rs",
+                kind: "content",
+                potential: true,
+                ours: { mode: 33188, oid: "ours-blob" },
+                base: null,
+                theirs: { mode: 33188, oid: "theirs-blob" },
+              },
+            ],
+            stats: {
+              trees_read: 3,
+              entries_compared: 4,
+              blobs_merged: 1,
+              wall_ms: 2.5,
+            },
+            commit: null,
+            fast_forwarded: false,
+          }),
+        };
+      },
+    );
+    installNativeStub({ repository: { mergeRepo } });
+
+    const client = new RepositoryClient({ apiKey: "k", projectId: "project-1" });
+    const report = await client.merge("linux", "main", "feature", {
+      preflight: true,
+      deep: true,
+      message: "merge feature",
+      base: "base-oid",
+    });
+
+    expect(report.traceId).toBe("tr-merge");
+    expect(report.mergeBase).toBe("base-oid");
+    expect(report.changedPaths).toBe(2);
+    expect(report.conflicts[0].potential).toBe(true);
+    expect(report.conflicts[0].base).toBeUndefined();
+    expect(report.stats.entriesCompared).toBe(4);
+  });
+
+  it("returns materialized merge conflict records", async () => {
+    const commitConflicts = vi.fn(async (repo: string, commit: string) => {
+      expect([repo, commit]).toEqual(["linux", "merge-oid"]);
+      return {
+        traceId: "tr-conflicts",
+        json: JSON.stringify({
+          version: 1,
+          ours_commit: "ours-oid",
+          theirs_commit: "theirs-oid",
+          base_commit: null,
+          paths: [
+            {
+              path: "src/main.rs",
+              kind: "content",
+              terms: [null, { mode: 33188, oid: "base-blob" }, null],
+            },
+          ],
+          truncated_paths: 0,
+        }),
+      };
+    });
+    installNativeStub({ repository: { commitConflicts } });
+
+    const client = new RepositoryClient({ apiKey: "k", projectId: "project-1" });
+    const record = await client.commitConflicts("linux", "merge-oid");
+
+    expect(record?.traceId).toBe("tr-conflicts");
+    expect(record?.oursCommit).toBe("ours-oid");
+    expect(record?.baseCommit).toBeUndefined();
+    expect(record?.paths[0].terms[0]).toBeNull();
+    expect(record?.paths[0].terms[1]?.oid).toBe("base-blob");
+  });
+
+  it("returns null when a commit has no conflict record", async () => {
+    installNativeStub({
+      repository: {
+        commitConflicts: vi.fn(async () => ({ traceId: "tr-none", json: "null" })),
+      },
+    });
+
+    const client = new RepositoryClient({ apiKey: "k", projectId: "project-1" });
+
+    await expect(client.commitConflicts("linux", "clean-oid")).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add Python and TypeScript repository clients backed by the Rust cloud SDK
- expose repository CRUD, refs/branches, Git credentials, push worktree, merge, and conflict-record APIs
- move reusable fastclone/ingest logic into the Rust core so CLI and SDKs share it
- require API-key based SDK setup for repository clients; PATs remain CLI-only
- bump CLI/SDK versions to 0.5.62

## Tests
- cargo fmt
- cargo check -p tensorlake -p tensorlake-rust-cloud-sdk-py -p tensorlake-rust-cloud-sdk-node
- cargo test -p tensorlake artifact_storage::merge
- npm run typecheck
- npm test -- --run tests/repositories.test.ts
- python3 -m py_compile src/tensorlake/repositories.py tests/test_repositories.py
- git diff --check