### PR TITLE
tl git create: mint a push credential; tl fs: default the mount path to the CWD's mount

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1282,6 +1282,107 @@ fn state_dir_for(path: &Path) -> Result<(String, PathBuf)> {
     Ok((mountpoint, PathBuf::from(state_dir)))
 }
 
+/// Whether `path` is a registered mountpoint. Used to disambiguate optional positional args
+/// (`tl fs diff <a> <b>` vs `tl fs diff <path> <a>`).
+pub fn is_registered_mount(path: &Path) -> bool {
+    state_dir_for(path).is_ok()
+}
+
+/// The registered mountpoint containing the current directory (the deepest one, for nested
+/// mounts). This is what path-addressed commands operate on when no path argument is given.
+pub fn mount_containing_cwd() -> Result<PathBuf> {
+    let cwd = std::env::current_dir()?;
+    let cwd = cwd.canonicalize().unwrap_or(cwd);
+    registry_load()
+        .keys()
+        .map(PathBuf::from)
+        .filter(|mountpoint| {
+            // Registry keys keep the leaf component un-canonicalized (it may be a live FUSE
+            // fs); compare against both spellings so a symlinked leaf still matches the
+            // canonicalized CWD.
+            cwd.starts_with(mountpoint)
+                || mountpoint
+                    .canonicalize()
+                    .is_ok_and(|canonical| cwd.starts_with(canonical))
+        })
+        .max_by_key(|mountpoint| mountpoint.components().count())
+        .ok_or_else(|| {
+            CliError::usage(format!(
+                "{} is not inside a tl fs mount; pass the mounted directory explicitly",
+                cwd.display()
+            ))
+        })
+}
+
+/// Resolve the optional mounted-directory argument of path-addressed commands: an explicit
+/// path wins; otherwise default to the mount containing the current directory.
+pub fn resolve_mount_path(path: Option<PathBuf>) -> Result<PathBuf> {
+    match path {
+        Some(path) => Ok(path),
+        None => mount_containing_cwd(),
+    }
+}
+
+/// Whether a positional argument is unmistakably a filesystem path rather than a snapshot,
+/// ref, or branch name: absolute, explicitly relative (`./`, `../`), or naming an existing
+/// directory. Branch names like `feature/x` contain separators too, so a bare separator is
+/// not enough. Used to keep the explicit "not a tl fs mount" error for typo'd or stale mount
+/// paths instead of silently reinterpreting them.
+fn is_path_shaped(value: &Path) -> bool {
+    use std::path::Component;
+    value.is_absolute()
+        || matches!(
+            value.components().next(),
+            Some(Component::CurDir | Component::ParentDir)
+        )
+        || value.is_dir()
+}
+
+/// `tl fs diff` positionals are ambiguous once the mount path is optional: one leading arg can
+/// be either the mounted directory or the older snapshot. Treat it as the mount when it's a
+/// registered mountpoint; reject it when it's path-shaped but unregistered (a typo or stale
+/// mount, not a snapshot ref); otherwise shift everything right and infer the mount from the
+/// current directory.
+pub fn resolve_diff_args(
+    path: Option<PathBuf>,
+    a: Option<String>,
+    b: Option<String>,
+) -> Result<(PathBuf, Option<String>, Option<String>)> {
+    match path {
+        Some(path) if is_registered_mount(&path) => Ok((path, a, b)),
+        Some(not_a_mount) => {
+            if b.is_some() || is_path_shaped(&not_a_mount) {
+                // Three args, or a path-shaped first arg that isn't registered: surface the
+                // real problem instead of treating the path as a snapshot ref.
+                return Err(CliError::usage(format!(
+                    "{} is not a tl fs mount; run `tl fs mount` first",
+                    not_a_mount.display()
+                )));
+            }
+            Ok((
+                mount_containing_cwd()?,
+                Some(not_a_mount.to_string_lossy().into_owned()),
+                a,
+            ))
+        }
+        None => Ok((mount_containing_cwd()?, a, b)),
+    }
+}
+
+/// Guard for `tl fs promote <branch>` / `tl fs restore <version>` with the mount path omitted:
+/// when the sole positional is itself a mounted directory (or an explicit path), the user
+/// almost certainly forgot the branch/version — without this, promote would publish the CWD
+/// mount onto a branch literally named after the directory.
+pub fn reject_mount_like_positional(value: &str, what: &str, usage: &str) -> Result<()> {
+    let as_path = Path::new(value);
+    if is_registered_mount(as_path) || is_path_shaped(as_path) {
+        return Err(CliError::usage(format!(
+            "{value} looks like a mounted directory, not a {what}; usage: {usage}"
+        )));
+    }
+    Ok(())
+}
+
 /// Path-addressed commands (snapshot/promote/status/restore/diff/unmount) know their scope
 /// from the mount they operate on; seed the auth context from the mount state so they work
 /// from any working directory. Without this, running `tl fs snapshot` from a CWD with no

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -617,9 +617,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 let dsts: Vec<String> =
                                     redirect_seals.iter().map(|s| s.dst.clone()).collect();
                                 if let Err(e) = overlay.consume_redirects(&dsts) {
-                                    eprintln!(
-                                        "auto-commit: consuming sealed renames failed: {e}"
-                                    );
+                                    eprintln!("auto-commit: consuming sealed renames failed: {e}");
                                 }
                             } else {
                                 eprintln!(

--- a/crates/cli/src/commands/fs/fusefs.rs
+++ b/crates/cli/src/commands/fs/fusefs.rs
@@ -55,7 +55,10 @@ mod tests {
     fn unsupported_maps_to_enotsup_not_eio() {
         // Renaming a committed directory is unsupported; it must surface ENOTSUP, not the
         // Protocol->EIO catch-all that read as a bewildering "Input/output error".
-        assert_eq!(errno(&MountError::Unsupported(String::new())), libc::ENOTSUP);
+        assert_eq!(
+            errno(&MountError::Unsupported(String::new())),
+            libc::ENOTSUP
+        );
         assert_ne!(errno(&MountError::Unsupported(String::new())), libc::EIO);
     }
 }

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -689,7 +689,11 @@ impl OverlayFs {
 
     /// The recorded source when `path` is itself a pending-rename destination root.
     fn redirect_source(&self, path: &str) -> Option<String> {
-        self.redirects.lock().expect("redirect lock").get(path).cloned()
+        self.redirects
+            .lock()
+            .expect("redirect lock")
+            .get(path)
+            .cloned()
     }
 
     /// Whether `path` is a pending-rename destination root or sits under one.
@@ -1729,7 +1733,10 @@ impl OverlayFs {
         // source coordinates are whiteouted and filter out below.
         let reverse: Vec<(String, String)> = {
             let redirects = self.redirects.lock().expect("redirect lock");
-            redirects.iter().map(|(d, s)| (s.clone(), d.clone())).collect()
+            redirects
+                .iter()
+                .map(|(d, s)| (s.clone(), d.clone()))
+                .collect()
         };
         let merged_path = |lower: &str| -> String {
             for (src, dst) in &reverse {
@@ -1758,7 +1765,10 @@ impl OverlayFs {
                 continue;
             };
             let (parent_ino, name) = match path.rfind('/') {
-                Some(i) => (inodes.index.get(&path[..i]).copied(), path[i + 1..].to_string()),
+                Some(i) => (
+                    inodes.index.get(&path[..i]).copied(),
+                    path[i + 1..].to_string(),
+                ),
                 None => (Some(ROOT_INO), path.clone()),
             };
             out.push(OverlayInval {
@@ -1850,8 +1860,10 @@ impl OverlayFs {
     /// The pending rename table (destination -> true-lower source), for status display.
     pub fn redirect_entries(&self) -> Vec<(String, String)> {
         let redirects = self.redirects.lock().expect("redirect lock");
-        let mut entries: Vec<(String, String)> =
-            redirects.iter().map(|(d, s)| (d.clone(), s.clone())).collect();
+        let mut entries: Vec<(String, String)> = redirects
+            .iter()
+            .map(|(d, s)| (d.clone(), s.clone()))
+            .collect();
         entries.sort();
         entries
     }
@@ -2062,7 +2074,10 @@ mod tests {
         // A file created in the upper (git's `config.lock`) — no lower binding.
         let (ino, _, _) = t.intern("config.lock".to_string(), None);
         let released = t.rename("config.lock", "config");
-        assert!(released.is_empty(), "pure-upper rename releases no core refs");
+        assert!(
+            released.is_empty(),
+            "pure-upper rename releases no core refs"
+        );
         assert!(
             !t.index.contains_key("config.lock"),
             "source path is vacated"
@@ -2619,7 +2634,10 @@ mod tests {
             dir_names(&fs, moved.ino).await,
             vec!["lib.rs", "sub", "tool.sh"]
         );
-        assert_eq!(read_all(&fs, moved.ino, "lib.rs").await, b"pub fn lib2() {}\n");
+        assert_eq!(
+            read_all(&fs, moved.ino, "lib.rs").await,
+            b"pub fn lib2() {}\n"
+        );
 
         // 3. A second move re-keys the same entry (chain stays one hop).
         fs.rename(ROOT_INO, "moved", ROOT_INO, "moved2")
@@ -2645,8 +2663,7 @@ mod tests {
         //    for the copy-up, and the source delete the whiteout produced.
         let seals = fs.expand_redirects().await.unwrap();
         assert_eq!(seals.len(), 1);
-        let mut sealed_paths: Vec<&str> =
-            seals[0].files.iter().map(|f| f.path.as_str()).collect();
+        let mut sealed_paths: Vec<&str> = seals[0].files.iter().map(|f| f.path.as_str()).collect();
         sealed_paths.sort();
         assert_eq!(
             sealed_paths,

--- a/crates/cli/src/commands/fs/vfsserver.rs
+++ b/crates/cli/src/commands/fs/vfsserver.rs
@@ -515,7 +515,10 @@ mod tests {
     fn unsupported_maps_to_enotsup_not_eio() {
         // Renaming a committed directory is unsupported; it must surface ENOTSUP, not the
         // Protocol->EIO catch-all that read as a bewildering "Input/output error".
-        assert_eq!(errno(&MountError::Unsupported(String::new())), libc::ENOTSUP);
+        assert_eq!(
+            errno(&MountError::Unsupported(String::new())),
+            libc::ENOTSUP
+        );
         assert_ne!(errno(&MountError::Unsupported(String::new())), libc::EIO);
     }
 }

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -113,16 +113,54 @@ pub async fn create_repo(
         .create_repo(&project_id, repo, default_branch)
         .await
         .map_err(map_sdk_error)?;
+    let remote_url = client.git_repo_url(&project_id, repo);
+    let branch = default_branch.unwrap_or("main");
+
+    // The repo exists once create_repo returns; the credential is a convenience. A mint
+    // failure (env-token dev setups, PATs without token scope, transient errors) must not
+    // turn the command into an error — a retry would just hit "repo already exists".
+    let credential = match client.mint_token_for_repo(&project_id, Some(repo)).await {
+        Ok(credential) => Some(credential.into_inner()),
+        Err(err) => {
+            eprintln!(
+                "warning: minting a push credential failed ({err}); run `tl git token {repo}` to mint one"
+            );
+            None
+        }
+    };
+
     if output_json {
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
                 "repo": repo,
-                "url": client.git_repo_url(&project_id, repo),
+                "url": remote_url,
+                "credential": credential,
             }))?
         );
-    } else {
-        println!("created {}", client.git_repo_url(&project_id, repo));
+        return Ok(());
+    }
+
+    println!("created {remote_url}");
+    println!();
+    println!("{}", style("Push to this repo").bold().green());
+    println!("  {}", style(format!("tl git push {repo} {branch}")).cyan());
+    println!("  (mints a fresh short-lived credential automatically on every push)");
+    if let Some(credential) = credential {
+        println!();
+        println!(
+            "{}",
+            style("Credential for CI or direct HTTP access")
+                .bold()
+                .green()
+        );
+        println!("  {} {}", style("username:").dim(), credential.git_username);
+        println!(
+            "  {} {}",
+            style("password:").dim(),
+            style(&credential.token).yellow()
+        );
+        println!("  {} {}", style("expires:").dim(), credential.expires_at);
     }
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -299,8 +299,8 @@ enum FsCommands {
 
     /// Seal local changes into a snapshot on the workspace ref
     Snapshot {
-        /// A mounted directory
-        path: PathBuf,
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
 
         /// Snapshot message
         #[arg(short, long)]
@@ -308,9 +308,10 @@ enum FsCommands {
     },
 
     /// Publish the workspace's snapshot onto a real branch (squash by default)
+    #[command(allow_missing_positional = true)]
     Promote {
-        /// A mounted directory
-        path: PathBuf,
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
 
         /// Target branch
         branch: String,
@@ -331,8 +332,8 @@ enum FsCommands {
 
     /// Pull the target branch into the workspace (server-side rebase-style merge)
     Sync {
-        /// A mounted directory
-        path: PathBuf,
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
 
         /// Branch to pull from (default: the branch the workspace was created from)
         #[arg(long)]
@@ -349,8 +350,8 @@ enum FsCommands {
 
     /// Show workspace, lease, and local-change status for a mount
     Status {
-        /// A mounted directory
-        path: PathBuf,
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
 
         /// Print status as JSON
         #[arg(long)]
@@ -358,9 +359,10 @@ enum FsCommands {
     },
 
     /// Restore a mount's tracked files to a snapshot or commit
+    #[command(allow_missing_positional = true)]
     Restore {
-        /// A mounted directory
-        path: PathBuf,
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
 
         /// Snapshot/commit hex, branch, or ref to restore to
         version: String,
@@ -368,8 +370,8 @@ enum FsCommands {
 
     /// List changed paths: local vs last snapshot, or between two snapshots
     Diff {
-        /// A mounted directory
-        path: PathBuf,
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
 
         /// Older snapshot/commit (omit both for local vs last snapshot)
         a: Option<String>,
@@ -380,8 +382,8 @@ enum FsCommands {
 
     /// Unmount: detach and forget local state; the workspace stays until deleted
     Unmount {
-        /// A mounted directory
-        path: PathBuf,
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
 
         /// Also delete the server-side workspace
         #[arg(long)]
@@ -2248,20 +2250,57 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
         }
         other => other,
     };
+    // Path-addressed commands default their mounted-directory argument to the mount containing
+    // the CWD; resolve it up front so scope hydration and the command agree on the path.
+    let mut subcmd = subcmd;
+    let mut mount_dir: Option<std::path::PathBuf> = None;
+    match &mut subcmd {
+        FsCommands::Promote { path, branch, .. } => {
+            if path.is_none() {
+                // With the path omitted, a sole positional that is itself a mounted
+                // directory is a forgotten branch — reject it before it becomes a publish
+                // onto a branch named after the directory.
+                commands::fs::reject_mount_like_positional(
+                    branch,
+                    "branch",
+                    "tl fs promote [PATH] <BRANCH>",
+                )?;
+            }
+            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
+        }
+        FsCommands::Restore { path, version } => {
+            if path.is_none() {
+                commands::fs::reject_mount_like_positional(
+                    version,
+                    "snapshot or ref",
+                    "tl fs restore [PATH] <VERSION>",
+                )?;
+            }
+            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
+        }
+        FsCommands::Diff { path, a, b } => {
+            let (path, ra, rb) = commands::fs::resolve_diff_args(path.take(), a.take(), b.take())?;
+            *a = ra;
+            *b = rb;
+            mount_dir = Some(path);
+        }
+        FsCommands::Snapshot { path, .. }
+        | FsCommands::Sync { path, .. }
+        | FsCommands::Status { path, .. }
+        | FsCommands::Unmount { path, .. } => {
+            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
+        }
+        _ => {}
+    }
     // Path-addressed commands carry their scope in the mount state; resolve it from there so
     // they work from any CWD instead of triggering the interactive init flow (which, run from
     // inside a mount, would write .tensorlake/config.toml into the workspace).
-    match &subcmd {
-        FsCommands::Snapshot { path, .. }
-        | FsCommands::Promote { path, .. }
-        | FsCommands::Sync { path, .. }
-        | FsCommands::Status { path, .. }
-        | FsCommands::Restore { path, .. }
-        | FsCommands::Diff { path, .. }
-        | FsCommands::Unmount { path, .. } => commands::fs::hydrate_scope_from_mount(ctx, path),
-        _ => {}
+    if let Some(mount_dir) = &mount_dir {
+        commands::fs::hydrate_scope_from_mount(ctx, mount_dir);
     }
     ensure_auth_and_project(ctx).await?;
+    // Set for exactly the path-addressed commands, whose dispatch arms are the only readers.
+    let mount_dir = move || mount_dir.expect("resolved for every path-addressed command above");
     let result = match subcmd {
         FsCommands::Setup { .. } => unreachable!("handled before the auth guard"),
         FsCommands::Ls { file_system, json } => {
@@ -2300,40 +2339,51 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             state_dir,
             log_level,
         } => commands::fs::daemon::run(ctx, &state_dir, &log_level).await,
-        FsCommands::Snapshot { path, message } => {
-            commands::fs::snapshot(ctx, &path, message.as_deref()).await
+        FsCommands::Snapshot { message, .. } => {
+            commands::fs::snapshot(ctx, &mount_dir(), message.as_deref()).await
         }
         FsCommands::Promote {
-            path,
             branch,
             full_history,
             merge,
             message,
+            ..
         } => {
-            commands::fs::promote(ctx, &path, &branch, full_history, merge, message.as_deref())
-                .await
+            commands::fs::promote(
+                ctx,
+                &mount_dir(),
+                &branch,
+                full_history,
+                merge,
+                message.as_deref(),
+            )
+            .await
         }
         FsCommands::Sync {
-            path,
             target,
             fail_on_conflict,
             message,
+            ..
         } => {
             commands::fs::sync(
                 ctx,
-                &path,
+                &mount_dir(),
                 target.as_deref(),
                 fail_on_conflict,
                 message.as_deref(),
             )
             .await
         }
-        FsCommands::Status { path, json } => commands::fs::status(ctx, &path, json).await,
-        FsCommands::Restore { path, version } => commands::fs::restore(ctx, &path, &version).await,
-        FsCommands::Diff { path, a, b } => {
-            commands::fs::diff(ctx, &path, a.as_deref(), b.as_deref()).await
+        FsCommands::Status { json, .. } => commands::fs::status(ctx, &mount_dir(), json).await,
+        FsCommands::Restore { version, .. } => {
+            commands::fs::restore(ctx, &mount_dir(), &version).await
         }
-        FsCommands::Unmount { path, delete } => commands::fs::unmount(ctx, &path, delete).await,
+        FsCommands::Diff { a, b, .. } => {
+            commands::fs::diff(ctx, &mount_dir(), a.as_deref(), b.as_deref()).await
+        }
+        FsCommands::Unmount { delete, .. } => {
+            commands::fs::unmount(ctx, &mount_dir(), delete).await
+        }
     };
     // A cached minted git credential can be revoked before its recorded expiry; purge
     // the cache on an auth failure so the next invocation re-mints instead of retrying
@@ -2867,6 +2917,53 @@ mod tests {
             }) => {}
             _ => panic!("expected fs setup command"),
         }
+
+        // Path-addressed commands default the mounted directory to the mount containing the
+        // CWD, so the path positional is optional everywhere.
+        match parse_command(["tl", "fs", "snapshot"]) {
+            Commands::Fs(FsCommands::Snapshot {
+                path: None,
+                message: None,
+            }) => {}
+            _ => panic!("expected fs snapshot command"),
+        }
+
+        match parse_command(["tl", "fs", "snapshot", "./w", "-m", "wip"]) {
+            Commands::Fs(FsCommands::Snapshot { path, message }) => {
+                assert_eq!(path, Some(PathBuf::from("./w")));
+                assert_eq!(message.as_deref(), Some("wip"));
+            }
+            _ => panic!("expected fs snapshot command"),
+        }
+
+        // Promote/restore have a required positional after the optional path; with a single
+        // value the path is the one skipped (allow_missing_positional).
+        match parse_command(["tl", "fs", "promote", "main"]) {
+            Commands::Fs(FsCommands::Promote { path, branch, .. }) => {
+                assert_eq!(path, None);
+                assert_eq!(branch, "main");
+            }
+            _ => panic!("expected fs promote command"),
+        }
+
+        match parse_command(["tl", "fs", "promote", "./w", "main"]) {
+            Commands::Fs(FsCommands::Promote { path, branch, .. }) => {
+                assert_eq!(path, Some(PathBuf::from("./w")));
+                assert_eq!(branch, "main");
+            }
+            _ => panic!("expected fs promote command"),
+        }
+
+        match parse_command(["tl", "fs", "restore", "0a1b2c3d"]) {
+            Commands::Fs(FsCommands::Restore { path, version }) => {
+                assert_eq!(path, None);
+                assert_eq!(version, "0a1b2c3d");
+            }
+            _ => panic!("expected fs restore command"),
+        }
+
+        assert!(Cli::try_parse_from(["tl", "fs", "promote"]).is_err());
+        assert!(Cli::try_parse_from(["tl", "fs", "restore"]).is_err());
 
         // The workspace subgroup is gone: workspaces ARE the `tl fs` surface.
         assert!(Cli::try_parse_from(["tl", "fs", "workspace", "ls", "data"]).is_err());


### PR DESCRIPTION
## What

**`tl git create` (and `tl git repo create`)** now makes new repos immediately usable:

- Prints the remote URL, a ready-to-run `tl git push <repo> <branch>` example, and a repo-scoped short-lived credential (username/password/expiry) for CI or direct HTTP access.
- `--json` output gains a `credential` object alongside `repo`/`url`.
- The creation is reported before minting: if the mint fails (env-token dev setups, PATs without token scope, transient errors), the command still succeeds with a `run tl git token <repo>` warning — no more "repo already exists" retry traps after a partial failure.

**`tl fs` path-addressed commands** (`snapshot`, `promote`, `sync`, `status`, `restore`, `diff`, `unmount`) now default their mounted-directory argument to the registered mount containing the current directory, so from inside a mount you can just run:

```
tl fs snapshot
tl fs status
tl fs promote main
tl fs diff abc123 def456
```

`promote`/`restore` use clap's `allow_missing_positional` so a single positional binds to the branch/version; explicit paths still work everywhere.

## Guardrails

The new optionality creates ambiguities; these keep the old explicit errors where a silent reinterpretation would mislead:

- `tl fs promote <mount-dir>` (branch forgotten) is rejected with a usage error instead of publishing the CWD mount onto a branch named after the directory. Same check for `restore`. Bare branch names like `feature/x` are unaffected — only registered mounts, absolute/`./`/`../` spellings, and existing directories trigger it.
- `tl fs diff` shifts a leading arg into the snapshot slot only when it isn't path-shaped; typo'd or stale mount paths keep the "not a tl fs mount" error.
- CWD-mount matching compares registry keys both raw and canonicalized, so mountpoints whose leaf is a symlink still resolve.
- The mount-path resolution is a single match in `run_fs_command` feeding one `mount_dir` local used by scope hydration and dispatch, rather than per-variant rebuilds.

## Testing

- `cargo test -p tensorlake-cli` (192 tests) and `cargo test -p tensorlake-cli --features mount,git-clone` with the private gsvc sources swapped in (219 tests) both pass.
- New parse tests cover the optional path, `promote`/`restore` single-arg binding, and rejection of the zero-arg forms of `promote`/`restore` without a branch/version.
- Reviewed with an 8-angle adversarial code review; all confirmed findings fixed in this PR.

Note: `tl git create` output (including `--json`) now contains a live short-lived repo-scoped token by design; if CI log hygiene becomes a concern, a flag to suppress it is an easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)