### PR TITLE
tl fs sync: converge kernel view for newly appeared files (ls shows it, cat says ENOENT)

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -2358,8 +2358,20 @@ pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> R
     bar.set_message("refreshing mount view...");
     // Swap the mount's lower layer to the new snapshot, then drop the overlay: the content the
     // upper layer held is now served (identically) by the lower commit.
-    daemon::control(&state_dir, "refresh").await?;
+    let refresh = daemon::control(&state_dir, "refresh").await?;
     daemon::control(&state_dir, "clear_upper").await?;
+    // The refresh may also have adopted foreign ref movement (a concurrent writer advanced the
+    // workspace ref past our snapshot commit), and the drained probe list can carry a backlog
+    // from background polls. Converge those the same way sync does — macOS only; the FUSE
+    // notifier already handled them on Linux. Our own sealed paths were upper-shadowed at
+    // refresh time and filter out of the probe list; the revalidate below covers them.
+    if cfg!(target_os = "macos") {
+        let (expect, _complete, _new_daemon) = parse_refresh_probes(&refresh);
+        if !expect.is_empty() {
+            let changed: std::collections::BTreeSet<String> = expect.keys().cloned().collect();
+            converge_kernel_view(Path::new(&mountpoint), &changed, &expect);
+        }
+    }
     // Content is byte-identical across the swap, but the previously-dirty paths' attributes
     // changed backing (upper mtimes -> lower commit time); refresh the kernel's view.
     let sealed: Vec<String> = upserts
@@ -2588,17 +2600,42 @@ pub async fn sync(
         ));
     }
     // The workspace ref moved server-side; swap the mount's lower layer now instead of
-    // waiting out the follow poll, then make sure the kernel drops stale views of the
-    // conflicted paths (their content changed to marker text behind its back).
-    daemon::control(&state_dir, "refresh").await?;
-    if !resp.conflicts.is_empty() {
-        let mut changed = std::collections::BTreeSet::new();
-        let mut expect = std::collections::BTreeMap::new();
-        for c in &resp.conflicts {
-            changed.insert(c.path.clone());
-            expect.insert(c.path.clone(), PathExpect::Present);
-        }
+    // waiting out the follow poll, then make sure the kernel drops stale views of every
+    // path the pull changed. This matters most for names that newly appeared: a lookup
+    // answered ENOENT before the sync can live on as a kernel-cached negative dentry that
+    // readdir traffic never revalidates (`ls` shows the file, `cat` says ENOENT), and on
+    // macOS there is no daemon-side notify channel to drop it — probing from out here is
+    // the only lever. Conflict paths get the same treatment (their content changed to
+    // marker text behind the kernel's back).
+    let refresh = daemon::control(&state_dir, "refresh").await?;
+    let (mut expect, complete, new_daemon) = parse_refresh_probes(&refresh);
+    // On Linux the daemon already pushed exact FUSE invalidations for these paths while
+    // serving the refresh; probing would redo that work through the mount. macOS (FSKit)
+    // has no notify channel — probing from out here is the only lever there.
+    if !cfg!(target_os = "macos") {
+        expect.clear();
+    }
+    for c in &resp.conflicts {
+        expect.insert(c.path.clone(), PathExpect::Present);
+    }
+    if !expect.is_empty() {
+        let changed: std::collections::BTreeSet<String> = expect.keys().cloned().collect();
         converge_kernel_view(Path::new(&mountpoint), &changed, &expect);
+    }
+    if cfg!(target_os = "macos") {
+        if !new_daemon {
+            eprintln!(
+                "{} the mount daemon predates this CLI; newly pulled files can transiently \
+                 answer ENOENT — remount to fix",
+                style("warning:").yellow(),
+            );
+        } else if !complete {
+            eprintln!(
+                "{} a refresh could not enumerate newly added paths; files pulled by this \
+                 sync can transiently answer ENOENT (kernel cache, ~30s)",
+                style("warning:").yellow(),
+            );
+        }
     }
     println!(
         "Synced with {} ({} path(s) pulled){}.",
@@ -3031,43 +3068,76 @@ fn converge_kernel_view(
     changed: &std::collections::BTreeSet<String>,
     expect: &std::collections::BTreeMap<String, PathExpect>,
 ) {
-    let changed: Vec<String> = changed.iter().cloned().collect();
+    // The first round nudges every changed path; later rounds re-probe only what has not
+    // settled, and the deadline is consulted per path so one huge round cannot blow far
+    // through the budget (a branch-jump sync can carry tens of thousands of paths).
+    let mut unsettled: Vec<String> = changed.iter().cloned().collect();
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        revalidate_paths(mountpoint, &changed);
-        let mut settled = true;
-        for (p, e) in expect {
-            let full = mountpoint.join(p);
-            match e {
-                PathExpect::Absent => {
-                    if open_truth(&full, false).is_some() {
-                        settled = false;
-                    }
-                }
-                PathExpect::Present => {
-                    if open_truth(&full, false).is_none() {
+    'rounds: loop {
+        revalidate_paths(mountpoint, &unsettled);
+        let mut still = Vec::new();
+        for p in unsettled {
+            if std::time::Instant::now() > deadline {
+                break 'rounds;
+            }
+            let full = mountpoint.join(&p);
+            let settled = match expect.get(&p) {
+                // A changed path with no expectation only needed the nudge above.
+                None => true,
+                Some(PathExpect::Absent) => open_truth(&full, false).is_none(),
+                Some(PathExpect::Present) => {
+                    open_truth(&full, false).is_some() || {
                         probe_negative_dentry(&full);
-                        if open_truth(&full, false).is_none() {
-                            settled = false;
-                        }
+                        open_truth(&full, false).is_some()
                     }
                 }
-                PathExpect::FileSize(size) => {
+                Some(PathExpect::FileSize(size)) => {
                     if open_truth(&full, true).is_none() {
                         probe_negative_dentry(&full);
                     }
-                    match open_truth(&full, true) {
-                        Some(len) if len == *size => {}
-                        _ => settled = false,
-                    }
+                    matches!(open_truth(&full, true), Some(len) if len == *size)
                 }
+            };
+            if !settled {
+                still.push(p);
             }
         }
-        if settled || std::time::Instant::now() > deadline {
+        if still.is_empty() || std::time::Instant::now() > deadline {
             break;
         }
+        unsettled = still;
         std::thread::sleep(std::time::Duration::from_millis(25));
     }
+}
+
+/// Parse a daemon `refresh` reply's drained probe expectations into converge inputs. Returns
+/// `(expectation map, complete, new_daemon)`: `complete` is false when some refresh since the
+/// last drain could not enumerate first-appearance names (stat-walk fallback), and
+/// `new_daemon` is false when the reply carries no `changed` key at all — a still-running
+/// daemon from an older tl binary, which cannot report probe lists.
+fn parse_refresh_probes(
+    reply: &serde_json::Value,
+) -> (std::collections::BTreeMap<String, PathExpect>, bool, bool) {
+    let new_daemon = reply.get("changed").is_some();
+    let items: Vec<overlay::KernelExpectation> =
+        serde_json::from_value(reply.get("changed").cloned().unwrap_or_default())
+            .unwrap_or_default();
+    let mut expect = std::collections::BTreeMap::new();
+    for e in items {
+        let want = match (e.present, e.size) {
+            (false, _) => PathExpect::Absent,
+            // A size means content changed behind the kernel: the prober must purge cached
+            // pages, not just confirm existence.
+            (true, Some(size)) => PathExpect::FileSize(size),
+            (true, None) => PathExpect::Present,
+        };
+        expect.insert(e.path, want);
+    }
+    let complete = reply
+        .get("complete")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    (expect, complete, new_daemon)
 }
 
 /// Write a whiteout marker file, superseding any container of child markers at the same path

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -9,6 +9,11 @@
 //! ```text
 //! {"op":"ping"}        -> {"ok":true,"commit":"<hex>"}
 //! {"op":"refresh"}     -> poll the workspace ref now; reply with the (possibly new) commit
+//!                         plus every probe expectation banked since the last drain
+//!                         ("changed": [{path, present, size?}], "complete": bool) so callers
+//!                         without a kernel notify channel (macOS) can converge the kernel
+//!                         view themselves. `complete: false` means some refresh since the
+//!                         last drain could not enumerate first-appearance names.
 //! {"op":"clear_upper"} -> drop all overlay state (post-snapshot / restore)
 //! {"op":"reindex"}     -> rebuild the overlay's dirty index from disk (post-restore)
 //! {"op":"shutdown"}    -> unmount and exit
@@ -32,7 +37,7 @@ use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
 
 #[cfg(unix)]
-use super::overlay::{OverlayFs, OverlayInval};
+use super::overlay::{KernelExpectation, OverlayFs, OverlayInval};
 #[cfg(unix)]
 use std::sync::Arc;
 
@@ -42,6 +47,50 @@ use std::sync::Arc;
 /// its own attribute protocol).
 #[cfg(unix)]
 type InvalSink = Arc<dyn Fn(Vec<OverlayInval>) + Send + Sync>;
+
+/// Probe expectations produced by refreshes but not yet drained to an out-of-process prober.
+/// On macOS there is no kernel notify channel; `tl fs sync` converges the kernel view by
+/// probing paths from outside the mount, fed by the `refresh` control reply. Every poll site
+/// deposits here — the background ref watcher or the auto-commit post-seal poll can consume
+/// the very ref advance a concurrent `tl fs sync` triggered, and the expectations must not be
+/// lost with it — and the control op drains the whole backlog into its reply.
+#[cfg(unix)]
+#[derive(Default)]
+struct PendingProbe {
+    /// Path → latest expectation (last write wins across deltas).
+    expect: std::collections::BTreeMap<String, KernelExpectation>,
+    /// Cleared when any absorbed delta had unknown appearance info (the stat-walk refresh
+    /// fallback cannot see first-appearance names); reset to complete on drain.
+    incomplete: bool,
+}
+
+/// Absorb one refresh delta: push kernel invalidations (Linux notify) and bank the probe
+/// expectations for the next `refresh` control drain (macOS convergence).
+#[cfg(unix)]
+fn absorb_refresh(
+    overlay: &OverlayFs,
+    invalidate: &InvalSink,
+    pending: &std::sync::Mutex<PendingProbe>,
+    delta: &gsvc_mount::RefreshDelta,
+) {
+    let outputs = overlay.refresh_outputs(delta);
+    {
+        let mut p = pending.lock().expect("pending probe lock");
+        if delta.appeared.is_none() {
+            p.incomplete = true;
+        }
+        for e in outputs.expectations {
+            p.expect.insert(e.path.clone(), e);
+        }
+        // A mount nobody syncs must not grow this without bound; dropping the backlog is
+        // honest as long as the drain reports it was incomplete.
+        if p.expect.len() > 65_536 {
+            p.expect.clear();
+            p.incomplete = true;
+        }
+    }
+    invalidate(outputs.invals);
+}
 
 /// Persisted per-mount state (`<state dir>/state.json`). No credentials: the daemon mints its
 /// own from the same CLI auth context.
@@ -347,13 +396,17 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         "mount daemon serving"
     );
 
+    // Expectations banked by every poll site below, drained by the `refresh` control op.
+    let pending = Arc::new(std::sync::Mutex::new(PendingProbe::default()));
+
     // Follow the workspace ref, pushing each refresh's exact delta to the kernel. Spawned after
     // attach because the invalidation sink is born with the kernel session.
     {
         let overlay = overlay.clone();
         let invalidate = invalidate.clone();
+        let pending = pending.clone();
         gsvc_mount::spawn_ref_watcher(&core, move |delta| {
-            invalidate(overlay.translate_delta(&delta));
+            absorb_refresh(&overlay, &invalidate, &pending, &delta);
         });
     }
 
@@ -381,6 +434,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         let overlay = overlay.clone();
         let core = core.clone();
         let invalidate = invalidate.clone();
+        let pending = pending.clone();
         tokio::spawn(async move {
             let mut sealed_gen = 0u64;
             // The overlay epoch this sealer's caches describe. clear_upper (manual snapshot,
@@ -600,7 +654,9 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         // lower presence and whiteouts normally. Best-effort — the guard
                         // above holds every unconfirmed seal, however long the lower lags.
                         match core.poll_ref().await {
-                            Ok(Some(refresh)) => invalidate(overlay.translate_delta(&refresh)),
+                            Ok(Some(refresh)) => {
+                                absorb_refresh(&overlay, &invalidate, &pending, &refresh)
+                            }
                             Ok(None) => {}
                             Err(e) => eprintln!(
                                 "auto-commit: post-seal refresh failed (follow poll catches \
@@ -646,6 +702,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         let core = core.clone();
         let mountpoint = mountpoint.clone();
         let invalidate = invalidate.clone();
+        let pending = pending.clone();
         tokio::spawn(async move {
             loop {
                 let Ok((stream, _)) = listener.accept().await else {
@@ -655,6 +712,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 let core = core.clone();
                 let mountpoint = mountpoint.clone();
                 let invalidate = invalidate.clone();
+                let pending = pending.clone();
                 tokio::spawn(async move {
                     let mut reader = tokio::io::BufReader::new(stream);
                     let mut line = String::new();
@@ -672,7 +730,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         "refresh" => match core.poll_ref().await {
                             Ok(delta) => {
                                 if let Some(delta) = delta {
-                                    invalidate(overlay.translate_delta(&delta));
+                                    absorb_refresh(&overlay, &invalidate, &pending, &delta);
                                 }
                                 // The advance may be the seal that published pending renames
                                 // (`tl fs snapshot` refreshes before clearing the overlay);
@@ -682,7 +740,22 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 {
                                     eprintln!("refresh: reaping sealed renames failed: {e}");
                                 }
-                                serde_json::json!({ "ok": true, "commit": core.current_commit() })
+                                // Drain every expectation banked since the last drain — not
+                                // just this poll's. A background poll may have consumed the
+                                // very ref advance this caller triggered; its probe list must
+                                // ride out on this reply or macOS never converges it.
+                                let (changed, complete) = {
+                                    let mut p = pending.lock().expect("pending probe lock");
+                                    let changed: Vec<KernelExpectation> =
+                                        std::mem::take(&mut p.expect).into_values().collect();
+                                    (changed, !std::mem::replace(&mut p.incomplete, false))
+                                };
+                                serde_json::json!({
+                                    "ok": true,
+                                    "commit": core.current_commit(),
+                                    "changed": changed,
+                                    "complete": complete,
+                                })
                             }
                             Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
                         },

--- a/crates/cli/src/commands/fs/fusefs.rs
+++ b/crates/cli/src/commands/fs/fusefs.rs
@@ -18,10 +18,11 @@ use super::overlay::{OverlayAttr, OverlayFs};
 /// Kernel entry/attr TTL. Effectively infinite (the EdenFS posture): nothing a mount serves can
 /// change between refresh deltas, and the daemon pushes exact invalidations for those
 /// (`Notifier::inval_entry`/`inval_inode`, handed out by [`WorkspaceFuse::run`]) — so repeat
-/// stats are kernel-cache hits instead of daemon round trips. Negative lookups are never
-/// kernel-cached (`reply.error(ENOENT)` carries no TTL), so newly created names are always
-/// discoverable. Bounded rather than literally infinite as a backstop for a missed
-/// invalidation edge.
+/// stats are kernel-cache hits instead of daemon round trips. Negative lookups get no TTL from
+/// us (`reply.error(ENOENT)`), but the kernel can still pin ENOENT for a name past any lookup
+/// we drive (see `probe_negative_dentry` in `fs.rs`), so refresh deltas additionally push
+/// `inval_entry` for names that newly appeared at a commit (`RefreshDelta::appeared`). Bounded
+/// rather than literally infinite as a backstop for a missed invalidation edge.
 const TTL: Duration = Duration::from_secs(3600);
 
 fn errno(e: &MountError) -> i32 {

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -1724,46 +1724,56 @@ impl OverlayFs {
     // Kernel-cache invalidation
     // -------------------------------------------------------------------------------------
 
-    /// Translate a core refresh delta into this overlay's ino space for kernel invalidation.
+    /// Translate a core refresh delta into everything the daemon needs to converge kernel
+    /// caches, in one pass: FUSE invalidations in this overlay's ino space (Linux notify sink)
+    /// and merged-coordinate probe expectations (macOS, where FSKit has no notify channel and
+    /// `tl fs sync` probes from outside the mount instead).
+    ///
     /// Entries whose kernel-visible content the lower change cannot affect — upper-shadowed or
-    /// whited-out paths — are dropped, as are paths the kernel never looked up here.
-    pub fn translate_delta(&self, delta: &gsvc_mount::RefreshDelta) -> Vec<OverlayInval> {
+    /// whited-out paths — are dropped, as are paths the kernel never looked up here (a rebound
+    /// or staled path with no interned ino, or an appeared name whose parent was never
+    /// interned, has no kernel cache entry — positive or negative — to converge). Appeared
+    /// paths have no ino by definition; they translate to an entry invalidation on their live
+    /// parent directory, which is what drops a kernel negative dentry cached from an `ENOENT`
+    /// answered before the refresh.
+    pub fn refresh_outputs(&self, delta: &gsvc_mount::RefreshDelta) -> RefreshOutputs {
         // Delta paths are lower coordinates; a pending rename serves that content under its
         // destination, so the kernel-visible path (and the interned ino) lives there. The
         // source coordinates are whiteouted and filter out below.
-        let reverse: Vec<(String, String)> = {
-            let redirects = self.redirects.lock().expect("redirect lock");
-            redirects
-                .iter()
-                .map(|(d, s)| (s.clone(), d.clone()))
-                .collect()
-        };
-        let merged_path = |lower: &str| -> String {
-            for (src, dst) in &reverse {
-                if lower == src {
-                    return dst.clone();
-                }
-                if let Some(rest) = lower.strip_prefix(&format!("{src}/")) {
-                    return format!("{dst}/{rest}");
-                }
-            }
-            lower.to_string()
-        };
-        let mut out = Vec::new();
+        //
+        // Filter pass first, without the inode lock: the shadow checks stat the upper tree,
+        // and a branch-jump delta can carry tens of thousands of paths — the lock is taken
+        // once, after the filesystem work, for the pure ino mapping.
+        enum Kind {
+            Rebound { size: Option<u64> },
+            Staled,
+            Appeared,
+        }
+        let reverse = self.reverse_redirects();
         let tagged = delta
             .rebound
             .iter()
-            .map(|e| (e, false))
-            .chain(delta.staled.iter().map(|e| (e, true)));
-        for (entry, staled) in tagged {
-            let path = merged_path(&entry.path);
+            .map(|e| (e.path.as_str(), Kind::Rebound { size: e.size }))
+            .chain(delta.staled.iter().map(|e| (e.path.as_str(), Kind::Staled)))
+            .chain(
+                delta
+                    .appeared
+                    .iter()
+                    .flatten()
+                    .map(|p| (p.as_str(), Kind::Appeared)),
+            );
+        let mut visible: Vec<(String, Kind)> = Vec::new();
+        for (lower, kind) in tagged {
+            let path = merged_of(&reverse, lower);
             if self.upper_meta(&path).is_some() || self.whited_out(&path) {
                 continue;
             }
-            let inodes = self.inodes.lock().expect("inode lock");
-            let Some(&ino) = inodes.index.get(&path) else {
-                continue;
-            };
+            visible.push((path, kind));
+        }
+
+        let mut out = RefreshOutputs::default();
+        let inodes = self.inodes.lock().expect("inode lock");
+        for (path, kind) in visible {
             let (parent_ino, name) = match path.rfind('/') {
                 Some(i) => (
                     inodes.index.get(&path[..i]).copied(),
@@ -1771,14 +1781,74 @@ impl OverlayFs {
                 ),
                 None => (Some(ROOT_INO), path.clone()),
             };
-            out.push(OverlayInval {
-                ino,
-                parent_ino,
-                name,
-                staled,
-            });
+            match kind {
+                // Rebound/staled: the kernel holds cache entries for this path only if it
+                // looked it up here (which interned it) and has not since forgotten it.
+                Kind::Rebound { size } => {
+                    let Some(&ino) = inodes.index.get(&path) else {
+                        continue;
+                    };
+                    out.invals.push(OverlayInval {
+                        ino,
+                        parent_ino,
+                        name,
+                        staled: false,
+                    });
+                    out.expectations.push(KernelExpectation {
+                        path,
+                        present: true,
+                        size,
+                    });
+                }
+                Kind::Staled => {
+                    let Some(&ino) = inodes.index.get(&path) else {
+                        continue;
+                    };
+                    out.invals.push(OverlayInval {
+                        ino,
+                        parent_ino,
+                        name,
+                        staled: true,
+                    });
+                    out.expectations.push(KernelExpectation {
+                        path,
+                        present: false,
+                        size: None,
+                    });
+                }
+                Kind::Appeared => {
+                    // A parent the kernel never looked up holds no dentries (negative or
+                    // otherwise) for children — nothing to drop or probe.
+                    let Some(parent_ino) = parent_ino else {
+                        continue;
+                    };
+                    // `ino` is the parent on purpose: the appeared name has no ino, and the
+                    // parent's kernel attrs/readdir cache went stale the moment the name
+                    // appeared under it.
+                    out.invals.push(OverlayInval {
+                        ino: parent_ino,
+                        parent_ino: Some(parent_ino),
+                        name,
+                        staled: true,
+                    });
+                    out.expectations.push(KernelExpectation {
+                        path,
+                        present: true,
+                        size: None,
+                    });
+                }
+            }
         }
         out
+    }
+
+    /// The redirect table inverted for lower→merged translation (source path -> destination).
+    fn reverse_redirects(&self) -> Vec<(String, String)> {
+        let redirects = self.redirects.lock().expect("redirect lock");
+        redirects
+            .iter()
+            .map(|(d, s)| (s.clone(), d.clone()))
+            .collect()
     }
 
     // -------------------------------------------------------------------------------------
@@ -2016,10 +2086,50 @@ pub struct RedirectFile {
     pub mode: u32,
 }
 
-/// One kernel invalidation in the overlay's ino space, produced by [`OverlayFs::translate_delta`]
+/// Translate a lower-coordinate path to its merged (kernel-visible) coordinates through an
+/// inverted redirect table (see [`OverlayFs::reverse_redirects`]).
+fn merged_of(reverse: &[(String, String)], lower: &str) -> String {
+    for (src, dst) in reverse {
+        if lower == src {
+            return dst.clone();
+        }
+        if let Some(rest) = lower.strip_prefix(&format!("{src}/")) {
+            return format!("{dst}/{rest}");
+        }
+    }
+    lower.to_string()
+}
+
+/// Everything a refresh delta implies for kernel-cache convergence, produced in one pass by
+/// [`OverlayFs::refresh_outputs`]: push invalidations for the Linux FUSE notify sink, and probe
+/// expectations for consumers without a notify channel (macOS — drained to `tl fs sync` through
+/// the daemon's `refresh` control reply).
+#[derive(Debug, Default)]
+pub struct RefreshOutputs {
+    pub invals: Vec<OverlayInval>,
+    pub expectations: Vec<KernelExpectation>,
+}
+
+/// One merged-coordinate kernel-view expectation: after the refresh, `path` should resolve
+/// (`present`, with `size` bytes when a file's content changed — the prober must purge cached
+/// pages, not just confirm existence) or be gone. Serialized verbatim into the daemon's
+/// `refresh` control reply (`"changed"`), and parsed back by `tl fs sync` — one shared type so
+/// the wire shape cannot drift between the two sides.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct KernelExpectation {
+    pub path: String,
+    pub present: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+}
+
+/// One kernel invalidation in the overlay's ino space, produced by [`OverlayFs::refresh_outputs`]
 /// (branch refresh) or [`OverlayFs::clear_upper`] (post-snapshot upper drop). `staled` entries
 /// need the `(parent_ino, name)` dentry invalidated in addition to the inode, so the next access
-/// re-looks the path up; rebound entries only need the inode's attrs/data dropped.
+/// re-looks the path up; rebound entries only need the inode's attrs/data dropped. For a path
+/// that newly appeared at a refresh there is no ino to invalidate: `ino` carries the parent
+/// directory (its readdir cache went stale) and `(parent_ino, name)` drops any negative dentry
+/// the kernel cached for the name before it existed.
 ///
 /// Consumed by the Linux FUSE notify sink (`inval_entry`/`inval_inode`); the macOS FSKit path
 /// uses a no-op sink, so these fields are unread there.


### PR DESCRIPTION
## Bug

After a clean fast-forward `tl fs sync`, a newly pulled file showed in `ls` but `cat` returned ENOENT:

```
❯ tl fs sync .
Synced with fa2499f44b8c (0 path(s) pulled); workspace fast-forwarded.
❯ cat hi.txt
cat: hi.txt: No such file or directory
❯ ls
hi.txt
```

A lookup answered ENOENT before the sync lives on as a kernel-cached negative dentry that readdir traffic never revalidates. Two gaps made it stick: the refresh delta only named paths the mount had already served (a first-appearance name is in neither `rebound` nor `staled`), and the sync-side probe — the only convergence lever on macOS/FSKit, which has no kernel notify channel — ran for conflict paths only.

## Fix

- **Overlay** (`refresh_outputs`, replacing `translate_delta` + the ad-hoc probe list): one pass over the delta produces both FUSE invalidations (Linux notifier: `inval_entry` on the live parent drops the negative dentry) and merged-coordinate probe expectations, with shared shadow/interned filters so the two views cannot drift.
- **Daemon**: every poll site (ref watcher, auto-commit post-seal poll, `refresh` control op) banks probe expectations in a shared accumulator; the `refresh` control op drains the whole backlog into its reply (`"changed": [{path, present, size?}], "complete": bool`). A background poll that consumes the very ref advance a concurrent sync triggered no longer swallows the probe list.
- **`tl fs sync` / `tl fs snapshot`**: converge the kernel view over the drained probe list on macOS — `Present`/`Absent` per change kind, and `FileSize` (with `msync(MS_INVALIDATE)` page purge) for rebound files so modified content doesn't serve stale cached bytes. Linux keeps relying on the notifier. Warnings surface a pre-fix daemon (remount to fix) and incomplete enumeration (stat-walk fallback, where appearance info is unknowable).
- **`converge_kernel_view`**: deadline checked per path, later rounds re-probe only unsettled paths — bounds branch-jump-sized syncs.
- Wire shape is a shared serde type (`KernelExpectation`), so daemon and CLI cannot drift.

## Dependencies

Requires the matching gsvc-mount change (`RefreshDelta::appeared: Option<Vec<String>>` + rebound sizes on `InvalEntry`) from the artifact_storage PR — vendored at build time via `just build-cli-full`.

## Testing

- `cargo test -p tensorlake-cli --features mount,git-clone` with real mount sources swapped in: 219 passed.
- artifact_storage: gsvc-mount unit tests + full `e2e_git` suite (105 passed), including a new regression assert that a name ENOENT'd before a snapshot is reported in `appeared` after the ref moves.
- Clippy clean on the touched code; placeholder crate sources restored (no private source committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)