### PR TITLE
tl git rm/archive/restore + SDK list_operations: mint a project credential for structural repo ops

### DIFF
--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -458,7 +458,8 @@ impl ArtifactStorageClient {
         project_id: &str,
         repo: &str,
     ) -> Result<Traced<ListOperationsResponse>, SdkError> {
-        let credential = self.git_credential_for_repo(project_id, repo).await?;
+        // The operation log is `project:admin`-gated, which repo-scoped mints omit.
+        let credential = self.git_credential_for_project(project_id).await?;
         self.list_operations_with_credential(
             project_id,
             repo,

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -190,7 +190,9 @@ impl ArtifactStorageClient {
     }
 
     pub async fn delete_repo(&self, project_id: &str, repo: &str) -> Result<Traced<()>, SdkError> {
-        let credential = self.git_credential_for_repo(project_id, repo).await?;
+        // Structural repo management needs the `repo:write` scope, which repo-scoped mints
+        // deliberately omit — mint project-wide, like `create_repo`/`fork_repo`.
+        let credential = self.git_credential_for_project(project_id).await?;
         self.delete_repo_with_credential(
             project_id,
             repo,
@@ -233,7 +235,8 @@ impl ArtifactStorageClient {
         repo: &str,
         status: &str,
     ) -> Result<Traced<()>, SdkError> {
-        let credential = self.git_credential_for_repo(project_id, repo).await?;
+        // Archive/restore is structural (`repo:write`), which repo-scoped mints omit.
+        let credential = self.git_credential_for_project(project_id).await?;
         self.set_repo_status_with_credential(
             project_id,
             repo,

--- a/crates/cloud-sdk/tests/repositories.rs
+++ b/crates/cloud-sdk/tests/repositories.rs
@@ -1,0 +1,86 @@
+use crate::common::random_string;
+
+mod common;
+
+/// Repo structural operations (create, archive/restore, operation log, delete) are gated by
+/// scopes that repo-scoped credential mints deliberately omit (`repo:write`, `project:admin`).
+/// This lifecycle pins that the SDK mints project-wide credentials for them — the #808
+/// regression made `delete_repo`/`set_repo_status`/`list_operations` mint repo-scoped tokens
+/// and 403 against a live server, which no offline test can catch.
+#[tokio::test]
+#[cfg_attr(not(feature = "integration-tests"), ignore)]
+async fn test_repository_structural_operations() {
+    let sdk = match common::create_sdk() {
+        Ok(sdk) => sdk,
+        Err(msg) => {
+            eprintln!("Skipping integration test: {msg}");
+            return;
+        }
+    };
+    let (_org_id, project_id) = match common::get_org_and_project_ids() {
+        Ok(ids) => ids,
+        Err(msg) => {
+            eprintln!("Skipping integration test: {msg}");
+            return;
+        }
+    };
+
+    let client = match sdk.artifact_storage() {
+        Ok(client) => client,
+        Err(e) => panic!("failed to create artifact storage client: {e}"),
+    };
+
+    let repo = format!("integration-test-repo-{}", random_string());
+    // Cleared once the in-flow delete succeeds; otherwise cleanup deletes best-effort.
+    let mut cleanup_repo = Some(repo.clone());
+
+    let result: Result<(), String> = async {
+        client
+            .create_repo(&project_id, &repo, None)
+            .await
+            .map_err(|e| format!("create_repo failed: {e}"))?;
+
+        client
+            .archive_repo(&project_id, &repo)
+            .await
+            .map_err(|e| format!("archive_repo failed: {e}"))?;
+
+        client
+            .restore_repo(&project_id, &repo)
+            .await
+            .map_err(|e| format!("restore_repo failed: {e}"))?;
+
+        let operations = client
+            .list_operations(&project_id, &repo)
+            .await
+            .map_err(|e| format!("list_operations failed: {e}"))?
+            .into_inner();
+        if operations.repo != repo {
+            return Err(format!(
+                "operation log is for repo {}, expected {repo}",
+                operations.repo
+            ));
+        }
+
+        client
+            .delete_repo(&project_id, &repo)
+            .await
+            .map_err(|e| format!("delete_repo failed: {e}"))?;
+        Ok(())
+    }
+    .await;
+
+    if result.is_ok() {
+        cleanup_repo = None;
+    }
+    // Best-effort cleanup when the flow failed before its delete.
+    if let Some(repo) = cleanup_repo {
+        if let Err(e) = client.delete_repo(&project_id, &repo).await {
+            eprintln!("Cleanup failed for repo {repo}: {e}");
+        }
+    }
+
+    if let Err(err) = result {
+        panic!("{err}");
+    }
+}


### PR DESCRIPTION
## Summary
- `tl git rm` (and `tl git archive`/`tl git restore`) fail with `permission denied. set TENSORLAKE_API_KEY with required permissions, or run 'tl init'.` even though the caller is a project member and `tl git ls` works.
- Regression from #808: SDK `delete_repo`, `set_repo_status`, and `list_operations` switched from a project-wide mint to a repo-scoped mint. The server deliberately keeps repo-scoped mints narrow — `git:read` + `git:write` only (pinned by the `wildcard_token_mint_grants_member_project_admin` e2e test in artifact_storage) — while `DELETE /project/{p}/repos/{r}` and `PUT .../status` are gated behind `repo:write`, and `GET .../admin/operations` behind `project:admin`. The mint succeeded, the call 403'd. `list_operations` affects the Python/Node repository clients; CLI `tl git ops` escapes only because it takes explicit `--git-username`/`--git-token`.
- Fix: mint project-wide (`git_credential_for_project`) for these structural operations, matching `create_repo`/`fork_repo` and restoring pre-#808 behavior. No server or wire-format change. All other repo-scoped call sites verified fine (`list_refs`, `repo_info`, `list_branches`, `get_commit_conflicts` need `git:read`; `delete_branch`, `merge_repo` need `git:write`).
- New env-gated integration test (`crates/cloud-sdk/tests/repositories.rs`) runs the full structural lifecycle — create, archive, restore, operation log, delete — so a wrong-scope mint 403s the suite; the client half of this contract previously had no coverage, which is how #808 regressed it silently.

The server-side alternative (adding `repo:write` to repo-scoped mints) was rejected: it would let a leaked clone/push credential delete the repo the token was scoped to.

## Tests
- `cargo check -p tensorlake -p tensorlake-cli --tests`
- `cargo fmt`
- `tests/repositories.rs` integration test compiles; runs under `--features integration-tests` with live-server env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)