### PR TITLE
Bump version to 0.5.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.67"
+version = "0.5.68"
 dependencies = [
  "anyhow",
  "base64",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.67"
+version = "0.5.68"
 dependencies = [
  "anyhow",
  "base64",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.67"
+version = "0.5.68"
 dependencies = [
  "napi",
  "napi-build",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.67"
+version = "0.5.68"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.67"
+version = "0.5.68"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.67"
+version = "0.5.68"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.67"
+version = "0.5.68"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.67",
+  "version": "0.5.68",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Lockstep version bump `0.5.67` → `0.5.68` across all published Tensorlake packages (Python / Rust / CLI / npm), via `.github/scripts/bump_version.py`.

Files updated:
- `Cargo.toml` (`[workspace.package] version`, inherited by all four Rust crates)
- `pyproject.toml` (`tensorlake` Python SDK)
- `crates/rust-cloud-sdk-py/pyproject.toml` (`tensorlake-rust-cloud-sdk`)
- `typescript/package.json` (`tensorlake` npm)
- `Cargo.lock` (refreshed: the four workspace crates → 0.5.68)

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)