### PR TITLE
tl git commit-status takes the repo positionally

### DIFF
--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -749,7 +749,7 @@ pub async fn push(
                 PushEvent::CommitDetached { job_id } => {
                     let line = format!(
                         "commit running as job {job_id} (survives disconnects; check from \
-                         anywhere with: tl git commit-status --repo <repo> {job_id})"
+                         anywhere with: tl git commit-status <repo> {job_id})"
                     );
                     // indicatif drops println on hidden draw targets (piped stderr) — and a
                     // scripted push is exactly where the out-of-band job id matters.
@@ -859,7 +859,7 @@ fn git_worktree_root_from(cwd: &std::path::Path) -> Result<std::path::PathBuf> {
     Ok(std::path::PathBuf::from(root))
 }
 
-/// `tl git commit-status --repo <repo> <job-id>` — the out-of-band view of a detached commit
+/// `tl git commit-status <repo> <job-id>` — the out-of-band view of a detached commit
 /// job's state machine, from any terminal or process.
 pub async fn commit_status(ctx: &CliContext, repo: &str, job_id: &str) -> Result<()> {
     let project_id = project_id(ctx)?;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -496,7 +496,6 @@ enum GitCommands {
     /// Check a detached commit job's progress (job id is printed when a push detaches)
     CommitStatus {
         /// Repo name
-        #[arg(long)]
         repo: String,
         /// Commit job id
         job_id: String,
@@ -2701,6 +2700,19 @@ mod tests {
             }
             _ => panic!("expected git push command"),
         }
+
+        // commit-status takes the repo positionally, like every other repo-addressed command.
+        match parse_command(["tl", "git", "commit-status", "demo", "job-123"]) {
+            Commands::Git(GitCommands::CommitStatus { repo, job_id }) => {
+                assert_eq!(repo, "demo");
+                assert_eq!(job_id, "job-123");
+            }
+            _ => panic!("expected git commit-status command"),
+        }
+        assert!(
+            Cli::try_parse_from(["tl", "git", "commit-status", "--repo", "demo", "job-123"])
+                .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
`tl git push` already moved to positional (`tl git push <repo> [branch] <paths>...`); `commit-status` was the last repo-addressed command still demanding `--repo`. Now:

```
tl git commit-status <repo> <job-id>
```

The job-id hint printed by a detaching push is updated to match, plus parse tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)