### PR TITLE
tl fs: fix renamed-inode resolution, honest errnos, daemon logging; rename committed directories instantly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,6 +1891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2208,6 +2214,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2603,7 +2618,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3318,6 +3333,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3614,6 +3638,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-subscriber",
  "url",
  "urlencoding",
 ]
@@ -3697,6 +3722,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3944,6 +3978,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4163,6 +4223,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ parking_lot = "0.12"
 rayon = "1"
 tempfile = "3"
 tracing = "0.1"
+tracing-subscriber = "0.3"
 
 # Compression & archives
 # zlib-rs matches artifact_storage's flate2 feature choice, which the (ephemerally vendored)

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 # Do NOT build with `--features mount` directly against the placeholder; use `just build-cli-full`,
 # which swaps in the real mount core from a sibling artifact_storage checkout (see that recipe and
 # crates/VENDORED_FROM).
-mount = ["dep:gsvc-mount", "dep:libc", "dep:fuser"]
+mount = ["dep:gsvc-mount", "dep:libc", "dep:fuser", "dep:tracing-subscriber"]
 # `tl git clone`: the fast-clone engine, backed by the private gsvc-codec packfile codec. Same
 # placeholder + ephemeral-vendor arrangement as `mount` (see crates/VENDORED_FROM): off by
 # default so this public crate builds with no access to the artifact_storage repo. Official
@@ -72,6 +72,9 @@ gsvc-codec = { workspace = true, optional = true }
 gsvc-mount = { workspace = true, optional = true }
 libc = { version = "0.2", optional = true }
 tracing = { workspace = true }
+# Only the mount daemon installs a subscriber (writing to the state dir's daemon.log); the
+# rest of the CLI stays subscriber-free.
+tracing-subscriber = { workspace = true, optional = true }
 flate2 = { workspace = true }
 sha1 = { workspace = true }
 ignore = { workspace = true }

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1378,6 +1378,7 @@ pub async fn mount(
     auto_commit_interval_secs: Option<u64>,
     foreground: bool,
     trace_ops: bool,
+    log_level: &str,
 ) -> Result<()> {
     #[cfg(not(target_os = "macos"))]
     let _ = trace_ops;
@@ -1655,17 +1656,19 @@ pub async fn mount(
     if foreground {
         #[cfg(target_os = "macos")]
         vfsserver::TRACE_OPS.store(trace_ops, std::sync::atomic::Ordering::Relaxed);
-        return daemon::run(ctx, &state_dir).await;
+        return daemon::run(ctx, &state_dir, log_level).await;
     }
 
-    // Detach the daemon and wait for its control socket to answer. Its stderr lands in the
-    // state dir so a daemon that dies on startup (no /dev/fuse access, missing fusermount3,
+    // Detach the daemon and wait for its control socket to answer. Its stderr — where the
+    // tracing subscriber writes — lands in the state dir's daemon.log (`tl fs status` prints
+    // the path), so a daemon that dies on startup (no /dev/fuse access, missing fusermount3,
     // FSKit extension disabled) explains itself instead of just never answering.
     let exe = std::env::current_exe()?;
     let daemon_log = state_dir.join("daemon.log");
     std::process::Command::new(exe)
         .args(["fs", "daemon", "--state-dir"])
         .arg(&state_dir)
+        .args(["--log-level", log_level])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::fs::File::create(&daemon_log)?)
@@ -2462,6 +2465,7 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
                 "workspace": ws,
                 "mounted": daemon_commit.is_some(),
                 "lower_commit": daemon_commit,
+                "log": state_dir.join("daemon.log"),
                 "dirty": upserts.iter().map(|(p, _, _)| p.clone())
                     .chain(deletes.iter().cloned()).collect::<Vec<_>>(),
             }))?
@@ -2497,6 +2501,11 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
             style("daemon:").dim()
         ),
     }
+    println!(
+        "{} {}",
+        style("log:").dim(),
+        state_dir.join("daemon.log").display()
+    );
     let dirty = upserts.len() + deletes.len();
     if dirty == 0 {
         println!("{} clean", style("local:").dim());

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -2109,6 +2109,57 @@ fn enumerate_overlay(state_dir: &Path, mount_root: &Path) -> Result<(OverlayUpse
     Ok((upserts, deletes))
 }
 
+/// Pending committed-directory renames recorded by the mount daemon (`redirects.json` in the
+/// state dir, destination -> true-lower source), sorted by destination. Empty when the file
+/// is absent or unreadable — the daemon owns the authoritative copy.
+fn pending_renames(state_dir: &Path) -> Vec<(String, String)> {
+    let Ok(raw) = std::fs::read(state_dir.join("redirects.json")) else {
+        return Vec::new();
+    };
+    let Ok(map) = serde_json::from_slice::<HashMap<String, String>>(&raw) else {
+        return Vec::new();
+    };
+    let mut entries: Vec<(String, String)> = map.into_iter().collect();
+    entries.sort();
+    entries
+}
+
+/// Expand pending renames through the daemon into by-oid push files, merged behind the
+/// regular dirty set (an upper copy-up under a renamed tree shadows its lower file). The
+/// daemon must be running: publishing the rename's source delete without its destination
+/// upserts would lose the subtree, so a failed expansion fails the seal.
+async fn redirect_push_files(
+    state_dir: &Path,
+    pending: usize,
+    files: &mut Vec<PushFile>,
+) -> Result<()> {
+    let resp = daemon::control(state_dir, "expand_redirects")
+        .await
+        .map_err(|e| {
+            CliError::usage(format!(
+                "this workspace has {pending} pending directory rename(s); the mount daemon \
+                 must be running to snapshot them: {e}"
+            ))
+        })?;
+    let seals: Vec<overlay::RedirectSeal> =
+        serde_json::from_value(resp.get("seals").cloned().unwrap_or_default())?;
+    let have: std::collections::HashSet<String> =
+        files.iter().map(|f| f.repo_path.clone()).collect();
+    for seal in &seals {
+        for file in &seal.files {
+            if !have.contains(&file.path) {
+                files.push(PushFile {
+                    repo_path: file.path.clone(),
+                    source: PushSource::KnownOid(file.oid.clone()),
+                    mode: Some(file.mode),
+                    delete: false,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 /// An enumerated dirty set as push files. Shared by `snapshot` and the daemon's auto-commit.
 fn overlay_push_files(upserts: &OverlayUpserts, deletes: &[String]) -> Result<Vec<PushFile>> {
     let mut files = Vec::with_capacity(upserts.len() + deletes.len());
@@ -2157,11 +2208,16 @@ pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> R
     heartbeat(&session, &state).await?;
 
     let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
-    if upserts.is_empty() && deletes.is_empty() {
+    let renames = pending_renames(&state_dir);
+    if upserts.is_empty() && deletes.is_empty() && renames.is_empty() {
         println!("Nothing to snapshot: workspace is clean.");
         return Ok(());
     }
-    let files = overlay_push_files(&upserts, &deletes)?;
+    let mut files = overlay_push_files(&upserts, &deletes)?;
+    if !renames.is_empty() {
+        redirect_push_files(&state_dir, renames.len(), &mut files).await?;
+    }
+    let files = files;
 
     let (user, token) = session.creds();
     let progress: Arc<dyn Fn(PushEvent) + Send + Sync> = Arc::new(|ev| {
@@ -2230,11 +2286,12 @@ pub async fn promote(
     let session = FsSession::open(ctx, Some(&state.repo)).await?;
     heartbeat(&session, &state).await?;
     let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
-    if !upserts.is_empty() || !deletes.is_empty() {
+    let renames = pending_renames(&state_dir);
+    if !upserts.is_empty() || !deletes.is_empty() || !renames.is_empty() {
         eprintln!(
             "{} {} local change(s) not in any snapshot; promoting the last snapshot only. Run `tl fs snapshot` first to include them.",
             style("note:").yellow(),
-            upserts.len() + deletes.len()
+            upserts.len() + deletes.len() + renames.len()
         );
     }
     let (user, token) = session.creds();
@@ -2334,10 +2391,11 @@ pub async fn sync(
     let session = FsSession::open(ctx, Some(&state.repo)).await?;
     heartbeat(&session, &state).await?;
     let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
-    if !upserts.is_empty() || !deletes.is_empty() {
+    let renames = pending_renames(&state_dir);
+    if !upserts.is_empty() || !deletes.is_empty() || !renames.is_empty() {
         return Err(CliError::usage(format!(
             "{} local change(s) not in any snapshot would shadow synced content. Run `tl fs snapshot {}` first.",
-            upserts.len() + deletes.len(),
+            upserts.len() + deletes.len() + renames.len(),
             path.display(),
         )));
     }
@@ -2468,6 +2526,10 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
                 "log": state_dir.join("daemon.log"),
                 "dirty": upserts.iter().map(|(p, _, _)| p.clone())
                     .chain(deletes.iter().cloned()).collect::<Vec<_>>(),
+                "pending_renames": pending_renames(&state_dir)
+                    .into_iter()
+                    .map(|(to, from)| serde_json::json!({ "from": from, "to": to }))
+                    .collect::<Vec<_>>(),
             }))?
         );
         return Ok(());
@@ -2506,18 +2568,28 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         style("log:").dim(),
         state_dir.join("daemon.log").display()
     );
-    let dirty = upserts.len() + deletes.len();
+    let renames = pending_renames(&state_dir);
+    // A pending rename's source whiteout is a real delete, but showing it next to the R line
+    // would read as two changes; the R line carries both sides.
+    let deletes: Vec<String> = deletes
+        .into_iter()
+        .filter(|p| !renames.iter().any(|(_, from)| from == p))
+        .collect();
+    let dirty = upserts.len() + deletes.len() + renames.len();
     if dirty == 0 {
         println!("{} clean", style("local:").dim());
     } else {
         println!("{} {} change(s):", style("local:").dim(), dirty);
+        for (to, from) in renames.iter().take(20) {
+            println!("  {} {from} -> {to}", style("R").cyan());
+        }
         for (p, _, _) in upserts.iter().take(20) {
             println!("  {} {p}", style("M").yellow());
         }
         for p in deletes.iter().take(20) {
             println!("  {} {p}", style("D").red());
         }
-        if dirty > 40 {
+        if dirty > 60 {
             println!("  … and more");
         }
     }

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -180,19 +180,42 @@ fn expires_in(expires_at: &str) -> Duration {
 }
 
 /// Run the daemon in the foreground of the current process. `tl fs mount` spawns this as a
-/// detached child (`tl fs daemon --state-dir ...`).
-pub async fn run(ctx: &CliContext, state_dir: &Path) -> Result<()> {
+/// detached child (`tl fs daemon --state-dir ...`) with stderr pointed at the state dir's
+/// `daemon.log`.
+pub async fn run(ctx: &CliContext, state_dir: &Path, log_level: &str) -> Result<()> {
     #[cfg(not(unix))]
     {
-        let _ = (ctx, state_dir);
+        let _ = (ctx, state_dir, log_level);
         Err(CliError::usage(
             "tl fs mount is supported on Linux (FUSE) and macOS (FSKit) only.",
         ))
     }
     #[cfg(unix)]
     {
+        init_logging(log_level)?;
         run_mount(ctx, state_dir).await
     }
+}
+
+/// Install the daemon's tracing subscriber, writing to stderr — which the detached spawn
+/// redirects to the state dir's `daemon.log` (foreground runs log to the terminal). Without
+/// this every `tracing::warn!` in the daemon is silently discarded.
+#[cfg(unix)]
+fn init_logging(level: &str) -> Result<()> {
+    use std::str::FromStr;
+    let level = tracing_subscriber::filter::LevelFilter::from_str(level).map_err(|_| {
+        CliError::usage(format!(
+            "invalid --log-level {level:?} (use off, error, warn, info, debug, or trace)"
+        ))
+    })?;
+    // try_init: the foreground path may run inside a process that already installed a
+    // subscriber; keep whatever is there rather than panic.
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(level)
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .try_init();
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -316,6 +339,13 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     // Attach the kernel: platform-specific. Only after this succeeds does the control socket
     // exist — the socket answering is what `tl fs mount` treats as success.
     let (served, invalidate) = attach(overlay.clone(), &mountpoint, owner).await?;
+    tracing::info!(
+        repo = %state.repo,
+        workspace = %state.workspace_id,
+        mountpoint = %mountpoint.display(),
+        commit = %core.current_commit(),
+        "mount daemon serving"
+    );
 
     // Follow the workspace ref, pushing each refresh's exact delta to the kernel. Spawned after
     // attach because the invalidation sink is born with the kernel session.
@@ -596,6 +626,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                             // teardown). A busy volume (a shell cd'd inside) keeps the daemon
                             // serving — exiting with the volume still attached is how zombie
                             // mounts are born.
+                            tracing::info!(mountpoint = %mountpoint.display(), "shutdown requested; unmounting");
                             if unmount(&mountpoint).await {
                                 let resp = serde_json::json!({ "ok": true });
                                 let mut stream = reader.into_inner();
@@ -609,6 +640,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 // the daemon's one job is over.
                                 std::process::exit(0);
                             }
+                            tracing::warn!(mountpoint = %mountpoint.display(), "unmount refused: volume busy");
                             serde_json::json!({
                                 "ok": false,
                                 "error": "the volume is busy (something is still using it)",
@@ -664,6 +696,11 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
 
     // Serve until the kernel lets go of the mountpoint.
     let result = served.wait().await;
+    if let Err(e) = &result {
+        tracing::error!("mount session ended with error: {e}");
+    } else {
+        tracing::info!("mount session ended");
+    }
     let _ = std::fs::remove_file(&sock_path);
     result
 }

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -418,9 +418,24 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 {
                     recent_seals.drain(..=i);
                 }
+                // Renames a previous seal published but never consumed (crash, or the lower
+                // lagged past our post-seal check) dangle once the lower advances; reap them
+                // before anything resolves through the table.
+                if overlay.has_redirects() {
+                    match overlay.reap_sealed_redirects().await {
+                        Ok(consumed) if !consumed.is_empty() => {
+                            eprintln!("auto-commit: reaped {} sealed rename(s)", consumed.len());
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            eprintln!("auto-commit: reaping sealed renames failed: {e}");
+                            continue;
+                        }
+                    }
+                }
                 let delta = overlay.dirty_since(sealed_gen);
                 let watermark = delta.watermark;
-                if delta.is_empty() {
+                if delta.is_empty() && !overlay.has_redirects() {
                     sealed_gen = watermark;
                     continue;
                 }
@@ -479,12 +494,50 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                     // through the plain-deletes arm and never re-lists these).
                     invalidate(overlay.invals_for(&resolved.tombstoned));
                 }
-                if resolved.files.is_empty() {
+                // Pending directory renames seal as by-oid references: every file the
+                // destination serves from the lower commits by blob oid (nothing uploads),
+                // alongside the source delete the whiteout already produced. Expansion
+                // failing leaves the whole delta pending — publishing the source delete
+                // without the destination would lose the subtree.
+                let redirect_seals = if overlay.has_redirects() {
+                    match overlay.expand_redirects().await {
+                        Ok(seals) => seals,
+                        Err(e) => {
+                            eprintln!(
+                                "auto-commit: expanding pending renames failed (will retry): {e}"
+                            );
+                            continue;
+                        }
+                    }
+                } else {
+                    Vec::new()
+                };
+                if resolved.files.is_empty() && redirect_seals.is_empty() {
                     // The whole delta was ignored paths, bare directories, or files that were
                     // born and died between seals: sealed through, nothing to publish.
                     sealed_gen = watermark;
                     overlay.prune_dirty(watermark);
                     continue;
+                }
+                {
+                    // An upper copy-up under a renamed tree shadows the lower file; the
+                    // resolved walk already carries it.
+                    let have: std::collections::HashSet<String> =
+                        resolved.files.iter().map(|f| f.repo_path.clone()).collect();
+                    for seal in &redirect_seals {
+                        for file in &seal.files {
+                            if !have.contains(&file.path) {
+                                resolved.files.push(
+                                    tensorlake::artifact_storage::ingest::PushFile {
+                                        repo_path: file.path.clone(),
+                                        source: PushSource::KnownOid(file.oid.clone()),
+                                        mode: Some(file.mode),
+                                        delete: false,
+                                    },
+                                );
+                            }
+                        }
+                    }
                 }
                 // Final validity check on every stable prefix: a write below the boundary
                 // that landed after the delta snapshot voids the stability claim — sealing
@@ -554,6 +607,29 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                  up): {e}"
                             ),
                         }
+                        // Published renames are consumed only once the lower serves the
+                        // sealed commit: the new tree carries their destinations directly
+                        // and drops their sources, so remapping through the entry would
+                        // dangle from here on — and conversely, consuming against an older
+                        // commit would make the destinations unreachable.
+                        if !redirect_seals.is_empty() {
+                            if core.current_commit() == report.commit {
+                                let dsts: Vec<String> =
+                                    redirect_seals.iter().map(|s| s.dst.clone()).collect();
+                                if let Err(e) = overlay.consume_redirects(&dsts) {
+                                    eprintln!(
+                                        "auto-commit: consuming sealed renames failed: {e}"
+                                    );
+                                }
+                            } else {
+                                eprintln!(
+                                    "auto-commit: lower has not reached sealed snapshot {}; \
+                                     pending renames stay recorded (next seal republishes \
+                                     them idempotently)",
+                                    report.commit
+                                );
+                            }
+                        }
                         eprintln!("auto-commit sealed snapshot {}", report.commit);
                     }
                     Err(e) => eprintln!("auto-commit push failed (will retry): {e}"),
@@ -600,6 +676,14 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 if let Some(delta) = delta {
                                     invalidate(overlay.translate_delta(&delta));
                                 }
+                                // The advance may be the seal that published pending renames
+                                // (`tl fs snapshot` refreshes before clearing the overlay);
+                                // reap so nothing remaps through consumed entries.
+                                if overlay.has_redirects()
+                                    && let Err(e) = overlay.reap_sealed_redirects().await
+                                {
+                                    eprintln!("refresh: reaping sealed renames failed: {e}");
+                                }
                                 serde_json::json!({ "ok": true, "commit": core.current_commit() })
                             }
                             Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
@@ -618,6 +702,12 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         // auto-commit mount seals the new state.
                         "reindex" => match overlay.rebuild_dirty_index() {
                             Ok(()) => serde_json::json!({ "ok": true }),
+                            Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
+                        },
+                        // Pending directory renames, expanded to the by-oid upserts a seal
+                        // must publish (`tl fs snapshot` merges these into its push).
+                        "expand_redirects" => match overlay.expand_redirects().await {
+                            Ok(seals) => serde_json::json!({ "ok": true, "seals": seals }),
                             Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
                         },
                         "shutdown" => {

--- a/crates/cli/src/commands/fs/fusefs.rs
+++ b/crates/cli/src/commands/fs/fusefs.rs
@@ -30,10 +30,33 @@ fn errno(e: &MountError) -> i32 {
         MountError::NotADirectory => libc::ENOTDIR,
         MountError::IsADirectory => libc::EISDIR,
         MountError::Exists => libc::EEXIST,
+        MountError::NotEmpty => libc::ENOTEMPTY,
+        MountError::Unsupported(_) => libc::ENOTSUP,
         MountError::IndexNotReady(_) => libc::EAGAIN,
         MountError::BadHandle => libc::EBADF,
         MountError::ReadOnly => libc::EROFS,
         _ => libc::EIO,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_empty_maps_to_enotempty_not_eio() {
+        // rmdir of a non-empty directory must surface ENOTEMPTY; the old Protocol("directory
+        // not empty") fell through to the EIO catch-all and `rm` reported "Input/output error".
+        assert_eq!(errno(&MountError::NotEmpty), libc::ENOTEMPTY);
+        assert_ne!(errno(&MountError::NotEmpty), libc::EIO);
+    }
+
+    #[test]
+    fn unsupported_maps_to_enotsup_not_eio() {
+        // Renaming a committed directory is unsupported; it must surface ENOTSUP, not the
+        // Protocol->EIO catch-all that read as a bewildering "Input/output error".
+        assert_eq!(errno(&MountError::Unsupported(String::new())), libc::ENOTSUP);
+        assert_ne!(errno(&MountError::Unsupported(String::new())), libc::EIO);
     }
 }
 

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -36,6 +36,10 @@ struct ONode {
     /// The core ref-generation this binding was made at; a mismatch with the core's current
     /// generation means the followed ref advanced and the binding must be re-walked.
     bound_gen: std::sync::atomic::AtomicU64,
+    /// The redirect-table generation this binding was made at (see
+    /// [`OverlayFs::redirect_gen`]); a mismatch means a pending directory rename changed how
+    /// this path maps onto the lower and the binding must be re-walked.
+    bound_rgen: std::sync::atomic::AtomicU64,
     /// Content identity at the last `open` of this node (the lower blob oid; `None` for
     /// upper-backed opens). An open whose identity matches gets `FOPEN_KEEP_CACHE`: same oid
     /// means byte-identical content, so the kernel page cache from earlier opens is still
@@ -50,6 +54,10 @@ impl ONode {
 
     fn bound_gen(&self) -> u64 {
         self.bound_gen.load(Ordering::SeqCst)
+    }
+
+    fn bound_rgen(&self) -> u64 {
+        self.bound_rgen.load(Ordering::SeqCst)
     }
 }
 
@@ -70,6 +78,7 @@ impl InodeTable {
                     path: String::new(),
                     core_ino: Mutex::new(Some(ROOT_INO)),
                     bound_gen: std::sync::atomic::AtomicU64::new(0),
+                    bound_rgen: std::sync::atomic::AtomicU64::new(0),
                     last_open_oid: Mutex::new(None),
                 }),
                 1,
@@ -113,6 +122,7 @@ impl InodeTable {
             path: path.clone(),
             core_ino: Mutex::new(fresh_core),
             bound_gen: std::sync::atomic::AtomicU64::new(0),
+            bound_rgen: std::sync::atomic::AtomicU64::new(0),
             last_open_oid: Mutex::new(None),
         });
         self.nodes.insert(ino, (node.clone(), 1));
@@ -186,6 +196,7 @@ impl InodeTable {
                 path: new.clone(),
                 core_ino: Mutex::new(None),
                 bound_gen: AtomicU64::new(0),
+                bound_rgen: AtomicU64::new(0),
                 last_open_oid: Mutex::new(node.last_open_oid.lock().expect("oid lock").clone()),
             });
             self.index.insert(new, ino);
@@ -193,6 +204,92 @@ impl InodeTable {
         }
         released
     }
+}
+
+/// The true-lower path serving `path` under a pending-rename table: the longest matching
+/// destination prefix rewritten to its recorded source. Entries store true-lower coordinates
+/// (composed at insert), so one hop resolves chains.
+fn remap_through_redirects(redirects: &HashMap<String, String>, path: &str) -> String {
+    if redirects.is_empty() {
+        return path.to_string();
+    }
+    let mut probe = path;
+    loop {
+        if let Some(src) = redirects.get(probe) {
+            return format!("{src}{}", &path[probe.len()..]);
+        }
+        match probe.rfind('/') {
+            Some(i) => probe = &probe[..i],
+            None => return path.to_string(),
+        }
+    }
+}
+
+/// Record a committed-directory move `src` -> `dst` in the pending-rename table. `true_src`
+/// is `src` already resolved to true-lower coordinates. The destination is replaced
+/// wholesale (a pending rename previously rooted there dies), pending renames nested inside
+/// the moved subtree follow their new ancestor name (their recorded sources are already in
+/// true-lower coordinates and don't change), and a source that is itself pending re-keys
+/// instead of chaining.
+fn record_committed_rename(
+    redirects: &mut HashMap<String, String>,
+    src: &str,
+    dst: &str,
+    true_src: String,
+) {
+    let dst_prefix = format!("{dst}/");
+    redirects.retain(|k, _| k != dst && !k.starts_with(&dst_prefix));
+    let src_prefix = format!("{src}/");
+    let nested: Vec<String> = redirects
+        .keys()
+        .filter(|k| k.starts_with(&src_prefix))
+        .cloned()
+        .collect();
+    for key in nested {
+        let value = redirects.remove(&key).expect("just enumerated");
+        redirects.insert(format!("{dst}/{}", &key[src_prefix.len()..]), value);
+    }
+    redirects.remove(src);
+    redirects.insert(dst.to_string(), true_src);
+}
+
+/// Whether `path` is hidden by a whiteout marker under `wh_root`, honoring pending-rename
+/// shielding. Markers are files; a directory at a wh path is only the container for child
+/// markers (wh/dir/b.txt marks dir/b.txt, not dir). A marker on an ancestor whiteouts the
+/// whole subtree — descendants must test as whited out too, or a node cached by inode keeps
+/// serving content from under a deleted directory.
+///
+/// A pending rename recorded *under* a marker shields its subtree: dropping redirects when
+/// their destination is removed (rmdir/overwrite) means a live entry below an ancestor
+/// marker can only postdate it — the destination was created inside a deleted-then-recreated
+/// directory, and its content must show. Deeper markers (deletions inside the renamed tree)
+/// still apply on the rest of the walk.
+fn whited_out_under(wh_root: &Path, redirects: &HashMap<String, String>, path: &str) -> bool {
+    if path.is_empty() {
+        return false;
+    }
+    let mut probe = String::with_capacity(path.len());
+    for component in path.split('/') {
+        if !probe.is_empty() {
+            probe.push('/');
+        }
+        probe.push_str(component);
+        let marker_is_file = wh_root
+            .join(&probe)
+            .symlink_metadata()
+            .map(|m| m.is_file())
+            .unwrap_or(false);
+        if marker_is_file {
+            let shielded = redirects.keys().any(|root| {
+                (path == root.as_str() || path.starts_with(&format!("{root}/")))
+                    && root.starts_with(&format!("{probe}/"))
+            });
+            if !shielded {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// An open handle in the merged namespace.
@@ -259,6 +356,17 @@ pub struct OverlayFs {
     dirty: Mutex<HashMap<String, DirtyEntry>>,
     /// Out-of-band mutation epoch: see [`OverlayFs::epoch`].
     epoch: AtomicU64,
+    /// Pending committed-directory renames: merged-namespace destination path -> lower source
+    /// path in **true lower coordinates** (composed through existing entries at insert, so
+    /// resolution is always one hop). A `rename(2)` of a lower-backed directory records here
+    /// instead of materializing the subtree; reads under the destination resolve through the
+    /// remap, and the seal reconciles each entry into by-oid upserts plus the source delete.
+    /// Persisted to `<state dir>/redirects.json` alongside `upper/` and `wh/`.
+    redirects: Mutex<HashMap<String, String>>,
+    redirects_path: PathBuf,
+    /// Bumped on every redirect-table mutation. Lower bindings record it
+    /// ([`ONode::bound_rgen`]) so cached path walks re-resolve when the remap changes.
+    redirect_gen: AtomicU64,
 }
 
 /// What the last recorded mutation of a path was. `Upsert` covers create/write/copy-up/rename
@@ -334,6 +442,15 @@ impl OverlayFs {
         let wh = state_dir.join("wh");
         std::fs::create_dir_all(&upper).map_err(io_err)?;
         std::fs::create_dir_all(&wh).map_err(io_err)?;
+        let redirects_path = state_dir.join("redirects.json");
+        // Pending renames from a previous daemon (re-mount, crash) still gate the merged
+        // namespace; an unreadable file is corrupt state worth failing loudly on.
+        let redirects: HashMap<String, String> = match std::fs::read(&redirects_path) {
+            Ok(raw) => serde_json::from_slice(&raw)
+                .map_err(|e| MountError::Protocol(format!("corrupt redirects.json: {e}")))?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
+            Err(e) => return Err(io_err(e)),
+        };
         let fs = Arc::new(OverlayFs {
             core,
             upper,
@@ -346,6 +463,9 @@ impl OverlayFs {
             write_gen: AtomicU64::new(0),
             dirty: Mutex::new(HashMap::new()),
             epoch: AtomicU64::new(0),
+            redirects: Mutex::new(redirects),
+            redirects_path,
+            redirect_gen: AtomicU64::new(0),
         });
         // Baseline: dirt left by a previous daemon (re-mount, crash) predates any events this
         // process will see; seed the index from disk so the first seal covers it.
@@ -550,29 +670,64 @@ impl OverlayFs {
     }
 
     fn whited_out(&self, path: &str) -> bool {
-        // Markers are files; a directory at a wh path is only the container for child markers
-        // (wh/dir/b.txt marks dir/b.txt, not dir). A marker on an ancestor whiteouts the whole
-        // subtree — descendants must test as whited out too, or a node cached by inode keeps
-        // serving content from under a deleted directory.
-        if path.is_empty() {
-            return false;
-        }
-        let mut probe = String::with_capacity(path.len());
-        for component in path.split('/') {
-            if !probe.is_empty() {
-                probe.push('/');
-            }
-            probe.push_str(component);
-            let marker_is_file = self
-                .wh_path(&probe)
-                .symlink_metadata()
-                .map(|m| m.is_file())
-                .unwrap_or(false);
-            if marker_is_file {
-                return true;
-            }
-        }
-        false
+        whited_out_under(
+            &self.wh,
+            &self.redirects.lock().expect("redirect lock"),
+            path,
+        )
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Pending directory renames (redirects)
+    // -------------------------------------------------------------------------------------
+
+    /// The true-lower path serving `path`: the longest pending-rename prefix rewritten to its
+    /// recorded source (entries store true-lower coordinates, so one hop resolves chains).
+    fn remap_lower(&self, path: &str) -> String {
+        remap_through_redirects(&self.redirects.lock().expect("redirect lock"), path)
+    }
+
+    /// The recorded source when `path` is itself a pending-rename destination root.
+    fn redirect_source(&self, path: &str) -> Option<String> {
+        self.redirects.lock().expect("redirect lock").get(path).cloned()
+    }
+
+    /// Whether `path` is a pending-rename destination root or sits under one.
+    fn redirect_covers(&self, path: &str) -> bool {
+        let redirects = self.redirects.lock().expect("redirect lock");
+        redirects
+            .keys()
+            .any(|root| path == root.as_str() || path.starts_with(&format!("{root}/")))
+    }
+
+    /// Child names of pending-rename destination roots directly inside `dir`.
+    fn redirect_roots_under(&self, dir: &str) -> Vec<String> {
+        let redirects = self.redirects.lock().expect("redirect lock");
+        redirects
+            .keys()
+            .filter_map(|root| {
+                let rest = if dir.is_empty() {
+                    root.as_str()
+                } else {
+                    root.strip_prefix(&format!("{dir}/"))?
+                };
+                (!rest.is_empty() && !rest.contains('/')).then(|| rest.to_string())
+            })
+            .collect()
+    }
+
+    /// Write the table through to `redirects.json` (tmp + rename: a crash never leaves a
+    /// torn file — pending renames gate the merged namespace and the seal).
+    fn persist_redirects(&self, redirects: &HashMap<String, String>) -> Result<(), MountError> {
+        let tmp = self.redirects_path.with_extension("json.tmp");
+        std::fs::write(
+            &tmp,
+            serde_json::to_vec_pretty(redirects)
+                .map_err(|e| MountError::Protocol(format!("encode redirects: {e}")))?,
+        )
+        .map_err(io_err)?;
+        std::fs::rename(&tmp, &self.redirects_path).map_err(io_err)?;
+        Ok(())
     }
 
     fn upper_meta(&self, path: &str) -> Option<std::fs::Metadata> {
@@ -653,6 +808,20 @@ impl OverlayFs {
             debug_assert!(release.is_none());
             return Ok(self.attr_from_meta(ino, &meta));
         }
+        // A pending rename serves its destination root here: the name exists in neither the
+        // upper nor the parent's lower listing — resolve through the remapped walk.
+        if self.redirect_source(&path).is_some() {
+            let attr = self.walk_lower(&path).await?;
+            let (ino, release) = {
+                let mut inodes = self.inodes.lock().expect("inode lock");
+                let (ino, _, release) = inodes.intern(path, Some(attr.ino));
+                (ino, release)
+            };
+            if let Some(stale) = release {
+                self.core.forget(stale, 1);
+            }
+            return Ok(self.attr_from_core(ino, &attr));
+        }
         if self.whited_out(&path) {
             return Err(not_found());
         }
@@ -682,39 +851,22 @@ impl OverlayFs {
         if node.path.is_empty() {
             return Ok(ROOT_INO);
         }
-        // Capture the generation BEFORE resolving: an advance racing the walk just means one
+        // Capture the generations BEFORE resolving: an advance racing the walk just means one
         // redundant re-walk later, never a stale binding recorded as fresh.
         let generation = self.core.current_generation();
+        let rgeneration = self.redirect_gen.load(Ordering::SeqCst);
         if let Some(ino) = node.core_ino()
             && node.bound_gen() == generation
+            && node.bound_rgen() == rgeneration
         {
             return Ok(ino);
         }
-        let mut cur = ROOT_INO;
-        let mut chain: Vec<u64> = Vec::new();
-        for component in node.path.split('/') {
-            match settle_lower!(self.core.lookup(cur, component).await) {
-                Ok(attr) => {
-                    chain.push(attr.ino);
-                    cur = attr.ino;
-                }
-                Err(e) => {
-                    for ino in chain {
-                        self.core.forget(ino, 1);
-                    }
-                    return Err(e);
-                }
-            }
-        }
-        // Keep one core reference on the leaf (owned by this node, repaid on forget); the
-        // intermediate lookups are repaid immediately.
-        let leaf = *chain.last().expect("path is never empty here");
-        for ino in &chain[..chain.len() - 1] {
-            self.core.forget(*ino, 1);
-        }
+        let attr = self.walk_lower(&node.path).await?;
+        let leaf = attr.ino;
         let mut stored = node.core_ino.lock().expect("core ino lock");
         let old = stored.replace(leaf);
         node.bound_gen.store(generation, Ordering::SeqCst);
+        node.bound_rgen.store(rgeneration, Ordering::SeqCst);
         drop(stored);
         if let Some(old) = old {
             if old != leaf {
@@ -723,6 +875,41 @@ impl OverlayFs {
                 // Same core node re-resolved: repay the duplicate reference.
                 self.core.forget(leaf, 1);
             }
+        }
+        Ok(leaf)
+    }
+
+    /// Walk a merged path component-by-component through the core, following any pending
+    /// rename remap. Returns the leaf's attributes holding **one counted core reference**
+    /// (on `attr.ino`) that the caller must own or repay.
+    async fn walk_lower(&self, merged_path: &str) -> Result<NodeAttr, MountError> {
+        let lower = self.remap_lower(merged_path);
+        self.walk_true_lower(&lower).await
+    }
+
+    /// [`Self::walk_lower`] without the pending-rename remap: resolve a path exactly as the
+    /// current lower commit spells it.
+    async fn walk_true_lower(&self, lower: &str) -> Result<NodeAttr, MountError> {
+        let mut cur = ROOT_INO;
+        let mut chain: Vec<NodeAttr> = Vec::new();
+        for component in lower.split('/') {
+            match settle_lower!(self.core.lookup(cur, component).await) {
+                Ok(attr) => {
+                    cur = attr.ino;
+                    chain.push(attr);
+                }
+                Err(e) => {
+                    for attr in chain {
+                        self.core.forget(attr.ino, 1);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        // Keep the reference on the leaf; the intermediate lookups are repaid immediately.
+        let leaf = chain.pop().expect("path is never empty here");
+        for attr in chain {
+            self.core.forget(attr.ino, 1);
         }
         Ok(leaf)
     }
@@ -799,6 +986,15 @@ impl OverlayFs {
                 };
                 seen.insert(name.clone());
                 merged.push((name, kind));
+            }
+        }
+
+        // Pending-rename destinations rooted here: physically absent from both the upper and
+        // this directory's lower listing, but part of the merged namespace. An upper dir of
+        // the same name (child copy-ups) already listed above; `seen` dedups.
+        for name in self.redirect_roots_under(&node.path) {
+            if seen.insert(name.clone()) {
+                merged.push((name, NodeKind::Dir));
             }
         }
 
@@ -1139,6 +1335,10 @@ impl OverlayFs {
         if self.upper_path(path).symlink_metadata().is_ok() {
             return true;
         }
+        // A pending rename occupies its destination root.
+        if self.redirect_source(path).is_some() {
+            return true;
+        }
         if self.whited_out(path) {
             return false;
         }
@@ -1287,6 +1487,9 @@ impl OverlayFs {
         if dest.symlink_metadata().is_ok() {
             std::fs::remove_dir_all(&dest).map_err(io_err)?;
         }
+        // A pending rename rooted here dies with the directory: its true source was
+        // whiteouted when the rename was recorded, so nothing further hides.
+        self.drop_redirect_tree(&path)?;
         if self.lower_has(parent_node.core_ino(), name).await {
             self.set_whiteout(&path)?;
         }
@@ -1294,10 +1497,82 @@ impl OverlayFs {
         Ok(())
     }
 
+    /// Move a committed (lower-backed) directory by recording a pending rename: the table
+    /// entry re-points the merged destination at the true-lower source, local state under the
+    /// source (child copy-ups in the upper, deletion markers in `wh/`) rides along, and no
+    /// content moves. The seal reconciles the entry into by-oid upserts plus the source
+    /// delete. Moving a destination that is itself pending re-keys the existing entry, so
+    /// chains stay one hop.
+    fn rename_committed_dir(&self, src: &str, dst: &str) -> Result<(), MountError> {
+        let true_src = self.remap_lower(src);
+        {
+            let mut redirects = self.redirects.lock().expect("redirect lock");
+            record_committed_rename(&mut redirects, src, dst, true_src);
+            self.persist_redirects(&redirects)?;
+        }
+        self.redirect_gen.fetch_add(1, Ordering::SeqCst);
+        // Stale deletion markers at the destination belong to whatever the replace displaced.
+        let dst_wh = self.wh_path(dst);
+        if dst_wh
+            .symlink_metadata()
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            std::fs::remove_dir_all(&dst_wh).map_err(io_err)?;
+        }
+        // Local state under the source rides along: child copy-ups in the upper...
+        let src_upper = self.upper_path(src);
+        if src_upper.symlink_metadata().is_ok() {
+            let dst_upper = self.upper_path(dst);
+            if dst_upper.symlink_metadata().is_ok() {
+                std::fs::remove_dir_all(&dst_upper).map_err(io_err)?;
+            }
+            std::fs::rename(&src_upper, &dst_upper).map_err(io_err)?;
+        }
+        // ...and deletions of paths inside the moved subtree.
+        let src_wh = self.wh_path(src);
+        if src_wh
+            .symlink_metadata()
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+        {
+            if let Some(dir) = dst_wh.parent() {
+                std::fs::create_dir_all(dir).map_err(io_err)?;
+            }
+            std::fs::rename(&src_wh, &dst_wh).map_err(io_err)?;
+        }
+        Ok(())
+    }
+
+    /// Drop the pending rename rooted at `path` (and defensively any nested under it) because
+    /// its destination was removed or replaced. Stale deletion markers under the destination
+    /// go with it — they described children of the dead entry and must not publish as deletes
+    /// of paths that never existed. Returns whether an entry was dropped.
+    fn drop_redirect_tree(&self, path: &str) -> Result<bool, MountError> {
+        let dropped = {
+            let mut redirects = self.redirects.lock().expect("redirect lock");
+            let prefix = format!("{path}/");
+            let before = redirects.len();
+            redirects.retain(|k, _| k != path && !k.starts_with(&prefix));
+            let dropped = redirects.len() != before;
+            if dropped {
+                self.persist_redirects(&redirects)?;
+            }
+            dropped
+        };
+        if dropped {
+            self.redirect_gen.fetch_add(1, Ordering::SeqCst);
+            let wh = self.wh_path(path);
+            if wh.symlink_metadata().map(|m| m.is_dir()).unwrap_or(false) {
+                std::fs::remove_dir_all(&wh).map_err(io_err)?;
+            }
+        }
+        Ok(dropped)
+    }
+
     /// Rename. Upper-only sources rename in place; a lower-backed file copies up, writes the
-    /// destination, and whiteouts the source. Renaming a directory with lower presence is not
-    /// supported (v1) — copy-up of a whole subtree belongs in a snapshot/promote flow, not a
-    /// syscall.
+    /// destination, and whiteouts the source. A lower-backed (committed) directory moves as a
+    /// pending rename — see [`OverlayFs::rename_committed_dir`].
     pub async fn rename(
         &self,
         parent: u64,
@@ -1317,30 +1592,40 @@ impl OverlayFs {
         }
 
         let src_meta = src_upper.symlink_metadata().ok();
+        let src_redirect = self.redirect_source(&src).is_some();
         let lower_src = self.lower_has(parent_node.core_ino(), name).await;
-        match src_meta {
-            Some(_) => {
-                std::fs::rename(&src_upper, &dst_upper).map_err(io_err)?;
-            }
-            None if lower_src => {
+        let upper_dir_over_redirect = src_redirect
+            && src_meta
+                .as_ref()
+                .map(|m| m.is_dir() && !m.file_type().is_symlink())
+                .unwrap_or(false);
+        let mut committed_dir_move = false;
+        if src_meta.is_some() && !upper_dir_over_redirect {
+            std::fs::rename(&src_upper, &dst_upper).map_err(io_err)?;
+        } else if lower_src || src_redirect {
+            let attr = self.lookup(parent, name).await?;
+            let node = self.node(attr.ino)?;
+            let kind = attr.kind;
+            self.forget(attr.ino, 1);
+            if matches!(kind, NodeKind::Dir) {
+                // A committed directory moves as a pending rename: metadata only, the seal
+                // reconciles it into by-oid upserts plus the source delete. Materializing the
+                // subtree here would put unbounded network I/O inside a syscall. An upper dir
+                // of the same name (child copy-ups) rides along inside the move.
+                self.rename_committed_dir(&src, &dst)?;
+                committed_dir_move = true;
+            } else {
                 // Copy the lower file up directly at the destination.
-                let attr = self.lookup(parent, name).await?;
-                let node = self.node(attr.ino)?;
-                if matches!(attr.kind, NodeKind::Dir) {
-                    self.forget(attr.ino, 1);
-                    // ENOTSUP, not the Protocol->EIO catch-all: whole-subtree copy-up is a
-                    // snapshot/promote concern, not a syscall, and a bare "Input/output error"
-                    // gives the user nothing to act on.
-                    return Err(MountError::Unsupported(
-                        "renaming a committed directory is not supported; snapshot first"
-                            .to_string(),
-                    ));
-                }
                 self.copy_up(&node).await?;
-                self.forget(attr.ino, 1);
                 std::fs::rename(self.upper_path(&src), &dst_upper).map_err(io_err)?;
             }
-            None => return Err(not_found()),
+        } else {
+            return Err(not_found());
+        }
+        if !committed_dir_move {
+            // Whatever the destination held is replaced wholesale; a pending rename that was
+            // rooted there dies with it.
+            self.drop_redirect_tree(&dst)?;
         }
         if lower_src {
             self.set_whiteout(&src)?;
@@ -1439,6 +1724,24 @@ impl OverlayFs {
     /// Entries whose kernel-visible content the lower change cannot affect — upper-shadowed or
     /// whited-out paths — are dropped, as are paths the kernel never looked up here.
     pub fn translate_delta(&self, delta: &gsvc_mount::RefreshDelta) -> Vec<OverlayInval> {
+        // Delta paths are lower coordinates; a pending rename serves that content under its
+        // destination, so the kernel-visible path (and the interned ino) lives there. The
+        // source coordinates are whiteouted and filter out below.
+        let reverse: Vec<(String, String)> = {
+            let redirects = self.redirects.lock().expect("redirect lock");
+            redirects.iter().map(|(d, s)| (s.clone(), d.clone())).collect()
+        };
+        let merged_path = |lower: &str| -> String {
+            for (src, dst) in &reverse {
+                if lower == src {
+                    return dst.clone();
+                }
+                if let Some(rest) = lower.strip_prefix(&format!("{src}/")) {
+                    return format!("{dst}/{rest}");
+                }
+            }
+            lower.to_string()
+        };
         let mut out = Vec::new();
         let tagged = delta
             .rebound
@@ -1446,21 +1749,22 @@ impl OverlayFs {
             .map(|e| (e, false))
             .chain(delta.staled.iter().map(|e| (e, true)));
         for (entry, staled) in tagged {
-            if self.upper_meta(&entry.path).is_some() || self.whited_out(&entry.path) {
+            let path = merged_path(&entry.path);
+            if self.upper_meta(&path).is_some() || self.whited_out(&path) {
                 continue;
             }
             let inodes = self.inodes.lock().expect("inode lock");
-            let Some(&ino) = inodes.index.get(&entry.path) else {
+            let Some(&ino) = inodes.index.get(&path) else {
                 continue;
             };
-            let parent_ino = match entry.path.rfind('/') {
-                Some(i) => inodes.index.get(&entry.path[..i]).copied(),
-                None => Some(ROOT_INO),
+            let (parent_ino, name) = match path.rfind('/') {
+                Some(i) => (inodes.index.get(&path[..i]).copied(), path[i + 1..].to_string()),
+                None => (Some(ROOT_INO), path.clone()),
             };
             out.push(OverlayInval {
                 ino,
                 parent_ino,
-                name: entry.name.clone(),
+                name,
                 staled,
             });
         }
@@ -1487,7 +1791,11 @@ impl OverlayFs {
                 .iter()
                 .filter(|(ino, _)| **ino != ROOT_INO)
                 .filter(|(_, (node, _))| {
-                    self.upper_meta(&node.path).is_some() || self.whited_out(&node.path)
+                    self.upper_meta(&node.path).is_some()
+                        || self.whited_out(&node.path)
+                        // Pending-rename paths flip from remapped resolution to the advanced
+                        // lower serving them directly; force fresh lookups there too.
+                        || self.redirect_covers(&node.path)
                 })
                 .map(|(&ino, (node, _))| {
                     let (parent_ino, name) = match node.path.rfind('/') {
@@ -1516,6 +1824,16 @@ impl OverlayFs {
                 }
             }
         }
+        // Pending renames were sealed into the commit this drop follows (or replaced by a
+        // restore); either way the advanced lower serves their destinations directly now.
+        {
+            let mut redirects = self.redirects.lock().expect("redirect lock");
+            if !redirects.is_empty() {
+                redirects.clear();
+                self.persist_redirects(&redirects)?;
+            }
+        }
+        self.redirect_gen.fetch_add(1, Ordering::SeqCst);
         // The dirty index described the dropped state; sealers fast-forward to the watermark.
         // The epoch bump tells them their other caches (chunk lists, sealed guards, in-flight
         // resolutions) describe a dead world too.
@@ -1523,6 +1841,167 @@ impl OverlayFs {
         self.epoch.fetch_add(1, Ordering::SeqCst);
         Ok(affected)
     }
+
+    /// Whether any pending directory renames await the next seal.
+    pub fn has_redirects(&self) -> bool {
+        !self.redirects.lock().expect("redirect lock").is_empty()
+    }
+
+    /// The pending rename table (destination -> true-lower source), for status display.
+    pub fn redirect_entries(&self) -> Vec<(String, String)> {
+        let redirects = self.redirects.lock().expect("redirect lock");
+        let mut entries: Vec<(String, String)> =
+            redirects.iter().map(|(d, s)| (d.clone(), s.clone())).collect();
+        entries.sort();
+        entries
+    }
+
+    /// Expand every pending rename into the per-file upserts a seal must publish: each file
+    /// the destination serves from the lower, as `(merged path, blob oid, git mode)` — the
+    /// content already exists server-side, so a sealer commits these **by oid reference**,
+    /// uploading nothing. Children the overlay already covers otherwise are skipped: upper
+    /// copy-ups seal through the regular walk, whiteouts are deletions.
+    pub async fn expand_redirects(&self) -> Result<Vec<RedirectSeal>, MountError> {
+        let pending = self.redirect_entries();
+        let mut out = Vec::new();
+        for (dst, src) in pending {
+            let mut files = Vec::new();
+            let mut dirs = vec![dst.clone()];
+            while let Some(dir) = dirs.pop() {
+                let dir_attr = self.walk_lower(&dir).await?;
+                let fh = match self.core.opendir(dir_attr.ino) {
+                    Ok(fh) => fh,
+                    Err(e) => {
+                        self.core.forget(dir_attr.ino, 1);
+                        return Err(e);
+                    }
+                };
+                let mut offset = 0u64;
+                let result: Result<(), MountError> = async {
+                    loop {
+                        let page = settle_lower!(self.core.readdir(fh, offset, 4096).await)?;
+                        if page.is_empty() {
+                            return Ok(());
+                        }
+                        offset = page.last().expect("nonempty page").next_offset;
+                        for entry in page {
+                            let child = Self::child_path(&dir, &entry.name);
+                            if self.whited_out(&child) {
+                                continue;
+                            }
+                            match entry.kind {
+                                NodeKind::Dir => dirs.push(child),
+                                NodeKind::File | NodeKind::Symlink => {
+                                    // An upper file shadows the lower one; the regular seal
+                                    // walk publishes it.
+                                    if self.upper_meta(&child).is_some() {
+                                        continue;
+                                    }
+                                    let attr = settle_lower!(
+                                        self.core.lookup(dir_attr.ino, &entry.name).await
+                                    )?;
+                                    let oid = attr.oid.clone();
+                                    let perm = attr.perm;
+                                    self.core.forget(attr.ino, 1);
+                                    if oid.is_empty() {
+                                        // Sealing by reference needs the identity; publishing
+                                        // without it would silently drop the file.
+                                        return Err(MountError::Protocol(format!(
+                                            "no oid for {child} under pending rename {dst}"
+                                        )));
+                                    }
+                                    let mode = match entry.kind {
+                                        NodeKind::Symlink => 0o120000,
+                                        _ if perm & 0o111 != 0 => 0o100755,
+                                        _ => 0o100644,
+                                    };
+                                    files.push(RedirectFile {
+                                        path: child,
+                                        oid,
+                                        mode,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+                .await;
+                self.core.releasedir(fh);
+                self.core.forget(dir_attr.ino, 1);
+                result?;
+            }
+            out.push(RedirectSeal { dst, src, files });
+        }
+        Ok(out)
+    }
+
+    /// Drop pending renames that a previous seal already published: once the lower advances
+    /// to the sealed commit, the tree serves each destination directly and the recorded
+    /// source is gone — remapping through the entry would dangle. Detected, never assumed:
+    /// an entry is reaped only when its source is absent **and** its destination present in
+    /// the current lower. Heals the crash/race window between a seal landing and its
+    /// [`Self::consume_redirects`]. Returns the consumed destinations.
+    pub async fn reap_sealed_redirects(&self) -> Result<Vec<String>, MountError> {
+        let mut consumed = Vec::new();
+        for (dst, src) in self.redirect_entries() {
+            match self.walk_true_lower(&src).await {
+                Err(MountError::NotFound(_)) => {}
+                Ok(attr) => {
+                    self.core.forget(attr.ino, 1);
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+            match self.walk_true_lower(&dst).await {
+                Ok(attr) => {
+                    self.core.forget(attr.ino, 1);
+                    consumed.push(dst);
+                }
+                Err(MountError::NotFound(_)) => {}
+                Err(e) => return Err(e),
+            }
+        }
+        if !consumed.is_empty() {
+            self.consume_redirects(&consumed)?;
+        }
+        Ok(consumed)
+    }
+
+    /// Drop pending renames a seal just published: the commit the workspace ref now points at
+    /// serves their destinations directly. Callers must refresh the lower **first** — dropping
+    /// against the old commit would leave the destinations unresolvable.
+    pub fn consume_redirects(&self, dsts: &[String]) -> Result<(), MountError> {
+        {
+            let mut redirects = self.redirects.lock().expect("redirect lock");
+            let before = redirects.len();
+            redirects.retain(|k, _| !dsts.contains(k));
+            if redirects.len() == before {
+                return Ok(());
+            }
+            self.persist_redirects(&redirects)?;
+        }
+        self.redirect_gen.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+/// One pending rename, expanded for sealing: every file the destination serves from the
+/// lower, ready to commit by oid reference.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct RedirectSeal {
+    pub dst: String,
+    pub src: String,
+    pub files: Vec<RedirectFile>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct RedirectFile {
+    /// Merged-namespace path (under the destination root).
+    pub path: String,
+    /// Git blob oid (40-hex) of the content, already present server-side.
+    pub oid: String,
+    /// Git mode (`0o100644`, `0o100755`, `0o120000`).
+    pub mode: u32,
 }
 
 /// One kernel invalidation in the overlay's ino space, produced by [`OverlayFs::translate_delta`]
@@ -1649,6 +2128,112 @@ mod tests {
             t.index.get("dst").copied(),
             Some(src),
             "forgetting the orphan preserves the live entry"
+        );
+    }
+
+    fn table(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(d, s)| (d.to_string(), s.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn redirect_remap_follows_longest_prefix() {
+        let t = table(&[("moved", "old"), ("moved/inner2", "elsewhere/inner")]);
+        assert_eq!(remap_through_redirects(&t, "moved"), "old");
+        assert_eq!(remap_through_redirects(&t, "moved/a/b.txt"), "old/a/b.txt");
+        // The deeper entry wins for its own subtree.
+        assert_eq!(
+            remap_through_redirects(&t, "moved/inner2/x"),
+            "elsewhere/inner/x"
+        );
+        // Prefix-shaped but not a path prefix: no remap.
+        assert_eq!(remap_through_redirects(&t, "movedx"), "movedx");
+        assert_eq!(remap_through_redirects(&t, "untouched/f"), "untouched/f");
+    }
+
+    #[test]
+    fn record_committed_rename_composes_chains_and_carries_nested_entries() {
+        let mut t = HashMap::new();
+        // mv a b — first move records true coordinates.
+        record_committed_rename(&mut t, "a", "b", "a".to_string());
+        assert_eq!(t.get("b").map(String::as_str), Some("a"));
+        // mv committed dir inside the pending tree: b/sub -> c (true src resolves through b).
+        let true_src = remap_through_redirects(&t, "b/sub");
+        record_committed_rename(&mut t, "b/sub", "c", true_src);
+        assert_eq!(t.get("c").map(String::as_str), Some("a/sub"), "one hop");
+        // mv b d — the root re-keys, nothing chains through the dead name.
+        let true_src = remap_through_redirects(&t, "b");
+        record_committed_rename(&mut t, "b", "d", true_src);
+        assert!(!t.contains_key("b"));
+        assert_eq!(t.get("d").map(String::as_str), Some("a"));
+        // A nested pending rename rides an ancestor move: mv x d/y, then mv d e.
+        record_committed_rename(&mut t, "x", "d/y", "x".to_string());
+        let true_src = remap_through_redirects(&t, "d");
+        record_committed_rename(&mut t, "d", "e", true_src);
+        assert_eq!(t.get("e").map(String::as_str), Some("a"));
+        assert_eq!(
+            t.get("e/y").map(String::as_str),
+            Some("x"),
+            "nested entry follows its new ancestor name"
+        );
+        assert!(!t.contains_key("d/y"));
+    }
+
+    #[test]
+    fn record_committed_rename_overwrite_drops_the_displaced_entry() {
+        let mut t = table(&[("dst", "old1"), ("dst/nested", "old2")]);
+        record_committed_rename(&mut t, "src", "dst", "src".to_string());
+        assert_eq!(t.len(), 1);
+        assert_eq!(
+            t.get("dst").map(String::as_str),
+            Some("src"),
+            "the replaced destination's entries die with it"
+        );
+    }
+
+    #[test]
+    fn whiteout_shielding_shows_redirects_under_ancestor_markers() {
+        // Defense-in-depth configuration: a subtree marker on an ancestor of a live pending
+        // rename. Normal flows can't build it (recreating the ancestor clears its marker, and
+        // a destination needs a visible parent), but if it ever arises the entry — which by
+        // the drop-on-remove invariant postdates any marker above it — must win.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let wh = tmp.path();
+        std::fs::write(wh.join("dir"), b"").unwrap();
+        let t = table(&[("dir/moved", "old")]);
+        assert!(!whited_out_under(wh, &t, "dir/moved"));
+        assert!(
+            !whited_out_under(wh, &t, "dir/moved/child.txt"),
+            "content under the destination shows too"
+        );
+        assert!(
+            whited_out_under(wh, &t, "dir/other"),
+            "the marker still hides everything the rename does not cover"
+        );
+        // A marker AT the destination root itself is not shielded by its own entry.
+        let t2 = table(&[("dir", "old")]);
+        assert!(
+            whited_out_under(wh, &t2, "dir"),
+            "a marker at the root outranks the entry"
+        );
+    }
+
+    #[test]
+    fn whiteouts_inside_a_renamed_tree_still_apply() {
+        // The normal case: files deleted under a pending-rename destination carry ordinary
+        // child markers, and the walk past the (unmarked) ancestors must honor them.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let wh = tmp.path();
+        std::fs::create_dir_all(wh.join("moved")).unwrap();
+        std::fs::write(wh.join("moved/gone.txt"), b"").unwrap();
+        let t = table(&[("moved", "old")]);
+        assert!(whited_out_under(wh, &t, "moved/gone.txt"));
+        assert!(!whited_out_under(wh, &t, "moved/kept.txt"));
+        assert!(
+            !whited_out_under(wh, &t, "moved"),
+            "the container dir is not a marker"
         );
     }
 
@@ -1925,6 +2510,218 @@ mod tests {
         // git drops empty trees: bin/ vanished with its only file.
         let names = dir_names(&fs, ROOT_INO).await;
         assert_eq!(names, vec!["README.md", "lnk", "new.txt", "run2.sh"]);
+
+        sdk.delete_workspace(PROJECT, &repo, "t", TOKEN, &ws.id)
+            .await
+            .unwrap();
+    }
+
+    /// Committed-directory rename end to end: the pending-rename redirect serves reads at the
+    /// destination without materializing anything, local edits and deletes inside the moved
+    /// tree layer on top, the seal publishes by-oid references plus the source delete, and
+    /// after the ref advances the reaped/cleared overlay serves the destination from the
+    /// lower — byte-identical.
+    #[tokio::test]
+    #[ignore = "requires a local artifact-storage server on 127.0.0.1:8080"]
+    async fn overlay_renames_committed_directory_and_seals_by_reference() {
+        if !server_up() {
+            eprintln!("skipping: no local artifact-storage server");
+            return;
+        }
+        let sdk = sdk();
+        let repo = format!(
+            "ofsmv-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        sdk.create_repo_with_credential(PROJECT, &repo, None, "t", TOKEN)
+            .await
+            .unwrap();
+        sdk.push_files(
+            PROJECT,
+            &repo,
+            "t",
+            TOKEN,
+            vec![
+                push_file("keep.md", b"stay\n", 0o100644),
+                push_file("pkg/lib.rs", b"pub fn lib() {}\n", 0o100644),
+                push_file("pkg/sub/deep.txt", b"deep\n", 0o100644),
+                push_file("pkg/tool.sh", b"#!/bin/sh\n", 0o100755),
+                push_file("pkg/gone.txt", b"delete me\n", 0o100644),
+            ],
+            PushOptions {
+                message: "seed".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let ws = sdk
+            .create_workspace(
+                PROJECT,
+                &repo,
+                "t",
+                TOKEN,
+                &CreateWorkspaceRequest::default(),
+            )
+            .await
+            .unwrap()
+            .into_inner();
+        let client = FsClient::new(BASE, PROJECT, &repo, Some(TOKEN.to_string())).unwrap();
+        let core = MountCore::new(
+            client,
+            MountOptions {
+                reference: ws.ref_name.clone(),
+                follow: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let fs: Arc<OverlayFs> = OverlayFs::new(core.clone(), state.path(), false).unwrap();
+
+        // 1. mv pkg moved — instant, nothing materializes.
+        fs.rename(ROOT_INO, "pkg", ROOT_INO, "moved").await.unwrap();
+        assert!(fs.lookup(ROOT_INO, "pkg").await.is_err(), "source gone");
+        assert!(
+            !state.path().join("upper/moved").exists(),
+            "no copy-up happened"
+        );
+        assert_eq!(dir_names(&fs, ROOT_INO).await, vec!["keep.md", "moved"]);
+        let moved = fs.lookup(ROOT_INO, "moved").await.unwrap();
+        assert!(matches!(moved.kind, NodeKind::Dir));
+        assert_eq!(
+            dir_names(&fs, moved.ino).await,
+            vec!["gone.txt", "lib.rs", "sub", "tool.sh"]
+        );
+        assert_eq!(
+            read_all(&fs, moved.ino, "lib.rs").await,
+            b"pub fn lib() {}\n"
+        );
+        let tool = fs.lookup(moved.ino, "tool.sh").await.unwrap();
+        assert_eq!(tool.perm & 0o111, 0o111, "exec bit survives the remap");
+        fs.forget(tool.ino, 1);
+        let sub = fs.lookup(moved.ino, "sub").await.unwrap();
+        assert_eq!(read_all(&fs, sub.ino, "deep.txt").await, b"deep\n");
+
+        // 2. Edits inside the moved tree: an upper copy-up shadows, a delete whiteouts.
+        let lib = fs.lookup(moved.ino, "lib.rs").await.unwrap();
+        let (fh, _) = fs.open(lib.ino, true).await.unwrap();
+        fs.write(fh, 0, b"pub fn lib2() {}\n").unwrap();
+        fs.setattr(lib.ino, Some(17), None).await.unwrap();
+        fs.release(fh);
+        fs.forget(lib.ino, 1);
+        fs.unlink(moved.ino, "gone.txt").await.unwrap();
+        assert_eq!(
+            dir_names(&fs, moved.ino).await,
+            vec!["lib.rs", "sub", "tool.sh"]
+        );
+        assert_eq!(read_all(&fs, moved.ino, "lib.rs").await, b"pub fn lib2() {}\n");
+
+        // 3. A second move re-keys the same entry (chain stays one hop).
+        fs.rename(ROOT_INO, "moved", ROOT_INO, "moved2")
+            .await
+            .unwrap();
+        assert!(fs.lookup(ROOT_INO, "moved").await.is_err());
+        fs.forget(moved.ino, 1);
+        fs.forget(sub.ino, 1);
+        let moved2 = fs.lookup(ROOT_INO, "moved2").await.unwrap();
+        assert_eq!(
+            dir_names(&fs, moved2.ino).await,
+            vec!["lib.rs", "sub", "tool.sh"]
+        );
+        assert_eq!(
+            read_all(&fs, moved2.ino, "lib.rs").await,
+            b"pub fn lib2() {}\n",
+            "the copy-up rode the second move"
+        );
+        assert_eq!(fs.redirect_entries(), vec![("moved2".into(), "pkg".into())]);
+
+        // 4. Seal exactly as `tl fs snapshot` would: the expansion's by-oid upserts (the
+        //    upper-shadowed lib.rs and whiteouted gone.txt are excluded), the regular upsert
+        //    for the copy-up, and the source delete the whiteout produced.
+        let seals = fs.expand_redirects().await.unwrap();
+        assert_eq!(seals.len(), 1);
+        let mut sealed_paths: Vec<&str> =
+            seals[0].files.iter().map(|f| f.path.as_str()).collect();
+        sealed_paths.sort();
+        assert_eq!(
+            sealed_paths,
+            vec!["moved2/sub/deep.txt", "moved2/tool.sh"],
+            "shadowed and deleted children stay out of the by-oid set"
+        );
+        let tool_mode = seals[0]
+            .files
+            .iter()
+            .find(|f| f.path == "moved2/tool.sh")
+            .unwrap()
+            .mode;
+        assert_eq!(tool_mode, 0o100755, "exec mode carried by reference");
+        let mut files: Vec<PushFile> = seals[0]
+            .files
+            .iter()
+            .map(|f| PushFile {
+                repo_path: f.path.clone(),
+                source: PushSource::KnownOid(f.oid.clone()),
+                mode: Some(f.mode),
+                delete: false,
+            })
+            .collect();
+        files.push(PushFile {
+            repo_path: "moved2/lib.rs".into(),
+            source: PushSource::Path(state.path().join("upper/moved2/lib.rs")),
+            mode: Some(0o100644),
+            delete: false,
+        });
+        files.push(PushFile {
+            repo_path: "pkg".into(),
+            source: PushSource::Bytes(Vec::new()),
+            mode: None,
+            delete: true,
+        });
+        sdk.push_files(
+            PROJECT,
+            &repo,
+            "t",
+            TOKEN,
+            files,
+            PushOptions {
+                message: "rename snapshot".into(),
+                workspace_snapshot: Some(ws.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        // 5. Ref advance + reap: the entry is detected as sealed (src gone, dst present) and
+        //    consumed; clear_upper drops the copy-up and whiteout.
+        assert!(core.poll_ref().await.unwrap().is_some(), "ref moved");
+        let consumed = fs.reap_sealed_redirects().await.unwrap();
+        assert_eq!(consumed, vec!["moved2".to_string()]);
+        assert!(!fs.has_redirects());
+        fs.clear_upper().unwrap();
+
+        // 6. The lower now serves the destination directly, byte-identical.
+        fs.forget(moved2.ino, 1);
+        assert!(fs.lookup(ROOT_INO, "pkg").await.is_err());
+        let moved2 = fs.lookup(ROOT_INO, "moved2").await.unwrap();
+        assert!(!moved2.upper);
+        assert_eq!(
+            dir_names(&fs, moved2.ino).await,
+            vec!["lib.rs", "sub", "tool.sh"]
+        );
+        assert_eq!(
+            read_all(&fs, moved2.ino, "lib.rs").await,
+            b"pub fn lib2() {}\n"
+        );
+        let sub2 = fs.lookup(moved2.ino, "sub").await.unwrap();
+        assert_eq!(read_all(&fs, sub2.ino, "deep.txt").await, b"deep\n");
+        let tool2 = fs.lookup(moved2.ino, "tool.sh").await.unwrap();
+        assert_eq!(tool2.perm & 0o111, 0o111);
 
         sdk.delete_workspace(PROJECT, &repo, "t", TOKEN, &ws.id)
             .await

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -134,11 +134,64 @@ impl InodeTable {
         if *count == 0 {
             let node = node.clone();
             self.nodes.remove(&ino);
-            self.index.remove(&node.path);
+            // Only evict the index entry if it still points here. A rename may have re-keyed
+            // this path onto a different ino (overwrite: the old occupant lingers by ino until
+            // forgotten while its path now resolves to the moved node) — evicting blindly would
+            // strand the live entry.
+            if self.index.get(&node.path).copied() == Some(ino) {
+                self.index.remove(&node.path);
+            }
             Some(node)
         } else {
             None
         }
+    }
+
+    /// Re-key interned nodes after a successful upper rename `src` -> `dst`.
+    ///
+    /// A FUSE `rename` keeps the source's nodeid and re-points its dentry at the destination,
+    /// then issues ino-based ops (`getattr`, `open`, `read`) against it. This table is path-keyed,
+    /// so unless the moved node's path follows, resolution walks the now-vacated source path and
+    /// returns `ENOENT` — the file lists in `readdir` (a fresh directory read) yet stats as gone.
+    /// (That is exactly what breaks `git init`/`git clone`, which write `HEAD`, `config`, refs and
+    /// every lockfile via write-temp-then-rename.)
+    ///
+    /// Handles subtree moves — a renamed directory carries its interned descendants — and
+    /// overwrite: a node already at `dst` is dropped from the index (it survives by ino until the
+    /// kernel forgets it, guarded by the path-conditional eviction in [`Self::forget`]). The moved
+    /// node's lower binding is dropped and re-resolved lazily against the destination path; any
+    /// counted core reference it held is returned for the caller to release.
+    #[must_use = "returned core inos must be released via MountCore::forget"]
+    fn rename(&mut self, src: &str, dst: &str) -> Vec<u64> {
+        let prefix = format!("{src}/");
+        let affected: Vec<String> = self
+            .index
+            .keys()
+            .filter(|p| p.as_str() == src || p.starts_with(&prefix))
+            .cloned()
+            .collect();
+        let mut released = Vec::new();
+        for old in affected {
+            let ino = self.index.remove(&old).expect("just enumerated from index");
+            let new = if old == src {
+                dst.to_string()
+            } else {
+                format!("{dst}/{}", &old[prefix.len()..])
+            };
+            let (node, count) = self.nodes.remove(&ino).expect("indexed node");
+            if let Some(core) = *node.core_ino.lock().expect("core ino lock") {
+                released.push(core);
+            }
+            let renamed = Arc::new(ONode {
+                path: new.clone(),
+                core_ino: Mutex::new(None),
+                bound_gen: AtomicU64::new(0),
+                last_open_oid: Mutex::new(node.last_open_oid.lock().expect("oid lock").clone()),
+            });
+            self.index.insert(new, ino);
+            self.nodes.insert(ino, (renamed, count));
+        }
+        released
     }
 }
 
@@ -1226,7 +1279,9 @@ impl OverlayFs {
         // lookup() above took a reference; balance it.
         self.forget(attr.ino, 1);
         if !empty {
-            return Err(MountError::Protocol("directory not empty".to_string()));
+            // A real errno, not the Protocol->EIO catch-all: `rm`/`rmdir` on a non-empty
+            // directory must see ENOTEMPTY, or it reports a bewildering "Input/output error".
+            return Err(MountError::NotEmpty);
         }
         let dest = self.upper_path(&path);
         if dest.symlink_metadata().is_ok() {
@@ -1273,7 +1328,10 @@ impl OverlayFs {
                 let node = self.node(attr.ino)?;
                 if matches!(attr.kind, NodeKind::Dir) {
                     self.forget(attr.ino, 1);
-                    return Err(MountError::Protocol(
+                    // ENOTSUP, not the Protocol->EIO catch-all: whole-subtree copy-up is a
+                    // snapshot/promote concern, not a syscall, and a bare "Input/output error"
+                    // gives the user nothing to act on.
+                    return Err(MountError::Unsupported(
                         "renaming a committed directory is not supported; snapshot first"
                             .to_string(),
                     ));
@@ -1329,8 +1387,16 @@ impl OverlayFs {
                 self.record(&format!("{dst}/{rel}"), DirtyKind::Upsert);
             }
         }
-        // The destination path may already be interned (overwrite): its ino now serves upper
-        // content automatically since attribute resolution is dynamic.
+        // Re-key the in-memory node table: the kernel keeps the source's nodeid and re-points its
+        // dentry at the destination, then addresses it by ino — so the moved node's path must
+        // follow it, or ino-based getattr/open resolve the vacated source path and return ENOENT.
+        let released = {
+            let mut inodes = self.inodes.lock().expect("inode lock");
+            inodes.rename(&src, &dst)
+        };
+        for core in released {
+            self.core.forget(core, 1);
+        }
         Ok(())
     }
 
@@ -1503,6 +1569,88 @@ mod tests {
     use tensorlake::artifact_storage::ArtifactStorageClient;
     use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
     use tensorlake::artifact_storage::workspaces::CreateWorkspaceRequest;
+
+    // ---------------------------------------------------------------------------------------
+    // Inode-table re-keying (pure, no server): the rename fix that lets `git init`/`git clone`
+    // work on the mount. A FUSE rename keeps the source nodeid and re-points its dentry at the
+    // destination, so the node's path must follow or ino-based ops resolve the vacated source
+    // path and return ENOENT.
+    // ---------------------------------------------------------------------------------------
+
+    #[test]
+    fn inode_table_rename_rekeys_source_ino_to_destination() {
+        let mut t = InodeTable::new();
+        // A file created in the upper (git's `config.lock`) — no lower binding.
+        let (ino, _, _) = t.intern("config.lock".to_string(), None);
+        let released = t.rename("config.lock", "config");
+        assert!(released.is_empty(), "pure-upper rename releases no core refs");
+        assert!(
+            !t.index.contains_key("config.lock"),
+            "source path is vacated"
+        );
+        assert_eq!(
+            t.index.get("config").copied(),
+            Some(ino),
+            "the same nodeid now resolves to the destination"
+        );
+        assert_eq!(
+            t.get(ino).unwrap().path,
+            "config",
+            "the node's path followed the rename"
+        );
+    }
+
+    #[test]
+    fn inode_table_rename_carries_interned_subtree() {
+        let mut t = InodeTable::new();
+        let (dir, _, _) = t.intern("d".to_string(), None);
+        let (child, _, _) = t.intern("d/x".to_string(), None);
+        let released = t.rename("d", "d2");
+        assert!(released.is_empty());
+        assert_eq!(t.index.get("d2").copied(), Some(dir));
+        assert_eq!(
+            t.index.get("d2/x").copied(),
+            Some(child),
+            "descendants move with the directory"
+        );
+        assert_eq!(t.get(child).unwrap().path, "d2/x");
+        assert!(!t.index.contains_key("d/x"));
+    }
+
+    #[test]
+    fn inode_table_rename_does_not_touch_prefix_siblings() {
+        let mut t = InodeTable::new();
+        let (_, _, _) = t.intern("d".to_string(), None);
+        let (sibling, _, _) = t.intern("dxy".to_string(), None);
+        let _ = t.rename("d", "d2");
+        assert_eq!(
+            t.index.get("dxy").copied(),
+            Some(sibling),
+            "a name that merely shares the prefix is not a descendant"
+        );
+    }
+
+    #[test]
+    fn inode_table_rename_overwrite_orphans_destination_until_forgotten() {
+        let mut t = InodeTable::new();
+        let (src, _, _) = t.intern("src".to_string(), None);
+        let (dst, _, _) = t.intern("dst".to_string(), None);
+        let _ = t.rename("src", "dst");
+        assert_eq!(
+            t.index.get("dst").copied(),
+            Some(src),
+            "destination path resolves to the moved (source) nodeid"
+        );
+        // The overwritten node lingers by ino until the kernel forgets it; forgetting it must not
+        // evict the re-keyed entry that now owns its former path.
+        let dropped = t.forget(dst, 1);
+        assert!(dropped.is_some(), "orphan is dropped at zero lookups");
+        assert_eq!(
+            t.index.get("dst").copied(),
+            Some(src),
+            "forgetting the orphan preserves the live entry"
+        );
+    }
 
     const BASE: &str = "http://127.0.0.1:8080";
     const PROJECT: &str = "overlaytest";
@@ -1698,8 +1846,12 @@ mod tests {
         assert_eq!(dir_names(&fs, dir.ino).await, vec!["a.txt"]);
         assert!(state.path().join("wh/dir/b.txt").is_file());
 
-        // 5. rmdir refuses non-empty; empties then whiteouts a lower dir.
-        assert!(fs.rmdir(ROOT_INO, "dir").await.is_err());
+        // 5. rmdir refuses non-empty (as ENOTEMPTY, not the Protocol->EIO catch-all); empties
+        //    then whiteouts a lower dir.
+        assert!(matches!(
+            fs.rmdir(ROOT_INO, "dir").await,
+            Err(MountError::NotEmpty)
+        ));
         fs.unlink(dir.ino, "a.txt").await.unwrap();
         fs.rmdir(ROOT_INO, "dir").await.unwrap();
         assert!(fs.lookup(ROOT_INO, "dir").await.is_err());

--- a/crates/cli/src/commands/fs/vfsserver.rs
+++ b/crates/cli/src/commands/fs/vfsserver.rs
@@ -65,6 +65,8 @@ fn errno(e: &MountError) -> i32 {
         MountError::NotADirectory => libc::ENOTDIR,
         MountError::IsADirectory => libc::EISDIR,
         MountError::Exists => libc::EEXIST,
+        MountError::NotEmpty => libc::ENOTEMPTY,
+        MountError::Unsupported(_) => libc::ENOTSUP,
         MountError::IndexNotReady(_) => libc::EAGAIN,
         MountError::BadHandle => libc::EBADF,
         MountError::ReadOnly => libc::EROFS,
@@ -499,5 +501,21 @@ mod tests {
         assert!(r.u64().is_err());
         let mut r = Reader::new(&[255, 255, 255, 255]);
         assert!(r.bytes().is_err());
+    }
+
+    #[test]
+    fn not_empty_maps_to_enotempty_not_eio() {
+        // rmdir of a non-empty directory must surface ENOTEMPTY; the old Protocol("directory
+        // not empty") fell through to the EIO catch-all and `rm` reported "Input/output error".
+        assert_eq!(errno(&MountError::NotEmpty), libc::ENOTEMPTY);
+        assert_ne!(errno(&MountError::NotEmpty), libc::EIO);
+    }
+
+    #[test]
+    fn unsupported_maps_to_enotsup_not_eio() {
+        // Renaming a committed directory is unsupported; it must surface ENOTSUP, not the
+        // Protocol->EIO catch-all that read as a bewildering "Input/output error".
+        assert_eq!(errno(&MountError::Unsupported(String::new())), libc::ENOTSUP);
+        assert_ne!(errno(&MountError::Unsupported(String::new())), libc::EIO);
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -261,6 +261,11 @@ enum FsCommands {
         /// Log every VFS operation the mount serves to stderr (macOS; requires --foreground)
         #[arg(long, requires = "foreground")]
         trace_ops: bool,
+
+        /// Daemon log level (off, error, warn, info, debug, trace). Detached daemons log to
+        /// `daemon.log` in the mount's state directory; foreground runs log to the terminal.
+        #[arg(long, default_value = "info")]
+        log_level: String,
     },
 
     /// List workspaces (all file systems, or one)
@@ -286,6 +291,10 @@ enum FsCommands {
     Daemon {
         #[arg(long)]
         state_dir: PathBuf,
+
+        /// Log level (off, error, warn, info, debug, trace)
+        #[arg(long, default_value = "info")]
+        log_level: String,
     },
 
     /// Seal local changes into a snapshot on the workspace ref
@@ -2267,6 +2276,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             auto_commit_interval_secs,
             foreground,
             trace_ops,
+            log_level,
         } => {
             let mode = match mode {
                 Some(MountWriteMode::Ro) => commands::fs::WritePolicy::Ro,
@@ -2282,10 +2292,14 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
                 auto_commit_interval_secs,
                 foreground,
                 trace_ops,
+                &log_level,
             )
             .await
         }
-        FsCommands::Daemon { state_dir } => commands::fs::daemon::run(ctx, &state_dir).await,
+        FsCommands::Daemon {
+            state_dir,
+            log_level,
+        } => commands::fs::daemon::run(ctx, &state_dir, &log_level).await,
         FsCommands::Snapshot { path, message } => {
             commands::fs::snapshot(ctx, &path, message.as_deref()).await
         }
@@ -2768,6 +2782,7 @@ mod tests {
                 auto_commit_interval_secs,
                 foreground,
                 trace_ops,
+                log_level,
             }) => {
                 assert_eq!(target, "data:main");
                 assert_eq!(path, PathBuf::from("./w"));
@@ -2776,6 +2791,7 @@ mod tests {
                 assert_eq!(auto_commit_interval_secs, None);
                 assert!(!foreground);
                 assert!(!trace_ops);
+                assert_eq!(log_level, "info");
             }
             _ => panic!("expected fs mount command"),
         }


### PR DESCRIPTION
## Summary

Root-caused from a live sandbox where `git clone` inside a tlfs mount died with `fatal: unknown error occurred while reading the configuration files`, then followed the thread to directory renames generally. Two commits:

### Commit 1 — rename re-key, honest errnos, daemon logging

**1. Rename left the moved file un-stat-able (the git breaker).** `OverlayFs::rename` physically moved the upper file but never updated the in-memory inode table. The kernel keeps the source's nodeid and re-points its dentry at the destination, so ino-based `getattr`/`open` resolved the vacated source path and returned ENOENT — every renamed file became a readdir-visible phantom (`-????????? config`). Git writes `HEAD`, `config`, refs and all lockfiles via write-temp-then-rename, so `git init`/`clone` inside a mount produced repos whose own config could not be read back. Fix: `InodeTable::rename(src, dst)` re-keys the interned node (and any interned subtree), reconciles overwrites, and `forget` only evicts the index entry when it still points at that ino. Four unit tests pin the behavior.

**2. rmdir non-empty → ENOTEMPTY (was EIO).** `rmdir` returned `Protocol("directory not empty")`, which both bindings' errno maps sent to the `_ => EIO` catch-all — so `rm`/`mv` onto an existing directory reported `Input/output error`. Now `MountError::NotEmpty` → `ENOTEMPTY` in both bindings, with mapping regression tests.

**3. Committed-dir rename → ENOTSUP (was EIO)** — superseded within this PR by commit 2, which makes the operation *work*; the variant and mapping remain for other unsupported operations.

**4. The daemon finally logs.** `daemon.log` existed but was always empty — no tracing subscriber was ever installed. Now: `tl fs daemon` installs a `tracing-subscriber` (workspace dep, compiled only with the `mount` feature) writing to stderr — `daemon.log` for detached daemons, the terminal for `--foreground`; a `--log-level` flag (default `info`, explicit flag, no env vars) on both `tl fs mount` and `tl fs daemon`; lifecycle events (serving / shutdown / volume-busy / session-ended); `tl fs status` prints the log path (text and `--json`).

### Commit 2 — rename committed directories instantly (v1 of tensorlakeai/artifact_storage#88)

`rename(2)` of a committed (lower-backed) directory breaks every tool that reorganizes directories on a mount (`git mv`, refactoring scripts, `shutil.move`). Content addressing makes a directory move the cheapest operation in the system — the subtree oid never changes — so the gap was purely mount-side. **Design: record at syscall time, reconcile at seal time.**

- **Overlay redirect:** a pending-rename table (`destination → true-lower source`, persisted to `redirects.json` in the state dir). `rename(2)` records an entry, whiteouts the source, and moves local state (child copy-ups, deletion markers) under the new name — metadata only, unbounded I/O never enters the syscall. Chains compose to one hop; reads resolve through a longest-prefix remap (lower-binding walks, lookup/readdir of destination roots, whiteout shielding, refresh-delta translation); removing or overwriting a destination drops its entry.
- **Seal reconciliation:** each pending rename expands to per-file `PushSource::KnownOid` upserts — zero bytes read or uploaded — plus the source delete. Wired into both sealers: `tl fs snapshot` (new `expand_redirects` control op; the daemon must be running when renames are pending — publishing the source delete without the destination would lose the subtree) and the auto-commit loop. Entries are consumed only once the lower serves the sealed commit; a reaper heals the crash/lag window by detecting entries whose source vanished and destination materialized.
- **UX:** `tl fs status` shows `R src -> dst` (and `pending_renames` in `--json`); `sync` refuses while renames are pending; `promote` counts them.

Follow-up (v2, artifact_storage): a tree-reference commit op to publish a move as one tree edit instead of O(files) by-oid rows — tracked in tensorlakeai/artifact_storage#88.

## Dependencies

Companion PR tensorlakeai/artifact_storage#87 adds the `NotEmpty`/`Unsupported` variants to `gsvc-mount` and **must land first** for vendored `--features mount` builds. Default (placeholder) builds are unaffected.

## Testing

- 22 `commands::fs` unit tests pass under the vendor swap (4 inode-rename re-key, 4 errno-mapping, 5 redirect-table/whiteout-shielding, plus existing sealer/enumeration tests); clippy clean on touched files.
- **Both live-server integration tests pass** against a local `gsvc-server` (open auth), including the new `overlay_renames_committed_directory_and_seals_by_reference`: instant rename → redirect-served reads (content, exec bits, nested dirs) → edits + deletes inside the moved tree → chained re-move → by-oid seal + source delete → ref advance → reap → byte-identical lower-served destination.
- Default no-mount build compiles.
- The errno repros were verified against a live sandbox mount (`tl-sbx`); full end-to-end revalidation there needs a Linux build with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)