### PR TITLE
tl fs ls: one workspace-fleet request instead of one listing per file system

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -28,7 +28,7 @@ use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
 use tensorlake::artifact_storage::models::GitCredential;
 use tensorlake::artifact_storage::workspaces::{
     CreateWorkspaceRequest, PromoteOutcome, PromoteWorkspaceRequest, SyncWorkspaceRequest,
-    TreeEntry, WorkspaceInfo,
+    TreeEntry, WorkspaceFleetItem, WorkspaceFleetQuery, WorkspaceInfo,
 };
 
 use crate::auth::context::CliContext;
@@ -143,68 +143,107 @@ pub enum WritePolicy {
     Rw,
 }
 
-async fn file_system_names(session: &FsSession) -> Result<Vec<String>> {
-    let (user, token) = session.creds();
-    Ok(session
-        .client
-        .list_repos_with_credential(&session.project_id, user, token)
-        .await?
-        .into_inner()
-        .repos
-        .into_iter()
-        .map(|r| r.name)
-        .collect())
+/// The authenticated subject inside a minted git credential — an unverified JWT-payload decode,
+/// used only to filter a listing client-side (the server enforces real principal checks). `None`
+/// for opaque tokens (dev/self-hosted `TENSORLAKE_GIT_TOKEN`), which matches open-mode servers
+/// where workspaces are unbound anyway.
+fn token_subject(token: &str) -> Option<String> {
+    use base64::Engine;
+    let payload = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    Some(claims.get("sub")?.as_str()?.to_string())
 }
 
-/// Every workspace across the given file systems, newest first: `(file system, workspace)`.
-async fn all_workspaces(
+/// Every workspace visible to this caller across the whole project — one fleet request per page
+/// instead of one listing per file system — newest first, as `(file system, item)`.
+///
+/// The server narrows to the caller's own + unbound workspaces (`principal=self`); the same
+/// filter is applied here too, because servers that predate the parameter ignore it and would
+/// leak other principals' rows into the listing.
+async fn fleet_workspaces(
     session: &FsSession,
-    fs_names: &[String],
-) -> Result<Vec<(String, WorkspaceInfo)>> {
+    file_system: Option<&str>,
+    id_query: Option<&str>,
+) -> Result<Vec<(String, WorkspaceFleetItem)>> {
     let (user, token) = session.creds();
-    let lists: Vec<Result<(String, Vec<WorkspaceInfo>)>> =
-        futures::stream::iter(fs_names.iter().cloned().map(|repo| {
-            let client = session.client.clone();
-            let (project, user, token) = (
-                session.project_id.clone(),
-                user.to_string(),
-                token.to_string(),
-            );
-            async move {
-                let list = client
-                    .list_workspaces(&project, &repo, &user, &token)
-                    .await?
-                    .into_inner();
-                Ok((repo, list))
-            }
-        }))
-        .buffer_unordered(8)
-        .collect()
-        .await;
-    let mut rows = Vec::new();
-    for list in lists {
-        let (repo, workspaces) = list?;
-        rows.extend(workspaces.into_iter().map(|ws| (repo.clone(), ws)));
+    let own_sub = token_subject(token);
+    let repo_prefix = format!("{}/", session.project_id);
+    let mut rows: Vec<(String, WorkspaceFleetItem)> = Vec::new();
+    let mut after: Option<String> = None;
+    loop {
+        let page = session
+            .client
+            .workspace_fleet(
+                &session.project_id,
+                user,
+                token,
+                &WorkspaceFleetQuery {
+                    repo: file_system,
+                    q: id_query,
+                    principal_self: true,
+                    after: after.as_deref(),
+                    limit: Some(200),
+                },
+            )
+            .await?
+            .into_inner();
+        rows.extend(
+            page.items
+                .into_iter()
+                .filter(|item| {
+                    item.created_by
+                        .as_ref()
+                        .is_none_or(|by| own_sub.as_ref().is_none_or(|sub| by.name.as_str() == sub))
+                })
+                .map(|item| {
+                    // The fleet reports full repo ids (`{project}/{repo}`); everything here
+                    // speaks bare file-system names.
+                    let fs = item
+                        .repo
+                        .strip_prefix(&repo_prefix)
+                        .unwrap_or(&item.repo)
+                        .to_string();
+                    (fs, item)
+                }),
+        );
+        after = page.next_after.clone();
+        if !page.truncated || after.is_none() {
+            break;
+        }
     }
-    rows.sort_by_key(|(_, ws)| std::cmp::Reverse(ws.created_at_secs));
+    rows.sort_by_key(|(_, item)| std::cmp::Reverse(item.created_at_secs));
     Ok(rows)
 }
 
-/// Resolve a workspace id (or unique prefix) to its file system + info, scanning every file
-/// system in the project.
+/// Resolve a workspace id (or unique prefix) to its file system + record, project-wide. The
+/// fleet index finds the id (`q` narrows server-side); the authoritative record then comes from
+/// the per-repo, principal-checked API — resolution never widens what the caller may touch.
 async fn resolve_workspace(
     session: &FsSession,
-    fs_names: &[String],
     id: &str,
 ) -> Result<Option<(String, WorkspaceInfo)>> {
-    let mut matches: Vec<(String, WorkspaceInfo)> = all_workspaces(session, fs_names)
+    let mut matches: Vec<(String, String)> = fleet_workspaces(session, None, Some(id))
         .await?
         .into_iter()
-        .filter(|(_, ws)| ws.id.starts_with(id))
+        // The fleet's `q` is a substring match; a prefix is what resolves here.
+        .filter(|(_, item)| item.id.starts_with(id))
+        .map(|(fs, item)| (fs, item.id))
         .collect();
     match matches.len() {
         0 => Ok(None),
-        1 => Ok(Some(matches.remove(0))),
+        1 => {
+            let (fs, full_id) = matches.remove(0);
+            let (user, token) = session.creds();
+            let ws = session
+                .client
+                .get_workspace(&session.project_id, &fs, user, token, &full_id)
+                .await?
+                .into_inner();
+            Ok(Some((fs, ws)))
+        }
         n => Err(CliError::usage(format!(
             "workspace id {id:?} is ambiguous ({n} matches); use more characters"
         ))),
@@ -214,12 +253,11 @@ async fn resolve_workspace(
 /// `tl fs ls [file-system]` — every live workspace (across all file systems by default), with
 /// where each one is currently mounted on this machine.
 pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) -> Result<()> {
-    let session = FsSession::open(ctx, file_system).await?;
-    let fs_names = match file_system {
-        Some(fs) => vec![fs.to_string()],
-        None => file_system_names(&session).await?,
-    };
-    let rows = all_workspaces(&session, &fs_names).await?;
+    // Always a project-wide session, even for a named file system: the fleet listing requires
+    // `project:read`, which repo-scoped credentials deliberately lack — the file system narrows
+    // server-side via `?repo=` instead of via the credential.
+    let session = FsSession::open(ctx, None).await?;
+    let rows = fleet_workspaces(&session, file_system, None).await?;
     let mounts = live_mounts();
     let bound = plaindir::bound_workspaces();
     // A workspace's local attachment: the directory plus what kind of attachment it is.
@@ -240,16 +278,39 @@ pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) 
     if output_json {
         let out: Vec<serde_json::Value> = rows
             .iter()
-            .map(|(fs, ws)| {
+            .map(|(fs, item)| {
                 // `mounted_at` is the plain path (machine-consumable); `kind` says whether it
                 // is a kernel mount or a plain-directory binding — decorating the path itself
                 // broke every consumer that fed it back to another command.
-                let attached = attachment(&ws.id);
+                let attached = attachment(&item.id);
                 serde_json::json!({
                     "file_system": fs,
-                    "workspace": ws,
+                    // The legacy per-workspace object, rebuilt from the fleet row. Workspaces
+                    // are durable (artifact_storage issue #24): no lease exists, so the lease
+                    // fields are constants rather than a fetched row.
+                    "workspace": WorkspaceInfo {
+                        id: item.id.clone(),
+                        ref_name: format!("refs/workspaces/{}", item.id),
+                        principal: item
+                            .created_by
+                            .as_ref()
+                            .map(|by| by.name.clone())
+                            .unwrap_or_default(),
+                        base: item.base.clone(),
+                        base_ref: item.base_ref.clone(),
+                        head: item.head.clone(),
+                        created_at_secs: item.created_at_secs,
+                        lease_secs: 0,
+                        lease_due_ms: None,
+                        pinned: true,
+                        shared_target: item.shared_target.clone(),
+                    },
                     "mounted_at": attached.as_ref().map(|(path, _)| path.clone()),
                     "kind": attached.as_ref().map(|(_, kind)| *kind),
+                    // Fleet-only enrichments (absent before the one-call listing).
+                    "status": item.status,
+                    "snapshot_count": item.snapshot_count,
+                    "mounted_on": item.mounted_on,
                 })
             })
             .collect();
@@ -269,23 +330,27 @@ pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) 
         "Mounted",
         "Age",
     ]);
-    for (fs, ws) in &rows {
+    for (fs, item) in &rows {
         table.add_row(vec![
-            Cell::new(&ws.id),
+            Cell::new(&item.id),
             Cell::new(fs),
-            Cell::new(ws.base_ref.as_deref().unwrap_or(&ws.base[..12])),
-            Cell::new(if ws.head == ws.base { "-" } else { "yes" }),
-            Cell::new(match &ws.shared_target {
+            Cell::new(item.base_ref.as_deref().unwrap_or(&item.base[..12])),
+            Cell::new(if item.head == item.base { "-" } else { "yes" }),
+            Cell::new(match &item.shared_target {
                 Some(target) => format!("shared-rw -> {target}"),
                 None => "workspace".to_string(),
             }),
             // Human output keeps the annotation; the JSON path/kind split serves machines.
-            Cell::new(match attachment(&ws.id) {
+            // A mount session on another machine (fleet liveness) shows as its host.
+            Cell::new(match attachment(&item.id) {
                 Some((path, "binding")) => format!("{path} (bound)"),
                 Some((path, _)) => path,
-                None => "-".to_string(),
+                None => match &item.mounted_on {
+                    Some(host) => format!("{host} (remote)"),
+                    None => "-".to_string(),
+                },
             }),
-            Cell::new(age_display(ws.created_at_secs)),
+            Cell::new(age_display(item.created_at_secs)),
         ]);
     }
     println!("{table}");
@@ -297,9 +362,7 @@ pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) 
 /// (promoted work is unaffected).
 pub async fn rm(ctx: &CliContext, workspace_id: &str) -> Result<()> {
     let session = FsSession::open(ctx, None).await?;
-    let fs_names = file_system_names(&session).await?;
-    let Some((file_system, ws)) = resolve_workspace(&session, &fs_names, workspace_id).await?
-    else {
+    let Some((file_system, ws)) = resolve_workspace(&session, workspace_id).await? else {
         return Err(CliError::usage(format!(
             "no workspace matches {workspace_id:?} (see: tl fs ls)"
         )));
@@ -1719,8 +1782,7 @@ pub async fn mount(
         Err(e) => match create_recovery(&e) {
             // No file system by this name and no branch was named: try it as a workspace id.
             Some(CreateRecovery::RepoMissing) if base.is_none() => {
-                let fs_names = file_system_names(&session).await?;
-                match resolve_workspace(&session, &fs_names, name).await? {
+                match resolve_workspace(&session, name).await? {
                     Some((repo, ws)) => Resolved::Attached(repo, ws),
                     None => {
                         return Err(CliError::usage(format!(
@@ -3657,6 +3719,24 @@ fn age_display(created_at_secs: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn token_subject_reads_jwt_sub_and_rejects_opaque_tokens() {
+        use base64::Engine;
+        let enc = |v: &serde_json::Value| {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(v.to_string())
+        };
+        let header = enc(&serde_json::json!({"alg": "ES256", "typ": "JWT"}));
+        let claims = enc(&serde_json::json!({"sub": "user:u1", "proj": "p1"}));
+        let token = format!("{header}.{claims}.not-a-real-signature");
+        assert_eq!(token_subject(&token).as_deref(), Some("user:u1"));
+        // Opaque dev tokens (TENSORLAKE_GIT_TOKEN) and malformed payloads yield None — the
+        // listing then skips client-side principal filtering, matching open-mode servers.
+        assert_eq!(token_subject("just-a-pat"), None);
+        assert_eq!(token_subject("a.b.c"), None);
+        let no_sub = format!("{header}.{}.sig", enc(&serde_json::json!({"proj": "p1"})));
+        assert_eq!(token_subject(&no_sub), None);
+    }
 
     #[test]
     fn registry_document_parses_as_table() {

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -145,8 +145,11 @@ pub enum WritePolicy {
 
 /// The authenticated subject inside a minted git credential — an unverified JWT-payload decode,
 /// used only to filter a listing client-side (the server enforces real principal checks). `None`
-/// for opaque tokens (dev/self-hosted `TENSORLAKE_GIT_TOKEN`), which matches open-mode servers
-/// where workspaces are unbound anyway.
+/// for opaque tokens: dev/self-hosted `TENSORLAKE_GIT_TOKEN` values, which usually mean an
+/// open-mode server where workspaces are unbound. Known gap: a *static-token* server binds
+/// workspaces to token fingerprints, so against one that also predates the server-side
+/// `principal=self` filter, an opaque token skips filtering entirely — deploy order (server
+/// before CLI) is what closes that window.
 fn token_subject(token: &str) -> Option<String> {
     use base64::Engine;
     let payload = token.split('.').nth(1)?;
@@ -157,8 +160,31 @@ fn token_subject(token: &str) -> Option<String> {
     Some(claims.get("sub")?.as_str()?.to_string())
 }
 
-/// Every workspace visible to this caller across the whole project — one fleet request per page
-/// instead of one listing per file system — newest first, as `(file system, item)`.
+/// The legacy per-workspace record, rebuilt from a fleet row. Lease fields come off the wire
+/// (`lease_due_ms` absent = pinned); servers that predate them omit both, which decodes to the
+/// durable-workspace constants.
+fn fleet_item_to_info(item: &WorkspaceFleetItem) -> WorkspaceInfo {
+    WorkspaceInfo {
+        id: item.id.clone(),
+        ref_name: format!("refs/workspaces/{}", item.id),
+        principal: item
+            .created_by
+            .as_ref()
+            .map(|by| by.name.clone())
+            .unwrap_or_default(),
+        base: item.base.clone(),
+        base_ref: item.base_ref.clone(),
+        head: item.head.clone(),
+        created_at_secs: item.created_at_secs,
+        lease_secs: item.lease_secs,
+        lease_due_ms: item.lease_due_ms,
+        pinned: item.lease_due_ms.is_none(),
+        shared_target: item.shared_target.clone(),
+    }
+}
+
+/// Every workspace visible to this caller across the whole project — one paginated fleet
+/// request instead of one listing per file system — newest first, as `(file system, item)`.
 ///
 /// The server narrows to the caller's own + unbound workspaces (`principal=self`); the same
 /// filter is applied here too, because servers that predate the parameter ignore it and would
@@ -171,49 +197,41 @@ async fn fleet_workspaces(
     let (user, token) = session.creds();
     let own_sub = token_subject(token);
     let repo_prefix = format!("{}/", session.project_id);
-    let mut rows: Vec<(String, WorkspaceFleetItem)> = Vec::new();
-    let mut after: Option<String> = None;
-    loop {
-        let page = session
-            .client
-            .workspace_fleet(
-                &session.project_id,
-                user,
-                token,
-                &WorkspaceFleetQuery {
-                    repo: file_system,
-                    q: id_query,
-                    principal_self: true,
-                    after: after.as_deref(),
-                    limit: Some(200),
-                },
-            )
-            .await?
-            .into_inner();
-        rows.extend(
-            page.items
-                .into_iter()
-                .filter(|item| {
-                    item.created_by
-                        .as_ref()
-                        .is_none_or(|by| own_sub.as_ref().is_none_or(|sub| by.name.as_str() == sub))
-                })
-                .map(|item| {
-                    // The fleet reports full repo ids (`{project}/{repo}`); everything here
-                    // speaks bare file-system names.
-                    let fs = item
-                        .repo
-                        .strip_prefix(&repo_prefix)
-                        .unwrap_or(&item.repo)
-                        .to_string();
-                    (fs, item)
-                }),
-        );
-        after = page.next_after.clone();
-        if !page.truncated || after.is_none() {
-            break;
-        }
-    }
+    let items = session
+        .client
+        .workspace_fleet_all(
+            &session.project_id,
+            user,
+            token,
+            &WorkspaceFleetQuery {
+                repo: file_system,
+                q: id_query,
+                principal_self: true,
+                after: None,
+                limit: Some(200),
+            },
+        )
+        .await?
+        .into_inner();
+    let mut rows: Vec<(String, WorkspaceFleetItem)> = items
+        .into_iter()
+        .filter(|item| match (&item.created_by, &own_sub) {
+            // Drop only what is provably someone else's: a bound workspace whose principal
+            // differs from our decoded subject. Unbound rows and undecodable tokens pass.
+            (Some(by), Some(sub)) => by.name == *sub,
+            _ => true,
+        })
+        .map(|item| {
+            // The fleet reports full repo ids (`{project}/{repo}`); everything here speaks
+            // bare file-system names.
+            let fs = item
+                .repo
+                .strip_prefix(&repo_prefix)
+                .unwrap_or(&item.repo)
+                .to_string();
+            (fs, item)
+        })
+        .collect();
     rows.sort_by_key(|(_, item)| std::cmp::Reverse(item.created_at_secs));
     Ok(rows)
 }
@@ -237,12 +255,21 @@ async fn resolve_workspace(
         1 => {
             let (fs, full_id) = matches.remove(0);
             let (user, token) = session.creds();
-            let ws = session
+            match session
                 .client
                 .get_workspace(&session.project_id, &fs, user, token, &full_id)
-                .await?
-                .into_inner();
-            Ok(Some((fs, ws)))
+                .await
+            {
+                Ok(ws) => Ok(Some((fs, ws.into_inner()))),
+                // Deleted between the fleet hit and this fetch: resolve as absent (the caller
+                // prints the friendly "no workspace matches"), not as a raw server error.
+                Err(tensorlake::error::SdkError::ServerError { status, .. })
+                    if status == reqwest::StatusCode::NOT_FOUND =>
+                {
+                    Ok(None)
+                }
+                Err(e) => Err(e.into()),
+            }
         }
         n => Err(CliError::usage(format!(
             "workspace id {id:?} is ambiguous ({n} matches); use more characters"
@@ -250,14 +277,60 @@ async fn resolve_workspace(
     }
 }
 
+/// One `tl fs ls` row: the workspace record plus the fleet's liveness enrichments — absent on
+/// the per-repo fallback path, where the server does no activity join.
+struct LsRow {
+    fs: String,
+    ws: WorkspaceInfo,
+    status: Option<String>,
+    snapshot_count: Option<u64>,
+    mounted_on: Option<String>,
+}
+
 /// `tl fs ls [file-system]` — every live workspace (across all file systems by default), with
 /// where each one is currently mounted on this machine.
 pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) -> Result<()> {
-    // Always a project-wide session, even for a named file system: the fleet listing requires
-    // `project:read`, which repo-scoped credentials deliberately lack — the file system narrows
-    // server-side via `?repo=` instead of via the credential.
+    // Project-wide session first: the fleet listing requires `project:read`, which repo-scoped
+    // credentials deliberately lack — a named file system narrows server-side via `?repo=`.
     let session = FsSession::open(ctx, None).await?;
-    let rows = fleet_workspaces(&session, file_system, None).await?;
+    let rows: Vec<LsRow> = match fleet_workspaces(&session, file_system, None).await {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|(fs, item)| LsRow {
+                fs,
+                ws: fleet_item_to_info(&item),
+                status: Some(item.status),
+                snapshot_count: Some(item.snapshot_count),
+                mounted_on: item.mounted_on,
+            })
+            .collect(),
+        // A caller holding only a repo-scoped credential is refused by the project-scope fleet
+        // but can still list one named file system the pre-fleet way: the per-repo,
+        // principal-bound listing (GitRead). Liveness enrichments are simply absent there.
+        Err(CliError::Sdk(tensorlake::error::SdkError::ServerError { status, .. }))
+            if status == reqwest::StatusCode::FORBIDDEN && file_system.is_some() =>
+        {
+            let fs = file_system.expect("guarded above");
+            let session = FsSession::open(ctx, Some(fs)).await?;
+            let (user, token) = session.creds();
+            let mut list = session
+                .client
+                .list_workspaces(&session.project_id, fs, user, token)
+                .await?
+                .into_inner();
+            list.sort_by_key(|ws| std::cmp::Reverse(ws.created_at_secs));
+            list.into_iter()
+                .map(|ws| LsRow {
+                    fs: fs.to_string(),
+                    ws,
+                    status: None,
+                    snapshot_count: None,
+                    mounted_on: None,
+                })
+                .collect()
+        }
+        Err(e) => return Err(e),
+    };
     let mounts = live_mounts();
     let bound = plaindir::bound_workspaces();
     // A workspace's local attachment: the directory plus what kind of attachment it is.
@@ -278,39 +351,20 @@ pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) 
     if output_json {
         let out: Vec<serde_json::Value> = rows
             .iter()
-            .map(|(fs, item)| {
+            .map(|row| {
                 // `mounted_at` is the plain path (machine-consumable); `kind` says whether it
                 // is a kernel mount or a plain-directory binding — decorating the path itself
                 // broke every consumer that fed it back to another command.
-                let attached = attachment(&item.id);
+                let attached = attachment(&row.ws.id);
                 serde_json::json!({
-                    "file_system": fs,
-                    // The legacy per-workspace object, rebuilt from the fleet row. Workspaces
-                    // are durable (artifact_storage issue #24): no lease exists, so the lease
-                    // fields are constants rather than a fetched row.
-                    "workspace": WorkspaceInfo {
-                        id: item.id.clone(),
-                        ref_name: format!("refs/workspaces/{}", item.id),
-                        principal: item
-                            .created_by
-                            .as_ref()
-                            .map(|by| by.name.clone())
-                            .unwrap_or_default(),
-                        base: item.base.clone(),
-                        base_ref: item.base_ref.clone(),
-                        head: item.head.clone(),
-                        created_at_secs: item.created_at_secs,
-                        lease_secs: 0,
-                        lease_due_ms: None,
-                        pinned: true,
-                        shared_target: item.shared_target.clone(),
-                    },
+                    "file_system": row.fs,
+                    "workspace": row.ws,
                     "mounted_at": attached.as_ref().map(|(path, _)| path.clone()),
                     "kind": attached.as_ref().map(|(_, kind)| *kind),
-                    // Fleet-only enrichments (absent before the one-call listing).
-                    "status": item.status,
-                    "snapshot_count": item.snapshot_count,
-                    "mounted_on": item.mounted_on,
+                    // Fleet liveness enrichments; null on the per-repo fallback path.
+                    "status": row.status,
+                    "snapshot_count": row.snapshot_count,
+                    "mounted_on": row.mounted_on,
                 })
             })
             .collect();
@@ -330,27 +384,28 @@ pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) 
         "Mounted",
         "Age",
     ]);
-    for (fs, item) in &rows {
+    for row in &rows {
+        let ws = &row.ws;
         table.add_row(vec![
-            Cell::new(&item.id),
-            Cell::new(fs),
-            Cell::new(item.base_ref.as_deref().unwrap_or(&item.base[..12])),
-            Cell::new(if item.head == item.base { "-" } else { "yes" }),
-            Cell::new(match &item.shared_target {
+            Cell::new(&ws.id),
+            Cell::new(&row.fs),
+            Cell::new(ws.base_ref.as_deref().unwrap_or(&ws.base[..12])),
+            Cell::new(if ws.head == ws.base { "-" } else { "yes" }),
+            Cell::new(match &ws.shared_target {
                 Some(target) => format!("shared-rw -> {target}"),
                 None => "workspace".to_string(),
             }),
             // Human output keeps the annotation; the JSON path/kind split serves machines.
             // A mount session on another machine (fleet liveness) shows as its host.
-            Cell::new(match attachment(&item.id) {
+            Cell::new(match attachment(&ws.id) {
                 Some((path, "binding")) => format!("{path} (bound)"),
                 Some((path, _)) => path,
-                None => match &item.mounted_on {
+                None => match &row.mounted_on {
                     Some(host) => format!("{host} (remote)"),
                     None => "-".to_string(),
                 },
             }),
-            Cell::new(age_display(item.created_at_secs)),
+            Cell::new(age_display(ws.created_at_secs)),
         ]);
     }
     println!("{table}");
@@ -3719,6 +3774,34 @@ fn age_display(created_at_secs: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fleet_item_to_info_carries_real_lease_state() {
+        let item: WorkspaceFleetItem = serde_json::from_value(serde_json::json!({
+            "id": "aa", "repo": "p1/demo", "status": "detached", "mode": "default",
+            "base": "1111111111111111111111111111111111111111",
+            "head": "1111111111111111111111111111111111111111",
+            "created_at_secs": 1,
+            "snapshot_count": 0,
+        }))
+        .unwrap();
+        // Durable workspace (no lease on the wire, the modern norm): pinned.
+        let info = fleet_item_to_info(&item);
+        assert!(info.pinned);
+        assert_eq!(info.lease_due_ms, None);
+        assert_eq!(info.ref_name, "refs/workspaces/aa");
+        assert_eq!(info.principal, "", "unbound: created_by omitted");
+        // Legacy leased workspace: the wire lease surfaces, not a fabricated constant.
+        let leased = WorkspaceFleetItem {
+            lease_secs: 3600,
+            lease_due_ms: Some(4_102_444_800_000),
+            ..item
+        };
+        let info = fleet_item_to_info(&leased);
+        assert!(!info.pinned);
+        assert_eq!(info.lease_due_ms, Some(4_102_444_800_000));
+        assert_eq!(info.lease_secs, 3600);
+    }
 
     #[test]
     fn token_subject_reads_jwt_sub_and_rejects_opaque_tokens() {

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -491,6 +491,25 @@ impl ArtifactStorageClient {
         Ok(self.git_request_url(method, path, git_username, git_token))
     }
 
+    /// A project-scope request (`/project/{project}/{suffix}`) with a git credential —
+    /// the URL shape for endpoints that span repos, like the workspace fleet.
+    fn project_git_request(
+        &self,
+        method: Method,
+        project_id: &str,
+        suffix: &str,
+        git_username: &str,
+        git_token: &str,
+    ) -> (reqwest::RequestBuilder, String) {
+        let url = format!(
+            "{}/project/{}/{}",
+            self.git_base_url,
+            encode_path_segment(project_id),
+            suffix
+        );
+        self.git_request_url(method, url, git_username, git_token)
+    }
+
     fn git_request_url(
         &self,
         method: Method,

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -183,6 +183,87 @@ pub struct TreeEntry {
     pub size: Option<u64>,
 }
 
+/// One row of the project-scope workspace fleet listing
+/// (`GET /project/{project}/workspaces`, artifact_storage issue #56).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WorkspaceFleetItem {
+    pub id: String,
+    /// Full repo id (`{project}/{repo}`).
+    pub repo: String,
+    /// Derived server-side at read time: `live` | `gap` | `idle` | `detached`.
+    pub status: String,
+    /// `default` | `shared-rw`.
+    pub mode: String,
+    /// Creating principal; absent for unbound (open-mode) workspaces.
+    #[serde(default)]
+    pub created_by: Option<WorkspaceActor>,
+    /// Base commit (hex) the workspace was created from.
+    pub base: String,
+    #[serde(default)]
+    pub base_ref: Option<String>,
+    /// Current snapshot tip (hex); equals `base` until the first snapshot.
+    pub head: String,
+    pub created_at_secs: u64,
+    #[serde(default)]
+    pub shared_target: Option<String>,
+    #[serde(default)]
+    pub snapshot_count: u64,
+    #[serde(default)]
+    pub last_snapshot_ms: Option<u64>,
+    #[serde(default)]
+    pub last_heartbeat_ms: Option<u64>,
+    /// Host reported by the currently-open mount session, if any.
+    #[serde(default)]
+    pub mounted_on: Option<String>,
+}
+
+/// A workspace's creating principal: the authenticated `sub` and its human/agent classification.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WorkspaceActor {
+    pub name: String,
+    /// `human` | `agent` | `unknown`.
+    pub kind: String,
+}
+
+/// Per-status totals for the fleet page's filter set (status filter excluded).
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct WorkspaceFleetCounts {
+    pub total: u64,
+    pub live: u64,
+    pub detached: u64,
+    pub gap: u64,
+    pub idle: u64,
+    /// Counts cover only the server's bounded scan prefix when the fleet exceeds its cap.
+    pub truncated: bool,
+}
+
+/// One page of the project-scope workspace fleet.
+#[derive(Clone, Debug, Deserialize)]
+pub struct WorkspaceFleetPage {
+    pub project: String,
+    pub items: Vec<WorkspaceFleetItem>,
+    pub counts: WorkspaceFleetCounts,
+    /// More items exist past this page; resume with `after = next_after`.
+    pub truncated: bool,
+    #[serde(default)]
+    pub next_after: Option<String>,
+}
+
+/// Filters for one fleet page. `repo` accepts the bare repo name (the server also matches the
+/// full `{project}/{repo}` id); `q` is an id substring match.
+#[derive(Clone, Debug, Default)]
+pub struct WorkspaceFleetQuery<'a> {
+    pub repo: Option<&'a str>,
+    pub q: Option<&'a str>,
+    /// Ask the server for the caller's own + unbound workspaces only (`principal=self`).
+    /// Servers that predate the param ignore it — callers relying on the narrowing must also
+    /// filter client-side.
+    pub principal_self: bool,
+    pub after: Option<&'a str>,
+    /// Page size; the server clamps to its own cap (200).
+    pub limit: Option<usize>,
+}
+
 impl ArtifactStorageClient {
     pub async fn create_workspace(
         &self,
@@ -222,6 +303,45 @@ impl ArtifactStorageClient {
         )?;
         let info = expect_json(req.send().await?).await?;
         Ok(Traced::new(trace_id, info))
+    }
+
+    /// One page of the project-scope workspace fleet: every repo in one call, joined with
+    /// liveness (status, `mounted_on`). Requires a project-wide credential — repo-scoped mints
+    /// carry no `project:read` and are refused. Page with `next_after` until `truncated` is
+    /// false.
+    pub async fn workspace_fleet(
+        &self,
+        project_id: &str,
+        git_username: &str,
+        git_token: &str,
+        query: &WorkspaceFleetQuery<'_>,
+    ) -> Result<Traced<WorkspaceFleetPage>, SdkError> {
+        let mut params = url::form_urlencoded::Serializer::new(String::new());
+        if let Some(repo) = query.repo {
+            params.append_pair("repo", repo);
+        }
+        if let Some(q) = query.q {
+            params.append_pair("q", q);
+        }
+        if query.principal_self {
+            params.append_pair("principal", "self");
+        }
+        if let Some(after) = query.after {
+            params.append_pair("after", after);
+        }
+        if let Some(limit) = query.limit {
+            params.append_pair("limit", &limit.to_string());
+        }
+        let params = params.finish();
+        let suffix = if params.is_empty() {
+            "workspaces".to_string()
+        } else {
+            format!("workspaces?{params}")
+        };
+        let (req, trace_id) =
+            self.project_git_request(Method::GET, project_id, &suffix, git_username, git_token);
+        let page = expect_json(req.send().await?).await?;
+        Ok(Traced::new(trace_id, page))
     }
 
     pub async fn list_workspaces(
@@ -478,6 +598,75 @@ mod tests {
         assert!(resp.squashed);
         assert!(!resp.merged);
         assert!(!resp.fast_forwarded);
+    }
+
+    /// The fleet page decodes gsvc-server's exact wire shape (`fleet_item_json` /
+    /// `WorkspaceFleetResponse` in `crates/gsvc-server/src/http.rs`) — every field the CLI
+    /// listing consumes. The server side of this contract is pinned by the fleet e2e test in
+    /// artifact_storage; change either together.
+    #[test]
+    fn fleet_page_decodes_server_shape() {
+        let body = r#"{
+            "project": "p1",
+            "items": [{
+                "id": "aabbccdd", "repo": "p1/demo", "status": "live", "mode": "shared-rw",
+                "created_by": {"name": "user:u1", "kind": "human"},
+                "base": "1111111111111111111111111111111111111111",
+                "base_ref": "refs/heads/main",
+                "head": "2222222222222222222222222222222222222222",
+                "created_at_secs": 1751000000,
+                "shared_target": "main",
+                "snapshot_count": 3,
+                "last_snapshot_ms": 1751000500000,
+                "last_heartbeat_ms": 1751000600000,
+                "mounted_on": "sandbox-42"
+            }],
+            "counts": {"total": 1, "live": 1, "detached": 0, "gap": 0, "idle": 0, "truncated": false},
+            "truncated": true,
+            "next_after": "aabbccdd"
+        }"#;
+        let page: WorkspaceFleetPage = serde_json::from_str(body).unwrap();
+        assert_eq!(page.project, "p1");
+        assert_eq!(page.counts.total, 1);
+        assert!(page.truncated);
+        assert_eq!(page.next_after.as_deref(), Some("aabbccdd"));
+        let item = &page.items[0];
+        assert_eq!(item.id, "aabbccdd");
+        assert_eq!(item.repo, "p1/demo");
+        assert_eq!(item.status, "live");
+        assert_eq!(item.mode, "shared-rw");
+        assert_eq!(item.created_by.as_ref().unwrap().name, "user:u1");
+        assert_eq!(item.created_by.as_ref().unwrap().kind, "human");
+        assert_eq!(item.base_ref.as_deref(), Some("refs/heads/main"));
+        assert_eq!(item.snapshot_count, 3);
+        assert_eq!(item.mounted_on.as_deref(), Some("sandbox-42"));
+    }
+
+    /// Optional fleet fields are `skip_serializing_if` on the server: an unbound, never-mounted,
+    /// never-snapshotted workspace omits them entirely and must still decode.
+    #[test]
+    fn fleet_item_tolerates_omitted_optionals() {
+        let body = r#"{
+            "project": "p1",
+            "items": [{
+                "id": "ee", "repo": "p1/demo", "status": "detached", "mode": "default",
+                "base": "1111111111111111111111111111111111111111",
+                "head": "1111111111111111111111111111111111111111",
+                "created_at_secs": 1751000000,
+                "snapshot_count": 0
+            }],
+            "counts": {"total": 1, "live": 0, "detached": 1, "gap": 0, "idle": 0, "truncated": false},
+            "truncated": false
+        }"#;
+        let page: WorkspaceFleetPage = serde_json::from_str(body).unwrap();
+        let item = &page.items[0];
+        assert!(item.created_by.is_none(), "unbound workspace");
+        assert!(item.base_ref.is_none());
+        assert!(item.shared_target.is_none());
+        assert!(item.last_snapshot_ms.is_none());
+        assert!(item.last_heartbeat_ms.is_none());
+        assert!(item.mounted_on.is_none());
+        assert!(page.next_after.is_none());
     }
 
     /// The sync response decodes the full server shape, conflicts included.

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -204,6 +204,14 @@ pub struct WorkspaceFleetItem {
     /// Current snapshot tip (hex); equals `base` until the first snapshot.
     pub head: String,
     pub created_at_secs: u64,
+    /// Lease duration from the identity record; 0 for durable (modern) workspaces. Defaults
+    /// to 0 against servers that predate the field.
+    #[serde(default)]
+    pub lease_secs: u64,
+    /// Epoch-ms lease expiry. `None` means pinned: never expires. Servers that predate the
+    /// field omit it, which decodes as pinned — correct for every durable workspace.
+    #[serde(default)]
+    pub lease_due_ms: Option<u64>,
     #[serde(default)]
     pub shared_target: Option<String>,
     #[serde(default)]
@@ -251,7 +259,7 @@ pub struct WorkspaceFleetPage {
 
 /// Filters for one fleet page. `repo` accepts the bare repo name (the server also matches the
 /// full `{project}/{repo}` id); `q` is an id substring match.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct WorkspaceFleetQuery<'a> {
     pub repo: Option<&'a str>,
     pub q: Option<&'a str>,
@@ -342,6 +350,43 @@ impl ArtifactStorageClient {
             self.project_git_request(Method::GET, project_id, &suffix, git_username, git_token);
         let page = expect_json(req.send().await?).await?;
         Ok(Traced::new(trace_id, page))
+    }
+
+    /// The complete fleet for the given filters: pages internally (like every other list
+    /// helper in this crate) until the server reports no more rows, starting from `query.after`
+    /// if set. Returns the items and the trace id of the final page.
+    pub async fn workspace_fleet_all(
+        &self,
+        project_id: &str,
+        git_username: &str,
+        git_token: &str,
+        query: &WorkspaceFleetQuery<'_>,
+    ) -> Result<Traced<Vec<WorkspaceFleetItem>>, SdkError> {
+        let mut items = Vec::new();
+        let mut after: Option<String> = query.after.map(str::to_string);
+        loop {
+            let page = self
+                .workspace_fleet(
+                    project_id,
+                    git_username,
+                    git_token,
+                    &WorkspaceFleetQuery {
+                        after: after.as_deref(),
+                        ..*query
+                    },
+                )
+                .await?;
+            let trace_id = page.trace_id.clone();
+            let page = page.into_inner();
+            items.extend(page.items);
+            if !page.truncated {
+                return Ok(Traced::new(trace_id, items));
+            }
+            let Some(next) = page.next_after else {
+                return Ok(Traced::new(trace_id, items));
+            };
+            after = Some(next);
+        }
     }
 
     pub async fn list_workspaces(
@@ -615,6 +660,8 @@ mod tests {
                 "base_ref": "refs/heads/main",
                 "head": "2222222222222222222222222222222222222222",
                 "created_at_secs": 1751000000,
+                "lease_secs": 3600,
+                "lease_due_ms": 1751003600000,
                 "shared_target": "main",
                 "snapshot_count": 3,
                 "last_snapshot_ms": 1751000500000,
@@ -638,12 +685,15 @@ mod tests {
         assert_eq!(item.created_by.as_ref().unwrap().name, "user:u1");
         assert_eq!(item.created_by.as_ref().unwrap().kind, "human");
         assert_eq!(item.base_ref.as_deref(), Some("refs/heads/main"));
+        assert_eq!(item.lease_secs, 3600);
+        assert_eq!(item.lease_due_ms, Some(1751003600000));
         assert_eq!(item.snapshot_count, 3);
         assert_eq!(item.mounted_on.as_deref(), Some("sandbox-42"));
     }
 
     /// Optional fleet fields are `skip_serializing_if` on the server: an unbound, never-mounted,
-    /// never-snapshotted workspace omits them entirely and must still decode.
+    /// never-snapshotted workspace omits them entirely and must still decode. Lease fields also
+    /// default (0 / pinned) against servers that predate them.
     #[test]
     fn fleet_item_tolerates_omitted_optionals() {
         let body = r#"{
@@ -662,6 +712,8 @@ mod tests {
         let item = &page.items[0];
         assert!(item.created_by.is_none(), "unbound workspace");
         assert!(item.base_ref.is_none());
+        assert_eq!(item.lease_secs, 0, "old servers omit lease_secs");
+        assert!(item.lease_due_ms.is_none(), "omitted lease row = pinned");
         assert!(item.shared_target.is_none());
         assert!(item.last_snapshot_ms.is_none());
         assert!(item.last_heartbeat_ms.is_none());


### PR DESCRIPTION
## Why

`tl fs ls` fanned out one HTTP request per file system in the project (after a `list_repos` call), each hitting artifact-storage's per-repo workspace listing. With many file systems that's `1 + ceil(N/8)` WAN round-trip waves per invocation; `tl fs rm` and mount's workspace-attach recovery paid the same fan-out to resolve an id.

## What

One paginated call to the project-scope fleet endpoint (`GET /project/{p}/workspaces?principal=self`, server half in [artifact_storage#101](https://github.com/tensorlakeai/artifact_storage/pull/101)):

- **cloud-sdk**: `workspace_fleet` method + `WorkspaceFleetPage`/`WorkspaceFleetItem` wire types, paginated via `next_after`. Decode is pinned by unit tests here; the server's encode is pinned by a matching key-set contract test in artifact_storage's fleet e2e — change either together.
- **Auth**: the listing session always mints the project-wide credential now — repo-scoped mints carry no `project:read`, so the fleet route would 403. A named file system narrows server-side via `?repo=` instead.
- **Old-server defense**: servers that predate `principal=self` ignore it; the CLI decodes the credential's `sub` (unverified, filter-only) and drops other principals' rows client-side. Opaque dev tokens skip the filter, matching open-mode semantics.
- **`resolve_workspace`**: finds the id project-wide via the fleet (`q=` substring, prefix-filtered client-side), then fetches the authoritative record through the per-repo principal-checked API — resolution never widens what mutations may touch.
- **Output**: JSON keeps its shape (`workspace` rebuilt from the fleet row; workspaces are durable, so the lease fields are constants) and gains `status` / `snapshot_count` / `mounted_on`. The table's Mounted column now shows `<host> (remote)` when the workspace is mounted on another machine.

## Sequencing

artifact_storage#101 should deploy before this releases — until then the client-side principal filter keeps the listing correct, and the fleet endpoint itself has been in prod since issue #56.

## Tests

- SDK: `fleet_page_decodes_server_shape`, `fleet_item_tolerates_omitted_optionals`
- CLI: `token_subject_reads_jwt_sub_and_rejects_opaque_tokens`
- Full suites green: `cargo test -p tensorlake --lib` (137), `cargo test -p tensorlake-cli --bin tl` (199 default / 260 with `--features mount,git-clone` and vendored gsvc crates); clippy + fmt clean on touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)