### PR TITLE
artifact_storage client: parallel fast-clone downloads, maintenance structures, zero-copy pushes

### DIFF
--- a/crates/cloud-sdk/src/artifact_storage/fastclone.rs
+++ b/crates/cloud-sdk/src/artifact_storage/fastclone.rs
@@ -215,8 +215,11 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
     // `(bytes, downloaded)` so the stats fold below stays order-independent. Artifacts are
     // independent immutable files with distinct cache paths, so a bounded number download
     // concurrently — wall-clock is set by the largest artifact, not the sum of all of them.
+    // `queued` dedups by cache path: concurrent jobs for one path would corrupt its shared
+    // `.partial` staging file, where the sequential loop just found the second copy cached.
     type Job<'a> = futures::future::BoxFuture<'a, Result<(u64, bool)>>;
     let mut jobs: Vec<Job<'_>> = Vec::new();
+    let mut queued: HashSet<PathBuf> = HashSet::new();
     for pack in &manifest.packs {
         let _storage_id = Oid::from_hex(&pack.pack_id)
             .with_context(|| format!("bad fast-clone pack id {}", pack.pack_id))?;
@@ -230,36 +233,43 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         let pack_url = resolve_artifact_url(&clean_base, &pack.pack_path)?;
         let idx_url = resolve_artifact_url(&clean_base, &pack.idx_path)?;
 
-        let (ctx_ref, pack_bytes) = (&ctx, pack.pack_bytes);
-        jobs.push(Box::pin(async move {
-            let downloaded =
-                ensure_cached_artifact(ctx_ref, pack_url, &pack_cache, pack_bytes, |path| {
-                    validate_pack_cache(path, pack_bytes, pack_hash)
-                })
-                .await?;
-            Ok((pack_bytes, downloaded))
-        }));
-        let (ctx_ref, idx_bytes) = (&ctx, pack.idx_bytes);
-        jobs.push(Box::pin(async move {
-            let downloaded =
-                ensure_cached_artifact(ctx_ref, idx_url, &idx_cache, idx_bytes, |path| {
-                    validate_idx_cache(path, idx_bytes, pack_hash)
-                })
-                .await?;
-            Ok((idx_bytes, downloaded))
-        }));
+        if queued.insert(pack_cache.clone()) {
+            let (ctx_ref, pack_bytes) = (&ctx, pack.pack_bytes);
+            jobs.push(Box::pin(async move {
+                let downloaded =
+                    ensure_cached_artifact(ctx_ref, pack_url, &pack_cache, pack_bytes, |path| {
+                        validate_pack_cache(path, pack_bytes, pack_hash)
+                    })
+                    .await?;
+                Ok((pack_bytes, downloaded))
+            }));
+        }
+        if queued.insert(idx_cache.clone()) {
+            let (ctx_ref, idx_bytes) = (&ctx, pack.idx_bytes);
+            jobs.push(Box::pin(async move {
+                let downloaded =
+                    ensure_cached_artifact(ctx_ref, idx_url, &idx_cache, idx_bytes, |path| {
+                        validate_idx_cache(path, idx_bytes, pack_hash)
+                    })
+                    .await?;
+                Ok((idx_bytes, downloaded))
+            }));
+        }
     }
     for blob in &manifest.large_blobs {
         let oid = Oid::from_hex(&blob.oid).with_context(|| format!("bad blob oid {}", blob.oid))?;
         stats.large_blob_bytes += blob.bytes;
         let blob_cache = cache_dir.join(format!("blob-{}.loose", blob.oid));
         let blob_url = resolve_artifact_url(&clean_base, &blob.path)?;
-        let (ctx_ref, blob_bytes) = (&ctx, blob.bytes);
-        jobs.push(Box::pin(async move {
-            let downloaded =
-                ensure_loose_blob_cached(ctx_ref, blob_url, &blob_cache, oid, blob_bytes).await?;
-            Ok((blob_bytes, downloaded))
-        }));
+        if queued.insert(blob_cache.clone()) {
+            let (ctx_ref, blob_bytes) = (&ctx, blob.bytes);
+            jobs.push(Box::pin(async move {
+                let downloaded =
+                    ensure_loose_blob_cached(ctx_ref, blob_url, &blob_cache, oid, blob_bytes)
+                        .await?;
+                Ok((blob_bytes, downloaded))
+            }));
+        }
     }
     {
         use futures::StreamExt as _;
@@ -317,12 +327,22 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
     // Serving-side maintenance structures: without a commit-graph the first `git log`/`blame` in
     // a large repo pays a full history walk, and a multi-pack install pays per-pack lookups until
     // a multi-pack-index exists. Both are derived data — a failure (old git, exotic pack) must
-    // not fail an otherwise-complete clone, so errors are recorded in stats and ignored.
-    let _ = run_git(
+    // not fail an otherwise-complete clone, so the commands are recorded in stats but their
+    // errors are ignored. `--changed-paths` (Bloom filters for path-scoped history) predates
+    // some deployed gits, so a plain commit-graph is the fallback.
+    if run_git(
         &mut stats,
         &opts.dest,
         &["commit-graph", "write", "--reachable", "--changed-paths"],
-    );
+    )
+    .is_err()
+    {
+        let _ = run_git(
+            &mut stats,
+            &opts.dest,
+            &["commit-graph", "write", "--reachable"],
+        );
+    }
     if manifest.packs.len() > 1 {
         let _ = run_git(&mut stats, &opts.dest, &["multi-pack-index", "write"]);
     }

--- a/crates/cloud-sdk/src/artifact_storage/fastclone.rs
+++ b/crates/cloud-sdk/src/artifact_storage/fastclone.rs
@@ -210,6 +210,13 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         large_blobs: manifest.large_blobs.len(),
         ..Default::default()
     };
+
+    // One download job per artifact (pack, idx, or loose blob), each yielding
+    // `(bytes, downloaded)` so the stats fold below stays order-independent. Artifacts are
+    // independent immutable files with distinct cache paths, so a bounded number download
+    // concurrently — wall-clock is set by the largest artifact, not the sum of all of them.
+    type Job<'a> = futures::future::BoxFuture<'a, Result<(u64, bool)>>;
+    let mut jobs: Vec<Job<'_>> = Vec::new();
     for pack in &manifest.packs {
         let _storage_id = Oid::from_hex(&pack.pack_id)
             .with_context(|| format!("bad fast-clone pack id {}", pack.pack_id))?;
@@ -223,34 +230,48 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         let pack_url = resolve_artifact_url(&clean_base, &pack.pack_path)?;
         let idx_url = resolve_artifact_url(&clean_base, &pack.idx_path)?;
 
-        if ensure_cached_artifact(&ctx, pack_url, &pack_cache, pack.pack_bytes, |path| {
-            validate_pack_cache(path, pack.pack_bytes, pack_hash)
-        })
-        .await?
-        {
-            stats.downloaded_bytes += pack.pack_bytes;
-        } else {
-            stats.reused_bytes += pack.pack_bytes;
-        }
-        if ensure_cached_artifact(&ctx, idx_url, &idx_cache, pack.idx_bytes, |path| {
-            validate_idx_cache(path, pack.idx_bytes, pack_hash)
-        })
-        .await?
-        {
-            stats.downloaded_bytes += pack.idx_bytes;
-        } else {
-            stats.reused_bytes += pack.idx_bytes;
-        }
+        let (ctx_ref, pack_bytes) = (&ctx, pack.pack_bytes);
+        jobs.push(Box::pin(async move {
+            let downloaded =
+                ensure_cached_artifact(ctx_ref, pack_url, &pack_cache, pack_bytes, |path| {
+                    validate_pack_cache(path, pack_bytes, pack_hash)
+                })
+                .await?;
+            Ok((pack_bytes, downloaded))
+        }));
+        let (ctx_ref, idx_bytes) = (&ctx, pack.idx_bytes);
+        jobs.push(Box::pin(async move {
+            let downloaded =
+                ensure_cached_artifact(ctx_ref, idx_url, &idx_cache, idx_bytes, |path| {
+                    validate_idx_cache(path, idx_bytes, pack_hash)
+                })
+                .await?;
+            Ok((idx_bytes, downloaded))
+        }));
     }
     for blob in &manifest.large_blobs {
         let oid = Oid::from_hex(&blob.oid).with_context(|| format!("bad blob oid {}", blob.oid))?;
         stats.large_blob_bytes += blob.bytes;
         let blob_cache = cache_dir.join(format!("blob-{}.loose", blob.oid));
         let blob_url = resolve_artifact_url(&clean_base, &blob.path)?;
-        if ensure_loose_blob_cached(&ctx, blob_url, &blob_cache, oid, blob.bytes).await? {
-            stats.downloaded_bytes += blob.bytes;
-        } else {
-            stats.reused_bytes += blob.bytes;
+        let (ctx_ref, blob_bytes) = (&ctx, blob.bytes);
+        jobs.push(Box::pin(async move {
+            let downloaded =
+                ensure_loose_blob_cached(ctx_ref, blob_url, &blob_cache, oid, blob_bytes).await?;
+            Ok((blob_bytes, downloaded))
+        }));
+    }
+    {
+        use futures::StreamExt as _;
+        const DOWNLOADS_IN_FLIGHT: usize = 4;
+        let mut results = futures::stream::iter(jobs).buffer_unordered(DOWNLOADS_IN_FLIGHT);
+        while let Some(done) = results.next().await {
+            let (bytes, downloaded) = done?;
+            if downloaded {
+                stats.downloaded_bytes += bytes;
+            } else {
+                stats.reused_bytes += bytes;
+            }
         }
     }
 
@@ -292,6 +313,18 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
 
     if opts.checkout && !manifest.refs.is_empty() {
         run_git(&mut stats, &opts.dest, &["reset", "--hard", "-q", "HEAD"])?;
+    }
+    // Serving-side maintenance structures: without a commit-graph the first `git log`/`blame` in
+    // a large repo pays a full history walk, and a multi-pack install pays per-pack lookups until
+    // a multi-pack-index exists. Both are derived data — a failure (old git, exotic pack) must
+    // not fail an otherwise-complete clone, so errors are recorded in stats and ignored.
+    let _ = run_git(
+        &mut stats,
+        &opts.dest,
+        &["commit-graph", "write", "--reachable", "--changed-paths"],
+    );
+    if manifest.packs.len() > 1 {
+        let _ = run_git(&mut stats, &opts.dest, &["multi-pack-index", "write"]);
     }
     if let Some(max_bytes) = opts.cache_max_bytes {
         let protected = protected_cache_entries(&manifest)?;
@@ -1259,5 +1292,116 @@ mod tests {
 
         assert!(downloaded);
         assert_eq!(std::fs::read(&dest).unwrap(), payload);
+    }
+
+    /// Live integration: push through the ingest API, then fast-clone the repo and prove the
+    /// installed checkout is a working Git repo with the maintenance structures in place
+    /// (commit-graph always; multi-pack-index only for multi-pack installs).
+    ///
+    /// `cargo run -p gsvc-server` in an artifact_storage checkout, then
+    /// `cargo test -p tensorlake --features git-clone --lib fast_clone_roundtrip -- --ignored`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "requires a local artifact-storage server on 127.0.0.1:8080 and git on PATH"]
+    async fn fast_clone_roundtrip_against_local_server() {
+        use crate::artifact_storage::ArtifactStorageClient;
+        use crate::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
+
+        const BASE: &str = "http://127.0.0.1:8080";
+        if std::net::TcpStream::connect_timeout(
+            &"127.0.0.1:8080".parse().unwrap(),
+            std::time::Duration::from_millis(500),
+        )
+        .is_err()
+        {
+            eprintln!("skipping: no local artifact-storage server");
+            return;
+        }
+        let client = crate::ClientBuilder::new(BASE)
+            .bearer_token("dummy")
+            .build()
+            .unwrap();
+        let sdk = ArtifactStorageClient::new(client, BASE).unwrap();
+        let repo = format!(
+            "fastclone-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        sdk.create_repo_with_credential("fastclonetest", &repo, None, "t", "devtoken")
+            .await
+            .unwrap();
+        let salt = repo.as_bytes().to_vec();
+        let payload: Vec<u8> = (0..512 * 1024usize)
+            .map(|i| (i as u8).wrapping_mul(7).wrapping_add(salt[i % salt.len()]))
+            .collect();
+        sdk.push_files(
+            "fastclonetest",
+            &repo,
+            "t",
+            "devtoken",
+            vec![
+                PushFile {
+                    repo_path: "README.md".to_string(),
+                    source: PushSource::Bytes(b"fast clone roundtrip\n".to_vec()),
+                    mode: None,
+                    delete: false,
+                },
+                PushFile {
+                    repo_path: "data.bin".to_string(),
+                    source: PushSource::Bytes(payload.clone()),
+                    mode: None,
+                    delete: false,
+                },
+            ],
+            PushOptions {
+                message: "seed".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("checkout");
+        let stats = fast_clone(FastCloneOptions {
+            repo_url: format!("{BASE}/fastclonetest/{repo}"),
+            dest: dest.clone(),
+            cache_dir: Some(tmp.path().join("cache")),
+            cache_max_bytes: None,
+            credential: Some(BasicAuth {
+                username: "t".to_string(),
+                password: Some("devtoken".to_string()),
+            }),
+            checkout: true,
+            progress: None,
+        })
+        .await
+        .unwrap();
+        assert!(stats.packs >= 1);
+        assert_eq!(std::fs::read(dest.join("data.bin")).unwrap(), payload);
+
+        // The maintenance structures land best-effort; with a stock git on PATH they must exist.
+        let objects = dest.join(".git/objects");
+        assert!(
+            objects.join("info/commit-graph").exists()
+                || objects.join("info/commit-graphs").exists(),
+            "fast clone should write a commit-graph"
+        );
+        if stats.packs > 1 {
+            assert!(
+                objects.join("pack/multi-pack-index").exists(),
+                "multi-pack installs should write a multi-pack-index"
+            );
+        }
+
+        // The checkout is an ordinary git repo: history walks work.
+        let log = Command::new("git")
+            .args(["log", "--oneline"])
+            .current_dir(&dest)
+            .output()
+            .unwrap();
+        assert!(log.status.success());
+        assert!(!log.stdout.is_empty());
     }
 }

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -350,9 +350,9 @@ fn chunk_source(
             ));
         }
     };
-    let reader: Box<dyn Read + Send> = match source {
+    let reader: Box<dyn Read + Send + '_> = match source {
         PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
-        PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
+        PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.as_slice())),
         PushSource::KnownOid(_) => unreachable!("guarded above"),
     };
     let mut blob_hasher = BlobOidHasher::new(len);
@@ -440,9 +440,13 @@ where
 /// never registered for dedup server-side — so small files skip the chunker (and, downstream,
 /// the `missing` negotiation) entirely.
 fn chunk_source_whole(source: &PushSource) -> Result<(Vec<([u8; 32], u32)>, String), SdkError> {
-    let data: Vec<u8> = match source {
-        PushSource::Path(p) => std::fs::read(p).map_err(io_err)?,
-        PushSource::Bytes(b) => b.clone(),
+    let owned: Vec<u8>;
+    let data: &[u8] = match source {
+        PushSource::Path(p) => {
+            owned = std::fs::read(p).map_err(io_err)?;
+            &owned
+        }
+        PushSource::Bytes(b) => b,
         PushSource::KnownOid(_) => {
             return Err(SdkError::ClientError(
                 "known-oid sources carry no bytes to hash".to_string(),
@@ -907,11 +911,11 @@ impl ArtifactStorageClient {
                         body.extend_from_slice(&total.to_be_bytes());
                         body.extend_from_slice(&(file.chunks.len() as u32).to_be_bytes());
                         body.extend_from_slice(token.as_bytes());
-                        let mut reader: Box<dyn Read + Send> = match &file.source {
+                        let mut reader: Box<dyn Read + Send + '_> = match &file.source {
                             PushSource::Path(p) => {
                                 Box::new(std::fs::File::open(p).map_err(io_err)?)
                             }
-                            PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
+                            PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.as_slice())),
                             PushSource::KnownOid(_) => {
                                 unreachable!("known-oid files are not tokened")
                             }
@@ -978,9 +982,9 @@ impl ArtifactStorageClient {
                 let batch_bytes = opts.upload_batch_bytes;
                 async move {
                     let total: u64 = file.chunks.iter().map(|(_, s)| *s as u64).sum();
-                    let mut reader: Box<dyn Read + Send> = match &file.source {
+                    let mut reader: Box<dyn Read + Send + '_> = match &file.source {
                         PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
-                        PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
+                        PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.as_slice())),
                         PushSource::KnownOid(_) => unreachable!("known-oid files are not tokened"),
                     };
                     // The whole file goes in ONE request when it fits a batch (required for
@@ -1088,9 +1092,9 @@ impl ArtifactStorageClient {
                 if file.chunks.is_empty() {
                     continue; // deletes and known-oid references carry no bytes
                 }
-                let mut reader: Box<dyn Read + Send> = match &file.source {
+                let mut reader: Box<dyn Read + Send + '_> = match &file.source {
                     PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
-                    PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
+                    PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.as_slice())),
                     PushSource::KnownOid(_) => unreachable!("no chunks to upload"),
                 };
                 for (hash, size) in &file.chunks {
@@ -1187,9 +1191,9 @@ impl ArtifactStorageClient {
                 if file.chunks.is_empty() {
                     continue; // deletes and known-oid references carry no bytes
                 }
-                let mut reader: Box<dyn Read + Send> = match &file.source {
+                let mut reader: Box<dyn Read + Send + '_> = match &file.source {
                     PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
-                    PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
+                    PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.as_slice())),
                     PushSource::KnownOid(_) => unreachable!("no chunks to upload"),
                 };
                 for (hash, size) in &file.chunks {

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -332,22 +332,21 @@ impl ArtifactStorageClient {
         repo: &str,
     ) -> Result<Traced<RepoInfo>, SdkError> {
         let credential = self.git_credential_for_repo(project_id, repo).await?;
-        let branches = self
-            .list_branches_with_credential(
+        // Independent reads — issue them concurrently.
+        let (branches, refs) = tokio::try_join!(
+            self.list_branches_with_credential(
+                project_id,
+                repo,
+                &credential.git_username,
+                &credential.token,
+            ),
+            self.list_refs_with_credential(
                 project_id,
                 repo,
                 &credential.git_username,
                 &credential.token,
             )
-            .await?;
-        let refs = self
-            .list_refs_with_credential(
-                project_id,
-                repo,
-                &credential.git_username,
-                &credential.token,
-            )
-            .await?;
+        )?;
         let trace_id = refs.trace_id.clone();
         let branches = branches.into_inner();
         let refs = refs.into_inner();


### PR DESCRIPTION
Client-side follow-ups from a review of the artifact_storage SDK module against the disaggregated-git design notes. Companion server PR: tensorlakeai/artifact_storage#76.

## Changes

**Fast clone: parallel artifact downloads.** `fast_clone` downloaded every pack, its idx, and every large blob strictly sequentially. Each artifact is an independent immutable file with its own content-addressed cache path, so they now run as one download-job stream with bounded concurrency (4 in flight). Wall-clock for multi-pack / many-blob manifests follows the largest artifact instead of the sum of all of them. Range-resume, validation, and the downloaded/reused stats accounting are unchanged (the fold is order-independent).

**Fast clone: maintenance structures after install.** A fresh fast clone had no commit-graph and no multi-pack-index, so the first `git log` / `blame` / `status` in a large checkout paid a full history walk across N packs. After checkout the clone now runs `git commit-graph write --reachable --changed-paths` (always) and `git multi-pack-index write` (multi-pack installs) — best-effort, so an old git still produces a working clone; the commands are recorded in `FastCloneStats::git_commands` either way.

**Ingest: zero-copy `PushSource::Bytes`.** Every reader construction did `Cursor::new(b.clone())`, and each file is read twice (hash pass + upload pass), so an in-memory source was duplicated up to twice its size. Readers now borrow the buffer (`Cursor::new(b.as_slice())`), and the whole-file small-path hash reads a borrowed slice.

**`repo_info`:** the branches and refs requests are independent — now issued concurrently via `try_join!`.

## Testing

- `cargo test -p tensorlake --lib` — 132 passed (default features).
- `cargo test -p tensorlake --features git-clone --lib` (real gsvc-codec swapped in) — 137 passed.
- Live e2e against a local gsvc-server running the companion branch:
  - `push_paths_roundtrip_against_local_server` — passes (validates the zero-copy ingest paths end-to-end: tokened/batch upload, dedup, known-oid commit).
  - **New** `fast_clone_roundtrip_against_local_server` (added in this PR, `#[ignore]`d like the ingest one) — pushes via the API, fast-clones, asserts checkout contents, a working `git log`, and the commit-graph on disk.

Note: all packages release in lockstep — bump the shared version (`python .github/scripts/bump_version.py <new-version>`) before cutting a release with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)