### PR TITLE
tl fs mount --auto-commit-interval-secs: event-driven async snapshots with an append fast path

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -832,6 +832,7 @@ pub async fn mount(
     path: &Path,
     mode: WritePolicy,
     shared_rw: bool,
+    auto_commit_interval_secs: Option<u64>,
     foreground: bool,
 ) -> Result<()> {
     // Bail before creating a workspace or spawning the daemon-wait loop.
@@ -851,6 +852,11 @@ pub async fn mount(
     if shared_rw && mode == WritePolicy::Ro {
         return Err(CliError::usage(
             "--shared-rw publishes every snapshot; it cannot be combined with --mode ro",
+        ));
+    }
+    if auto_commit_interval_secs.is_some() && mode == WritePolicy::Ro {
+        return Err(CliError::usage(
+            "--auto-commit-interval-secs seals local writes; a read-only mount has none",
         ));
     }
     if shared_rw && base.is_none() {
@@ -1008,6 +1014,15 @@ pub async fn mount(
         }
     };
 
+    // An attach can resolve read-only implicitly (the workspace is live-mounted elsewhere);
+    // nothing server-side was created on that path, so erroring here leaks nothing.
+    if auto_commit_interval_secs.is_some() && read_only {
+        return Err(CliError::usage(
+            "--auto-commit-interval-secs needs a writable mount; this workspace is already \
+             mounted elsewhere and attached read-only (pass --mode rw to take writes)",
+        ));
+    }
+
     let mountpoint = canonical_mountpoint(path)?;
     let state_dir = alloc_state_dir(&ws.id);
     let (owner_uid, owner_gid) = mount_owner();
@@ -1024,6 +1039,7 @@ pub async fn mount(
             mountpoint: PathBuf::from(&mountpoint),
             follow_ref,
             read_only: Some(read_only),
+            auto_commit_interval_secs,
         },
     )?;
     registry_add(&mountpoint, &state_dir)?;
@@ -1088,6 +1104,11 @@ pub async fn mount(
                         "Lower commit {}. Work in the mount, then: tl fs snapshot {}",
                         resp.get("commit").and_then(|c| c.as_str()).unwrap_or("?"),
                         path.display()
+                    );
+                }
+                if let Some(secs) = auto_commit_interval_secs {
+                    println!(
+                        "Auto-commit: local changes seal into a snapshot every {secs}s (async)."
                     );
                 }
                 return Ok(());
@@ -1381,26 +1402,10 @@ fn enumerate_overlay(state_dir: &Path, mount_root: &Path) -> Result<(OverlayUpse
     Ok((upserts, deletes))
 }
 
-pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> Result<()> {
-    let (mountpoint, state_dir) = state_dir_for(path)?;
-    let state = daemon::load_mount_state(&state_dir)?;
-    if state.read_only() {
-        return Err(CliError::usage(format!(
-            "this is a read-only mount following {}; there is nothing to {}",
-            state.follow_ref.as_deref().unwrap_or("the branch"),
-            "snapshot",
-        )));
-    }
-    let session = FsSession::open(ctx, Some(&state.repo)).await?;
-    heartbeat(&session, &state).await?;
-
-    let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
-    if upserts.is_empty() && deletes.is_empty() {
-        println!("Nothing to snapshot: workspace is clean.");
-        return Ok(());
-    }
+/// An enumerated dirty set as push files. Shared by `snapshot` and the daemon's auto-commit.
+fn overlay_push_files(upserts: &OverlayUpserts, deletes: &[String]) -> Result<Vec<PushFile>> {
     let mut files = Vec::with_capacity(upserts.len() + deletes.len());
-    for (rel, abs, mode) in &upserts {
+    for (rel, abs, mode) in upserts {
         // A symlink's blob content is its target path; reading through `abs` would upload the
         // target file's bytes instead.
         let source = if *mode == 0o120000 {
@@ -1420,7 +1425,7 @@ pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> R
             delete: false,
         });
     }
-    for rel in &deletes {
+    for rel in deletes {
         files.push(PushFile {
             repo_path: rel.clone(),
             source: PushSource::Bytes(Vec::new()),
@@ -1428,6 +1433,28 @@ pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> R
             delete: true,
         });
     }
+    Ok(files)
+}
+
+pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> Result<()> {
+    let (mountpoint, state_dir) = state_dir_for(path)?;
+    let state = daemon::load_mount_state(&state_dir)?;
+    if state.read_only() {
+        return Err(CliError::usage(format!(
+            "this is a read-only mount following {}; there is nothing to {}",
+            state.follow_ref.as_deref().unwrap_or("the branch"),
+            "snapshot",
+        )));
+    }
+    let session = FsSession::open(ctx, Some(&state.repo)).await?;
+    heartbeat(&session, &state).await?;
+
+    let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
+    if upserts.is_empty() && deletes.is_empty() {
+        println!("Nothing to snapshot: workspace is clean.");
+        return Ok(());
+    }
+    let files = overlay_push_files(&upserts, &deletes)?;
 
     let (user, token) = session.creds();
     let progress: Arc<dyn Fn(PushEvent) + Send + Sync> = Arc::new(|ev| {
@@ -1752,6 +1779,13 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
             style("mode:").dim()
         );
     }
+    if let Some(secs) = state.auto_commit_interval_secs {
+        println!(
+            "{} local changes seal into a snapshot every {secs}s (local: below stays dirty \
+             until tl fs snapshot clears it)",
+            style("auto-commit:").dim()
+        );
+    }
     match &daemon_commit {
         Some(commit) => println!("{} mounted at {commit}", style("daemon:").dim()),
         None => println!(
@@ -1926,6 +1960,9 @@ pub async fn restore(ctx: &CliContext, path: &Path, version: &str) -> Result<()>
         expect.insert(p.clone(), e);
         changed.insert(p);
     }
+    // The upper was refilled behind the daemon's back; rebuild its dirty index so an
+    // auto-commit mount seals the restored state (clear_upper above reset the index).
+    daemon::control(&state_dir, "reindex").await?;
     converge_kernel_view(Path::new(&mountpoint), &changed, &expect);
     println!(
         "Restored {} to {} ({restored} file(s) refreshed, {removed} removed).",

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1962,7 +1962,16 @@ pub async fn restore(ctx: &CliContext, path: &Path, version: &str) -> Result<()>
     }
     // The upper was refilled behind the daemon's back; rebuild its dirty index so an
     // auto-commit mount seals the restored state (clear_upper above reset the index).
-    daemon::control(&state_dir, "reindex").await?;
+    // Tolerated failure: a still-running daemon from an older tl binary doesn't know the op,
+    // and the restore has already materially completed — failing here would skip the
+    // kernel-view convergence below and report a false failure.
+    if let Err(e) = daemon::control(&state_dir, "reindex").await {
+        eprintln!(
+            "{} the mount daemon predates auto-commit ({e}); if this mount uses \
+             --auto-commit-interval-secs, remount so the restored state seals",
+            style("warning:").yellow()
+        );
+    }
     converge_kernel_view(Path::new(&mountpoint), &changed, &expect);
     println!(
         "Restored {} to {} ({restored} file(s) refreshed, {removed} removed).",

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -10,6 +10,7 @@
 //! {"op":"ping"}        -> {"ok":true,"commit":"<hex>"}
 //! {"op":"refresh"}     -> poll the workspace ref now; reply with the (possibly new) commit
 //! {"op":"clear_upper"} -> drop all overlay state (post-snapshot / restore)
+//! {"op":"reindex"}     -> rebuild the overlay's dirty index from disk (post-restore)
 //! {"op":"shutdown"}    -> unmount and exit
 //! ```
 //!
@@ -73,6 +74,12 @@ pub struct MountState {
     /// when they followed, which is what the accessor falls back to.
     #[serde(default)]
     pub read_only: Option<bool>,
+    /// Periodic auto-commit: the daemon seals the overlay's dirty set into a snapshot commit
+    /// every this many seconds. The overlay is kept (only `tl fs snapshot` seals-and-clears),
+    /// so writes racing an auto-commit are never dropped — they ride the next one. Absent on
+    /// mounts that didn't opt in and in state files from before the feature.
+    #[serde(default)]
+    pub auto_commit_interval_secs: Option<u64>,
 }
 
 impl MountState {
@@ -198,16 +205,24 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     let project = project_id(ctx)?;
 
     // Initial credential: the dev override, or a fresh mint.
-    let (token, mut expires_at) = match std::env::var("TENSORLAKE_GIT_TOKEN") {
-        Ok(token) => (token, None),
+    let (git_username, token, mut expires_at) = match std::env::var("TENSORLAKE_GIT_TOKEN") {
+        Ok(token) => (
+            std::env::var("TENSORLAKE_GIT_USERNAME").unwrap_or_else(|_| "t".to_string()),
+            token,
+            None,
+        ),
         Err(_) => {
             let cred = sdk
                 .mint_token_for_repo(&project, Some(&state.repo))
                 .await?
                 .into_inner();
-            (cred.token, Some(cred.expires_at))
+            (cred.git_username, cred.token, Some(cred.expires_at))
         }
     };
+    // The daemon's long-lived `(user, token)` credential: heartbeats and auto-commits read it,
+    // and the rotation task below swaps it in place before expiry — a static copy would start
+    // failing an hour into the mount's life.
+    let api_creds = Arc::new(std::sync::Mutex::new((git_username, token.clone())));
 
     let client = FsClient::new(
         sdk.git_base_url(),
@@ -246,6 +261,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         let sdk = sdk.clone();
         let (project, repo) = (project.clone(), state.repo.clone());
         let rotate = rotating_client;
+        let creds = api_creds.clone();
         tokio::spawn(async move {
             loop {
                 let due = expires_in(expires_at.as_deref().unwrap_or_default())
@@ -254,7 +270,8 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 match sdk.mint_token_for_repo(&project, Some(&repo)).await {
                     Ok(cred) => {
                         let cred = cred.into_inner();
-                        rotate.set_token(Some(cred.token));
+                        rotate.set_token(Some(cred.token.clone()));
+                        *creds.lock().expect("creds lock") = (cred.git_username, cred.token);
                         expires_at = Some(cred.expires_at);
                     }
                     Err(e) => {
@@ -274,12 +291,12 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
             state.repo.clone(),
             state.workspace_id.clone(),
         );
-        let creds = crate::commands::fs::FsSession::open(ctx, Some(&state.repo)).await?;
+        let creds = api_creds.clone();
         tokio::spawn(async move {
             loop {
-                let (user, token) = creds.creds();
+                let (user, token) = creds.lock().expect("creds lock").clone();
                 if let Err(e) = sdk
-                    .workspace_heartbeat(&project, &repo, user, token, &ws)
+                    .workspace_heartbeat(&project, &repo, &user, &token, &ws)
                     .await
                 {
                     tracing::warn!("workspace heartbeat failed: {e}");
@@ -307,6 +324,153 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         let invalidate = invalidate.clone();
         gsvc_mount::spawn_ref_watcher(&core, move |delta| {
             invalidate(overlay.translate_delta(&delta));
+        });
+    }
+
+    // Auto-commit: seal dirty paths into snapshot commits every interval, event-driven. The
+    // overlay records every mutation in its dirty index, so nothing is ever scanned — an idle
+    // tick is one atomic load. Each seal pushes only paths touched since the last sealed
+    // generation: everything sealed earlier is already served by the lower (the workspace ref
+    // advances with each snapshot), so commits are incremental deltas, and unchanged dirty
+    // files are never re-hashed or re-sent. The overlay is deliberately NOT cleared — the
+    // on-demand snapshot's clear-after-push is only safe with writes quiesced; here the upper
+    // keeps shadowing the byte-identical sealed content.
+    if let Some(secs) = state.auto_commit_interval_secs
+        && !state.read_only()
+    {
+        use tensorlake::artifact_storage::ingest::PushOptions;
+        let sdk = sdk.clone();
+        let creds = api_creds.clone();
+        let (project, repo, ws) = (
+            project.clone(),
+            state.repo.clone(),
+            state.workspace_id.clone(),
+        );
+        let state_dir = state_dir.to_path_buf();
+        let mountpoint = mountpoint.clone();
+        let overlay = overlay.clone();
+        let core = core.clone();
+        let invalidate = invalidate.clone();
+        tokio::spawn(async move {
+            let mut sealed_gen = 0u64;
+            // Paths published by the last two seals: the guard set for deletes racing the
+            // lower's advance past their seal (see resolve_seal's tombstone arm).
+            let mut recent_seals: std::collections::VecDeque<std::collections::HashSet<String>> =
+                std::collections::VecDeque::new();
+            // Chunk lists from previous seals (path -> the pushed CDC chunk list): the append
+            // fast path's memory. A re-touched file whose writes never went below a cached
+            // boundary seals as a `StablePrefix` — only bytes past that boundary are re-read.
+            // Daemon-local; a restart just means one full-cost seal per file to re-learn.
+            let mut chunk_cache: std::collections::HashMap<String, ChunkList> =
+                std::collections::HashMap::new();
+            loop {
+                tokio::time::sleep(Duration::from_secs(secs.max(1))).await;
+                let delta = overlay.dirty_since(sealed_gen);
+                let watermark = delta.watermark;
+                if delta.is_empty() {
+                    sealed_gen = watermark;
+                    continue;
+                }
+                // Resolution reads ignore files through the mountpoint — FUSE round-trips
+                // served by this very process. Run it on the blocking pool so it can never
+                // starve the runtime workers serving it.
+                let recently: std::collections::HashSet<String> =
+                    recent_seals.iter().flatten().cloned().collect();
+                let cached: std::collections::HashMap<String, ChunkList> = delta
+                    .upserts
+                    .iter()
+                    .filter_map(|(path, _)| {
+                        chunk_cache
+                            .get(path)
+                            .map(|chunks| (path.clone(), chunks.clone()))
+                    })
+                    .collect();
+                let (sd, mp) = (state_dir.clone(), mountpoint.clone());
+                let resolved = tokio::task::spawn_blocking(move || {
+                    resolve_seal(&sd, &mp, &delta, &recently, &cached)
+                })
+                .await;
+                // eprintln, not tracing: the daemon installs no subscriber, and its stderr is
+                // the state dir's daemon.log — the one place a user can see an async flush fail.
+                let resolved = match resolved {
+                    Ok(Ok(resolved)) => resolved,
+                    Ok(Err(e)) => {
+                        eprintln!("auto-commit: resolving the dirty delta failed: {e}");
+                        continue;
+                    }
+                    Err(e) => {
+                        eprintln!("auto-commit: resolution task failed: {e}");
+                        continue;
+                    }
+                };
+                if resolved.files.is_empty() {
+                    // The whole delta was ignored paths, bare directories, or files that were
+                    // born and died between seals: sealed through, nothing to publish.
+                    sealed_gen = watermark;
+                    overlay.prune_dirty(watermark);
+                    continue;
+                }
+                let (user, token) = creds.lock().expect("creds lock").clone();
+                let delete_paths: Vec<String> = resolved
+                    .files
+                    .iter()
+                    .filter(|f| f.delete)
+                    .map(|f| f.repo_path.clone())
+                    .collect();
+                match sdk
+                    .push_files(
+                        &project,
+                        &repo,
+                        &user,
+                        &token,
+                        resolved.files,
+                        PushOptions {
+                            message: "tl fs auto-commit".to_string(),
+                            workspace_snapshot: Some(ws.clone()),
+                            collect_file_chunks: true,
+                            ..Default::default()
+                        },
+                    )
+                    .await
+                {
+                    Ok(report) => {
+                        sealed_gen = watermark;
+                        overlay.prune_dirty(watermark);
+                        recent_seals.push_back(resolved.sealed_upserts);
+                        if recent_seals.len() > 2 {
+                            recent_seals.pop_front();
+                        }
+                        let report = report.into_inner();
+                        // Remember what each file's content chunked to; a blunt cap bounds
+                        // daemon memory (a full re-learn is just one full-cost seal per file).
+                        for (path, chunks) in &report.file_chunks {
+                            chunk_cache.insert(path.clone(), chunks.clone());
+                        }
+                        for path in &delete_paths {
+                            chunk_cache.remove(path);
+                        }
+                        if chunk_cache.len() > 8192 {
+                            chunk_cache.clear();
+                        }
+                        // Advance the lower to the sealed commit now instead of waiting out
+                        // the follow poll: from here on, a delete of a just-sealed path sees
+                        // lower presence and whiteouts normally.
+                        match core.poll_ref().await {
+                            Ok(Some(refresh)) => invalidate(overlay.translate_delta(&refresh)),
+                            Ok(None) => {}
+                            Err(e) => eprintln!(
+                                "auto-commit: post-seal refresh failed (follow poll catches \
+                                 up): {e}"
+                            ),
+                        }
+                        if !resolved.tombstoned.is_empty() {
+                            invalidate(overlay.invals_for(&resolved.tombstoned));
+                        }
+                        eprintln!("auto-commit sealed snapshot {}", report.commit);
+                    }
+                    Err(e) => eprintln!("auto-commit push failed (will retry): {e}"),
+                }
+            }
         });
     }
 
@@ -361,6 +525,13 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                             }
                             Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
                         },
+                        // The upper was mutated out-of-band (restore writes into the state dir
+                        // from the CLI process); rebuild the dirty index from disk so an
+                        // auto-commit mount seals the new state.
+                        "reindex" => match overlay.rebuild_dirty_index() {
+                            Ok(()) => serde_json::json!({ "ok": true }),
+                            Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
+                        },
                         "shutdown" => {
                             // Unmount BEFORE replying: the reply is the CLI's signal that the
                             // kernel released the volume (the slow phase on macOS — fskitd
@@ -400,6 +571,167 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     let result = served.wait().await;
     let _ = std::fs::remove_file(&sock_path);
     result
+}
+
+/// A pushed file's CDC chunk list, as returned in `PushReport::file_chunks`.
+#[cfg(unix)]
+type ChunkList = Vec<([u8; 32], u32)>;
+
+/// One tick's seal work, resolved from the overlay's event delta against the on-disk overlay
+/// state. Produced by [`resolve_seal`].
+#[cfg(unix)]
+struct ResolvedSeal {
+    files: Vec<tensorlake::artifact_storage::ingest::PushFile>,
+    /// Paths whose content this seal publishes — the next ticks' resurrection guard.
+    sealed_upserts: std::collections::HashSet<String>,
+    /// Vanished-but-recently-sealed paths that got a whiteout written here; their merged view
+    /// flipped without a kernel-visible operation, so the kernel needs invalidations.
+    tombstoned: Vec<String>,
+}
+
+/// Resolve an event delta into upload-ready push files. The dirty index's kinds are routing
+/// hints; the on-disk overlay is the authority — a path is an upsert if the upper serves it,
+/// a delete if a whiteout covers it, and skipped when it is a bare directory or ignored.
+///
+/// The subtle arm is the tombstone: a path sealed by a recent commit, then deleted before the
+/// lower advanced to that commit. The unlink saw no lower presence, so no whiteout was written
+/// — once the lower catches up the path would silently resurrect. Recognize it by membership
+/// in the recent seals, write the whiteout the unlink would have, and publish the delete.
+///
+/// Runs on the blocking pool: the ignore rules read `.gitignore` files through the mountpoint,
+/// which this very daemon serves.
+#[cfg(unix)]
+fn resolve_seal(
+    state_dir: &Path,
+    mount_root: &Path,
+    delta: &super::overlay::DirtyDelta,
+    recently_sealed: &std::collections::HashSet<String>,
+    chunk_cache: &std::collections::HashMap<String, ChunkList>,
+) -> crate::error::Result<ResolvedSeal> {
+    let mut ignore = super::SnapshotIgnore::new(mount_root);
+    let upper = state_dir.join("upper");
+    let wh = state_dir.join("wh");
+    let mut upserts: super::OverlayUpserts = Vec::new();
+    let mut deletes: Vec<String> = Vec::new();
+    let mut tombstoned: Vec<String> = Vec::new();
+    let mut vanished: Vec<String> = Vec::new();
+
+    for (path, _) in &delta.upserts {
+        let abs = upper.join(path);
+        let Ok(meta) = std::fs::symlink_metadata(&abs) else {
+            // Gone from the upper with no delete event in this delta (a rename or unlink
+            // racing the tick): route through the delete resolution below.
+            vanished.push(path.clone());
+            continue;
+        };
+        if meta.is_dir() && !meta.file_type().is_symlink() {
+            // Directories materialize through their children; git has no empty trees.
+            continue;
+        }
+        if ignore.is_ignored(path, false)? {
+            continue;
+        }
+        use std::os::unix::fs::PermissionsExt;
+        let mode = if meta.file_type().is_symlink() {
+            0o120000
+        } else if meta.permissions().mode() & 0o111 != 0 {
+            0o100755
+        } else {
+            0o100644
+        };
+        upserts.push((path.clone(), abs, mode));
+    }
+    for path in delta.deletes.iter().chain(vanished.iter()) {
+        if upper.join(path).symlink_metadata().is_ok() {
+            // Re-created since the event; its own upsert event covers it.
+            continue;
+        }
+        if ignore.is_ignored(path, false)? {
+            continue;
+        }
+        if whited_out_on_disk(&wh, path) {
+            deletes.push(path.clone());
+        } else if recently_sealed.contains(path) {
+            super::write_whiteout(&wh, path)?;
+            deletes.push(path.clone());
+            tombstoned.push(path.clone());
+        }
+        // Neither: born and died locally between seals — nothing was ever published.
+    }
+    upserts.sort_by(|a, b| a.0.cmp(&b.0));
+    deletes.sort();
+    deletes.dedup();
+    let mut files = super::overlay_push_files(&upserts, &deletes)?;
+
+    // Append fast path: a file with a cached chunk list from its previous seal, whose writes
+    // since then never went below a cached boundary, seals as a `StablePrefix` — the push
+    // reads only bytes past that boundary. The cached FINAL chunk is never reused (it was cut
+    // at the old EOF, not at a content-chosen boundary), and neither is anything at or past
+    // the lowest written offset.
+    let min_write: std::collections::HashMap<&str, u64> = delta
+        .upserts
+        .iter()
+        .map(|(path, min)| (path.as_str(), *min))
+        .collect();
+    use tensorlake::artifact_storage::ingest::PushSource;
+    for file in &mut files {
+        if file.delete || file.mode == Some(0o120000) {
+            continue;
+        }
+        let (Some(min_offset), Some(cached)) = (
+            min_write.get(file.repo_path.as_str()),
+            chunk_cache.get(&file.repo_path),
+        ) else {
+            continue;
+        };
+        let usable = &cached[..cached.len().saturating_sub(1)];
+        let mut stable: ChunkList = Vec::new();
+        let mut end = 0u64;
+        for (hash, size) in usable {
+            if end + *size as u64 > *min_offset {
+                break;
+            }
+            end += *size as u64;
+            stable.push((*hash, *size));
+        }
+        if stable.is_empty() {
+            continue;
+        }
+        if let PushSource::Path(path) = &file.source {
+            file.source = PushSource::StablePrefix {
+                path: path.clone(),
+                stable_chunks: stable,
+            };
+        }
+    }
+
+    Ok(ResolvedSeal {
+        sealed_upserts: upserts.iter().map(|(p, _, _)| p.clone()).collect(),
+        files,
+        tombstoned,
+    })
+}
+
+/// Whether a whiteout marker covers `path` (at the path or any ancestor) — the on-disk mirror
+/// of the overlay's whiteout rule, so resolution can run without the overlay.
+#[cfg(unix)]
+fn whited_out_on_disk(wh: &Path, path: &str) -> bool {
+    let mut probe = String::with_capacity(path.len());
+    for component in path.split('/') {
+        if !probe.is_empty() {
+            probe.push('/');
+        }
+        probe.push_str(component);
+        let marker_is_file = wh
+            .join(&probe)
+            .symlink_metadata()
+            .map(|m| m.is_file())
+            .unwrap_or(false);
+        if marker_is_file {
+            return true;
+        }
+    }
+    false
 }
 
 /// A live kernel attachment; `wait` returns when the mount ends.
@@ -607,5 +939,203 @@ pub(crate) fn still_mounted(mountpoint: &Path) -> bool {
                     .any(|line| line.split_whitespace().nth(1) == Some(path.as_ref()))
             })
             .unwrap_or(false)
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::super::overlay::DirtyDelta;
+    use super::*;
+
+    pub(super) fn state_with(upper: &[(&str, &str)], wh: &[&str]) -> tempfile::TempDir {
+        let state = tempfile::tempdir().unwrap();
+        for (path, content) in upper {
+            let abs = state.path().join("upper").join(path);
+            std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            std::fs::write(abs, content).unwrap();
+        }
+        for path in wh {
+            let abs = state.path().join("wh").join(path);
+            std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            std::fs::write(abs, b"").unwrap();
+        }
+        state
+    }
+
+    fn delta(upserts: &[&str], deletes: &[&str]) -> DirtyDelta {
+        // Structural events pin min_write_offset to 0; extent-carrying cases build their own.
+        DirtyDelta {
+            upserts: upserts.iter().map(|s| (s.to_string(), 0)).collect(),
+            deletes: deletes.iter().map(|s| s.to_string()).collect(),
+            watermark: 1,
+        }
+    }
+
+    fn no_cache() -> std::collections::HashMap<String, ChunkList> {
+        std::collections::HashMap::new()
+    }
+
+    #[test]
+    fn resolve_seal_routes_upserts_deletes_and_skips() {
+        let state = state_with(
+            &[("kept.txt", "hi"), ("dir/nested.txt", "deep")],
+            &["gone.txt"],
+        );
+        let mount = tempfile::tempdir().unwrap();
+        std::fs::write(mount.path().join(".gitignore"), "*.tmp\n").unwrap();
+        std::fs::write(state.path().join("upper/junk.tmp"), "x").unwrap();
+        std::fs::create_dir_all(state.path().join("upper/empty-dir")).unwrap();
+
+        let resolved = resolve_seal(
+            state.path(),
+            mount.path(),
+            &delta(
+                &["dir", "dir/nested.txt", "empty-dir", "junk.tmp", "kept.txt"],
+                &["gone.txt"],
+            ),
+            &std::collections::HashSet::new(),
+            &no_cache(),
+        )
+        .unwrap();
+
+        let mut published: Vec<(&str, bool)> = resolved
+            .files
+            .iter()
+            .map(|f| (f.repo_path.as_str(), f.delete))
+            .collect();
+        published.sort();
+        // Directories and gitignored paths never publish; whiteouts publish as deletes.
+        assert_eq!(
+            published,
+            vec![
+                ("dir/nested.txt", false),
+                ("gone.txt", true),
+                ("kept.txt", false),
+            ]
+        );
+        assert!(resolved.sealed_upserts.contains("kept.txt"));
+        assert!(resolved.tombstoned.is_empty());
+    }
+
+    #[test]
+    fn resolve_seal_tombstones_vanished_recently_sealed_paths() {
+        // The resurrection race: a path sealed by the previous commit, then deleted before the
+        // lower advanced — no upper file, no whiteout. The delete must still publish, and a
+        // whiteout must be written so the local view stays deleted once the lower catches up.
+        let state = state_with(&[], &[]);
+        let mount = tempfile::tempdir().unwrap();
+        let recently: std::collections::HashSet<String> = ["sealed-then-deleted.txt".to_string()]
+            .into_iter()
+            .collect();
+
+        let resolved = resolve_seal(
+            state.path(),
+            mount.path(),
+            &delta(&[], &["sealed-then-deleted.txt", "never-sealed.txt"]),
+            &recently,
+            &no_cache(),
+        )
+        .unwrap();
+
+        let published: Vec<(&str, bool)> = resolved
+            .files
+            .iter()
+            .map(|f| (f.repo_path.as_str(), f.delete))
+            .collect();
+        // The never-sealed path was born and died locally: nothing to publish for it.
+        assert_eq!(published, vec![("sealed-then-deleted.txt", true)]);
+        assert_eq!(resolved.tombstoned, vec!["sealed-then-deleted.txt"]);
+        assert!(
+            state.path().join("wh/sealed-then-deleted.txt").is_file(),
+            "the whiteout the unlink would have written"
+        );
+    }
+
+    #[test]
+    fn resolve_seal_skips_recreated_paths_and_honors_ancestor_whiteouts() {
+        let state = state_with(&[("back.txt", "again")], &["dead-dir"]);
+        let mount = tempfile::tempdir().unwrap();
+
+        let resolved = resolve_seal(
+            state.path(),
+            mount.path(),
+            // back.txt carries a stale delete event but the upper serves it again; a child of
+            // a whiteouted directory is covered by the ancestor marker.
+            &delta(&[], &["back.txt", "dead-dir/child.txt"]),
+            &std::collections::HashSet::new(),
+            &no_cache(),
+        )
+        .unwrap();
+
+        let published: Vec<(&str, bool)> = resolved
+            .files
+            .iter()
+            .map(|f| (f.repo_path.as_str(), f.delete))
+            .collect();
+        assert_eq!(published, vec![("dead-dir/child.txt", true)]);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod stable_prefix_tests {
+    use tensorlake::artifact_storage::ingest::PushSource;
+
+    use super::super::overlay::DirtyDelta;
+    use super::tests::state_with;
+    use super::*;
+
+    fn resolve_with_cache(min_offset: u64) -> ResolvedSeal {
+        let state = state_with(&[("log.bin", "0123456789")], &[]);
+        let mount = tempfile::tempdir().unwrap();
+        // The previous seal chunked the 10-byte file as 4+4+2; the trailing 2-byte chunk was
+        // cut at the old EOF and must never be reused as a stable boundary.
+        let cache: std::collections::HashMap<String, ChunkList> = [(
+            "log.bin".to_string(),
+            vec![([1u8; 32], 4), ([2u8; 32], 4), ([3u8; 32], 2)],
+        )]
+        .into_iter()
+        .collect();
+        resolve_seal(
+            state.path(),
+            mount.path(),
+            &DirtyDelta {
+                upserts: vec![("log.bin".to_string(), min_offset)],
+                deletes: Vec::new(),
+                watermark: 1,
+            },
+            &std::collections::HashSet::new(),
+            &cache,
+        )
+        .unwrap()
+    }
+
+    fn stable_of(resolved: &ResolvedSeal) -> Option<Vec<u32>> {
+        match &resolved.files[0].source {
+            PushSource::StablePrefix { stable_chunks, .. } => {
+                Some(stable_chunks.iter().map(|(_, s)| *s).collect())
+            }
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn append_reuses_all_but_the_eof_cut_chunk() {
+        // Writes started at the old EOF (10): both content-boundary chunks are stable.
+        let resolved = resolve_with_cache(10);
+        assert_eq!(stable_of(&resolved), Some(vec![4, 4]));
+    }
+
+    #[test]
+    fn mid_file_write_keeps_only_chunks_fully_before_it() {
+        // A write at offset 5 lands inside the second chunk: only the first survives.
+        let resolved = resolve_with_cache(5);
+        assert_eq!(stable_of(&resolved), Some(vec![4]));
+    }
+
+    #[test]
+    fn structural_change_falls_back_to_a_full_read() {
+        let resolved = resolve_with_cache(0);
+        assert_eq!(stable_of(&resolved), None);
+        assert!(matches!(resolved.files[0].source, PushSource::Path(_)));
     }
 }

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -338,7 +338,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     if let Some(secs) = state.auto_commit_interval_secs
         && !state.read_only()
     {
-        use tensorlake::artifact_storage::ingest::PushOptions;
+        use tensorlake::artifact_storage::ingest::{PushOptions, PushSource};
         let sdk = sdk.clone();
         let creds = api_creds.clone();
         let (project, repo, ws) = (
@@ -353,10 +353,17 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         let invalidate = invalidate.clone();
         tokio::spawn(async move {
             let mut sealed_gen = 0u64;
-            // Paths published by the last two seals: the guard set for deletes racing the
-            // lower's advance past their seal (see resolve_seal's tombstone arm).
-            let mut recent_seals: std::collections::VecDeque<std::collections::HashSet<String>> =
-                std::collections::VecDeque::new();
+            // The overlay epoch this sealer's caches describe. clear_upper (manual snapshot,
+            // restore) and rebuild_dirty_index rewrite the overlay's world out-of-band; every
+            // cache below is a claim about the old world and dies with it.
+            let mut seen_epoch = overlay.epoch();
+            // Upserts of not-yet-confirmed seals, in seal order, each tagged with its commit:
+            // the guard set for deletes racing the lower's advance past their seal (see
+            // resolve_seal's tombstone arm). Confirmation-based — a set is only dropped once
+            // the lower is observed at (or past) its seal — because eviction-by-count expires
+            // the guard exactly when index materialization lags behind hot pushes. Memory is
+            // bounded by the unconfirmed window, not a fixed depth.
+            let mut recent_seals: Vec<(String, std::collections::HashSet<String>)> = Vec::new();
             // Chunk lists from previous seals (path -> the pushed CDC chunk list): the append
             // fast path's memory. A re-touched file whose writes never went below a cached
             // boundary seals as a `StablePrefix` — only bytes past that boundary are re-read.
@@ -365,6 +372,22 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 std::collections::HashMap::new();
             loop {
                 tokio::time::sleep(Duration::from_secs(secs.max(1))).await;
+                let epoch = overlay.epoch();
+                if epoch != seen_epoch {
+                    seen_epoch = epoch;
+                    chunk_cache.clear();
+                    recent_seals.clear();
+                }
+                // Drop guard sets the lower has caught up with: the followed ref only moves
+                // along this workspace's snapshots, so matching the current lower commit
+                // confirms it and everything sealed before it.
+                let lower = core.current_commit();
+                if let Some(i) = recent_seals
+                    .iter()
+                    .rposition(|(commit, _)| *commit == lower)
+                {
+                    recent_seals.drain(..=i);
+                }
                 let delta = overlay.dirty_since(sealed_gen);
                 let watermark = delta.watermark;
                 if delta.is_empty() {
@@ -374,8 +397,11 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 // Resolution reads ignore files through the mountpoint — FUSE round-trips
                 // served by this very process. Run it on the blocking pool so it can never
                 // starve the runtime workers serving it.
-                let recently: std::collections::HashSet<String> =
-                    recent_seals.iter().flatten().cloned().collect();
+                let recently: std::collections::HashSet<String> = recent_seals
+                    .iter()
+                    .flat_map(|(_, set)| set)
+                    .cloned()
+                    .collect();
                 let cached: std::collections::HashMap<String, ChunkList> = delta
                     .upserts
                     .iter()
@@ -392,7 +418,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 .await;
                 // eprintln, not tracing: the daemon installs no subscriber, and its stderr is
                 // the state dir's daemon.log — the one place a user can see an async flush fail.
-                let resolved = match resolved {
+                let mut resolved = match resolved {
                     Ok(Ok(resolved)) => resolved,
                     Ok(Err(e)) => {
                         eprintln!("auto-commit: resolving the dirty delta failed: {e}");
@@ -403,12 +429,49 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         continue;
                     }
                 };
+                if overlay.epoch() != seen_epoch {
+                    // clear_upper/restore raced this tick: the resolution described a world
+                    // that no longer exists — publishing it would delete files a manual
+                    // snapshot just sealed. Undo the whiteouts the tombstone arm wrote and
+                    // start over next tick (the epoch check up top clears the caches).
+                    for path in &resolved.tombstoned {
+                        let _ = std::fs::remove_file(state_dir.join("wh").join(path));
+                    }
+                    if !resolved.tombstoned.is_empty() {
+                        invalidate(overlay.invals_for(&resolved.tombstoned));
+                    }
+                    continue;
+                }
+                if !resolved.tombstoned.is_empty() {
+                    // The on-disk merged view already flipped when resolve wrote the
+                    // whiteouts; tell the kernel now — deferring to push success would leave
+                    // stale positive dentries until TTL if the push fails (the retry routes
+                    // through the plain-deletes arm and never re-lists these).
+                    invalidate(overlay.invals_for(&resolved.tombstoned));
+                }
                 if resolved.files.is_empty() {
                     // The whole delta was ignored paths, bare directories, or files that were
                     // born and died between seals: sealed through, nothing to publish.
                     sealed_gen = watermark;
                     overlay.prune_dirty(watermark);
                     continue;
+                }
+                // Final validity check on every stable prefix: a write below the boundary
+                // that landed after the delta snapshot voids the stability claim — sealing
+                // it would publish a prefix+tail chimera that never existed on disk. Demote
+                // to a full read; the racing write's entry stays pending for the next tick.
+                for file in &mut resolved.files {
+                    let PushSource::StablePrefix {
+                        path,
+                        stable_chunks,
+                    } = &file.source
+                    else {
+                        continue;
+                    };
+                    let stable_len: u64 = stable_chunks.iter().map(|(_, s)| *s as u64).sum();
+                    if overlay.min_write_offset(&file.repo_path).unwrap_or(0) < stable_len {
+                        file.source = PushSource::Path(path.clone());
+                    }
                 }
                 let (user, token) = creds.lock().expect("creds lock").clone();
                 let delete_paths: Vec<String> = resolved
@@ -436,11 +499,8 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                     Ok(report) => {
                         sealed_gen = watermark;
                         overlay.prune_dirty(watermark);
-                        recent_seals.push_back(resolved.sealed_upserts);
-                        if recent_seals.len() > 2 {
-                            recent_seals.pop_front();
-                        }
                         let report = report.into_inner();
+                        recent_seals.push((report.commit.clone(), resolved.sealed_upserts));
                         // Remember what each file's content chunked to; a blunt cap bounds
                         // daemon memory (a full re-learn is just one full-cost seal per file).
                         for (path, chunks) in &report.file_chunks {
@@ -454,7 +514,8 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         }
                         // Advance the lower to the sealed commit now instead of waiting out
                         // the follow poll: from here on, a delete of a just-sealed path sees
-                        // lower presence and whiteouts normally.
+                        // lower presence and whiteouts normally. Best-effort — the guard
+                        // above holds every unconfirmed seal, however long the lower lags.
                         match core.poll_ref().await {
                             Ok(Some(refresh)) => invalidate(overlay.translate_delta(&refresh)),
                             Ok(None) => {}
@@ -462,9 +523,6 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 "auto-commit: post-seal refresh failed (follow poll catches \
                                  up): {e}"
                             ),
-                        }
-                        if !resolved.tombstoned.is_empty() {
-                            invalidate(overlay.invals_for(&resolved.tombstoned));
                         }
                         eprintln!("auto-commit sealed snapshot {}", report.commit);
                     }
@@ -625,21 +683,17 @@ fn resolve_seal(
             continue;
         };
         if meta.is_dir() && !meta.file_type().is_symlink() {
-            // Directories materialize through their children; git has no empty trees.
+            // A directory upsert names a subtree (a directory rename lands one alongside its
+            // per-child events; future bulk ops may not): publish its files so nothing under
+            // it can be missed. The sort+dedup below collapses overlap with child events.
+            // Empty directories still publish nothing — git has no empty trees.
+            collect_dir_upserts(&upper, path, &mut ignore, &mut upserts)?;
             continue;
         }
         if ignore.is_ignored(path, false)? {
             continue;
         }
-        use std::os::unix::fs::PermissionsExt;
-        let mode = if meta.file_type().is_symlink() {
-            0o120000
-        } else if meta.permissions().mode() & 0o111 != 0 {
-            0o100755
-        } else {
-            0o100644
-        };
-        upserts.push((path.clone(), abs, mode));
+        upserts.push((path.clone(), abs, git_mode(&meta)));
     }
     for path in delta.deletes.iter().chain(vanished.iter()) {
         if upper.join(path).symlink_metadata().is_ok() {
@@ -659,6 +713,7 @@ fn resolve_seal(
         // Neither: born and died locally between seals — nothing was ever published.
     }
     upserts.sort_by(|a, b| a.0.cmp(&b.0));
+    upserts.dedup_by(|a, b| a.0 == b.0);
     deletes.sort();
     deletes.dedup();
     let mut files = super::overlay_push_files(&upserts, &deletes)?;
@@ -710,6 +765,50 @@ fn resolve_seal(
         files,
         tombstoned,
     })
+}
+
+/// The git mode a local file publishes as (same policy as `enumerate_overlay`'s walk).
+#[cfg(unix)]
+fn git_mode(meta: &std::fs::Metadata) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    if meta.file_type().is_symlink() {
+        0o120000
+    } else if meta.permissions().mode() & 0o111 != 0 {
+        0o100755
+    } else {
+        0o100644
+    }
+}
+
+/// Recursively enqueue every non-ignored file/symlink under an upper directory as an upsert —
+/// the resolution for directory-level events (renames especially), whose per-child events may
+/// or may not exist.
+#[cfg(unix)]
+fn collect_dir_upserts(
+    upper: &Path,
+    dir_rel: &str,
+    ignore: &mut super::SnapshotIgnore,
+    upserts: &mut super::OverlayUpserts,
+) -> crate::error::Result<()> {
+    let abs_dir = upper.join(dir_rel);
+    let Ok(read) = std::fs::read_dir(&abs_dir) else {
+        return Ok(());
+    };
+    for entry in read.flatten() {
+        let abs = entry.path();
+        let Ok(meta) = std::fs::symlink_metadata(&abs) else {
+            continue;
+        };
+        let rel = format!("{dir_rel}/{}", entry.file_name().to_string_lossy());
+        if meta.is_dir() && !meta.file_type().is_symlink() {
+            if !ignore.is_ignored(&rel, true)? {
+                collect_dir_upserts(upper, &rel, ignore, upserts)?;
+            }
+        } else if !ignore.is_ignored(&rel, false)? {
+            upserts.push((rel, abs, git_mode(&meta)));
+        }
+    }
+    Ok(())
 }
 
 /// Whether a whiteout marker covers `path` (at the path or any ancestor) — the on-disk mirror
@@ -973,6 +1072,37 @@ mod tests {
 
     fn no_cache() -> std::collections::HashMap<String, ChunkList> {
         std::collections::HashMap::new()
+    }
+
+    #[test]
+    fn resolve_seal_walks_directory_upserts() {
+        // A directory rename records dir-level events (plus per-child events); even with only
+        // the dir event, the seal must publish every file under it — the pre-review bug lost
+        // a renamed directory's entire contents from the snapshot lineage.
+        let state = state_with(
+            &[("moved/a.txt", "alpha"), ("moved/sub/b.txt", "beta")],
+            &[],
+        );
+        let mount = tempfile::tempdir().unwrap();
+        std::fs::write(mount.path().join(".gitignore"), "*.tmp\n").unwrap();
+        std::fs::write(state.path().join("upper/moved/junk.tmp"), "x").unwrap();
+
+        let resolved = resolve_seal(
+            state.path(),
+            mount.path(),
+            &delta(&["moved"], &[]),
+            &std::collections::HashSet::new(),
+            &no_cache(),
+        )
+        .unwrap();
+
+        let mut published: Vec<&str> = resolved
+            .files
+            .iter()
+            .map(|f| f.repo_path.as_str())
+            .collect();
+        published.sort();
+        assert_eq!(published, vec!["moved/a.txt", "moved/sub/b.txt"]);
     }
 
     #[test]

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -144,8 +144,9 @@ impl InodeTable {
 
 /// An open handle in the merged namespace.
 enum OHandle {
-    /// Backed by a real upper file (reads and writes are positional on this descriptor).
-    Upper { file: std::fs::File },
+    /// Backed by a real upper file (reads and writes are positional on this descriptor). The
+    /// path is carried so writes can feed the dirty index — a write only knows its handle.
+    Upper { file: std::fs::File, path: String },
     /// Backed by the read-only core.
     Lower { core_fh: u64 },
     /// A merged directory listing, fixed at opendir time.
@@ -195,6 +196,49 @@ pub struct OverlayFs {
     next_fh: AtomicU64,
     /// When each lower commit was first served by this mount — the stable mtime for its nodes.
     lower_times: Mutex<HashMap<String, std::time::SystemTime>>,
+    /// Global mutation clock: bumped by every recorded namespace/content change. The dirty
+    /// index below is keyed to it, so "anything new since generation G?" is one atomic load.
+    write_gen: AtomicU64,
+    /// Event-driven dirty index: `path -> (generation, kind of last mutation)`. Every mutating
+    /// op records here as it happens, so the auto-commit sealer never walks the upper tree —
+    /// it asks [`OverlayFs::dirty_since`] for the exact delta. Rebuilt from the on-disk overlay
+    /// at startup (and after out-of-band upper refills — restore) and pruned after each seal.
+    dirty: Mutex<HashMap<String, DirtyEntry>>,
+}
+
+/// What the last recorded mutation of a path was. `Upsert` covers create/write/copy-up/rename
+/// destinations; `Delete` covers unlink/rmdir/rename sources. Last event wins — the sealer
+/// re-resolves against the on-disk overlay anyway, the kind is only a routing hint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DirtyKind {
+    Upsert,
+    Delete,
+}
+
+struct DirtyEntry {
+    generation: u64,
+    kind: DirtyKind,
+    /// Lowest byte offset any write touched over this entry's lifetime: bytes below it are
+    /// unchanged since the entry was born (i.e. since the last sealed-and-pruned state), which
+    /// is what lets a sealer reuse a previous push's chunk list for the untouched prefix.
+    /// Structural mutations (create, truncate, rename, mode) pin it to 0 — nothing stable.
+    min_write_offset: u64,
+}
+
+/// Everything that changed after a given generation, plus the clock value the snapshot was
+/// taken at. Sealing through `watermark` and pruning to it leaves exactly the mutations that
+/// raced the seal pending for the next tick. Upserts carry their entry's
+/// [`min write offset`](DirtyEntry::min_write_offset).
+pub struct DirtyDelta {
+    pub upserts: Vec<(String, u64)>,
+    pub deletes: Vec<String>,
+    pub watermark: u64,
+}
+
+impl DirtyDelta {
+    pub fn is_empty(&self) -> bool {
+        self.upserts.is_empty() && self.deletes.is_empty()
+    }
 }
 
 fn not_found() -> MountError {
@@ -235,7 +279,7 @@ impl OverlayFs {
         let wh = state_dir.join("wh");
         std::fs::create_dir_all(&upper).map_err(io_err)?;
         std::fs::create_dir_all(&wh).map_err(io_err)?;
-        Ok(Arc::new(OverlayFs {
+        let fs = Arc::new(OverlayFs {
             core,
             upper,
             wh,
@@ -244,7 +288,154 @@ impl OverlayFs {
             handles: Mutex::new(HashMap::new()),
             next_fh: AtomicU64::new(1),
             lower_times: Mutex::new(HashMap::new()),
-        }))
+            write_gen: AtomicU64::new(0),
+            dirty: Mutex::new(HashMap::new()),
+        });
+        // Baseline: dirt left by a previous daemon (re-mount, crash) predates any events this
+        // process will see; seed the index from disk so the first seal covers it.
+        fs.rebuild_dirty_index()?;
+        Ok(fs)
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Dirty tracking: the event feed behind auto-commit. Every mutating op below records the
+    // path it touched, so sealing never scans — and an idle tick is one atomic load.
+    // -------------------------------------------------------------------------------------
+
+    fn record(&self, path: &str, kind: DirtyKind) {
+        self.record_at(path, kind, 0);
+    }
+
+    /// A content write at `offset`: like [`OverlayFs::record`], but bytes below the offset are
+    /// left claimable as stable.
+    fn record_write(&self, path: &str, offset: u64) {
+        self.record_at(path, DirtyKind::Upsert, offset);
+    }
+
+    fn record_at(&self, path: &str, kind: DirtyKind, offset: u64) {
+        let generation = self.write_gen.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut dirty = self.dirty.lock().expect("dirty lock");
+        match dirty.get_mut(path) {
+            Some(entry) => {
+                entry.generation = generation;
+                // A kind flip (delete then re-create, or vice versa) restarts content
+                // identity: nothing before this event is stable.
+                if entry.kind != kind {
+                    entry.min_write_offset = 0;
+                }
+                entry.kind = kind;
+                entry.min_write_offset = entry.min_write_offset.min(offset);
+            }
+            None => {
+                dirty.insert(
+                    path.to_string(),
+                    DirtyEntry {
+                        generation,
+                        kind,
+                        min_write_offset: offset,
+                    },
+                );
+            }
+        }
+    }
+
+    /// Every path mutated after `since`, split by the kind of its last mutation. The watermark
+    /// is the clock at snapshot time: a caller that seals this delta records the watermark and
+    /// prunes to it — mutations racing the seal carry higher generations and stay pending.
+    pub fn dirty_since(&self, since: u64) -> DirtyDelta {
+        let watermark = self.write_gen.load(Ordering::SeqCst);
+        let dirty = self.dirty.lock().expect("dirty lock");
+        let mut upserts = Vec::new();
+        let mut deletes = Vec::new();
+        for (path, entry) in dirty.iter() {
+            if entry.generation <= since {
+                continue;
+            }
+            match entry.kind {
+                DirtyKind::Upsert => upserts.push((path.clone(), entry.min_write_offset)),
+                DirtyKind::Delete => deletes.push(path.clone()),
+            }
+        }
+        upserts.sort();
+        deletes.sort();
+        DirtyDelta {
+            upserts,
+            deletes,
+            watermark,
+        }
+    }
+
+    /// Drop index entries sealed through `upto` so the map holds only unsealed dirt.
+    pub fn prune_dirty(&self, upto: u64) {
+        self.dirty
+            .lock()
+            .expect("dirty lock")
+            .retain(|_, entry| entry.generation > upto);
+    }
+
+    /// Rebuild the dirty index from the on-disk overlay: every upper file/symlink is an
+    /// upsert, every whiteout marker a delete. For dirt this process did not witness as
+    /// events — startup, and `tl fs restore` refilling the upper out-of-band (the CLI writes
+    /// straight into the state dir and then asks for a reindex).
+    pub fn rebuild_dirty_index(&self) -> Result<(), MountError> {
+        fn walk(root: &Path, dir: &Path, out: &mut dyn FnMut(String)) -> std::io::Result<()> {
+            let Ok(read) = std::fs::read_dir(dir) else {
+                return Ok(());
+            };
+            for entry in read.flatten() {
+                let abs = entry.path();
+                let meta = std::fs::symlink_metadata(&abs)?;
+                if meta.is_dir() && !meta.file_type().is_symlink() {
+                    walk(root, &abs, out)?;
+                } else {
+                    let rel = abs
+                        .strip_prefix(root)
+                        .expect("under root")
+                        .components()
+                        .map(|c| c.as_os_str().to_string_lossy())
+                        .collect::<Vec<_>>()
+                        .join("/");
+                    out(rel);
+                }
+            }
+            Ok(())
+        }
+        self.dirty.lock().expect("dirty lock").clear();
+        walk(&self.upper, &self.upper, &mut |rel| {
+            self.record(&rel, DirtyKind::Upsert)
+        })
+        .map_err(io_err)?;
+        walk(&self.wh, &self.wh, &mut |rel| {
+            self.record(&rel, DirtyKind::Delete)
+        })
+        .map_err(io_err)?;
+        Ok(())
+    }
+
+    /// Kernel invalidations for paths whose merged view changed without a kernel-visible
+    /// operation (the sealer writing a whiteout for a vanished-but-sealed path). Paths the
+    /// kernel never interned need nothing.
+    pub(super) fn invals_for(&self, paths: &[String]) -> Vec<OverlayInval> {
+        let inodes = self.inodes.lock().expect("inode lock");
+        paths
+            .iter()
+            .filter_map(|path| {
+                let &ino = inodes.index.get(path)?;
+                let (parent_ino, name) = match path.rfind('/') {
+                    Some(i) => (
+                        inodes.index.get(&path[..i]).copied(),
+                        path[i + 1..].to_string(),
+                    ),
+                    None => (Some(ROOT_INO), path.clone()),
+                };
+                Some(OverlayInval {
+                    ino,
+                    parent_ino,
+                    name,
+                    staled: true,
+                })
+            })
+            .collect()
     }
 
     /// Every mutating entry point funnels through this guard: a shared-ro mount is a window
@@ -663,7 +854,13 @@ impl OverlayFs {
                 .write(write)
                 .open(self.upper_path(&node.path))
                 .map_err(io_err)?;
-            (OHandle::Upper { file }, None)
+            (
+                OHandle::Upper {
+                    file,
+                    path: node.path.clone(),
+                },
+                None,
+            )
         } else {
             let core_ino = self.lower_binding(&node).await?;
             let ident = self
@@ -694,7 +891,7 @@ impl OverlayFs {
         let core_fh = {
             let handles = self.handles.lock().expect("handle lock");
             match handles.get(&fh) {
-                Some(OHandle::Upper { file }) => {
+                Some(OHandle::Upper { file, .. }) => {
                     use std::os::unix::fs::FileExt;
                     let mut buf = vec![0u8; size as usize];
                     let n = file.read_at(&mut buf, offset).map_err(io_err)?;
@@ -711,24 +908,30 @@ impl OverlayFs {
     pub fn write(&self, fh: u64, offset: u64, data: &[u8]) -> Result<u32, MountError> {
         self.write_guard()?;
         use std::os::unix::fs::FileExt;
-        let handles = self.handles.lock().expect("handle lock");
-        match handles.get(&fh) {
-            Some(OHandle::Upper { file }) => {
-                file.write_all_at(data, offset).map_err(io_err)?;
-                Ok(data.len() as u32)
+        let path = {
+            let handles = self.handles.lock().expect("handle lock");
+            match handles.get(&fh) {
+                Some(OHandle::Upper { file, path }) => {
+                    file.write_all_at(data, offset).map_err(io_err)?;
+                    path.clone()
+                }
+                // open(write=true) always yields an upper handle; a write on a lower handle
+                // means the kernel opened read-only, which it won't for writes.
+                Some(OHandle::Lower { .. }) => {
+                    return Err(MountError::Protocol(
+                        "write on read-only handle".to_string(),
+                    ));
+                }
+                _ => return Err(not_found()),
             }
-            // open(write=true) always yields an upper handle; a write on a lower handle means
-            // the kernel opened read-only, which it won't for writes.
-            Some(OHandle::Lower { .. }) => Err(MountError::Protocol(
-                "write on read-only handle".to_string(),
-            )),
-            _ => Err(not_found()),
-        }
+        };
+        self.record_write(&path, offset);
+        Ok(data.len() as u32)
     }
 
     pub fn fsync(&self, fh: u64) -> Result<(), MountError> {
         let handles = self.handles.lock().expect("handle lock");
-        if let Some(OHandle::Upper { file }) = handles.get(&fh) {
+        if let Some(OHandle::Upper { file, .. }) = handles.get(&fh) {
             file.sync_all().map_err(io_err)?;
         }
         Ok(())
@@ -893,14 +1096,19 @@ impl OverlayFs {
                 .map_err(io_err)?;
         }
         self.clear_whiteout(&path);
+        self.record(&path, DirtyKind::Upsert);
         let meta = dest.symlink_metadata().map_err(io_err)?;
-        let (ino, _, _) = self.inodes.lock().expect("inode lock").intern(path, None);
+        let (ino, _, _) = self
+            .inodes
+            .lock()
+            .expect("inode lock")
+            .intern(path.clone(), None);
         let attr = self.attr_from_meta(ino, &meta);
         let fh = self.next_fh.fetch_add(1, Ordering::Relaxed);
         self.handles
             .lock()
             .expect("handle lock")
-            .insert(fh, OHandle::Upper { file });
+            .insert(fh, OHandle::Upper { file, path });
         Ok((attr, fh))
     }
 
@@ -917,6 +1125,7 @@ impl OverlayFs {
         let dest = self.upper_path(&path);
         std::fs::create_dir_all(&dest).map_err(io_err)?;
         self.clear_whiteout(&path);
+        self.record(&path, DirtyKind::Upsert);
         let meta = dest.symlink_metadata().map_err(io_err)?;
         let (ino, _, _) = self.inodes.lock().expect("inode lock").intern(path, None);
         Ok(self.attr_from_meta(ino, &meta))
@@ -944,6 +1153,7 @@ impl OverlayFs {
         let _ = std::fs::remove_file(&dest);
         std::os::unix::fs::symlink(target, &dest).map_err(io_err)?;
         self.clear_whiteout(&path);
+        self.record(&path, DirtyKind::Upsert);
         let meta = dest.symlink_metadata().map_err(io_err)?;
         let (ino, _, _) = self.inodes.lock().expect("inode lock").intern(path, None);
         Ok(self.attr_from_meta(ino, &meta))
@@ -963,6 +1173,7 @@ impl OverlayFs {
         } else if !had_upper {
             return Err(not_found());
         }
+        self.record(&path, DirtyKind::Delete);
         Ok(())
     }
 
@@ -987,6 +1198,7 @@ impl OverlayFs {
         if self.lower_has(parent_node.core_ino(), name).await {
             self.set_whiteout(&path)?;
         }
+        self.record(&path, DirtyKind::Delete);
         Ok(())
     }
 
@@ -1039,6 +1251,8 @@ impl OverlayFs {
             self.set_whiteout(&src)?;
         }
         self.clear_whiteout(&dst);
+        self.record(&src, DirtyKind::Delete);
+        self.record(&dst, DirtyKind::Upsert);
         // The destination path may already be interned (overwrite): its ino now serves upper
         // content automatically since attribute resolution is dynamic.
         Ok(())
@@ -1070,6 +1284,7 @@ impl OverlayFs {
                 std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(perm))
                     .map_err(io_err)?;
             }
+            self.record(&node.path, DirtyKind::Upsert);
         }
         self.getattr(ino).await
     }
@@ -1159,6 +1374,8 @@ impl OverlayFs {
                 }
             }
         }
+        // The dirty index described the dropped state; sealers fast-forward to the watermark.
+        self.dirty.lock().expect("dirty lock").clear();
         Ok(affected)
     }
 }

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -204,6 +204,8 @@ pub struct OverlayFs {
     /// it asks [`OverlayFs::dirty_since`] for the exact delta. Rebuilt from the on-disk overlay
     /// at startup (and after out-of-band upper refills — restore) and pruned after each seal.
     dirty: Mutex<HashMap<String, DirtyEntry>>,
+    /// Out-of-band mutation epoch: see [`OverlayFs::epoch`].
+    epoch: AtomicU64,
 }
 
 /// What the last recorded mutation of a path was. `Upsert` covers create/write/copy-up/rename
@@ -290,6 +292,7 @@ impl OverlayFs {
             lower_times: Mutex::new(HashMap::new()),
             write_gen: AtomicU64::new(0),
             dirty: Mutex::new(HashMap::new()),
+            epoch: AtomicU64::new(0),
         });
         // Baseline: dirt left by a previous daemon (re-mount, crash) predates any events this
         // process will see; seed the index from disk so the first seal covers it.
@@ -313,8 +316,13 @@ impl OverlayFs {
     }
 
     fn record_at(&self, path: &str, kind: DirtyKind, offset: u64) {
-        let generation = self.write_gen.fetch_add(1, Ordering::SeqCst) + 1;
         let mut dirty = self.dirty.lock().expect("dirty lock");
+        // The clock bump happens UNDER the map lock: a sealer that loaded watermark W is then
+        // guaranteed to either see this entry (we inserted before it acquired the lock) or to
+        // have loaded W < generation (we bumped after its load) — a generation can never be
+        // both covered by a watermark and invisible to that watermark's delta, which is what
+        // made a racing write silently unsealable forever.
+        let generation = self.write_gen.fetch_add(1, Ordering::SeqCst) + 1;
         match dirty.get_mut(path) {
             Some(entry) => {
                 entry.generation = generation;
@@ -344,6 +352,15 @@ impl OverlayFs {
     /// prunes to it — mutations racing the seal carry higher generations and stay pending.
     pub fn dirty_since(&self, since: u64) -> DirtyDelta {
         let watermark = self.write_gen.load(Ordering::SeqCst);
+        // The idle fast path: nothing was recorded since the caller's last seal, so don't
+        // lock or scan (with failing pushes the map can hold a large unsealed backlog).
+        if watermark == since {
+            return DirtyDelta {
+                upserts: Vec::new(),
+                deletes: Vec::new(),
+                watermark,
+            };
+        }
         let dirty = self.dirty.lock().expect("dirty lock");
         let mut upserts = Vec::new();
         let mut deletes = Vec::new();
@@ -373,11 +390,31 @@ impl OverlayFs {
             .retain(|_, entry| entry.generation > upto);
     }
 
+    /// The path's current lowest written offset, if it is dirty. A sealer that built a stable
+    /// prefix from an earlier snapshot of this value re-checks it here just before pushing: a
+    /// racing write below the prefix invalidates the claim.
+    pub fn min_write_offset(&self, path: &str) -> Option<u64> {
+        self.dirty
+            .lock()
+            .expect("dirty lock")
+            .get(path)
+            .map(|entry| entry.min_write_offset)
+    }
+
+    /// The out-of-band mutation epoch: bumped whenever something other than kernel ops rewrote
+    /// the overlay's state wholesale (`clear_upper`, `rebuild_dirty_index`). Sealer-side caches
+    /// (chunk lists, recently-sealed guards, in-flight resolutions) describe the previous
+    /// epoch's world and must be discarded when this moves.
+    pub fn epoch(&self) -> u64 {
+        self.epoch.load(Ordering::SeqCst)
+    }
+
     /// Rebuild the dirty index from the on-disk overlay: every upper file/symlink is an
     /// upsert, every whiteout marker a delete. For dirt this process did not witness as
     /// events — startup, and `tl fs restore` refilling the upper out-of-band (the CLI writes
     /// straight into the state dir and then asks for a reindex).
     pub fn rebuild_dirty_index(&self) -> Result<(), MountError> {
+        self.epoch.fetch_add(1, Ordering::SeqCst);
         fn walk(root: &Path, dir: &Path, out: &mut dyn FnMut(String)) -> std::io::Result<()> {
             let Ok(read) = std::fs::read_dir(dir) else {
                 return Ok(());
@@ -1253,6 +1290,45 @@ impl OverlayFs {
         self.clear_whiteout(&dst);
         self.record(&src, DirtyKind::Delete);
         self.record(&dst, DirtyKind::Upsert);
+        // A directory rename moved a whole subtree with the two events above naming only the
+        // directory — but seals publish FILES: without per-child events the relocated files
+        // never seal and previously-sealed old paths never tombstone. Walk the moved tree
+        // (it's local upper state) and record both sides for every leaf.
+        if dst_upper
+            .symlink_metadata()
+            .map(|m| m.is_dir() && !m.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            fn leaves(root: &Path, dir: &Path, out: &mut Vec<String>) {
+                let Ok(read) = std::fs::read_dir(dir) else {
+                    return;
+                };
+                for entry in read.flatten() {
+                    let abs = entry.path();
+                    let Ok(meta) = std::fs::symlink_metadata(&abs) else {
+                        continue;
+                    };
+                    if meta.is_dir() && !meta.file_type().is_symlink() {
+                        leaves(root, &abs, out);
+                    } else {
+                        out.push(
+                            abs.strip_prefix(root)
+                                .expect("under root")
+                                .components()
+                                .map(|c| c.as_os_str().to_string_lossy())
+                                .collect::<Vec<_>>()
+                                .join("/"),
+                        );
+                    }
+                }
+            }
+            let mut moved = Vec::new();
+            leaves(&dst_upper, &dst_upper, &mut moved);
+            for rel in moved {
+                self.record(&format!("{src}/{rel}"), DirtyKind::Delete);
+                self.record(&format!("{dst}/{rel}"), DirtyKind::Upsert);
+            }
+        }
         // The destination path may already be interned (overwrite): its ino now serves upper
         // content automatically since attribute resolution is dynamic.
         Ok(())
@@ -1375,7 +1451,10 @@ impl OverlayFs {
             }
         }
         // The dirty index described the dropped state; sealers fast-forward to the watermark.
+        // The epoch bump tells them their other caches (chunk lists, sealed guards, in-flight
+        // resolutions) describe a dead world too.
         self.dirty.lock().expect("dirty lock").clear();
+        self.epoch.fetch_add(1, Ordering::SeqCst);
         Ok(affected)
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -247,6 +247,12 @@ enum FsCommands {
         #[arg(long)]
         shared_rw: bool,
 
+        /// Automatically seal local changes into a snapshot commit every N seconds (async,
+        /// in the mount daemon). Local overlay state is kept; `tl fs snapshot` remains the
+        /// on-demand seal. Requires a writable mount
+        #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+        auto_commit_interval_secs: Option<u64>,
+
         /// Run the mount daemon in the foreground (debugging)
         #[arg(long)]
         foreground: bool,
@@ -2244,6 +2250,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             path,
             mode,
             shared_rw,
+            auto_commit_interval_secs,
             foreground,
         } => {
             let mode = match mode {
@@ -2251,7 +2258,16 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
                 Some(MountWriteMode::Rw) => commands::fs::WritePolicy::Rw,
                 None => commands::fs::WritePolicy::Auto,
             };
-            commands::fs::mount(ctx, &target, &path, mode, shared_rw, foreground).await
+            commands::fs::mount(
+                ctx,
+                &target,
+                &path,
+                mode,
+                shared_rw,
+                auto_commit_interval_secs,
+                foreground,
+            )
+            .await
         }
         FsCommands::Daemon { state_dir } => commands::fs::daemon::run(ctx, &state_dir).await,
         FsCommands::Snapshot { path, message } => {
@@ -2733,12 +2749,14 @@ mod tests {
                 path,
                 mode,
                 shared_rw,
+                auto_commit_interval_secs,
                 foreground,
             }) => {
                 assert_eq!(target, "data:main");
                 assert_eq!(path, PathBuf::from("./w"));
                 assert_eq!(mode, Some(MountWriteMode::Ro));
                 assert!(!shared_rw);
+                assert_eq!(auto_commit_interval_secs, None);
                 assert!(!foreground);
             }
             _ => panic!("expected fs mount command"),
@@ -2752,6 +2770,38 @@ mod tests {
             }
             _ => panic!("expected fs mount command"),
         }
+
+        match parse_command([
+            "tl",
+            "fs",
+            "mount",
+            "data",
+            "./w",
+            "--auto-commit-interval-secs",
+            "30",
+        ]) {
+            Commands::Fs(FsCommands::Mount {
+                auto_commit_interval_secs,
+                ..
+            }) => {
+                assert_eq!(auto_commit_interval_secs, Some(30));
+            }
+            _ => panic!("expected fs mount command"),
+        }
+
+        // Zero is rejected at parse time: an interval of 0 is not a debounce, it's a busy loop.
+        assert!(
+            Cli::try_parse_from([
+                "tl",
+                "fs",
+                "mount",
+                "data",
+                "./w",
+                "--auto-commit-interval-secs",
+                "0",
+            ])
+            .is_err()
+        );
 
         match parse_command(["tl", "fs", "ls"]) {
             Commands::Fs(FsCommands::Ls {

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -48,6 +48,9 @@ pub struct PushFile {
     pub delete: bool,
 }
 
+// Variants get added (StablePrefix arrived after KnownOid, and more will follow); external
+// matches must carry a wildcard arm so additions stay semver-compatible on this published crate.
+#[non_exhaustive]
 #[derive(Clone, Debug)]
 pub enum PushSource {
     /// Read (twice: hash pass + upload pass) from the local filesystem.
@@ -159,6 +162,9 @@ impl Default for PushOptions {
 }
 
 /// Outcome of a push.
+// Fields get added (file_chunks most recently); non_exhaustive keeps external full-literal
+// construction/destructuring from breaking on this published crate's lockstep releases.
+#[non_exhaustive]
 #[derive(Clone, Debug, Serialize)]
 pub struct PushReport {
     pub commit: String,

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -63,6 +63,25 @@ pub enum PushSource {
     /// Requires a server advertising the `oid_files` ingest capability; `push_files` fails
     /// fast otherwise (an older server would ignore the field and publish an empty file).
     KnownOid(String),
+    /// The append fast path: a file whose leading bytes are byte-identical to a previous push
+    /// of the same content, described by that push's CDC chunk list. Only bytes past the
+    /// prefix are read and chunked, so a growing log seals in O(appended bytes) instead of
+    /// O(file size). The caller owns the stability claim (e.g. a mount overlay's write
+    /// extents prove no write touched the prefix) and must end the prefix on a boundary a
+    /// previous CDC pass produced (`PushReport::file_chunks`) — FastCDC restarts its state at
+    /// every boundary, so chunking resumed there matches a full re-chunk exactly.
+    ///
+    /// These files always take the dedup upload path (never tokened), and their
+    /// `PushReport::file_blob_oids` entry is empty: the blob oid is a whole-content hash this
+    /// path deliberately never computes — the server derives identity from commit-time
+    /// read-back of the chunk list. Falls back to a full read (as `Path`) when the file
+    /// shrank below the prefix, the prefix is empty, or the file is under the server's
+    /// small-file threshold.
+    StablePrefix {
+        path: PathBuf,
+        /// `(sha256, size)` covering exactly the file's leading bytes, in file order.
+        stable_chunks: Vec<([u8; 32], u32)>,
+    },
 }
 
 /// Progress events, emitted in order. Rendering (progress bars, logs) is the caller's concern.
@@ -118,6 +137,10 @@ pub struct PushOptions {
     /// When set, the commit publishes as a snapshot on this workspace's ref
     /// (`workspaces/{id}/snapshots`) instead of advancing `branch`; `branch`/`base` are ignored.
     pub workspace_snapshot: Option<String>,
+    /// Return every CDC-path file's chunk list in `PushReport::file_chunks`, so the caller can
+    /// hand them back as `PushSource::StablePrefix` prefixes on the next push of the same
+    /// content. Off by default: the lists cost memory proportional to the push.
+    pub collect_file_chunks: bool,
 }
 
 impl Default for PushOptions {
@@ -130,6 +153,7 @@ impl Default for PushOptions {
             upload_batch_bytes: 48 * 1024 * 1024,
             progress: None,
             workspace_snapshot: None,
+            collect_file_chunks: false,
         }
     }
 }
@@ -148,8 +172,14 @@ pub struct PushReport {
     pub chunks_uploaded: usize,
     pub bytes_uploaded: u64,
     /// Client-computed git blob oid per file (`(repo_path, hex oid)`), from the chunk pass.
-    /// Deletes carry an empty oid.
+    /// Deletes carry an empty oid — as do `StablePrefix` fast-path files, which never hash
+    /// their full content.
     pub file_blob_oids: Vec<(String, String)>,
+    /// CDC chunk lists per content file (`(repo_path, [(sha256, size)])`), populated only
+    /// when `PushOptions::collect_file_chunks` is set. The raw material for the next push's
+    /// `PushSource::StablePrefix`. Never serialized: caller-local plumbing, not wire data.
+    #[serde(skip_serializing)]
+    pub file_chunks: Vec<(String, Vec<([u8; 32], u32)>)>,
 }
 
 #[derive(Deserialize)]
@@ -330,6 +360,9 @@ struct ChunkedFile {
     /// The file is a `PushSource::KnownOid` reference: commit by oid, move no bytes.
     known_oid: bool,
     blob_oid: String,
+    /// The chunk list came from the CDC chunker (not the whole-file small path), so it is
+    /// boundary-stable and reusable as a future `StablePrefix`.
+    cdc: bool,
 }
 
 /// One streaming pass over the source produces both the CDC chunk list and the git blob oid
@@ -344,16 +377,18 @@ fn chunk_source(
     let len: u64 = match source {
         PushSource::Path(p) => std::fs::metadata(p).map_err(io_err)?.len(),
         PushSource::Bytes(b) => b.len() as u64,
-        PushSource::KnownOid(_) => {
+        PushSource::KnownOid(_) | PushSource::StablePrefix { .. } => {
             return Err(SdkError::ClientError(
-                "known-oid sources carry no bytes to chunk".to_string(),
+                "source kind carries no full byte stream to chunk".to_string(),
             ));
         }
     };
     let reader: Box<dyn Read + Send> = match source {
         PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
         PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
-        PushSource::KnownOid(_) => unreachable!("guarded above"),
+        PushSource::KnownOid(_) | PushSource::StablePrefix { .. } => {
+            unreachable!("guarded above")
+        }
     };
     let mut blob_hasher = BlobOidHasher::new(len);
     let mut out = Vec::new();
@@ -364,6 +399,32 @@ fn chunk_source(
         out.push((hash, chunk.data.len() as u32));
     }
     Ok((out, blob_hasher.finalize_hex()))
+}
+
+/// The append fast path behind [`PushSource::StablePrefix`]: keep the caller's prefix chunk
+/// list verbatim and read only bytes past it. FastCDC restarts its rolling state at every
+/// emitted boundary, so resuming at a previous pass's boundary yields exactly the chunks a
+/// full re-chunk would from that offset. No blob oid comes out of this — the prefix is never
+/// read (see the variant's docs).
+fn chunk_stable_prefix(
+    path: &Path,
+    stable_chunks: &[([u8; 32], u32)],
+    min: usize,
+    avg: usize,
+    max: usize,
+) -> Result<Vec<([u8; 32], u32)>, SdkError> {
+    use std::io::Seek as _;
+    let stable_len: u64 = stable_chunks.iter().map(|(_, s)| *s as u64).sum();
+    let mut file = std::fs::File::open(path).map_err(io_err)?;
+    file.seek(std::io::SeekFrom::Start(stable_len))
+        .map_err(io_err)?;
+    let mut out = stable_chunks.to_vec();
+    for chunk in fastcdc::v2020::StreamCDC::new(file, min as u32, avg as u32, max as u32) {
+        let chunk = chunk.map_err(|e| SdkError::ClientError(format!("chunking failed: {e}")))?;
+        let hash: [u8; 32] = Sha256::digest(&chunk.data).into();
+        out.push((hash, chunk.data.len() as u32));
+    }
+    Ok(out)
 }
 
 fn io_err(e: std::io::Error) -> SdkError {
@@ -443,9 +504,9 @@ fn chunk_source_whole(source: &PushSource) -> Result<(Vec<([u8; 32], u32)>, Stri
     let data: Vec<u8> = match source {
         PushSource::Path(p) => std::fs::read(p).map_err(io_err)?,
         PushSource::Bytes(b) => b.clone(),
-        PushSource::KnownOid(_) => {
+        PushSource::KnownOid(_) | PushSource::StablePrefix { .. } => {
             return Err(SdkError::ClientError(
-                "known-oid sources carry no bytes to hash".to_string(),
+                "source kind carries no full byte stream to hash".to_string(),
             ));
         }
     };
@@ -462,6 +523,45 @@ fn chunk_source_whole(source: &PushSource) -> Result<(Vec<([u8; 32], u32)>, Stri
     Ok((chunks, blob.finalize_hex()))
 }
 
+/// A chunk-bearing source re-opened for the upload pass. Chunks are visited in file order;
+/// [`UploadReader::skip`] seeks past chunks the upload does not need, so a mostly-deduped file
+/// (an appended log especially) never re-reads the bytes the server already has.
+enum UploadReader {
+    File(std::fs::File),
+    Bytes(std::io::Cursor<Vec<u8>>),
+}
+
+impl UploadReader {
+    fn open(source: &PushSource) -> Result<UploadReader, SdkError> {
+        match source {
+            PushSource::Path(p) => Ok(UploadReader::File(std::fs::File::open(p).map_err(io_err)?)),
+            PushSource::StablePrefix { path, .. } => Ok(UploadReader::File(
+                std::fs::File::open(path).map_err(io_err)?,
+            )),
+            PushSource::Bytes(b) => Ok(UploadReader::Bytes(std::io::Cursor::new(b.clone()))),
+            PushSource::KnownOid(_) => Err(SdkError::ClientError(
+                "known-oid sources carry no bytes to upload".to_string(),
+            )),
+        }
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), SdkError> {
+        match self {
+            UploadReader::File(f) => f.read_exact(buf).map_err(io_err),
+            UploadReader::Bytes(c) => c.read_exact(buf).map_err(io_err),
+        }
+    }
+
+    fn skip(&mut self, n: u64) -> Result<(), SdkError> {
+        use std::io::Seek as _;
+        match self {
+            UploadReader::File(f) => f.seek(std::io::SeekFrom::Current(n as i64)).map(|_| ()),
+            UploadReader::Bytes(c) => c.seek(std::io::SeekFrom::Current(n as i64)).map(|_| ()),
+        }
+        .map_err(io_err)
+    }
+}
+
 /// Which files take the tokened (verified-at-upload) path: content-bearing files whose bytes the
 /// server mostly lacks. Mostly-present files stay on the dedup path (upload only missing chunks,
 /// accept commit-time read-back proportional to reused bytes); deletes and known-oid references
@@ -475,6 +575,11 @@ fn elect_tokened(
         .iter()
         .map(|file| {
             if file.delete || file.known_oid || file.chunks.is_empty() {
+                return false;
+            }
+            // Stable-prefix files never computed a blob oid (tokening's identity check needs
+            // one) and exist to avoid re-reading their prefix (tokening streams every byte).
+            if matches!(file.source, PushSource::StablePrefix { .. }) {
                 return false;
             }
             let total: u64 = file.chunks.iter().map(|(_, s)| *s as u64).sum();
@@ -693,6 +798,7 @@ impl ArtifactStorageClient {
                         delete: true,
                         known_oid: false,
                         blob_oid: String::new(),
+                        cdc: false,
                     });
                 }
                 if let PushSource::KnownOid(oid) = &f.source {
@@ -711,19 +817,50 @@ impl ArtifactStorageClient {
                         mode: f.mode,
                         delete: false,
                         known_oid: true,
+                        cdc: false,
                     });
                 }
+                let mut f = f;
                 let source_len: u64 = match &f.source {
                     PushSource::Path(p) => std::fs::metadata(p).map_err(io_err)?.len(),
                     PushSource::Bytes(b) => b.len() as u64,
+                    PushSource::StablePrefix { path, .. } => {
+                        std::fs::metadata(path).map_err(io_err)?.len()
+                    }
                     PushSource::KnownOid(_) => unreachable!("handled above"),
                 };
                 let whole = small_max > 0 && source_len < small_max;
+                // A stable prefix is only usable on the CDC path and only while the file still
+                // covers it; otherwise demote to a plain path so every downstream stage (small
+                // staging, tokened election, oid computation) treats the file normally.
+                if let PushSource::StablePrefix {
+                    path,
+                    stable_chunks,
+                } = &f.source
+                {
+                    let stable_len: u64 = stable_chunks.iter().map(|(_, s)| *s as u64).sum();
+                    if whole || stable_chunks.is_empty() || stable_len > source_len {
+                        f.source = PushSource::Path(path.clone());
+                    }
+                }
                 tokio::task::spawn_blocking(move || {
-                    let (chunks, blob_oid) = if whole {
-                        chunk_source_whole(&f.source)?
-                    } else {
-                        chunk_source(&f.source, min, avg, max)?
+                    let (chunks, blob_oid, cdc) = match &f.source {
+                        PushSource::StablePrefix {
+                            path,
+                            stable_chunks,
+                        } => (
+                            chunk_stable_prefix(path, stable_chunks, min, avg, max)?,
+                            String::new(),
+                            true,
+                        ),
+                        source if whole => {
+                            let (chunks, oid) = chunk_source_whole(source)?;
+                            (chunks, oid, false)
+                        }
+                        source => {
+                            let (chunks, oid) = chunk_source(source, min, avg, max)?;
+                            (chunks, oid, true)
+                        }
                     };
                     Ok(ChunkedFile {
                         repo_path: f.repo_path,
@@ -733,6 +870,7 @@ impl ArtifactStorageClient {
                         delete: false,
                         known_oid: false,
                         blob_oid,
+                        cdc,
                     })
                 })
                 .await
@@ -912,8 +1050,8 @@ impl ArtifactStorageClient {
                                 Box::new(std::fs::File::open(p).map_err(io_err)?)
                             }
                             PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
-                            PushSource::KnownOid(_) => {
-                                unreachable!("known-oid files are not tokened")
+                            PushSource::KnownOid(_) | PushSource::StablePrefix { .. } => {
+                                unreachable!("never tokened")
                             }
                         };
                         for (hash, size) in &file.chunks {
@@ -981,7 +1119,9 @@ impl ArtifactStorageClient {
                     let mut reader: Box<dyn Read + Send> = match &file.source {
                         PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
                         PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
-                        PushSource::KnownOid(_) => unreachable!("known-oid files are not tokened"),
+                        PushSource::KnownOid(_) | PushSource::StablePrefix { .. } => {
+                            unreachable!("never tokened")
+                        }
                     };
                     // The whole file goes in ONE request when it fits a batch (required for
                     // small files on staging servers — they cannot resume — and one round trip
@@ -1088,17 +1228,14 @@ impl ArtifactStorageClient {
                 if file.chunks.is_empty() {
                     continue; // deletes and known-oid references carry no bytes
                 }
-                let mut reader: Box<dyn Read + Send> = match &file.source {
-                    PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
-                    PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
-                    PushSource::KnownOid(_) => unreachable!("no chunks to upload"),
-                };
+                let mut reader = UploadReader::open(&file.source)?;
                 for (hash, size) in &file.chunks {
-                    let mut data = vec![0u8; *size as usize];
-                    reader.read_exact(&mut data).map_err(io_err)?;
                     if !to_upload.remove(hash) {
+                        reader.skip(*size as u64)?;
                         continue;
                     }
+                    let mut data = vec![0u8; *size as usize];
+                    reader.read_exact(&mut data)?;
                     let zframe = zstd::encode_all(&data[..], STAGED_ZSTD_LEVEL)
                         .map_err(|e| SdkError::ClientError(format!("zstd encode: {e}")))?;
                     entries.push(StagedEntryWire {
@@ -1187,17 +1324,14 @@ impl ArtifactStorageClient {
                 if file.chunks.is_empty() {
                     continue; // deletes and known-oid references carry no bytes
                 }
-                let mut reader: Box<dyn Read + Send> = match &file.source {
-                    PushSource::Path(p) => Box::new(std::fs::File::open(p).map_err(io_err)?),
-                    PushSource::Bytes(b) => Box::new(std::io::Cursor::new(b.clone())),
-                    PushSource::KnownOid(_) => unreachable!("no chunks to upload"),
-                };
+                let mut reader = UploadReader::open(&file.source)?;
                 for (hash, size) in &file.chunks {
-                    let mut data = vec![0u8; *size as usize];
-                    reader.read_exact(&mut data).map_err(io_err)?;
                     if !to_upload.remove(hash) {
+                        reader.skip(*size as u64)?;
                         continue;
                     }
+                    let mut data = vec![0u8; *size as usize];
+                    reader.read_exact(&mut data)?;
                     frame.extend_from_slice(hash);
                     frame.extend_from_slice(&(data.len() as u32).to_be_bytes());
                     frame.extend_from_slice(&data);
@@ -1415,6 +1549,15 @@ impl ArtifactStorageClient {
                 chunks_total: distinct.len(),
                 chunks_uploaded: uploaded_chunks,
                 bytes_uploaded: uploaded_bytes,
+                file_chunks: if opts.collect_file_chunks {
+                    chunked
+                        .iter()
+                        .filter(|f| !f.delete && !f.known_oid && f.cdc)
+                        .map(|f| (f.repo_path.clone(), f.chunks.clone()))
+                        .collect()
+                } else {
+                    Vec::new()
+                },
                 file_blob_oids: chunked
                     .into_iter()
                     .map(|f| (f.repo_path, f.blob_oid))
@@ -1691,6 +1834,7 @@ mod tests {
     use super::*;
 
     fn cf(chunks: Vec<([u8; 32], u32)>, delete: bool, known_oid: bool) -> ChunkedFile {
+        let cdc = !delete && !known_oid && !chunks.is_empty();
         ChunkedFile {
             repo_path: "p".to_string(),
             source: PushSource::Bytes(Vec::new()),
@@ -1699,6 +1843,7 @@ mod tests {
             delete,
             known_oid,
             blob_oid: String::new(),
+            cdc,
         }
     }
 
@@ -2143,5 +2288,39 @@ mod tests {
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].1 as usize, data.len());
         assert_eq!(chunks[0].0, <[u8; 32]>::from(Sha256::digest(&data)));
+    }
+
+    /// The append fast path's whole premise: FastCDC restarts its state at every emitted
+    /// boundary, so chunking resumed at a previous pass's boundary yields exactly what a full
+    /// re-chunk of the grown file yields from that offset — the reused prefix plus the resumed
+    /// tail must equal the full pass chunk-for-chunk.
+    #[test]
+    fn stable_prefix_chunking_matches_a_full_rechunk() {
+        let (min, avg, max) = (256 * 1024, 1024 * 1024, 4 * 1024 * 1024);
+        let old: Vec<u8> = (0..5_000_000usize).map(|i| (i % 251) as u8).collect();
+        let appended: Vec<u8> = (0..2_000_000usize).map(|i| (i % 13) as u8).collect();
+        let mut grown = old.clone();
+        grown.extend_from_slice(&appended);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("grown.bin");
+        std::fs::write(&path, &grown).unwrap();
+
+        let (old_chunks, _) = chunk_source(&PushSource::Bytes(old), min, avg, max).unwrap();
+        // The sealer's contract: the final chunk of the previous pass was cut at the old EOF
+        // (not a content boundary) and is dropped before reuse.
+        let stable = &old_chunks[..old_chunks.len() - 1];
+        let resumed = chunk_stable_prefix(&path, stable, min, avg, max).unwrap();
+
+        let (full, _) = chunk_source(&PushSource::Path(path.clone()), min, avg, max).unwrap();
+        assert_eq!(
+            resumed, full,
+            "prefix + resumed tail must equal a full re-chunk exactly"
+        );
+        assert_eq!(
+            resumed.iter().map(|(_, s)| *s as u64).sum::<u64>(),
+            grown.len() as u64,
+            "chunks must cover the grown file exactly"
+        );
     }
 }


### PR DESCRIPTION
## What

`tl fs mount <target> <path> --auto-commit-interval-secs <N>` makes the mount daemon seal local changes into workspace snapshot commits every N seconds, asynchronously. `tl fs snapshot` stays the on-demand seal-and-clear. Read-only mounts reject the flag; `tl fs status` and the mount output surface it.

## How it stays cheap

**Event-driven dirty index (no scanning).** Every `OverlayFs` mutation records `path → (generation, kind, min written offset)` inline — the daemon *is* the write path, so dirtiness is never re-discovered by walking. An idle tick is one atomic load. The index rebuilds from disk at daemon start and after `tl fs restore` (new `reindex` control op).

**Incremental seals.** The workspace ref advances with each snapshot, so each commit carries only paths touched since the last sealed generation. Unchanged dirty files are served by the lower and never re-hashed or re-sent. The overlay is deliberately not cleared: clear-after-push is only safe with writes quiesced (racing writes would drop; open write handles would orphan) — the upper keeps shadowing byte-identical sealed content.

**Append fast path — O(appended bytes).** New `PushSource::StablePrefix` in the SDK reuses the previous seal's CDC chunk list for the untouched prefix; FastCDC restarts its rolling state at every boundary, so resumed chunking equals a full re-chunk exactly (unit-tested). Dedup-path files never send a client blob oid (identity comes from server read-back), so the prefix is never re-read at all. The upload pass now also seeks past chunks the server already has instead of re-reading them — a win for every mostly-deduped push. The daemon feeds this from a per-path chunk cache returned via `PushOptions::collect_file_chunks`.

## Also fixed along the way

- A resurrection race: a path deleted right after being sealed (before the lower advanced) wrote no whiteout and silently reappeared. The daemon now polls the ref immediately after each push and tombstones vanished-but-recently-sealed paths.
- The daemon's heartbeat held a static git credential that went stale ~1h into a mount's life; heartbeats and auto-commits now share the rotation task's refreshed `(user, token)` slot.

## Measured (local gsvc-server, macOS FSKit, debug build)

| Scenario | Before | After |
|---|---|---|
| Idle tick | tree walk + stat per dirty file | one atomic load |
| 1-byte change, 500 MB dirty | 22.3 s | ~tick-instant |
| Append 1 MB to 500 MB file | full re-hash (~27 s) | seals within a 2 s tick |
| In-mount read+write+ls during a push | — | 22–40 ms (idle baseline 33 ms) |

Correctness verified live: 5 append seals with adversarial sizes (517 B … 3 MB) reconstruct byte-identical content on a fresh mount (`cmp` over 68 MB); deletes propagate; `tl fs snapshot`/`promote`/`restore` interplay intact. 202 tests pass with `--features mount`, 535 across both crates default; new unit tests cover `resolve_seal` routing, the tombstone arm, stable-prefix selection, and CDC resume equivalence.

Companion PR in artifact_storage fixes a pre-existing mount bug this work surfaced (cold sequential reads of large files EIO when the server's rate limiter trips — the vendored `FsClient` had no retry handling); link to follow.

Note for release: version bump ships separately per convention (`python .github/scripts/bump_version.py`) — the `tensorlake` crate gains public SDK surface (`PushSource::StablePrefix`, `PushOptions::collect_file_chunks`, `PushReport::file_chunks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)