### PR TITLE
tl fs mount: one-round-trip fast path, credential reuse, phase timings

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1182,6 +1182,32 @@ fn unzip_app(archive: &Path, staging: &Path) -> Result<PathBuf> {
         .ok_or_else(|| CliError::usage(format!("no .app found inside {}", archive.display())))
 }
 
+/// The two workspace-create failures `tl fs mount` can recover from, read off the server's
+/// answer. Mount tries the create outright (its one required round trip) instead of
+/// pre-flighting with list-repos and ref-status calls; these are the answers that pick the
+/// recovery path. Anything else propagates as-is.
+enum CreateRecovery {
+    /// 404: no repo by that name — a bare target may be a workspace id to attach.
+    RepoMissing,
+    /// 400 on base resolution — an unborn default branch is seedable; other branches are not.
+    BaseUnresolved,
+}
+
+fn create_recovery(e: &tensorlake::error::SdkError) -> Option<CreateRecovery> {
+    let tensorlake::error::SdkError::ServerError { status, message } = e else {
+        return None;
+    };
+    match status.as_u16() {
+        404 if message.contains("not found") => Some(CreateRecovery::RepoMissing),
+        400 if message.contains("does not resolve to a commit")
+            || message.contains("has no commits") =>
+        {
+            Some(CreateRecovery::BaseUnresolved)
+        }
+        _ => None,
+    }
+}
+
 /// A workspace needs a base commit, but a file system fresh out of `tl git create` has an
 /// unborn default branch. Seed it with an empty initial commit so the first mount just works.
 async fn ensure_seeded(session: &FsSession, default_branch: &str, repo: &str) -> Result<()> {
@@ -1488,6 +1514,10 @@ pub async fn mount(
             "tl fs mount is supported on Linux (FUSE) and macOS (FSKit) only.",
         ));
     }
+    // The CLI's own phase timings (`phase=… "mount timing"`) surface on stderr through the
+    // same subscriber the daemon uses for daemon.log; --log-level governs both.
+    daemon::init_logging(log_level)?;
+    let started = std::time::Instant::now();
     #[cfg(target_os = "macos")]
     ensure_fskit_ready().await?;
     #[cfg(target_os = "linux")]
@@ -1576,39 +1606,104 @@ pub async fn mount(
     }
     let session = FsSession::open(ctx, None).await?;
     let (user, token) = session.creds();
-    let file_systems = session
-        .client
-        .list_repos_with_credential(&session.project_id, user, token)
-        .await?
-        .into_inner();
-    let known_fs = |n: &str| file_systems.repos.iter().find(|r| r.name == n);
+    tracing::info!(
+        phase = "session",
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "mount timing"
+    );
+    let workspace_started = std::time::Instant::now();
 
     // `<file-system>[:<base>]` creates a workspace; a bare target that names no file system is
     // resolved as a workspace id (unique prefix) and attached. Attach = reconnect: the
     // workspace ref (and everything snapshotted onto it) survived whatever happened to the
     // previous mount — sandbox crash, timeout, unmount.
-    let attach = if base.is_none() && known_fs(name).is_none() {
-        let fs_names: Vec<String> = file_systems.repos.iter().map(|r| r.name.clone()).collect();
-        match resolve_workspace(&session, &fs_names, name).await? {
-            Some(found) => Some(found),
-            None => {
+    //
+    // The create is attempted outright — the common path's one required round trip — and the
+    // server's answer picks the slow path when one applies: 404 means `name` is no file
+    // system (perhaps a workspace id: attach), an unresolvable base may be an unborn default
+    // branch (seed and retry). The old pre-flight (list repos, ref-status the base) re-derived
+    // what the create response already says, at two extra round trips per mount.
+    enum Resolved {
+        Created(WorkspaceInfo),
+        Attached(String, WorkspaceInfo),
+    }
+    let create_req = CreateWorkspaceRequest {
+        base: base.clone(),
+        shared_target: shared_rw.then(|| base.clone().expect("guarded above")),
+        ..Default::default()
+    };
+    let create = session
+        .client
+        .create_workspace(&session.project_id, name, user, token, &create_req)
+        .await;
+    let resolved = match create {
+        Ok(ws) => Resolved::Created(ws.into_inner()),
+        Err(e) => match create_recovery(&e) {
+            // No file system by this name and no branch was named: try it as a workspace id.
+            Some(CreateRecovery::RepoMissing) if base.is_none() => {
+                let fs_names = file_system_names(&session).await?;
+                match resolve_workspace(&session, &fs_names, name).await? {
+                    Some((repo, ws)) => Resolved::Attached(repo, ws),
+                    None => {
+                        return Err(CliError::usage(format!(
+                            "no file system or workspace matches {name:?}. See `tl fs ls`, or \
+                             create the file system first: tl git create {name}"
+                        )));
+                    }
+                }
+            }
+            Some(CreateRecovery::RepoMissing) => {
                 return Err(CliError::usage(format!(
-                    "no file system or workspace matches {name:?}. See `tl fs ls`, or create \
-                     the file system first: tl git create {name}"
+                    "no file system named {name:?}; create it first: tl git create {name}"
                 )));
             }
-        }
-    } else {
-        if base.is_some() && known_fs(name).is_none() {
-            return Err(CliError::usage(format!(
-                "no file system named {name:?}; create it first: tl git create {name}"
-            )));
-        }
-        None
+            // Seed an unborn default branch whether it is implied OR named (either spelling):
+            // a fresh `tl git create` repo has no commits, and `tl fs mount repo:main` used to
+            // fail with `base "main" does not resolve to a commit` while plain
+            // `tl fs mount repo` worked. Writable mounts only — a read-only view must never
+            // write to the server (and with read-scoped credentials the seed push would fail
+            // opaquely); ro keeps the clear server error. Other branch names stay strict —
+            // seeding cannot conjure them.
+            Some(CreateRecovery::BaseUnresolved) => {
+                let file_systems = session
+                    .client
+                    .list_repos_with_credential(&session.project_id, user, token)
+                    .await?
+                    .into_inner();
+                let Some(fs) = file_systems.repos.iter().find(|r| r.name == name) else {
+                    return Err(e.into());
+                };
+                let default_branch = fs.default_branch.clone();
+                let names_default = base.as_deref().is_none_or(|b| {
+                    b == default_branch || b.strip_prefix("refs/heads/") == Some(&default_branch)
+                });
+                if !names_default || mode == WritePolicy::Ro {
+                    return Err(e.into());
+                }
+                ensure_seeded(&session, &default_branch, name).await?;
+                let ws = session
+                    .client
+                    .create_workspace(&session.project_id, name, user, token, &create_req)
+                    .await?
+                    .into_inner();
+                Resolved::Created(ws)
+            }
+            None => return Err(e.into()),
+        },
     };
+    tracing::info!(
+        phase = "workspace",
+        attached = matches!(resolved, Resolved::Attached(..)),
+        elapsed_ms = workspace_started.elapsed().as_millis() as u64,
+        "mount timing"
+    );
 
-    let (repo, ws, attached, read_only, follow_ref) = match attach {
-        Some((repo, ws)) => {
+    // `start_oid` hands the daemon the commit this response resolved the view to, so it comes
+    // up with zero round trips of its own. The exception is a writable attach of a shared-rw
+    // workspace: its view follows the target branch — a ref this response says nothing about —
+    // so the daemon resolves that itself.
+    let (repo, ws, attached, read_only, follow_ref, start_oid) = match resolved {
+        Resolved::Attached(repo, ws) => {
             if shared_rw {
                 return Err(CliError::usage(
                     "--shared-rw is chosen when creating a workspace on a branch: tl fs mount \
@@ -1645,42 +1740,14 @@ pub async fn mount(
                     .as_ref()
                     .map(|target| format!("refs/heads/{target}"))
             };
-            (repo, ws, true, read_only, follow_ref)
+            let start_oid = match &follow_ref {
+                Some(f) if *f != ws.ref_name => None,
+                _ => Some(ws.head.clone()),
+            };
+            (repo, ws, true, read_only, follow_ref, start_oid)
         }
-        None => {
+        Resolved::Created(ws) => {
             let read_only = mode == WritePolicy::Ro;
-            // Seed an unborn default branch whether it is implied OR named (either spelling):
-            // a fresh `tl git create` repo has no commits, and `tl fs mount repo:main` used to
-            // fail with `base "main" does not resolve to a commit` while plain
-            // `tl fs mount repo` worked. Writable mounts only — a read-only view must never
-            // write to the server (and with read-scoped credentials the seed push would fail
-            // opaquely); ro keeps the clear server error. Other branch names stay strict —
-            // seeding cannot conjure them.
-            let default_branch = known_fs(name)
-                .expect("checked above")
-                .default_branch
-                .clone();
-            let names_default = base.as_deref().is_none_or(|b| {
-                b == default_branch || b.strip_prefix("refs/heads/") == Some(&default_branch)
-            });
-            if names_default && !read_only {
-                ensure_seeded(&session, &default_branch, name).await?;
-            }
-            let ws = session
-                .client
-                .create_workspace(
-                    &session.project_id,
-                    name,
-                    user,
-                    token,
-                    &CreateWorkspaceRequest {
-                        base: base.clone(),
-                        shared_target: shared_rw.then(|| base.clone().expect("guarded above")),
-                        ..Default::default()
-                    },
-                )
-                .await?
-                .into_inner();
             // What the view follows. Writable workspaces follow their own ref; shared-rw
             // follows the branch it publishes to, so every writer's view converges on the
             // reconciled branch rather than staying pinned to its own snapshots. A read-only
@@ -1719,7 +1786,19 @@ pub async fn mount(
             } else {
                 None
             };
-            (name.to_string(), ws, false, read_only, follow_ref)
+            // Everything a fresh workspace can follow was resolved by the create response
+            // itself: the workspace ref sits at `head` (== base), and a followed branch is the
+            // one `base` was just resolved from (a snapshot racing in between is caught by the
+            // daemon's first follow poll).
+            let start_oid = Some(ws.head.clone());
+            (
+                name.to_string(),
+                ws,
+                false,
+                read_only,
+                follow_ref,
+                start_oid,
+            )
         }
     };
 
@@ -1749,6 +1828,7 @@ pub async fn mount(
             follow_ref,
             read_only: Some(read_only),
             auto_commit_interval_secs,
+            start_oid,
         },
     )?;
     registry_add(&mountpoint, &state_dir)?;
@@ -1773,10 +1853,21 @@ pub async fn mount(
         .stdout(std::process::Stdio::null())
         .stderr(std::fs::File::create(&daemon_log)?)
         .spawn()?;
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let daemon_started = std::time::Instant::now();
+    let deadline = daemon_started + std::time::Duration::from_secs(20);
+    // Ramp the readiness poll: a healthy daemon (cached credential, caller-resolved commit)
+    // answers within tens of milliseconds, so a flat 250ms grid would dominate its startup;
+    // one that needs real work still gets probed only ~4 times a second.
+    let mut backoff = std::time::Duration::from_millis(15);
     loop {
         match daemon::control(&state_dir, "ping").await {
             Ok(resp) => {
+                tracing::info!(
+                    phase = "daemon",
+                    elapsed_ms = daemon_started.elapsed().as_millis() as u64,
+                    total_ms = started.elapsed().as_millis() as u64,
+                    "mount timing"
+                );
                 if attached {
                     println!(
                         "Mounted workspace {} ({}) at {}{}",
@@ -1825,7 +1916,8 @@ pub async fn mount(
                 return Ok(());
             }
             Err(_) if std::time::Instant::now() < deadline => {
-                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(std::time::Duration::from_millis(250));
             }
             Err(e) => {
                 registry_remove(&mountpoint)?;

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1198,7 +1198,13 @@ fn create_recovery(e: &tensorlake::error::SdkError) -> Option<CreateRecovery> {
         return None;
     };
     match status.as_u16() {
-        404 if message.contains("not found") => Some(CreateRecovery::RepoMissing),
+        // Require the server's actual wording ("repo <id> not found"), not just any 404 body:
+        // a misrouted base URL answered by a generic proxy ("404 page not found") must surface
+        // raw, not masquerade as a missing file system. Pinned server-side by the e2e test
+        // `workspace_create_errors_keep_the_cli_recovery_contract`.
+        404 if message.contains("repo") && message.contains("not found") => {
+            Some(CreateRecovery::RepoMissing)
+        }
         400 if message.contains("does not resolve to a commit")
             || message.contains("has no commits") =>
         {
@@ -1210,16 +1216,12 @@ fn create_recovery(e: &tensorlake::error::SdkError) -> Option<CreateRecovery> {
 
 /// A workspace needs a base commit, but a file system fresh out of `tl git create` has an
 /// unborn default branch. Seed it with an empty initial commit so the first mount just works.
+/// No existence pre-check: the caller just learned from the failed create that the branch has
+/// no commits, and a raced concurrent seed is benign anyway — the commit endpoint defaults its
+/// base to the branch tip, so the push lands a harmless empty commit and the retried create
+/// still succeeds.
 async fn ensure_seeded(session: &FsSession, default_branch: &str, repo: &str) -> Result<()> {
     let (user, token) = session.creds();
-    let status = session
-        .client
-        .ref_status(&session.project_id, repo, user, token, default_branch)
-        .await?
-        .into_inner();
-    if status.oid.is_some() {
-        return Ok(());
-    }
     session
         .client
         .push_files(
@@ -1514,8 +1516,9 @@ pub async fn mount(
             "tl fs mount is supported on Linux (FUSE) and macOS (FSKit) only.",
         ));
     }
-    // The CLI's own phase timings (`phase=… "mount timing"`) surface on stderr through the
-    // same subscriber the daemon uses for daemon.log; --log-level governs both.
+    // The CLI's own phase timings (`phase=… "mount timing"`, debug level) surface on stderr
+    // through the same subscriber the daemon uses for daemon.log — pass `--log-level debug`
+    // to see them; the default "info" keeps mount's stderr clean for scripts.
     daemon::init_logging(log_level)?;
     let started = std::time::Instant::now();
     #[cfg(target_os = "macos")]
@@ -1606,7 +1609,7 @@ pub async fn mount(
     }
     let session = FsSession::open(ctx, None).await?;
     let (user, token) = session.creds();
-    tracing::info!(
+    tracing::debug!(
         phase = "session",
         elapsed_ms = started.elapsed().as_millis() as u64,
         "mount timing"
@@ -1632,11 +1635,14 @@ pub async fn mount(
         shared_target: shared_rw.then(|| base.clone().expect("guarded above")),
         ..Default::default()
     };
-    let create = session
-        .client
-        .create_workspace(&session.project_id, name, user, token, &create_req)
-        .await;
-    let resolved = match create {
+    // One create call site for both the first attempt and the post-seed retry, so the two can
+    // never drift apart.
+    let try_create = || {
+        session
+            .client
+            .create_workspace(&session.project_id, name, user, token, &create_req)
+    };
+    let resolved = match try_create().await {
         Ok(ws) => Resolved::Created(ws.into_inner()),
         Err(e) => match create_recovery(&e) {
             // No file system by this name and no branch was named: try it as a workspace id.
@@ -1681,27 +1687,23 @@ pub async fn mount(
                     return Err(e.into());
                 }
                 ensure_seeded(&session, &default_branch, name).await?;
-                let ws = session
-                    .client
-                    .create_workspace(&session.project_id, name, user, token, &create_req)
-                    .await?
-                    .into_inner();
-                Resolved::Created(ws)
+                Resolved::Created(try_create().await?.into_inner())
             }
             None => return Err(e.into()),
         },
     };
-    tracing::info!(
+    tracing::debug!(
         phase = "workspace",
         attached = matches!(resolved, Resolved::Attached(..)),
         elapsed_ms = workspace_started.elapsed().as_millis() as u64,
         "mount timing"
     );
 
-    // `start_oid` hands the daemon the commit this response resolved the view to, so it comes
-    // up with zero round trips of its own. The exception is a writable attach of a shared-rw
-    // workspace: its view follows the target branch — a ref this response says nothing about —
-    // so the daemon resolves that itself.
+    // `start_oid` hands the daemon the commit this response resolved the view to, letting the
+    // mount core overlap its serve probe with ref resolution (one startup round trip instead
+    // of two chained). The exception is a writable attach of a shared-rw workspace: its view
+    // follows the target branch — a ref this response says nothing about — so the daemon
+    // resolves that one serially.
     let (repo, ws, attached, read_only, follow_ref, start_oid) = match resolved {
         Resolved::Attached(repo, ws) => {
             if shared_rw {
@@ -1732,17 +1734,15 @@ pub async fn mount(
             }
             // A read-only view follows the workspace ref, so it sees each snapshot as the
             // writer seals one; a writable attach of a shared-rw workspace keeps following the
-            // branch its snapshots publish to.
-            let follow_ref = if read_only {
-                Some(ws.ref_name.clone())
+            // branch its snapshots publish to — and only that branch case gets no start hint,
+            // since this response resolved the workspace ref (`head`), not the branch.
+            let (follow_ref, start_oid) = if read_only {
+                (Some(ws.ref_name.clone()), Some(ws.head.clone()))
             } else {
-                ws.shared_target
-                    .as_ref()
-                    .map(|target| format!("refs/heads/{target}"))
-            };
-            let start_oid = match &follow_ref {
-                Some(f) if *f != ws.ref_name => None,
-                _ => Some(ws.head.clone()),
+                match &ws.shared_target {
+                    Some(target) => (Some(format!("refs/heads/{target}")), None),
+                    None => (None, Some(ws.head.clone())),
+                }
             };
             (repo, ws, true, read_only, follow_ref, start_oid)
         }
@@ -1862,7 +1862,7 @@ pub async fn mount(
     loop {
         match daemon::control(&state_dir, "ping").await {
             Ok(resp) => {
-                tracing::info!(
+                tracing::debug!(
                     phase = "daemon",
                     elapsed_ms = daemon_started.elapsed().as_millis() as u64,
                     total_ms = started.elapsed().as_millis() as u64,

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -129,6 +129,12 @@ pub struct MountState {
     /// mounts that didn't opt in and in state files from before the feature.
     #[serde(default)]
     pub auto_commit_interval_secs: Option<u64>,
+    /// The commit the followed ref resolved to in the create/attach response that produced
+    /// this state file. Lets the daemon adopt the view with zero startup round trips
+    /// (`MountOptions::start_oid`); if it aged (a hand-rerun `tl fs daemon` on an old state
+    /// dir), the first follow poll reconciles. Absent in older state files: resolve at mount.
+    #[serde(default)]
+    pub start_oid: Option<String>,
 }
 
 impl MountState {
@@ -248,9 +254,18 @@ pub async fn run(ctx: &CliContext, state_dir: &Path, log_level: &str) -> Result<
 
 /// Install the daemon's tracing subscriber, writing to stderr — which the detached spawn
 /// redirects to the state dir's `daemon.log` (foreground runs log to the terminal). Without
+/// this every `tracing::warn!` in the daemon is silently discarded. `tl fs mount` installs
+/// the same subscriber in the CLI process, which is what surfaces its phase-timing lines.
+#[cfg(not(unix))]
+pub(crate) fn init_logging(_level: &str) -> Result<()> {
+    Ok(())
+}
+
+/// Install the daemon's tracing subscriber, writing to stderr — which the detached spawn
+/// redirects to the state dir's `daemon.log` (foreground runs log to the terminal). Without
 /// this every `tracing::warn!` in the daemon is silently discarded.
 #[cfg(unix)]
-fn init_logging(level: &str) -> Result<()> {
+pub(crate) fn init_logging(level: &str) -> Result<()> {
     use std::str::FromStr;
     let level = tracing_subscriber::filter::LevelFilter::from_str(level).map_err(|_| {
         CliError::usage(format!(
@@ -272,25 +287,46 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     use crate::commands::git::{artifact_storage_client, project_id};
     use gsvc_mount::{FsClient, MountCore, MountOptions};
 
+    let started = std::time::Instant::now();
     let state = load_mount_state(state_dir)?;
     let sdk = artifact_storage_client(ctx)?;
     let project = project_id(ctx)?;
 
-    // Initial credential: the dev override, or a fresh mint.
-    let (git_username, token, mut expires_at) = match std::env::var("TENSORLAKE_GIT_TOKEN") {
-        Ok(token) => (
-            std::env::var("TENSORLAKE_GIT_USERNAME").unwrap_or_else(|_| "t".to_string()),
-            token,
-            None,
-        ),
-        Err(_) => {
-            let cred = sdk
-                .mint_token_for_repo(&project, Some(&state.repo))
-                .await?
-                .into_inner();
-            (cred.git_username, cred.token, Some(cred.expires_at))
-        }
-    };
+    // Initial credential: the dev override, the cache the mounting CLI just wrote (the mint
+    // round trip through the platform ingress is the slowest single call in daemon startup,
+    // and the CLI paid it moments ago), or a fresh mint. The rotation task below re-mints
+    // before whichever credential this is expires.
+    let (git_username, token, mut expires_at, credential_source) =
+        match std::env::var("TENSORLAKE_GIT_TOKEN") {
+            Ok(token) => (
+                std::env::var("TENSORLAKE_GIT_USERNAME").unwrap_or_else(|_| "t".to_string()),
+                token,
+                None,
+                "env",
+            ),
+            Err(_) => {
+                let cached = [state.repo.as_str(), "*"].iter().find_map(|scope| {
+                    crate::config::files::load_git_credential(&ctx.api_url, &project, scope)
+                });
+                match cached {
+                    Some((username, token, expires_at)) => {
+                        (username, token, Some(expires_at), "cache")
+                    }
+                    None => {
+                        let cred = sdk
+                            .mint_token_for_repo(&project, Some(&state.repo))
+                            .await?
+                            .into_inner();
+                        (cred.git_username, cred.token, Some(cred.expires_at), "mint")
+                    }
+                }
+            }
+        };
+    tracing::info!(
+        source = credential_source,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "mount daemon: credential ready"
+    );
     // The daemon's long-lived `(user, token)` credential: heartbeats and auto-commits read it,
     // and the rotation task below swaps it in place before expiry — a static copy would start
     // failing an hour into the mount's life.
@@ -320,6 +356,9 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
             // Manifest-driven cache prefill in the background: first walks serve warm instead
             // of paying a per-directory crawl. Best-effort — a failed warmup just starts cold.
             warmup: true,
+            // The create/attach response's commit: adopt it with no startup round trips; the
+            // follow poll reconciles a stale one.
+            start_oid: state.start_oid.clone(),
             ..Default::default()
         },
     )
@@ -393,6 +432,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         workspace = %state.workspace_id,
         mountpoint = %mountpoint.display(),
         commit = %core.current_commit(),
+        startup_ms = started.elapsed().as_millis() as u64,
         "mount daemon serving"
     );
 

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -130,9 +130,10 @@ pub struct MountState {
     #[serde(default)]
     pub auto_commit_interval_secs: Option<u64>,
     /// The commit the followed ref resolved to in the create/attach response that produced
-    /// this state file. Lets the daemon adopt the view with zero startup round trips
-    /// (`MountOptions::start_oid`); if it aged (a hand-rerun `tl fs daemon` on an old state
-    /// dir), the first follow poll reconciles. Absent in older state files: resolve at mount.
+    /// this state file — a latency hint (`MountOptions::start_oid`) that lets the mount core
+    /// overlap its serve probe with ref resolution. The ref answer stays authoritative, so an
+    /// aged value (a hand-rerun `tl fs daemon` on an old state dir) is superseded at mount.
+    /// Absent in older state files: the core resolves serially, one extra round trip.
     #[serde(default)]
     pub start_oid: Option<String>,
 }
@@ -234,6 +235,33 @@ fn expires_in(expires_at: &str) -> Duration {
         .unwrap_or(Duration::from_secs(30 * 60))
 }
 
+/// Mint a repo-scoped git credential and write it through to the CLI's on-disk cache, so a
+/// daemon-side mint (startup fallback, rotation, auth recovery) also warms the cache the next
+/// `tl fs` command reads — the same save `FsSession::open` does for CLI-side mints.
+#[cfg(unix)]
+async fn mint_and_cache(
+    sdk: &tensorlake::artifact_storage::ArtifactStorageClient,
+    api_url: &str,
+    project: &str,
+    repo: &str,
+) -> Result<(String, String, String)> {
+    let cred = sdk
+        .mint_token_for_repo(project, Some(repo))
+        .await?
+        .into_inner();
+    if let Err(e) = crate::config::files::save_git_credential(
+        api_url,
+        project,
+        repo,
+        &cred.git_username,
+        &cred.token,
+        &cred.expires_at,
+    ) {
+        tracing::warn!("could not cache minted git credential: {e}");
+    }
+    Ok((cred.git_username, cred.token, cred.expires_at))
+}
+
 /// Run the daemon in the foreground of the current process. `tl fs mount` spawns this as a
 /// detached child (`tl fs daemon --state-dir ...`) with stderr pointed at the state dir's
 /// `daemon.log`.
@@ -293,31 +321,34 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     let project = project_id(ctx)?;
 
     // Initial credential: the dev override, the cache the mounting CLI just wrote (the mint
-    // round trip through the platform ingress is the slowest single call in daemon startup,
-    // and the CLI paid it moments ago), or a fresh mint. The rotation task below re-mints
+    // round trip through the platform ingress is the slowest single call in daemon startup),
+    // or a fresh mint. A cached credential is adopted only with comfortable runway — anything
+    // the rotation task would replace within minutes is minted fresh instead, so the
+    // rotation schedule never starts inside its own margin. The rotation task re-mints
     // before whichever credential this is expires.
     let (git_username, token, mut expires_at, credential_source) =
-        match std::env::var("TENSORLAKE_GIT_TOKEN") {
-            Ok(token) => (
-                std::env::var("TENSORLAKE_GIT_USERNAME").unwrap_or_else(|_| "t".to_string()),
-                token,
-                None,
-                "env",
-            ),
-            Err(_) => {
-                let cached = [state.repo.as_str(), "*"].iter().find_map(|scope| {
-                    crate::config::files::load_git_credential(&ctx.api_url, &project, scope)
-                });
-                match cached {
+        match tensorlake::artifact_storage::ArtifactStorageClient::git_credential_from_env() {
+            Some(cred) => (cred.git_username, cred.token, None, "env"),
+            None => {
+                // Freshest cached entry wins across scopes: a stale repo-scoped token from an
+                // earlier credential-helper use must not shadow the "*" token the mounting
+                // CLI just wrote.
+                let cached = [state.repo.as_str(), "*"]
+                    .iter()
+                    .filter_map(|scope| {
+                        crate::config::files::load_git_credential(&ctx.api_url, &project, scope)
+                    })
+                    .max_by_key(|(_, _, expires_at)| expires_in(expires_at));
+                match cached.filter(|(_, _, expires_at)| {
+                    expires_in(expires_at) > CREDENTIAL_ROTATE_MARGIN + Duration::from_secs(5 * 60)
+                }) {
                     Some((username, token, expires_at)) => {
                         (username, token, Some(expires_at), "cache")
                     }
                     None => {
-                        let cred = sdk
-                            .mint_token_for_repo(&project, Some(&state.repo))
-                            .await?
-                            .into_inner();
-                        (cred.git_username, cred.token, Some(cred.expires_at), "mint")
+                        let (username, token, expires_at) =
+                            mint_and_cache(&sdk, &ctx.api_url, &project, &state.repo).await?;
+                        (username, token, Some(expires_at), "mint")
                     }
                 }
             }
@@ -347,54 +378,78 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         .follow_ref
         .clone()
         .unwrap_or_else(|| state.ref_name.clone());
-    let core = MountCore::new(
-        client,
-        MountOptions {
-            reference: followed,
-            follow: true,
-            poll_interval: Duration::from_secs(5),
-            // Manifest-driven cache prefill in the background: first walks serve warm instead
-            // of paying a per-directory crawl. Best-effort — a failed warmup just starts cold.
-            warmup: true,
-            // The create/attach response's commit: adopt it with no startup round trips; the
-            // follow poll reconciles a stale one.
-            start_oid: state.start_oid.clone(),
-            ..Default::default()
-        },
-    )
-    .await
+    let mount_options = MountOptions {
+        reference: followed,
+        follow: true,
+        poll_interval: Duration::from_secs(5),
+        // Manifest-driven cache prefill in the background: first walks serve warm instead
+        // of paying a per-directory crawl. Best-effort — a failed warmup just starts cold.
+        warmup: true,
+        // The create/attach response's commit: lets the core overlap its serve probe with
+        // ref resolution (one startup round trip instead of two chained). The ref answer
+        // stays authoritative, so a stale value is superseded at mount.
+        start_oid: state.start_oid.clone(),
+        ..Default::default()
+    };
+    // MountCore::new is also the adopted credential's first live use: a cached token can be
+    // revoked before its recorded expiry (project auth-epoch rotation), which its expires_at
+    // cannot reveal. On an auth failure, purge the poisoned cache, mint fresh, and retry once.
+    let core = match MountCore::new(client.clone(), mount_options.clone()).await {
+        Err(gsvc_mount::MountError::Status { status: 401, .. }) if credential_source == "cache" => {
+            tracing::warn!("cached git credential rejected (revoked?); re-minting");
+            crate::config::files::purge_git_credentials();
+            let (username, token, fresh_expires) =
+                mint_and_cache(&sdk, &ctx.api_url, &project, &state.repo).await?;
+            rotating_client.set_token(Some(token.clone()));
+            *api_creds.lock().expect("creds lock") = (username, token);
+            expires_at = Some(fresh_expires);
+            MountCore::new(client, mount_options).await
+        }
+        other => other,
+    }
     .map_err(|e| CliError::usage(format!("mount init: {e}")))?;
     let overlay = OverlayFs::new(core.clone(), state_dir, state.read_only())
         .map_err(|e| CliError::usage(format!("overlay init: {e}")))?;
 
-    // Credential rotation: re-mint comfortably before expiry, swap in place.
-    if expires_at.is_some() {
+    // Credential rotation: re-mint comfortably before expiry (or on demand — the heartbeat
+    // task nudges `remint` when the server rejects the current token), swap in place, and
+    // keep the on-disk cache warm for the next CLI command. A failed mint retries on a short
+    // fixed cadence: `expires_at` is left untouched, so `due` collapses toward the 60s floor
+    // instead of the old 30-minute parse-fallback sleep that could strand a near-expiry
+    // token unrotated.
+    let remint = Arc::new(tokio::sync::Notify::new());
+    let rotates = expires_at.is_some();
+    if rotates {
         let sdk = sdk.clone();
-        let (project, repo) = (project.clone(), state.repo.clone());
+        let (api_url, project, repo) = (ctx.api_url.clone(), project.clone(), state.repo.clone());
         let rotate = rotating_client;
         let creds = api_creds.clone();
+        let remint = remint.clone();
         tokio::spawn(async move {
             loop {
                 let due = expires_in(expires_at.as_deref().unwrap_or_default())
                     .saturating_sub(CREDENTIAL_ROTATE_MARGIN);
-                tokio::time::sleep(due.max(Duration::from_secs(60))).await;
-                match sdk.mint_token_for_repo(&project, Some(&repo)).await {
-                    Ok(cred) => {
-                        let cred = cred.into_inner();
-                        rotate.set_token(Some(cred.token.clone()));
-                        *creds.lock().expect("creds lock") = (cred.git_username, cred.token);
-                        expires_at = Some(cred.expires_at);
+                tokio::select! {
+                    _ = tokio::time::sleep(due.max(Duration::from_secs(60))) => {}
+                    _ = remint.notified() => {}
+                }
+                match mint_and_cache(&sdk, &api_url, &project, &repo).await {
+                    Ok((username, token, fresh_expires)) => {
+                        rotate.set_token(Some(token.clone()));
+                        *creds.lock().expect("creds lock") = (username, token);
+                        expires_at = Some(fresh_expires);
                     }
                     Err(e) => {
-                        tracing::warn!("credential rotation failed (will retry): {e}");
-                        expires_at = None; // retry on the fallback cadence
+                        tracing::warn!("credential rotation failed (retrying in ~60s): {e}");
                     }
                 }
             }
         });
     }
 
-    // Lease heartbeat.
+    // Lease heartbeat. An auth failure here is the running daemon's signal that its token
+    // died early (revocation, epoch rotation): nudge the rotation task instead of waiting
+    // out the scheduled re-mint.
     {
         let sdk = sdk.clone();
         let (project, repo, ws) = (
@@ -403,6 +458,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
             state.workspace_id.clone(),
         );
         let creds = api_creds.clone();
+        let remint = rotates.then(|| remint.clone());
         tokio::spawn(async move {
             loop {
                 let (user, token) = creds.lock().expect("creds lock").clone();
@@ -411,6 +467,14 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                     .await
                 {
                     tracing::warn!("workspace heartbeat failed: {e}");
+                    if let (
+                        Some(remint),
+                        tensorlake::error::SdkError::Authentication(_)
+                        | tensorlake::error::SdkError::Authorization(_),
+                    ) = (&remint, &e)
+                    {
+                        remint.notify_one();
+                    }
                 }
                 tokio::time::sleep(HEARTBEAT_INTERVAL).await;
             }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -262,8 +262,10 @@ enum FsCommands {
         #[arg(long, requires = "foreground")]
         trace_ops: bool,
 
-        /// Daemon log level (off, error, warn, info, debug, trace). Detached daemons log to
-        /// `daemon.log` in the mount's state directory; foreground runs log to the terminal.
+        /// Log level (off, error, warn, info, debug, trace) for the mount daemon AND this
+        /// command's own stderr diagnostics. Detached daemons log to `daemon.log` in the
+        /// mount's state directory; foreground runs log to the terminal. `debug` also prints
+        /// the CLI's `mount timing` phase lines.
         #[arg(long, default_value = "info")]
         log_level: String,
     },


### PR DESCRIPTION
## Why

`time tl fs mount nomad nomad101` → 5.3s on a sandbox. The daemon.log showed the FUSE attach takes 3ms; the rest was a strictly serial chain of HTTPS round trips across two processes, about half of it redundant:

1. CLI: mint (or cached) → `list_repos` (existence probe) → `ref_status` (seed pre-check) → `create_workspace`
2. Daemon: **a second unconditional platform mint** → `ref_status` + serve-probe of the commit the create response had already named → FUSE attach
3. CLI: readiness poll on a flat 250ms grid

## What

- **One-round-trip fast path**: the CLI attempts `create_workspace` outright and classifies the server's answer for the slow paths — 404 "not found" → try the target as a workspace id (attach), 400 "has no commits" / "does not resolve to a commit" → seed the unborn default branch and retry (writable mounts only; same rules and error messages as before). `list_repos` and the `ref_status` pre-check leave the common path entirely.
- **Credential reuse**: the daemon reads the config-dir credential cache the CLI just wrote (repo scope, then `*`) before minting; the rotation task still re-mints before expiry. Kills the second platform-ingress mint.
- **`MountState.start_oid`** → `MountOptions::start_oid` (new in gsvc-mount): the daemon adopts the create/attach response's commit with zero round trips of its own; the follow poll reconciles a stale start within one interval. Exception: a writable attach of a shared-rw workspace follows the target branch (a ref the response says nothing about) and still resolves itself.
- **Readiness poll ramps 15ms→250ms** instead of a flat 250ms grid.
- **Phase timings**, info level: the CLI logs `phase=session|workspace|daemon … "mount timing"` (+`total_ms`) to stderr; the daemon logs credential source, `mount: core ready`, warmup, and `startup_ms` on the serving line into daemon.log.

Net: daemon startup goes from 3+ serial network calls (incl. a platform mint) to zero before the kernel attach; the CLI chain drops from 4 round trips to ~1–2 (create, plus mint only when the cache is cold).

## Ordering

Requires gsvc-mount with `MountOptions::start_oid`: **merge tensorlakeai/artifact_storage#95 first** — the full CLI build vendors gsvc-mount from that repo's main, so this PR's `mount`-feature build fails until it lands.

## Validation

- `cargo test -p tensorlake-cli --features mount,git-clone` (against artifact_storage#95's gsvc-mount, swapped in via the build-cli-full mechanism): 226 passed
- Default-features build + tests (placeholder crates): 199 passed
- clippy introduces no new warnings; `cargo fmt` clean
- Server-side contract test pinning the 404/400 statuses + messages the classifier reads lands in artifact_storage#95

🤖 Generated with [Claude Code](https://claude.com/claude-code)