### PR TITLE
sudo tl fs mount serves the invoking user, not root

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -542,21 +542,45 @@ async fn ensure_fskit_ready() -> Result<()> {
     }
 }
 
-/// Mount's pre-flight on Linux: unprivileged FUSE needs /dev/fuse to be openable plus the
+/// Who a new mount belongs to: the human who asked for it. Under `sudo tl fs mount` that is
+/// the invoking user (SUDO_UID/SUDO_GID), not root — the daemon presents every file as theirs
+/// and mounts with allow_other so the volume is actually usable by them.
+fn mount_owner() -> (u32, u32) {
+    #[cfg(unix)]
+    {
+        let sudo_id = |key: &str| std::env::var(key).ok().and_then(|v| v.parse::<u32>().ok());
+        if unsafe { libc::geteuid() } == 0
+            && let (Some(uid), Some(gid)) = (sudo_id("SUDO_UID"), sudo_id("SUDO_GID"))
+        {
+            return (uid, gid);
+        }
+        unsafe { (libc::getuid(), libc::getgid()) }
+    }
+    #[cfg(not(unix))]
+    {
+        (0, 0)
+    }
+}
+
+/// Mount's pre-flight on Linux. Unprivileged FUSE needs /dev/fuse to be openable plus the
 /// setuid fusermount3 helper (fuse3 package) — mount(2) itself needs CAP_SYS_ADMIN regardless
-/// of device permissions. Checking up front turns "mount daemon did not come up" into the
-/// exact missing piece, and heads off the `sudo tl fs mount` reflex: a root mount is visible
-/// ONLY to root (FUSE denies other users without allow_other), with state and credentials
-/// under /root.
+/// of device permissions, and not every environment grants either. `sudo tl fs mount` is the
+/// universal fallback: root mounts directly, and the volume is presented to (and owned by)
+/// the invoking user, not root. Checking up front turns "mount daemon did not come up" into
+/// the exact missing piece.
 #[cfg(target_os = "linux")]
 fn ensure_fuse_ready() -> Result<()> {
     if unsafe { libc::geteuid() } == 0 {
-        eprintln!(
-            "{} mounting as root: the volume will be accessible ONLY to root (FUSE default), \
-             and mount state lands in root's home. Prefer unprivileged mounts — they work \
-             wherever /dev/fuse is mode 666 and the fuse3 package is installed.",
-            style("warning:").yellow()
-        );
+        let (uid, _) = mount_owner();
+        if uid != 0 {
+            eprintln!(
+                "{} mounting via sudo: the volume is presented to uid {uid} ({}). Mount state \
+                 lives in root's home — run the other commands (snapshot, promote, unmount) \
+                 with sudo too.",
+                style("note:").yellow(),
+                std::env::var("SUDO_USER").unwrap_or_else(|_| "the invoking user".to_string()),
+            );
+        }
         return Ok(());
     }
     if let Err(e) = std::fs::OpenOptions::new()
@@ -565,9 +589,10 @@ fn ensure_fuse_ready() -> Result<()> {
         .open("/dev/fuse")
     {
         return Err(CliError::usage(format!(
-            "cannot open /dev/fuse ({e}); unprivileged mounts need it read/write. Fix:\n  \
-             sudo chmod 666 /dev/fuse\n(the fuse3 package's udev rule persists this on most \
-             distros; on minimal images add a tmpfiles.d entry: z /dev/fuse 0666 - - -)"
+            "cannot open /dev/fuse ({e}); unprivileged mounts need it read/write.\nEither run \
+             with sudo (works everywhere; the mount is presented to your user):\n  sudo tl fs \
+             mount ...\nor enable unprivileged FUSE:\n  sudo chmod 666 /dev/fuse\n(the fuse3 \
+             package's udev rule persists this on most distros)"
         )));
     }
     let helper_on_path = |name: &str| {
@@ -577,7 +602,9 @@ fn ensure_fuse_ready() -> Result<()> {
     if !helper_on_path("fusermount3") && !helper_on_path("fusermount") {
         return Err(CliError::usage(
             "fusermount3 not found; unprivileged FUSE mounts go through the setuid helper from \
-             the fuse3 package. Fix:\n  sudo apt-get install fuse3",
+             the fuse3 package.\nEither run with sudo (works everywhere; the mount is presented \
+             to your user):\n  sudo tl fs mount ...\nor enable unprivileged FUSE:\n  sudo \
+             apt-get install fuse3",
         ));
     }
     if !Path::new("/etc/mtab").exists() {
@@ -983,11 +1010,14 @@ pub async fn mount(
 
     let mountpoint = canonical_mountpoint(path)?;
     let state_dir = alloc_state_dir(&ws.id);
+    let (owner_uid, owner_gid) = mount_owner();
     daemon::save_mount_state(
         &state_dir,
         &MountState {
             project_id: session.project_id.clone(),
             organization_id: ctx.effective_organization_id(),
+            owner_uid: Some(owner_uid),
+            owner_gid: Some(owner_gid),
             repo: repo.clone(),
             workspace_id: ws.id.clone(),
             ref_name: ws.ref_name.clone(),

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1146,15 +1146,31 @@ pub async fn unmount(ctx: &CliContext, path: &Path, delete: bool) -> Result<()> 
     ));
     if let Err(e) = daemon::control(&state_dir, "shutdown").await {
         // A dead daemon is not an obstacle — the mount is already gone; clean up local state.
-        // Anything else (EBUSY, most likely) means the volume is still live and serving.
+        // A busy volume means it is still live and serving. There is a third shape (measured):
+        // the daemon unmounts, replies, and exits so fast that the reply read loses the race
+        // and errors — poll briefly, and if the daemon is gone and the kernel released the
+        // volume, that IS success.
         let message = e.to_string();
         if !message.contains("mount daemon is not running") {
-            bar.finish_and_clear();
-            return Err(CliError::usage(format!(
-                "could not unmount {mountpoint}: {message}\nThe volume stays mounted and \
-                 usable. Close whatever is using it (shells cd'd inside, editors holding \
-                 files), then re-run: tl fs unmount {mountpoint}"
-            )));
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            let settled = loop {
+                let daemon_gone = daemon::daemon_pid(&state_dir).is_none_or(|p| !daemon_alive(p));
+                if daemon_gone && !daemon::still_mounted(Path::new(&mountpoint)) {
+                    break true;
+                }
+                if std::time::Instant::now() >= deadline {
+                    break false;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            };
+            if !settled {
+                bar.finish_and_clear();
+                return Err(CliError::usage(format!(
+                    "could not unmount {mountpoint}: {message}\nThe volume stays mounted and \
+                     usable. Close whatever is using it (shells cd'd inside, editors holding \
+                     files), then re-run: tl fs unmount {mountpoint}"
+                )));
+            }
         }
     }
     // Wait for the daemon to actually exit before tearing down its state dir: the shutdown op

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -51,6 +51,14 @@ pub struct MountState {
     /// path-addressed commands resolved their scope from the mount instead of the CWD.
     #[serde(default)]
     pub organization_id: Option<String>,
+    /// Who the mount belongs to: every file is presented as owned by this uid/gid. Differs
+    /// from the daemon's identity under `sudo tl fs mount` (daemon root, owner the invoking
+    /// user) — the escape hatch for environments without unprivileged FUSE. Absent in state
+    /// files from before that; the daemon then presents its own identity.
+    #[serde(default)]
+    pub owner_uid: Option<u32>,
+    #[serde(default)]
+    pub owner_gid: Option<u32>,
     pub repo: String,
     pub workspace_id: String,
     pub ref_name: String,
@@ -283,9 +291,14 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
 
     let mountpoint = state.mountpoint.clone();
 
+    let owner = (
+        state.owner_uid.unwrap_or_else(|| unsafe { libc::getuid() }),
+        state.owner_gid.unwrap_or_else(|| unsafe { libc::getgid() }),
+    );
+
     // Attach the kernel: platform-specific. Only after this succeeds does the control socket
     // exist — the socket answering is what `tl fs mount` treats as success.
-    let (served, invalidate) = attach(overlay.clone(), &mountpoint).await?;
+    let (served, invalidate) = attach(overlay.clone(), &mountpoint, owner).await?;
 
     // Follow the workspace ref, pushing each refresh's exact delta to the kernel. Spawned after
     // attach because the invalidation sink is born with the kernel session.
@@ -420,9 +433,13 @@ impl Attached {
 }
 
 #[cfg(target_os = "linux")]
-async fn attach(overlay: Arc<OverlayFs>, mountpoint: &Path) -> Result<(Attached, InvalSink)> {
+async fn attach(
+    overlay: Arc<OverlayFs>,
+    mountpoint: &Path,
+    owner: (u32, u32),
+) -> Result<(Attached, InvalSink)> {
     let (mounted_tx, mounted_rx) = tokio::sync::oneshot::channel();
-    let fuse = super::fusefs::WorkspaceFuse::new(overlay, tokio::runtime::Handle::current());
+    let fuse = super::fusefs::WorkspaceFuse::new(overlay, tokio::runtime::Handle::current(), owner);
     let mp = mountpoint.to_path_buf();
     let served = tokio::task::spawn_blocking(move || fuse.run(&mp, mounted_tx));
     let notifier = match mounted_rx.await {
@@ -454,7 +471,13 @@ async fn attach(overlay: Arc<OverlayFs>, mountpoint: &Path) -> Result<(Attached,
 /// TensorLake FSKit extension. There is no notify channel in the FSKit protocol, so the
 /// invalidation sink is a no-op — FSKit revalidates through its own attribute traffic.
 #[cfg(target_os = "macos")]
-async fn attach(overlay: Arc<OverlayFs>, mountpoint: &Path) -> Result<(Attached, InvalSink)> {
+async fn attach(
+    overlay: Arc<OverlayFs>,
+    mountpoint: &Path,
+    _owner: (u32, u32),
+) -> Result<(Attached, InvalSink)> {
+    // Ownership presentation is a Linux concern: FSKit user mounts never need sudo, so the
+    // daemon and the human are the same identity.
     let server = super::vfsserver::serve(overlay)
         .await
         .map_err(|e| CliError::usage(format!("vfs server: {e}")))?;

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -371,9 +371,13 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 let resp = serde_json::json!({ "ok": true });
                                 let mut stream = reader.into_inner();
                                 let _ = stream.write_all(format!("{resp}\n").as_bytes()).await;
+                                // Orderly FIN before exiting: dying with the reply still in
+                                // flight can surface client-side as a lost reply (measured on
+                                // Linux; the CLI then double-checks the mount table).
+                                let _ = stream.shutdown().await;
                                 // Exit outright: session-wait is not guaranteed to return after
                                 // an external unmount (observed leaked daemons on Linux), and
-                                // the daemon's one job is over. The reply above already flushed.
+                                // the daemon's one job is over.
                                 std::process::exit(0);
                             }
                             serde_json::json!({
@@ -548,9 +552,15 @@ fn is_mounted(mountpoint: &Path) -> bool {
 async fn unmount(mountpoint: &Path) -> bool {
     // fuse3 systems ship only `fusermount3`, fuse2 systems only `fusermount` — try in that
     // order (measured: Ubuntu 24.04's fuse3 has no `fusermount` compat name, and the old
-    // single-name spawn failed instantly, misreporting a free volume as busy).
+    // single-name spawn failed instantly, misreporting a free volume as busy). A root daemon
+    // (`sudo tl fs mount`) unmounts directly with umount(8): the sudo path serves exactly the
+    // environments where no fusermount helper exists at all.
     #[cfg(target_os = "linux")]
-    let unmounters: &[(&str, &[&str])] = &[("fusermount3", &["-u"]), ("fusermount", &["-u"])];
+    let unmounters: &[(&str, &[&str])] = if unsafe { libc::geteuid() } == 0 {
+        &[("umount", &[])]
+    } else {
+        &[("fusermount3", &["-u"]), ("fusermount", &["-u"])]
+    };
     #[cfg(not(target_os = "linux"))]
     let unmounters: &[(&str, &[&str])] = &[("umount", &[])];
     let mut child = None;
@@ -582,7 +592,7 @@ async fn unmount(mountpoint: &Path) -> bool {
 
 /// Whether the kernel still shows a live mount at `mountpoint`.
 #[cfg(unix)]
-fn still_mounted(mountpoint: &Path) -> bool {
+pub(crate) fn still_mounted(mountpoint: &Path) -> bool {
     #[cfg(target_os = "macos")]
     {
         is_mounted(mountpoint)

--- a/crates/cli/src/commands/fs/fusefs.rs
+++ b/crates/cli/src/commands/fs/fusefs.rs
@@ -45,7 +45,7 @@ fn file_type(kind: NodeKind) -> fuser::FileType {
     }
 }
 
-fn file_attr(attr: &OverlayAttr) -> fuser::FileAttr {
+fn file_attr(attr: &OverlayAttr, owner: (u32, u32)) -> fuser::FileAttr {
     // The overlay's content timestamp (see OverlayAttr::mtime): stable while content is
     // unchanged, moves when it can have changed — what kernel cache revalidation needs.
     let mtime = attr.mtime;
@@ -60,8 +60,8 @@ fn file_attr(attr: &OverlayAttr) -> fuser::FileAttr {
         kind: file_type(attr.kind),
         perm: attr.perm,
         nlink: 1,
-        uid: unsafe { libc::getuid() },
-        gid: unsafe { libc::getgid() },
+        uid: owner.0,
+        gid: owner.1,
         rdev: 0,
         blksize: 4096,
         flags: 0,
@@ -71,11 +71,14 @@ fn file_attr(attr: &OverlayAttr) -> fuser::FileAttr {
 pub struct WorkspaceFuse {
     fs: Arc<OverlayFs>,
     rt: tokio::runtime::Handle,
+    /// Presented as every file's uid/gid. Differs from the daemon's identity under
+    /// `sudo tl fs mount`: the daemon is root, the mount belongs to the invoking user.
+    owner: (u32, u32),
 }
 
 impl WorkspaceFuse {
-    pub fn new(fs: Arc<OverlayFs>, rt: tokio::runtime::Handle) -> WorkspaceFuse {
-        WorkspaceFuse { fs, rt }
+    pub fn new(fs: Arc<OverlayFs>, rt: tokio::runtime::Handle, owner: (u32, u32)) -> WorkspaceFuse {
+        WorkspaceFuse { fs, rt, owner }
     }
 
     /// Establish the kernel mount (fails fast when FUSE is unavailable), then serve until
@@ -89,11 +92,18 @@ impl WorkspaceFuse {
         mountpoint: &Path,
         mounted: tokio::sync::oneshot::Sender<fuser::Notifier>,
     ) -> std::io::Result<()> {
-        let options = vec![
+        let mut options = vec![
             fuser::MountOption::FSName("tlfs".to_string()),
             fuser::MountOption::DefaultPermissions,
             fuser::MountOption::NoAtime,
         ];
+        // A sudo mount serves a different human than the daemon's identity: without
+        // allow_other, FUSE rejects every access by anyone but the mounting user (root),
+        // making the volume invisible to the person who asked for it. DefaultPermissions
+        // stays on, so the presented owner's file modes still gate access.
+        if self.owner != unsafe { (libc::getuid(), libc::getgid()) } {
+            options.push(fuser::MountOption::AllowOther);
+        }
         let mut session = fuser::Session::new(self, mountpoint, &options)?;
         let _ = mounted.send(session.notifier());
         session.run()
@@ -110,7 +120,7 @@ impl fuser::Filesystem for WorkspaceFuse {
     ) {
         let name = name.to_string_lossy();
         match self.rt.block_on(self.fs.lookup(parent, &name)) {
-            Ok(attr) => reply.entry(&TTL, &file_attr(&attr), 0),
+            Ok(attr) => reply.entry(&TTL, &file_attr(&attr, self.owner), 0),
             Err(e) => reply.error(errno(&e)),
         }
     }
@@ -127,7 +137,7 @@ impl fuser::Filesystem for WorkspaceFuse {
         reply: fuser::ReplyAttr,
     ) {
         match self.rt.block_on(self.fs.getattr(ino)) {
-            Ok(attr) => reply.attr(&TTL, &file_attr(&attr)),
+            Ok(attr) => reply.attr(&TTL, &file_attr(&attr, self.owner)),
             Err(e) => reply.error(errno(&e)),
         }
     }
@@ -151,7 +161,7 @@ impl fuser::Filesystem for WorkspaceFuse {
         reply: fuser::ReplyAttr,
     ) {
         match self.rt.block_on(self.fs.setattr(ino, size, mode)) {
-            Ok(attr) => reply.attr(&TTL, &file_attr(&attr)),
+            Ok(attr) => reply.attr(&TTL, &file_attr(&attr, self.owner)),
             Err(e) => reply.error(errno(&e)),
         }
     }
@@ -229,7 +239,7 @@ impl fuser::Filesystem for WorkspaceFuse {
                             entry.next_offset as i64,
                             &entry.name,
                             &TTL,
-                            &file_attr(&attr),
+                            &file_attr(&attr, self.owner),
                             0,
                         )
                     {
@@ -365,7 +375,7 @@ impl fuser::Filesystem for WorkspaceFuse {
         let name = name.to_string_lossy();
         let exec = mode & 0o111 != 0;
         match self.rt.block_on(self.fs.create(parent, &name, exec)) {
-            Ok((attr, fh)) => reply.created(&TTL, &file_attr(&attr), 0, fh, 0),
+            Ok((attr, fh)) => reply.created(&TTL, &file_attr(&attr, self.owner), 0, fh, 0),
             Err(e) => reply.error(errno(&e)),
         }
     }
@@ -381,7 +391,7 @@ impl fuser::Filesystem for WorkspaceFuse {
     ) {
         let name = name.to_string_lossy();
         match self.rt.block_on(self.fs.mkdir(parent, &name)) {
-            Ok(attr) => reply.entry(&TTL, &file_attr(&attr), 0),
+            Ok(attr) => reply.entry(&TTL, &file_attr(&attr, self.owner), 0),
             Err(e) => reply.error(errno(&e)),
         }
     }
@@ -397,7 +407,7 @@ impl fuser::Filesystem for WorkspaceFuse {
         let name = link_name.to_string_lossy();
         let target = target.to_string_lossy();
         match self.rt.block_on(self.fs.symlink(parent, &name, &target)) {
-            Ok(attr) => reply.entry(&TTL, &file_attr(&attr), 0),
+            Ok(attr) => reply.entry(&TTL, &file_attr(&attr, self.owner), 0),
             Err(e) => reply.error(errno(&e)),
         }
     }


### PR DESCRIPTION
Team decision: unprivileged FUSE can't be guaranteed across environments (other sandbox providers may ship `/dev/fuse` root-only, no setuid fusermount3 — and `mount(2)` always needs CAP_SYS_ADMIN). `sudo tl fs mount` is the universal fallback, but a naive root mount is a trap: FUSE rejects every other user's access, so the volume is invisible to the human who asked for it.

This makes the sudo path first-class:

- **MountState records the mount's owner** — `SUDO_UID`/`SUDO_GID` when invoked via sudo, the current user otherwise (serde-defaulted, old state files behave as before).
- **The daemon presents every file as owned by that user** and mounts with `allow_other` when its identity differs from the owner. `DefaultPermissions` stays on, so the presented owner's file modes still gate access for everyone.
- **The Linux pre-flight documents both paths**: its `/dev/fuse` / fusermount3 errors now offer `sudo tl fs mount` as the works-everywhere alternative alongside the one-time unprivileged-FUSE setup, and a sudo mount prints exactly what will happen (volume presented to `$SUDO_USER`; run snapshot/promote/unmount with sudo too, since mount state lives in root's home).

macOS is untouched — FSKit user mounts never need sudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)