### PR TITLE
test: hoist hand-rolled HTTP mock-server framing into shared test support

### DIFF
--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -1688,7 +1688,9 @@ impl ArtifactStorageClient {
         // push can fail against a job that is succeeding.
         let (suffix, timeout) = match wait_generation {
             Some(g) => (
-                format!("commits/jobs/{id}?wait_generation={g}&timeout_ms={JOB_LONG_POLL_TIMEOUT_MS}"),
+                format!(
+                    "commits/jobs/{id}?wait_generation={g}&timeout_ms={JOB_LONG_POLL_TIMEOUT_MS}"
+                ),
                 std::time::Duration::from_millis(JOB_LONG_POLL_TIMEOUT_MS + 10_000),
             ),
             None => (
@@ -2155,8 +2157,8 @@ mod tests {
     /// against a local canned-response HTTP server and asserts the URL of every request.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn detached_snapshot_push_polls_commit_job_route() {
+        use crate::test_support::{read_http_request_keep_alive, write_json_response_keep_alive};
         use std::sync::{Arc, Mutex};
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         // Canned responses keyed by path: session (oid_files so a known-oid push uploads
         // nothing), a 202 detach from the snapshot submit, and a terminal job status.
@@ -2236,37 +2238,12 @@ mod tests {
                 };
                 let seen = seen_srv.clone();
                 tokio::spawn(async move {
-                    let mut buf: Vec<u8> = Vec::new();
-                    loop {
-                        // One request: headers to CRLFCRLF, then a content-length body.
-                        let head_end = loop {
-                            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
-                                break pos + 4;
-                            }
-                            let mut tmp = [0u8; 4096];
-                            match sock.read(&mut tmp).await {
-                                Ok(0) | Err(_) => return,
-                                Ok(n) => buf.extend_from_slice(&tmp[..n]),
-                            }
-                        };
-                        let head = String::from_utf8_lossy(&buf[..head_end]).to_string();
+                    let mut carry: Vec<u8> = Vec::new();
+                    while let Some(request) =
+                        read_http_request_keep_alive(&mut sock, &mut carry).await
+                    {
+                        let head = String::from_utf8_lossy(&request);
                         let request_line = head.lines().next().unwrap_or_default().to_string();
-                        let content_length: usize = head
-                            .lines()
-                            .find_map(|l| {
-                                l.to_ascii_lowercase()
-                                    .strip_prefix("content-length:")
-                                    .map(|v| v.trim().parse().unwrap_or(0))
-                            })
-                            .unwrap_or(0);
-                        while buf.len() < head_end + content_length {
-                            let mut tmp = [0u8; 4096];
-                            match sock.read(&mut tmp).await {
-                                Ok(0) | Err(_) => return,
-                                Ok(n) => buf.extend_from_slice(&tmp[..n]),
-                            }
-                        }
-                        buf.drain(..head_end + content_length);
                         seen.lock().unwrap().push(request_line.clone());
                         let path = request_line
                             .split_whitespace()
@@ -2274,11 +2251,10 @@ mod tests {
                             .unwrap_or_default()
                             .to_string();
                         let (status, body) = respond(&path);
-                        let resp = format!(
-                            "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{body}",
-                            body.len()
-                        );
-                        if sock.write_all(resp.as_bytes()).await.is_err() {
+                        if write_json_response_keep_alive(&mut sock, status, &body)
+                            .await
+                            .is_err()
+                        {
                             return;
                         }
                     }

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -88,6 +88,8 @@ use sandboxes::*;
 use secrets::*;
 
 mod client;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub use client::{Client, ClientBuilder, Traced};
 
 /// Derive the sandbox lifecycle base URL from the API URL.

--- a/crates/cloud-sdk/src/test_support.rs
+++ b/crates/cloud-sdk/src/test_support.rs
@@ -1,0 +1,106 @@
+//! Minimal HTTP/1.1 framing helpers for hand-rolled mock servers in tests.
+//!
+//! Hand-rolled rather than a mock-server crate because these tests assert on the raw
+//! request bytes the client puts on the wire (header casing, framing, multipart body
+//! content), which parsed-request mocks don't expose.
+//!
+//! Compiled twice on purpose: as `crate::test_support` for in-crate unit tests, and via
+//! a `#[path]` module in `tests/common.rs` for integration tests.
+#![allow(dead_code)]
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Read one HTTP/1.1 request — headers through CRLFCRLF plus a `content-length` body —
+/// from a connection carrying a single request. If the peer closes early, returns the
+/// partial bytes so the caller's assertions fail with what actually arrived.
+pub async fn read_http_request(socket: &mut TcpStream) -> Vec<u8> {
+    let mut carry = Vec::new();
+    match read_http_request_keep_alive(socket, &mut carry).await {
+        Some(request) => request,
+        None => carry,
+    }
+}
+
+/// Read one HTTP/1.1 request from a keep-alive connection. `carry` holds bytes beyond
+/// the returned request between calls. Returns `None` once the peer closes or errors
+/// before a complete request arrives; partial bytes remain in `carry`.
+pub async fn read_http_request_keep_alive(
+    socket: &mut TcpStream,
+    carry: &mut Vec<u8>,
+) -> Option<Vec<u8>> {
+    let head_end = loop {
+        if let Some(pos) = carry.windows(4).position(|window| window == b"\r\n\r\n") {
+            break pos + 4;
+        }
+        let mut buf = [0_u8; 4096];
+        match socket.read(&mut buf).await {
+            Ok(0) | Err(_) => return None,
+            Ok(read) => carry.extend_from_slice(&buf[..read]),
+        }
+    };
+
+    let headers = String::from_utf8_lossy(&carry[..head_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+
+    while carry.len() < head_end + content_length {
+        let mut buf = [0_u8; 4096];
+        match socket.read(&mut buf).await {
+            Ok(0) | Err(_) => return None,
+            Ok(read) => carry.extend_from_slice(&buf[..read]),
+        }
+    }
+
+    Some(carry.drain(..head_end + content_length).collect())
+}
+
+/// Write a bodyless 204 and close the connection.
+pub async fn write_empty_response(socket: &mut TcpStream) -> std::io::Result<()> {
+    socket
+        .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        .await
+}
+
+/// Write `body` as a 200 JSON response and close the connection, so pooled clients open
+/// a fresh connection for their next request.
+pub async fn write_json_response(socket: &mut TcpStream, body: &str) -> std::io::Result<()> {
+    write_json(socket, "200 OK", body, false).await
+}
+
+/// Write `body` as a JSON response with the given status line (e.g. "202 Accepted"),
+/// leaving the connection open for further requests.
+pub async fn write_json_response_keep_alive(
+    socket: &mut TcpStream,
+    status: &str,
+    body: &str,
+) -> std::io::Result<()> {
+    write_json(socket, status, body, true).await
+}
+
+async fn write_json(
+    socket: &mut TcpStream,
+    status: &str,
+    body: &str,
+    keep_alive: bool,
+) -> std::io::Result<()> {
+    let connection = if keep_alive {
+        ""
+    } else {
+        "Connection: close\r\n"
+    };
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{connection}\r\n{body}",
+        body.len(),
+    );
+    socket.write_all(response.as_bytes()).await
+}

--- a/crates/cloud-sdk/tests/common.rs
+++ b/crates/cloud-sdk/tests/common.rs
@@ -2,10 +2,16 @@ use rand::Rng;
 use std::env;
 use tensorlake::{Sdk, images::models::*};
 
+// Shared HTTP/1.1 mock-server framing helpers, single-sourced with the in-crate
+// `crate::test_support` module used by unit tests.
+#[path = "../src/test_support.rs"]
+pub mod http_mock;
+
 fn env_var(name: &str) -> Result<String, String> {
     env::var(name).map_err(|_| format!("{name} must be set"))
 }
 
+#[allow(dead_code)]
 pub fn create_sdk() -> Result<Sdk, String> {
     let url = env_var("TENSORLAKE_API_URL")?;
     let api_key = env_var("TENSORLAKE_API_KEY")?;
@@ -63,6 +69,7 @@ pub fn get_org_and_project_ids() -> Result<(String, String), String> {
     Ok((org_id, project_id))
 }
 
+#[allow(dead_code)]
 pub fn random_string() -> String {
     const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
     let mut rng = rand::rng();

--- a/crates/cloud-sdk/tests/images.rs
+++ b/crates/cloud-sdk/tests/images.rs
@@ -1,8 +1,8 @@
 use tensorlake::images::models::*;
 use tensorlake::{ClientBuilder, images::ImagesClient};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
+use crate::common::http_mock::{read_http_request, write_json_response};
 use crate::common::random_string;
 
 mod common;
@@ -19,13 +19,7 @@ async fn test_create_application_build_sends_application_json_and_context_parts(
         let request_bytes = read_http_request(&mut socket).await;
 
         let response_body = r#"{"id":"app-build-1","organization_id":"org-1","project_id":"proj-1","name":"app_fn","version":"v1","status":"building","image_builds":[{"id":"img-build-1","app_version_id":"app-version-1","key":"img-1","name":"image-a","status":"pending","function_names":["fn-1","fn-2"],"created_at":"2026-03-07T10:00:00Z","updated_at":"2026-03-07T10:01:00Z"}]}"#;
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            response_body.len(),
-            response_body
-        );
-        socket
-            .write_all(response.as_bytes())
+        write_json_response(&mut socket, response_body)
             .await
             .expect("write response");
 
@@ -97,40 +91,6 @@ async fn test_create_application_build_sends_application_json_and_context_parts(
     assert_eq!(response.status.as_deref(), Some("building"));
     assert_eq!(response.image_builds.len(), 1);
     assert_eq!(response.image_builds[0].status, "pending");
-}
-
-async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Vec<u8> {
-    let mut request = Vec::new();
-    let mut buf = [0_u8; 4096];
-
-    loop {
-        let read = socket.read(&mut buf).await.expect("read request");
-        if read == 0 {
-            break;
-        }
-        request.extend_from_slice(&buf[..read]);
-
-        if let Some(headers_end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
-            let headers = String::from_utf8_lossy(&request[..headers_end + 4]);
-            let content_length = headers
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    if name.eq_ignore_ascii_case("content-length") {
-                        value.trim().parse::<usize>().ok()
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or(0);
-
-            if request.len() >= headers_end + 4 + content_length {
-                break;
-            }
-        }
-    }
-
-    request
 }
 
 #[tokio::test]

--- a/crates/cloud-sdk/tests/sandbox_templates.rs
+++ b/crates/cloud-sdk/tests/sandbox_templates.rs
@@ -1,8 +1,9 @@
 use tensorlake::{ClientBuilder, sandbox_templates::SandboxTemplatesClient};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
 mod common;
+
+use common::http_mock::{read_http_request, write_empty_response, write_json_response};
 
 #[tokio::test]
 async fn delete_sandbox_template_sends_encoded_delete_request() {
@@ -14,9 +15,7 @@ async fn delete_sandbox_template_sends_encoded_delete_request() {
     let server = tokio::spawn(async move {
         let (mut socket, _) = listener.accept().await.expect("accept request");
         let request_bytes = read_http_request(&mut socket).await;
-        let response = "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n";
-        socket
-            .write_all(response.as_bytes())
+        write_empty_response(&mut socket)
             .await
             .expect("write response");
         request_bytes
@@ -62,7 +61,9 @@ async fn list_sandbox_templates_follows_pagination() {
             }
         })
         .to_string();
-        write_json_response(&mut socket, &page_1).await;
+        write_json_response(&mut socket, &page_1)
+            .await
+            .expect("write response");
 
         // Page 2: one template and no further pages.
         let (mut socket, _) = listener.accept().await.expect("accept page 2");
@@ -74,7 +75,9 @@ async fn list_sandbox_templates_follows_pagination() {
             "pagination": { "next": serde_json::Value::Null }
         })
         .to_string();
-        write_json_response(&mut socket, &page_2).await;
+        write_json_response(&mut socket, &page_2)
+            .await
+            .expect("write response");
 
         (request_1, request_2)
     });
@@ -189,35 +192,4 @@ async fn test_create_then_delete_sandbox_image() {
     if let Err(err) = result {
         panic!("{err}");
     }
-}
-
-async fn write_json_response(socket: &mut tokio::net::TcpStream, body: &str) {
-    let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-        body.len(),
-        body
-    );
-    socket
-        .write_all(response.as_bytes())
-        .await
-        .expect("write response");
-}
-
-async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Vec<u8> {
-    let mut request = Vec::new();
-    let mut buf = [0_u8; 4096];
-
-    loop {
-        let read = socket.read(&mut buf).await.expect("read request");
-        if read == 0 {
-            break;
-        }
-        request.extend_from_slice(&buf[..read]);
-
-        if request.windows(4).any(|window| window == b"\r\n\r\n") {
-            break;
-        }
-    }
-
-    request
 }

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -2,8 +2,11 @@ use tensorlake::{
     ClientBuilder,
     sandboxes::{SandboxProxyClient, SandboxesClient},
 };
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpListener;
+
+mod common;
+
+use common::http_mock::{read_http_request, write_empty_response, write_json_response};
 
 #[tokio::test]
 async fn sandbox_proxy_raw_and_empty_posts_send_content_length_and_routing_headers() {
@@ -15,16 +18,22 @@ async fn sandbox_proxy_raw_and_empty_posts_send_content_length_and_routing_heade
     let server = tokio::spawn(async move {
         let (mut socket, _) = listener.accept().await.expect("accept write_stdin");
         let write_stdin = read_http_request(&mut socket).await;
-        write_empty_response(&mut socket).await;
+        write_empty_response(&mut socket)
+            .await
+            .expect("write response");
 
         let (mut socket, _) = listener.accept().await.expect("accept close_stdin");
         let close_stdin = read_http_request(&mut socket).await;
-        write_empty_response(&mut socket).await;
+        write_empty_response(&mut socket)
+            .await
+            .expect("write response");
 
         let (mut socket, _) = listener.accept().await.expect("accept restart");
         let restart = read_http_request(&mut socket).await;
         let body = r#"{"pid":101,"status":"running","command":"bash","args":[],"started_at":0}"#;
-        write_json_response(&mut socket, body).await;
+        write_json_response(&mut socket, body)
+            .await
+            .expect("write response");
 
         (write_stdin, close_stdin, restart)
     });
@@ -78,7 +87,9 @@ async fn direct_empty_post_helper_sends_content_length_zero() {
         let (mut socket, _) = listener.accept().await.expect("accept request");
         let request = read_http_request(&mut socket).await;
         let body = r#"{"sandbox_id":"sbx-1","status":"running"}"#;
-        write_json_response(&mut socket, body).await;
+        write_json_response(&mut socket, body)
+            .await
+            .expect("write response");
         request
     });
 
@@ -93,57 +104,4 @@ async fn direct_empty_post_helper_sends_content_length_zero() {
     let request_text = String::from_utf8_lossy(&request);
     assert!(request_text.starts_with("POST /sandbox-pools/pool-1/sandboxes HTTP/1.1\r\n"));
     assert!(request_text.contains("\r\ncontent-length: 0\r\n"));
-}
-
-async fn read_http_request(socket: &mut TcpStream) -> Vec<u8> {
-    let mut request = Vec::new();
-    let mut buf = [0_u8; 4096];
-
-    loop {
-        let read = socket.read(&mut buf).await.expect("read request");
-        if read == 0 {
-            break;
-        }
-        request.extend_from_slice(&buf[..read]);
-
-        if let Some(headers_end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
-            let headers = String::from_utf8_lossy(&request[..headers_end + 4]);
-            let content_length = headers
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    if name.eq_ignore_ascii_case("content-length") {
-                        value.trim().parse::<usize>().ok()
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or(0);
-
-            if request.len() >= headers_end + 4 + content_length {
-                break;
-            }
-        }
-    }
-
-    request
-}
-
-async fn write_empty_response(socket: &mut TcpStream) {
-    socket
-        .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
-        .await
-        .expect("write response");
-}
-
-async fn write_json_response(socket: &mut TcpStream, body: &str) {
-    let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-        body.len(),
-        body
-    );
-    socket
-        .write_all(response.as_bytes())
-        .await
-        .expect("write response");
 }


### PR DESCRIPTION
## Summary

Four places hand-rolled the same minimal HTTP/1.1 mock-server framing (CRLFCRLF header scan + content-length body read + canned JSON response writer):

- `crates/cloud-sdk/tests/sandboxes.rs`
- `crates/cloud-sdk/tests/sandbox_templates.rs`
- `crates/cloud-sdk/tests/images.rs`
- the `detached_snapshot_push_polls_commit_job_route` unit test in `crates/cloud-sdk/src/artifact_storage/ingest.rs` (the only copy with keep-alive connection reuse)

This PR single-sources them in `src/test_support.rs`, compiled twice on purpose from one file: as `#[cfg(test)] crate::test_support` for in-crate unit tests, and re-included via `#[path]` as `common::http_mock` for the integration test binaries. Net −125 lines of test code.

The helper API preserves both connection disciplines:
- `read_http_request` / `write_empty_response` / `write_json_response` — `Connection: close`, so pooled clients open a fresh connection per request (the integration tests accept one connection per expected request and would hang otherwise)
- `read_http_request_keep_alive` / `write_json_response_keep_alive` — carries leftover bytes across requests on one socket and sends no close header, which the ingest detached-job poll test depends on

## Why not wiremock

Evaluated and rejected: these tests assert on the **raw bytes** the client puts on the wire — header casing (`\r\nhost: sandbox-host.test\r\n`), exact framing (`ends_with(b"\r\n\r\nhello")`), and raw multipart body content. wiremock hands you a parsed `Request`, so those wire-level assertions (the point of several of these tests) would be lost.

Intentional, test-invisible behavior notes: the shared reader is content-length-aware everywhere (sandbox_templates' old copy stopped at CRLFCRLF, fine for its bodyless GET/DELETE requests), and the shared 204 writer includes `Content-Length: 0`, which one old inline response omitted.

Test-only change; no runtime code is affected, so no version bump.

## Test plan

- `cargo test -p tensorlake --lib` — 135 passed, including the detached-snapshot regression test
- `cargo test -p tensorlake --test sandboxes --test sandbox_templates --test images` — 5 passed (live-API tests ignored as usual)
- `cargo test -p tensorlake --no-run` — all targets compile with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)