### PR TITLE
Fix empty-file tl git push; tl git token takes the repo positionally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.62"
+version = "0.5.63"
 dependencies = [
  "anyhow",
  "base64",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.62"
+version = "0.5.63"
 dependencies = [
  "anyhow",
  "base64",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.62"
+version = "0.5.63"
 dependencies = [
  "napi",
  "napi-build",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.62"
+version = "0.5.63"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.62"
+version = "0.5.63"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -532,8 +532,8 @@ enum GitCommands {
     },
     /// Mint a short-lived Git credential for this project
     Token {
-        /// Limit the credential to one repository and grant only Git read/write scopes
-        #[arg(long)]
+        /// Limit the credential to one repository and grant only Git read/write scopes;
+        /// omit for a project-wide credential
         repo: Option<String>,
         /// Output JSON
         #[arg(long)]
@@ -2601,13 +2601,23 @@ mod tests {
             _ => panic!("expected git op ls command"),
         }
 
-        match parse_command(["tl", "git", "token", "--repo", "demo"]) {
+        // token takes the repo positionally, like every other repo-addressed command;
+        // omitting it mints a project-wide credential.
+        match parse_command(["tl", "git", "token", "demo"]) {
             Commands::Git(GitCommands::Token { repo, json }) => {
                 assert_eq!(repo.as_deref(), Some("demo"));
                 assert!(!json);
             }
             _ => panic!("expected git token command"),
         }
+        match parse_command(["tl", "git", "token", "--json"]) {
+            Commands::Git(GitCommands::Token { repo, json }) => {
+                assert_eq!(repo, None);
+                assert!(json);
+            }
+            _ => panic!("expected git token command"),
+        }
+        assert!(Cli::try_parse_from(["tl", "git", "token", "--repo", "demo"]).is_err());
 
         match parse_command(["tl", "git", "info", "demo", "--json"]) {
             Commands::Git(GitCommands::Info { repo, json }) => {

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -449,10 +449,17 @@ fn chunk_source_whole(source: &PushSource) -> Result<(Vec<([u8; 32], u32)>, Stri
             ));
         }
     };
-    let hash: [u8; 32] = Sha256::digest(&data).into();
     let mut blob = BlobOidHasher::new(data.len() as u64);
     blob.update(&data);
-    Ok((vec![(hash, data.len() as u32)], blob.finalize_hex()))
+    // An empty file has an empty chunk list (like the CDC path) so it publishes as inline
+    // `content` — a zero-length chunk frame is rejected by the server.
+    let chunks = if data.is_empty() {
+        Vec::new()
+    } else {
+        let hash: [u8; 32] = Sha256::digest(&data).into();
+        vec![(hash, data.len() as u32)]
+    };
+    Ok((chunks, blob.finalize_hex()))
 }
 
 /// Which files take the tokened (verified-at-upload) path: content-bearing files whose bytes the
@@ -1985,6 +1992,14 @@ mod tests {
                         mode: None,
                         delete: false,
                     },
+                    // Zero-byte file: must publish as inline content, never as a
+                    // zero-length chunk (the server rejects those).
+                    PushFile {
+                        repo_path: "empty.txt".to_string(),
+                        source: PushSource::Bytes(Vec::new()),
+                        mode: None,
+                        delete: false,
+                    },
                 ],
                 PushOptions {
                     message: "seed".into(),
@@ -1994,7 +2009,17 @@ mod tests {
             .await
             .unwrap()
             .into_inner();
-        assert_eq!(report.files, 3);
+        assert_eq!(report.files, 4);
+        assert_eq!(
+            report
+                .file_blob_oids
+                .iter()
+                .find(|(p, _)| p == "empty.txt")
+                .unwrap()
+                .1,
+            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+            "empty file must carry git's empty-blob oid"
+        );
         let a_oid = report
             .file_blob_oids
             .iter()
@@ -2093,5 +2118,30 @@ mod tests {
             hash,
             "framed bytes must hash to the declared id"
         );
+    }
+
+    /// The whole-file (small staged) pass must match the CDC pass's contract for empty files:
+    /// no chunks — a zero-length chunk frame is rejected by the server ("chunk length 0
+    /// outside (0, 8388608]"), and an empty chunk list is what routes the file to inline
+    /// `content` at commit.
+    #[test]
+    fn whole_file_pass_yields_no_chunks_for_empty_files() {
+        let (chunks, oid) = chunk_source_whole(&PushSource::Bytes(Vec::new())).unwrap();
+        assert!(chunks.is_empty(), "an empty file must have no chunks");
+        assert_eq!(
+            oid, "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+            "must still hash to git's empty-blob oid"
+        );
+        let (cdc_chunks, cdc_oid) =
+            chunk_source(&PushSource::Bytes(Vec::new()), 256, 1024, 4096).unwrap();
+        assert_eq!(chunks, cdc_chunks, "both passes must agree on empty input");
+        assert_eq!(oid, cdc_oid);
+
+        // Non-empty small files still produce exactly one whole-file chunk.
+        let data = b"hello".to_vec();
+        let (chunks, _) = chunk_source_whole(&PushSource::Bytes(data.clone())).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].1 as usize, data.len());
+        assert_eq!(chunks[0].0, <[u8; 32]>::from(Sha256::digest(&data)));
     }
 }

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.62"
+version = "0.5.63"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.62"
+version = "0.5.63"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.62",
+  "version": "0.5.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.62",
+      "version": "0.5.63",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.62",
+  "version": "0.5.63",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Empty files no longer break `tl git push` on staging servers

Pushing a worktree containing a zero-byte file failed against servers that advertise small-file staging:

```
Error: Server error: 400 Bad Request - chunk length 0 outside (0, 8388608]
```

`chunk_source_whole` (the whole-file identity pass for files under the small-file threshold) emitted a single zero-length chunk for empty files, electing them onto the tokened/batch upload path whose zero-length frame the server rejects. The CDC pass already returns an **empty chunk list** for empty input — which is what routes a file to inline `content` at commit — so the whole-file pass now matches that contract. The blob oid still hashes to git's empty-blob oid (`e69de29b…`).

- Unit test pins both passes to the same empty-input result.
- The local-server roundtrip test now pushes an empty file end-to-end.

## `tl git token` takes the repo positionally

Like `push` and `commit-status` (#812) before it:

```
tl git token <repo>   # repo-scoped credential (was --repo <repo>)
tl git token          # project-wide credential, unchanged
```

Parse tests cover positional, omitted, and rejected `--repo` forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)