### PR TITLE
tl fs snapshot: live progress spinner + per-phase timings; share the push progress sink with tl git push

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -13,7 +13,6 @@
 
 use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
 
 use comfy_table::Cell;
 use console::style;
@@ -21,7 +20,7 @@ use futures::StreamExt;
 use ignore::Match;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use tensorlake::artifact_storage::ArtifactStorageClient;
-use tensorlake::artifact_storage::ingest::{PushEvent, PushFile, PushOptions, PushSource};
+use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
 use tensorlake::artifact_storage::models::GitCredential;
 use tensorlake::artifact_storage::workspaces::{
     CreateWorkspaceRequest, PromoteOutcome, PromoteWorkspaceRequest, SyncWorkspaceRequest,
@@ -2207,24 +2206,32 @@ pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> R
     let session = FsSession::open(ctx, Some(&state.repo)).await?;
     heartbeat(&session, &state).await?;
 
+    let started = std::time::Instant::now();
+    let bar = indicatif::ProgressBar::new_spinner();
+    bar.enable_steady_tick(std::time::Duration::from_millis(120));
+    bar.set_message("enumerating workspace changes...");
+
     let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
     let renames = pending_renames(&state_dir);
     if upserts.is_empty() && deletes.is_empty() && renames.is_empty() {
+        bar.finish_and_clear();
         println!("Nothing to snapshot: workspace is clean.");
         return Ok(());
     }
+    let t_enumerate = started.elapsed();
+    bar.set_message(format!(
+        "preparing {} change(s)...",
+        upserts.len() + deletes.len() + renames.len()
+    ));
     let mut files = overlay_push_files(&upserts, &deletes)?;
     if !renames.is_empty() {
         redirect_push_files(&state_dir, renames.len(), &mut files).await?;
     }
     let files = files;
+    let t_prepare = started.elapsed() - t_enumerate;
 
     let (user, token) = session.creds();
-    let progress: Arc<dyn Fn(PushEvent) + Send + Sync> = Arc::new(|ev| {
-        if let PushEvent::Negotiated { missing, total } = ev {
-            eprintln!("uploading {missing} of {total} chunks (rest already stored)");
-        }
-    });
+    let progress = super::push_progress_spinner(&bar);
     let report = session
         .client
         .push_files(
@@ -2242,7 +2249,12 @@ pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> R
         )
         .await?
         .into_inner();
+    // `push` covers the whole push_files call: local chunk/hash, chunk negotiation, byte upload,
+    // and the server-side commit (tree build + read-back) — for a large snapshot the commit, not
+    // the transfer, can dominate this bucket.
+    let t_push = started.elapsed() - t_prepare - t_enumerate;
 
+    bar.set_message("refreshing mount view...");
     // Swap the mount's lower layer to the new snapshot, then drop the overlay: the content the
     // upper layer held is now served (identically) by the lower commit.
     daemon::control(&state_dir, "refresh").await?;
@@ -2255,16 +2267,37 @@ pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> R
         .chain(deletes.iter().cloned())
         .collect();
     revalidate_paths(Path::new(&mountpoint), &sealed);
+    let total = started.elapsed();
+    let t_refresh = total - t_push - t_prepare - t_enumerate;
+    bar.finish_and_clear();
     // Small files skip chunk negotiation (token-only commits), so uploads can exceed the
     // negotiated chunk count — clamp so the summary never reads "3 of 0 chunks".
     println!(
-        "Snapshot {} ({} file(s), {} of {} chunks uploaded)",
+        "Snapshot {} ({} file(s), {} of {} chunks uploaded in {})",
         report.commit,
         report.files,
         report.chunks_uploaded,
         report.chunks_total.max(report.chunks_uploaded),
+        fmt_dur(total),
+    );
+    println!(
+        "  enumerate {}  prepare {}  push {}  refresh {}",
+        fmt_dur(t_enumerate),
+        fmt_dur(t_prepare),
+        fmt_dur(t_push),
+        fmt_dur(t_refresh),
     );
     Ok(())
+}
+
+/// Render a phase duration compactly: sub-second phases as whole milliseconds (`42ms`), longer
+/// ones as fractional seconds (`1.83s`). `{:.2}s` alone would flatten every fast phase to `0.00s`.
+fn fmt_dur(d: std::time::Duration) -> String {
+    if d.as_secs() == 0 {
+        format!("{}ms", d.as_millis())
+    } else {
+        format!("{:.2}s", d.as_secs_f64())
+    }
 }
 
 pub async fn promote(

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -702,7 +702,7 @@ pub async fn push(
     expect_oid: Option<String>,
     output_json: bool,
 ) -> Result<()> {
-    use tensorlake::artifact_storage::ingest::{PushEvent, PushOptions};
+    use tensorlake::artifact_storage::ingest::PushOptions;
 
     let root = current_git_worktree_root()?;
     let project_id = project_id(ctx)?;
@@ -715,68 +715,12 @@ pub async fn push(
     let bar = indicatif::ProgressBar::new_spinner();
     bar.enable_steady_tick(std::time::Duration::from_millis(120));
     bar.set_message("hashing worktree files...");
-    let bar_for_events = bar.clone();
     let opts = PushOptions {
         branch: branch.to_string(),
         message: message.to_string(),
         base: None,
         expect_oid,
-        progress: Some(std::sync::Arc::new(move |ev: PushEvent| {
-            use indicatif::HumanBytes;
-            match ev {
-                PushEvent::Chunking {
-                    files_done,
-                    files_total,
-                    bytes_hashed,
-                } => bar_for_events.set_message(format!(
-                    "hashing {files_done}/{files_total} files ({})...",
-                    HumanBytes(bytes_hashed)
-                )),
-                PushEvent::Hashed {
-                    files,
-                    chunks,
-                    bytes,
-                } => bar_for_events.set_message(format!(
-                    "hashed {files} files ({chunks} chunks, {}); asking the server what it already has...",
-                    HumanBytes(bytes)
-                )),
-                PushEvent::Negotiated { missing, total } => bar_for_events.set_message(format!(
-                    "server lacks {missing} of {total} chunks; uploading..."
-                )),
-                PushEvent::UploadedBatch { chunks, bytes } => bar_for_events.set_message(format!(
-                    "uploaded {chunks} chunks ({})...",
-                    HumanBytes(bytes)
-                )),
-                PushEvent::Committing { files } => bar_for_events.set_message(format!(
-                    "all bytes on the server; committing {files} files (server builds the tree)..."
-                )),
-                PushEvent::CommitDetached { job_id } => {
-                    let line = format!(
-                        "commit running as job {job_id} (survives disconnects; check from \
-                         anywhere with: tl git commit-status <repo> {job_id})"
-                    );
-                    // indicatif drops println on hidden draw targets (piped stderr) — and a
-                    // scripted push is exactly where the out-of-band job id matters.
-                    if bar_for_events.is_hidden() {
-                        println!("{line}");
-                    } else {
-                        bar_for_events.println(line);
-                    }
-                }
-                PushEvent::CommitProgress { phase, done, total } => {
-                    if total > 0 {
-                        bar_for_events.set_message(format!(
-                            "committing: {phase} {done}/{total} chunks..."
-                        ))
-                    } else {
-                        bar_for_events.set_message(format!("committing: {phase}..."))
-                    }
-                }
-                PushEvent::Committed { ref_name, .. } => {
-                    bar_for_events.set_message(format!("committed to {ref_name}"))
-                }
-            }
-        })),
+        progress: Some(super::push_progress_spinner(&bar)),
         ..Default::default()
     };
     let report = client

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -15,3 +15,70 @@ pub mod sbx;
 pub mod secrets;
 pub mod ssh_keys;
 pub mod whoami;
+
+use std::sync::Arc;
+
+use tensorlake::artifact_storage::ingest::PushEvent;
+
+/// Build a `PushEvent` progress sink that narrates a push/commit onto `bar`.
+///
+/// Shared by `tl git push` and `tl fs snapshot` so the two commands report identical,
+/// in-lockstep progress wording — a new `PushEvent` variant or a phrasing tweak lands in one
+/// place. Every arm only sets the spinner message, except the detached-commit job id, which is
+/// printed directly so it survives a hidden (piped/non-TTY) bar where the out-of-band id matters.
+pub(crate) fn push_progress_spinner(
+    bar: &indicatif::ProgressBar,
+) -> Arc<dyn Fn(PushEvent) + Send + Sync> {
+    let bar = bar.clone();
+    Arc::new(move |ev| {
+        use indicatif::HumanBytes;
+        match ev {
+            PushEvent::Chunking {
+                files_done,
+                files_total,
+                bytes_hashed,
+            } => bar.set_message(format!(
+                "hashing {files_done}/{files_total} files ({})...",
+                HumanBytes(bytes_hashed)
+            )),
+            PushEvent::Hashed {
+                files,
+                chunks,
+                bytes,
+            } => bar.set_message(format!(
+                "hashed {files} files ({chunks} chunks, {}); asking the server what it already has...",
+                HumanBytes(bytes)
+            )),
+            PushEvent::Negotiated { missing, total } => bar.set_message(format!(
+                "uploading {missing} of {total} chunks (rest already stored)..."
+            )),
+            PushEvent::UploadedBatch { chunks, bytes } => {
+                bar.set_message(format!("uploaded {chunks} chunks ({})...", HumanBytes(bytes)))
+            }
+            PushEvent::Committing { files } => bar.set_message(format!(
+                "all bytes on the server; committing {files} files (server builds the tree)..."
+            )),
+            PushEvent::CommitDetached { job_id } => {
+                let line = format!(
+                    "commit running as job {job_id} (survives disconnects; check from anywhere \
+                     with: tl git commit-status <repo> {job_id})"
+                );
+                if bar.is_hidden() {
+                    println!("{line}");
+                } else {
+                    bar.println(line);
+                }
+            }
+            PushEvent::CommitProgress { phase, done, total } => {
+                if total > 0 {
+                    bar.set_message(format!("committing: {phase} {done}/{total} chunks..."))
+                } else {
+                    bar.set_message(format!("committing: {phase}..."))
+                }
+            }
+            PushEvent::Committed { ref_name, .. } => {
+                bar.set_message(format!("committed to {ref_name}"))
+            }
+        }
+    })
+}


### PR DESCRIPTION
## What

`tl fs snapshot` previously printed a single negotiation line (`uploading 0 of 0 chunks (rest already stored)` — confusing for small-file pushes, which skip chunk negotiation entirely) and a bare summary. It now:

- narrates every phase on an indicatif steady-tick spinner: enumerating changes → preparing → hashing → negotiating → uploading → committing → refreshing the mount view (same live wording as `tl git push`)
- appends total wall time to the summary and adds a per-phase breakdown line:

```
Snapshot d5172716… (668 file(s), 557 of 557 chunks uploaded in 1.83s)
  enumerate 41ms  prepare 6ms  push 1.78s  refresh 12ms
```

`push` covers the whole `push_files` call (hash + negotiate + upload + server-side commit), and sub-second phases render as milliseconds instead of `0.00s`.

## Shared progress sink

The `PushEvent`→spinner mapping is extracted into `commands::push_progress_spinner`, now used by both `tl git push` and `tl fs snapshot`, so the two commands report identical progress wording and can't drift (they had already diverged once). Net for git.rs: −55 lines. `tl git push` picks up the clearer `uploading N of M chunks (rest already stored)` phrasing.

## Notes

- Rebased on main after #822; snapshot's pending-rename set is folded into the clean-check, the `preparing N change(s)` count, and the prepare phase bucket.
- Known tradeoff (unchanged from `tl git push` behavior): on a hidden draw target (piped stderr / non-TTY) spinner messages are dropped, so scripted runs only get the final summary — except the detached-commit job id, which still prints.
- Follow-ups queued from a review pass (not in this PR): clear the spinner on early-error paths via `ProgressFinish::AndClear`, move the helper + bar construction into `output/`, stream the detached-job line to stderr when hidden.

Verified: `cargo check -p tensorlake-cli` (default features) and `cargo check -p tensorlake-cli --features mount,git-clone` with gsvc-mount/gsvc-codec vendored from artifact_storage origin/main — both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)