### PR TITLE
tl fs: one definition of dirty — sealed index, daemon dirty/trim ops, truthful status, non-destructive sync

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -5,15 +5,20 @@
 //! artifact-storage repo backing them (managed with `tl git`); a mounted workspace (private
 //! leased ref) is served by a FUSE daemon — reads stream lazily from the server through the
 //! vendored `gsvc-mount` core's immutable caches, writes land in a local overlay.
-//! **The overlay is the dirty set**: the daemon's sealer resolves its dirty index into
-//! incremental snapshot commits on the workspace ref (auto-commit ticks it; `tl fs snapshot`
-//! runs one cycle through the `seal` control op), and the mount's lower layer follows the ref
-//! to the new snapshot. The overlay is **kept** after sealing —
-//! the upper keeps serving the byte-identical sealed content; `snapshot --clear` is the
-//! explicit, destructive opt-in that drops it (required before `sync`). `promote`
-//! CAS-advances a real branch (squash by default); `restore` refills the overlay from any
-//! snapshot. FUSE is the only mount path — Linux builds
-//! carry it unconditionally, macOS requires macFUSE and the `macfuse` build feature.
+//! **The daemon's sealer owns the definition of dirty**: the overlay's dirty index resolves
+//! into incremental snapshot commits on the workspace ref (auto-commit ticks it; `tl fs
+//! snapshot` runs one cycle through the `seal` control op), and the mount's lower layer
+//! follows the ref to the new snapshot. Every dirt-consulting command (`status`, `promote`,
+//! `sync`, `diff`) reads the same view through the `dirty` control op, so none of them can
+//! disagree with what a snapshot would seal. The overlay is **kept** after sealing — the
+//! upper keeps serving the byte-identical sealed content as a local byte cache, accounted
+//! for by the sealed index (`sealed.json`, which also survives daemon restarts) and
+//! reported by `status` as `retained`. `sync` asks the daemon to `trim` retained content
+//! (safe: it is all in workspace history; ignored files survive); `snapshot --clear`
+//! remains the explicit, destructive opt-in that drops the WHOLE overlay, ignored files
+//! included. `promote` CAS-advances a real branch (squash by default); `restore` refills
+//! the overlay from any snapshot. FUSE is the only mount path — Linux builds carry it
+//! unconditionally, macOS requires macFUSE and the `macfuse` build feature.
 
 use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
@@ -2465,6 +2470,121 @@ fn pending_renames(state_dir: &Path) -> Vec<(String, String)> {
     entries
 }
 
+/// A mount's local-change picture. `exact: true` means the daemon's sealer answered — the
+/// dirty set is exactly what the next snapshot would publish (same dirty index, same ignore
+/// rules, same resolution walk), and retained/ignored account for every other upper file.
+/// `exact: false` is the daemon-down fallback: a raw upper walk that cannot distinguish
+/// unsealed dirt from retained sealed content, so it may over-report.
+struct LocalChanges {
+    upserts: Vec<String>,
+    deletes: Vec<String>,
+    /// Pending committed-directory renames, `(from, to)`.
+    renames: Vec<(String, String)>,
+    /// Upper files sealed into a snapshot and kept as the local byte cache.
+    retained: usize,
+    /// Ignored local-only files (never enter a snapshot; only `snapshot --clear` drops them).
+    ignored: usize,
+    exact: bool,
+}
+
+impl LocalChanges {
+    fn dirty(&self) -> usize {
+        self.upserts.len() + self.deletes.len() + self.renames.len()
+    }
+}
+
+/// The one authoritative answer to "what is dirty": ask the daemon's sealer (`dirty` control
+/// op); fall back to the raw overlay walk only when the daemon is not answering. Every
+/// dirt-consulting command (`status`, `promote`, `sync`, `diff`) routes through here so none
+/// of them can disagree with what `tl fs snapshot` would actually seal.
+async fn local_changes(state_dir: &Path, mountpoint: &str) -> Result<LocalChanges> {
+    if let Ok(reply) = daemon::control(state_dir, "dirty").await
+        && reply.get("ok").and_then(|v| v.as_bool()) == Some(true)
+        && let Ok(dirty) = serde_json::from_value::<daemon::DirtyReply>(reply)
+    {
+        // Retained/ignored accounting: everything in the upper that is not dirty is either
+        // sealed-and-kept or ignored. The walk is local disk, and the ignore rules are the
+        // same ones the sealer applies.
+        let dirty_set: std::collections::HashSet<&str> =
+            dirty.upserts.iter().map(String::as_str).collect();
+        let mut ignore = SnapshotIgnore::new(Path::new(mountpoint));
+        let (mut retained, mut ignored) = (0usize, 0usize);
+        let upper = state_dir.join("upper");
+        let mut stack = vec![upper.clone()];
+        while let Some(dir) = stack.pop() {
+            let Ok(read) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in read.flatten() {
+                let abs = entry.path();
+                let Ok(meta) = abs.symlink_metadata() else {
+                    continue;
+                };
+                let rel = abs
+                    .strip_prefix(&upper)
+                    .expect("under upper")
+                    .components()
+                    .map(|c| c.as_os_str().to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join("/");
+                let is_dir = meta.is_dir() && !meta.file_type().is_symlink();
+                if ignore.is_ignored(&rel, is_dir).unwrap_or(false) {
+                    // An ignored directory's whole subtree is ignored — count its files.
+                    ignored += if is_dir { count_files_under(&abs) } else { 1 };
+                    continue;
+                }
+                if is_dir {
+                    stack.push(abs);
+                } else if !dirty_set.contains(rel.as_str()) {
+                    retained += 1;
+                }
+            }
+        }
+        return Ok(LocalChanges {
+            upserts: dirty.upserts,
+            deletes: dirty.deletes,
+            renames: dirty.renames,
+            retained,
+            ignored,
+            exact: true,
+        });
+    }
+    let (upserts, deletes) = enumerate_overlay(state_dir, Path::new(mountpoint))?;
+    Ok(LocalChanges {
+        upserts: upserts.into_iter().map(|(rel, _, _)| rel).collect(),
+        deletes,
+        renames: pending_renames(state_dir)
+            .into_iter()
+            .map(|(to, from)| (from, to))
+            .collect(),
+        retained: 0,
+        ignored: 0,
+        exact: false,
+    })
+}
+
+/// Every file/symlink under `dir`, recursively — [`local_changes`]'s ignored-subtree counter.
+fn count_files_under(dir: &Path) -> usize {
+    let mut n = 0;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(read) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in read.flatten() {
+            let Ok(meta) = entry.path().symlink_metadata() else {
+                continue;
+            };
+            if meta.is_dir() && !meta.file_type().is_symlink() {
+                stack.push(entry.path());
+            } else {
+                n += 1;
+            }
+        }
+    }
+    n
+}
+
 /// An enumerated dirty set as push files, used by the daemon's sealer (`tl fs snapshot`
 /// seals through the daemon, so nothing pushes from the CLI process).
 fn overlay_push_files(upserts: &OverlayUpserts, deletes: &[String]) -> Result<Vec<PushFile>> {
@@ -2726,13 +2846,18 @@ pub async fn promote(
     }
     let session = FsSession::open(ctx, Some(&state.repo)).await?;
     heartbeat(&session, &state).await?;
-    let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
-    let renames = pending_renames(&state_dir);
-    if !upserts.is_empty() || !deletes.is_empty() || !renames.is_empty() {
+    let changes = local_changes(&state_dir, &mountpoint).await?;
+    if changes.dirty() > 0 {
         eprintln!(
-            "{} {} local change(s) that may not be in a snapshot; promoting the last snapshot only. Run `tl fs snapshot` first to be sure they are included.",
+            "{} {} local change(s) not in any snapshot; promoting the last snapshot only. Run `tl fs snapshot` first to include them.{}",
             style("note:").yellow(),
-            upserts.len() + deletes.len() + renames.len()
+            changes.dirty(),
+            if changes.exact {
+                ""
+            } else {
+                " (The mount daemon did not answer the dirty query; the count may include \
+                 already-sealed files.)"
+            },
         );
     }
     let (user, token) = session.creds();
@@ -2812,9 +2937,11 @@ pub async fn promote(
 /// Sync: pull the target branch into a behind workspace — one server-side rebase-style merge
 /// commit on the target head; the mount's lower layer then advances to it. Under the default
 /// materialize policy conflicts land as diff3 markers in the workspace files; resolve them and
-/// snapshot. Local overlay changes would shadow synced content (markers included), so a dirty
-/// mount must seal-and-clear (`tl fs snapshot --clear`) first — a plain snapshot keeps the
-/// overlay, which still shadows.
+/// snapshot. Local overlay changes would shadow synced content (markers included), so the
+/// pre-flight is: refuse while anything is DIRTY (fix: `tl fs snapshot` — non-destructive),
+/// then ask the daemon to `trim` retained sealed content out of the overlay (safe: those bytes
+/// are in workspace history) so nothing sealed shadows the pull either. Ignored local-only
+/// files survive; a sealed file held open by a live writer blocks the sync by name.
 pub async fn sync(
     ctx: &CliContext,
     path: &Path,
@@ -2838,13 +2965,36 @@ pub async fn sync(
     }
     let session = FsSession::open(ctx, Some(&state.repo)).await?;
     heartbeat(&session, &state).await?;
-    let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
-    let renames = pending_renames(&state_dir);
-    if !upserts.is_empty() || !deletes.is_empty() || !renames.is_empty() {
+    let changes = local_changes(&state_dir, &mountpoint).await?;
+    if !changes.exact {
+        // The trim pre-flight and the post-sync refresh both need a live daemon; without the
+        // exact dirty answer a raw-walk count would also re-introduce the old false refusal
+        // on retained files.
+        return Err(CliError::usage(
+            "the mount daemon is not answering the dirty query (not running, or it predates \
+             this CLI); remount with `tl fs mount` and retry the sync",
+        ));
+    }
+    if changes.dirty() > 0 {
         return Err(CliError::usage(format!(
-            "{} local change(s) would shadow synced content. Seal and drop them first: `tl fs snapshot --clear {}` (pause writers first — the clear also drops ignored files and any writes made while the snapshot uploads).",
-            upserts.len() + deletes.len() + renames.len(),
+            "{} local change(s) would shadow synced content. Seal them first: `tl fs snapshot {}`, then rerun the sync.",
+            changes.dirty(),
             path.display(),
+        )));
+    }
+    // Retained sealed content shadows pulled bytes exactly like dirt would — but it is all in
+    // workspace history, so the daemon can drop it without losing anything. Ignored files
+    // survive the trim (the pull may still be shadowed where an ignored file collides with a
+    // synced path — local wins there, same as before).
+    let trim = daemon::control(&state_dir, "trim").await?;
+    let trim: daemon::TrimReply = serde_json::from_value(trim)
+        .map_err(|e| CliError::usage(format!("the daemon's trim reply did not parse: {e}")))?;
+    if !trim.held_open.is_empty() {
+        return Err(CliError::usage(format!(
+            "{} sealed file(s) are held open by running processes (first: {}); close them and \
+             rerun the sync",
+            trim.held_open.len(),
+            trim.held_open[0],
         )));
     }
     let (user, token) = session.creds();
@@ -2990,7 +3140,7 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         .await
         .ok()
         .and_then(|r| r.get("commit").and_then(|c| c.as_str().map(str::to_string)));
-    let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
+    let changes = local_changes(&state_dir, &mountpoint).await?;
 
     if output_json {
         println!(
@@ -3000,11 +3150,16 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
                 "mounted": daemon_commit.is_some(),
                 "lower_commit": daemon_commit,
                 "log": state_dir.join("daemon.log"),
-                "dirty": upserts.iter().map(|(p, _, _)| p.clone())
-                    .chain(deletes.iter().cloned()).collect::<Vec<_>>(),
-                "pending_renames": pending_renames(&state_dir)
-                    .into_iter()
-                    .map(|(to, from)| serde_json::json!({ "from": from, "to": to }))
+                "dirty": changes.upserts.iter().cloned()
+                    .chain(changes.deletes.iter().cloned()).collect::<Vec<_>>(),
+                // False when the daemon did not answer the dirty query and the counts fell
+                // back to a raw overlay walk (which may include already-sealed files).
+                "dirty_exact": changes.exact,
+                "retained": changes.retained,
+                "ignored": changes.ignored,
+                "pending_renames": changes.renames
+                    .iter()
+                    .map(|(from, to)| serde_json::json!({ "from": from, "to": to }))
                     .collect::<Vec<_>>(),
             }))?
         );
@@ -3044,22 +3199,22 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         style("log:").dim(),
         state_dir.join("daemon.log").display()
     );
-    let renames = pending_renames(&state_dir);
     // A pending rename's source whiteout is a real delete, but showing it next to the R line
     // would read as two changes; the R line carries both sides.
-    let deletes: Vec<String> = deletes
-        .into_iter()
-        .filter(|p| !renames.iter().any(|(_, from)| from == p))
+    let deletes: Vec<&String> = changes
+        .deletes
+        .iter()
+        .filter(|p| !changes.renames.iter().any(|(from, _)| &from == p))
         .collect();
-    let dirty = upserts.len() + deletes.len() + renames.len();
+    let dirty = changes.upserts.len() + deletes.len() + changes.renames.len();
     if dirty == 0 {
         println!("{} clean", style("local:").dim());
     } else {
         println!("{} {} change(s):", style("local:").dim(), dirty);
-        for (to, from) in renames.iter().take(20) {
+        for (from, to) in changes.renames.iter().take(20) {
             println!("  {} {from} -> {to}", style("R").cyan());
         }
-        for (p, _, _) in upserts.iter().take(20) {
+        for p in changes.upserts.iter().take(20) {
             println!("  {} {p}", style("M").yellow());
         }
         for p in deletes.iter().take(20) {
@@ -3068,6 +3223,28 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         if dirty > 60 {
             println!("  … and more");
         }
+        if !changes.exact {
+            println!(
+                "{} the mount daemon did not answer the dirty query; counts may include \
+                 files already sealed into a snapshot",
+                style("note:").yellow()
+            );
+        }
+    }
+    if changes.retained > 0 {
+        println!(
+            "{} {} file(s) sealed into snapshots and kept locally as the byte cache \
+             (`tl fs snapshot --clear` drops them)",
+            style("retained:").dim(),
+            changes.retained
+        );
+    }
+    if changes.ignored > 0 {
+        println!(
+            "{} {} local-only ignored file(s) (never snapshotted)",
+            style("ignored:").dim(),
+            changes.ignored
+        );
     }
     Ok(())
 }
@@ -3494,12 +3671,25 @@ pub async fn diff(ctx: &CliContext, path: &Path, a: Option<&str>, b: Option<&str
     let state = daemon::load_mount_state(&state_dir)?;
     match (a, b) {
         (None, None) => {
-            let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
-            for (p, _, _) in &upserts {
+            let changes = local_changes(&state_dir, &mountpoint).await?;
+            for (from, to) in &changes.renames {
+                println!("R {from} -> {to}");
+            }
+            for p in &changes.upserts {
                 println!("M {p}");
             }
-            for p in &deletes {
+            for p in changes
+                .deletes
+                .iter()
+                .filter(|p| !changes.renames.iter().any(|(from, _)| &from == p))
+            {
                 println!("D {p}");
+            }
+            if !changes.exact {
+                eprintln!(
+                    "note: the mount daemon did not answer the dirty query; this may include \
+                     files already sealed into a snapshot"
+                );
             }
             Ok(())
         }
@@ -3758,6 +3948,114 @@ mod tests {
     #[cfg(unix)]
     fn fake_daemon(state_dir: &Path) -> std::sync::Arc<std::sync::Mutex<Vec<String>>> {
         fake_daemon_with_events(state_dir, Vec::new())
+    }
+
+    /// A fake daemon that answers each op with a canned reply (`{"ok":true}` for ops not in
+    /// the map) — for exercising the CLI side of non-streaming ops (`dirty`, `trim`).
+    #[cfg(unix)]
+    fn fake_daemon_with_replies(
+        state_dir: &Path,
+        replies: std::collections::HashMap<String, serde_json::Value>,
+    ) -> std::sync::Arc<std::sync::Mutex<Vec<String>>> {
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
+        let ops = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let listener = std::os::unix::net::UnixListener::bind(daemon::control_socket(state_dir))
+            .expect("bind control socket");
+        listener.set_nonblocking(true).unwrap();
+        let listener = tokio::net::UnixListener::from_std(listener).unwrap();
+        let recorded = ops.clone();
+        let replies = std::sync::Arc::new(replies);
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let recorded = recorded.clone();
+                let replies = replies.clone();
+                tokio::spawn(async move {
+                    let mut reader = tokio::io::BufReader::new(stream);
+                    let mut line = String::new();
+                    if reader.read_line(&mut line).await.is_err() {
+                        return;
+                    }
+                    let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+                    let op = v["op"].as_str().unwrap_or_default().to_string();
+                    recorded.lock().unwrap().push(op.clone());
+                    let resp = replies
+                        .get(&op)
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::json!({ "ok": true }));
+                    let mut stream = reader.into_inner();
+                    let _ = stream.write_all(format!("{resp}\n").as_bytes()).await;
+                });
+            }
+        });
+        ops
+    }
+
+    /// The truthful-status contract: when the daemon answers the `dirty` op, its answer IS the
+    /// dirty set — retained (sealed-and-kept) and ignored upper files are accounted
+    /// separately instead of over-reporting as dirt (the #834 regression this replaces).
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn local_changes_prefers_the_daemon_dirty_view() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        std::fs::write(mount.path().join(".gitignore"), "*.tmp\n").unwrap();
+        for (rel, content) in [
+            ("dirty.txt", "unsealed"),
+            ("retained.txt", "sealed-and-kept"),
+            ("junk.tmp", "ignored"),
+        ] {
+            let abs = state.path().join("upper").join(rel);
+            std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            std::fs::write(abs, content).unwrap();
+        }
+        let _ops = fake_daemon_with_replies(
+            state.path(),
+            [(
+                "dirty".to_string(),
+                serde_json::json!({
+                    "ok": true,
+                    "upserts": ["dirty.txt"],
+                    "deletes": [],
+                    "renames": [],
+                    "commit": "cafe0000",
+                }),
+            )]
+            .into_iter()
+            .collect(),
+        );
+
+        let changes = local_changes(state.path(), &mount.path().to_string_lossy())
+            .await
+            .unwrap();
+        assert!(changes.exact, "the daemon answered; the view is exact");
+        assert_eq!(changes.upserts, vec!["dirty.txt"]);
+        assert_eq!(changes.dirty(), 1);
+        assert_eq!(
+            changes.retained, 1,
+            "the sealed-and-kept file is retained, not dirt"
+        );
+        assert_eq!(changes.ignored, 1, "the ignored file is counted separately");
+    }
+
+    /// Daemon down: the raw walk still answers (labeled inexact) so status never goes dark —
+    /// it just can't tell retained content from dirt.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn local_changes_falls_back_to_the_raw_walk_without_a_daemon() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        for rel in ["a.txt", "b.txt"] {
+            let abs = state.path().join("upper").join(rel);
+            std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            std::fs::write(abs, rel).unwrap();
+        }
+        let changes = local_changes(state.path(), &mount.path().to_string_lossy())
+            .await
+            .unwrap();
+        assert!(!changes.exact, "no daemon: the view is the raw walk");
+        assert_eq!(changes.upserts, vec!["a.txt", "b.txt"]);
+        assert_eq!(changes.retained, 0);
+        assert_eq!(changes.ignored, 0);
     }
 
     /// Regression for the snapshot data-loss bug: sealing must KEEP the overlay, and the seal

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -2500,6 +2500,11 @@ impl LocalChanges {
 async fn local_changes(state_dir: &Path, mountpoint: &str) -> Result<LocalChanges> {
     if let Ok(reply) = daemon::control(state_dir, "dirty").await
         && reply.get("ok").and_then(|v| v.as_bool()) == Some(true)
+        // Every DirtyReply field is serde-defaulted, so a bare `{"ok":true}` ack (a handler
+        // that acknowledges an op it never implemented) would otherwise parse as an EXACT
+        // all-clean answer; requiring the payload field keeps that failure in the labeled
+        // fallback instead.
+        && reply.get("upserts").is_some()
         && let Ok(dirty) = serde_json::from_value::<daemon::DirtyReply>(reply)
     {
         // Retained/ignored accounting: everything in the upper that is not dirty is either
@@ -2991,8 +2996,8 @@ pub async fn sync(
         .map_err(|e| CliError::usage(format!("the daemon's trim reply did not parse: {e}")))?;
     if !trim.held_open.is_empty() {
         return Err(CliError::usage(format!(
-            "{} sealed file(s) are held open by running processes (first: {}); close them and \
-             rerun the sync",
+            "{} sealed file(s) could not be released (held open by a running process, or the \
+             drop failed — first: {}); resolve that and rerun the sync",
             trim.held_open.len(),
             trim.held_open[0],
         )));

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -383,8 +383,9 @@ pub(crate) struct DirtyReply {
 
 /// Final reply of the `trim` control op: retained (sealed-and-kept) overlay state dropped in
 /// place, the non-destructive alternative to `clear_upper` — dirty and ignored files are never
-/// touched. `held_open` lists sealed paths a live writer's descriptor pinned; the caller
-/// decides whether that blocks (sync does).
+/// touched. `held_open` lists sealed paths that could not be dropped and still shadow the
+/// lower (a live writer's descriptor, or an unlink failure); the caller decides whether that
+/// blocks (sync does).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub(crate) struct TrimReply {
     #[serde(default)]
@@ -1585,20 +1586,30 @@ impl Sealer {
             st.chunk_cache.clear();
         }
         self.publish_mirror(&st);
-        // Record what this seal vouched for: each pushed upper file under its resolve-time
-        // stat, each published delete as an inert whiteout. The save failing costs nothing but
-        // a pessimistic restart.
-        for (path, stat) in &resolved.stats {
-            st.sealed.upserts.insert(path.clone(), *stat);
-            st.sealed.deletes.remove(path);
-        }
-        for path in &delete_paths {
-            st.sealed.upserts.remove(path);
-            st.sealed.deletes.insert(path.clone());
-        }
-        st.sealed.commit = report.commit.clone();
-        if let Err(e) = st.sealed.save(&self.state_dir) {
-            eprintln!("seal: persisting sealed index failed: {e}");
+        if self.overlay.epoch() != st.seen_epoch {
+            // clear_upper/restore raced the push window: the snapshot itself published fine,
+            // but every resolve-time record describes the dropped world — saving it would
+            // resurrect a sealed.json the clear just reset, and a stat-coincident future file
+            // could absolve against dead content. The next cycle's epoch check retires the
+            // remaining caches.
+            st.sealed = SealedIndex::default();
+            SealedIndex::reset(&self.state_dir);
+        } else {
+            // Record what this seal vouched for: each pushed upper file under its
+            // resolve-time stat, each published delete as an inert whiteout. The save failing
+            // costs nothing but a pessimistic restart.
+            for (path, stat) in &resolved.stats {
+                st.sealed.upserts.insert(path.clone(), *stat);
+                st.sealed.deletes.remove(path);
+            }
+            for path in &delete_paths {
+                st.sealed.upserts.remove(path);
+                st.sealed.deletes.insert(path.clone());
+            }
+            st.sealed.commit = report.commit.clone();
+            if let Err(e) = st.sealed.save(&self.state_dir) {
+                eprintln!("seal: persisting sealed index failed: {e}");
+            }
         }
         // Advance the lower to the sealed commit now instead of waiting out the follow poll:
         // from here on, a delete of a just-sealed path sees lower presence and whiteouts
@@ -1639,8 +1650,12 @@ impl Sealer {
         // server. `tl fs sync` is the flow that needs them gone, and it asks via `trim`.
         if self.core.current_commit() == report.commit && !st.sealed.deletes.is_empty() {
             let tombstones: Vec<String> = st.sealed.deletes.iter().cloned().collect();
-            let outcome = self.overlay.trim_retained(&[], &tombstones).await;
-            if !outcome.tombstones_removed.is_empty() {
+            // try, not wait: hygiene must never park the seal (and, transitively, every new
+            // mutating op queued behind the write-preferring fence) behind one slow in-flight
+            // copy-up. A contended fence just leaves the markers for the next seal.
+            if let Some(outcome) = self.overlay.try_trim_retained(&[], &tombstones)
+                && !outcome.tombstones_removed.is_empty()
+            {
                 for path in &outcome.tombstones_removed {
                     st.sealed.deletes.remove(path);
                 }
@@ -1778,7 +1793,16 @@ impl Sealer {
             return Ok(TrimReply::default());
         }
         let candidates: Vec<String> = st.sealed.upserts.keys().cloned().collect();
-        let tombstones: Vec<String> = st.sealed.deletes.iter().cloned().collect();
+        // Retained UPSERTS may drop regardless of where the lower ref sits — their bytes are
+        // in workspace history and the caller (sync) is about to move the view anyway. A
+        // whiteout is different: until the lower serves the commit that published its delete,
+        // the marker is still actively hiding the path — removing it early resurrects the
+        // deleted file. Leave tombstones for a later seal/trim when the lower lags.
+        let tombstones: Vec<String> = if self.core.current_commit() == st.sealed.commit {
+            st.sealed.deletes.iter().cloned().collect()
+        } else {
+            Vec::new()
+        };
         if candidates.is_empty() && tombstones.is_empty() {
             return Ok(TrimReply::default());
         }

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -202,6 +202,124 @@ pub fn daemon_pid(state_dir: &Path) -> Option<i32> {
         .ok()
 }
 
+/// One retained upper file's identity at the moment its content was resolved for a seal.
+/// Capturing the stat at resolve time (not after the push) is what makes the record safe: a
+/// write racing the push changes the file's mtime relative to this, so a mismatch always
+/// classifies the racier state as dirty. The residual exposure is a same-size write inside
+/// the filesystem's timestamp granularity — the classic racy-git window, accepted here for
+/// the same reason git accepts it.
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SealedStat {
+    pub size: u64,
+    pub mtime_secs: i64,
+    pub mtime_nanos: u32,
+    /// Git mode (100644/100755/120000) — a chmod flips it without touching size or mtime.
+    pub mode: u32,
+}
+
+#[cfg(unix)]
+impl SealedStat {
+    fn of(meta: &std::fs::Metadata) -> Self {
+        use std::os::unix::fs::MetadataExt;
+        SealedStat {
+            size: meta.size(),
+            mtime_secs: meta.mtime(),
+            mtime_nanos: meta.mtime_nsec() as u32,
+            mode: git_mode(meta),
+        }
+    }
+}
+
+/// The persisted seal record (`<state dir>/sealed.json`): every overlay path whose current
+/// on-disk state a snapshot has published — upserts with the [`SealedStat`] identity of the
+/// sealed content, deletes as inert-whiteout markers — plus the last sealed commit. The
+/// sealer owns it (written after each successful push, under the sealer state lock); daemon
+/// startup and the `reindex` op read it to absolve rebuild-marked dirt whose identity still
+/// matches. Losing or corrupting the file is safe: everything degrades to the rebuild's
+/// pessimistic all-dirty answer, and the next seal re-records (content dedup makes the
+/// re-push free).
+#[cfg(unix)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct SealedIndex {
+    #[serde(default)]
+    pub commit: String,
+    #[serde(default)]
+    pub upserts: std::collections::BTreeMap<String, SealedStat>,
+    #[serde(default)]
+    pub deletes: std::collections::BTreeSet<String>,
+}
+
+#[cfg(unix)]
+impl SealedIndex {
+    fn file(state_dir: &Path) -> PathBuf {
+        state_dir.join("sealed.json")
+    }
+
+    pub(crate) fn load(state_dir: &Path) -> SealedIndex {
+        std::fs::read(Self::file(state_dir))
+            .ok()
+            .and_then(|raw| serde_json::from_slice(&raw).ok())
+            .unwrap_or_default()
+    }
+
+    fn save(&self, state_dir: &Path) -> std::io::Result<()> {
+        let tmp = state_dir.join("sealed.json.tmp");
+        std::fs::write(&tmp, serde_json::to_vec(self).expect("plain data serializes"))?;
+        std::fs::rename(&tmp, Self::file(state_dir))
+    }
+
+    fn reset(state_dir: &Path) {
+        let _ = std::fs::remove_file(Self::file(state_dir));
+    }
+}
+
+/// Startup/reindex reconciliation. [`OverlayFs::rebuild_dirty_index`] pessimistically marks
+/// every upper file an upsert and every whiteout a delete; absolve the ones whose on-disk
+/// identity still matches their persisted seal record — they are retained sealed content, not
+/// dirt, and without this every daemon restart re-reports (and the next seal re-hashes) the
+/// whole ever-written set. Returns (absolved upserts, absolved deletes) for the startup log.
+#[cfg(unix)]
+fn reconcile_sealed(state_dir: &Path, overlay: &OverlayFs) -> (usize, usize) {
+    let index = SealedIndex::load(state_dir);
+    if index.upserts.is_empty() && index.deletes.is_empty() {
+        return (0, 0);
+    }
+    // Clock snapshot BEFORE the stat pass: anything mutated after this proves nothing.
+    let upto = overlay.current_generation();
+    let (clean_upserts, clean_deletes) = sealed_survivors(state_dir, &index);
+    overlay.absolve_clean(&clean_upserts, &clean_deletes, upto);
+    (clean_upserts.len(), clean_deletes.len())
+}
+
+/// The sealed-index entries whose on-disk overlay state still matches the seal record: upserts
+/// by exact [`SealedStat`] identity, deletes by the whiteout marker still being present.
+#[cfg(unix)]
+fn sealed_survivors(state_dir: &Path, index: &SealedIndex) -> (Vec<String>, Vec<String>) {
+    let upper = state_dir.join("upper");
+    let wh = state_dir.join("wh");
+    let clean_upserts: Vec<String> = index
+        .upserts
+        .iter()
+        .filter(|(path, sealed)| {
+            std::fs::symlink_metadata(upper.join(path))
+                .is_ok_and(|meta| SealedStat::of(&meta) == **sealed)
+        })
+        .map(|(path, _)| path.clone())
+        .collect();
+    let clean_deletes: Vec<String> = index
+        .deletes
+        .iter()
+        .filter(|path| {
+            wh.join(path)
+                .symlink_metadata()
+                .is_ok_and(|meta| meta.is_file())
+        })
+        .cloned()
+        .collect();
+    (clean_upserts, clean_deletes)
+}
+
 /// Request body of the `seal` control op — shared by the daemon's handler and the CLI's
 /// client path (`fs::seal_via_daemon`) so the wire shape cannot drift between them.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -241,6 +359,38 @@ pub(crate) struct SealReply {
     /// revalidation set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cleared: Option<Vec<String>>,
+}
+
+/// Final reply of the `dirty` control op: the sealer's truthful dirty view — exactly what the
+/// next `seal` would publish, resolved by the same dry-run walk (ignore rules applied,
+/// directory events expanded, no side effects). Shared by the daemon's handler and every CLI
+/// consumer (`status`, `promote`, `sync`, `diff`) so there is ONE definition of dirty.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct DirtyReply {
+    /// Paths the next seal would upsert.
+    #[serde(default)]
+    pub upserts: Vec<String>,
+    /// Paths the next seal would delete.
+    #[serde(default)]
+    pub deletes: Vec<String>,
+    /// Pending committed-directory renames, `(from, to)`.
+    #[serde(default)]
+    pub renames: Vec<(String, String)>,
+    /// The lower commit currently served.
+    #[serde(default)]
+    pub commit: String,
+}
+
+/// Final reply of the `trim` control op: retained (sealed-and-kept) overlay state dropped in
+/// place, the non-destructive alternative to `clear_upper` — dirty and ignored files are never
+/// touched. `held_open` lists sealed paths a live writer's descriptor pinned; the caller
+/// decides whether that blocks (sync does).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub(crate) struct TrimReply {
+    #[serde(default)]
+    pub trimmed: u64,
+    #[serde(default)]
+    pub held_open: Vec<String>,
 }
 
 /// One control round-trip from a CLI command to the daemon. Mounts (and so daemons) exist
@@ -570,6 +720,18 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     .map_err(|e| CliError::usage(format!("mount init: {e}")))?;
     let overlay = OverlayFs::new(core.clone(), state_dir, state.read_only())
         .map_err(|e| CliError::usage(format!("overlay init: {e}")))?;
+    // Before the kernel attaches (no events can race the absolve): retained sealed content the
+    // rebuild pessimistically marked dirty is reconciled back out against sealed.json.
+    if !state.read_only() {
+        let (upserts, deletes) = reconcile_sealed(state_dir, &overlay);
+        if upserts + deletes > 0 {
+            tracing::info!(
+                retained_files = upserts,
+                inert_whiteouts = deletes,
+                "mount: reconciled retained sealed state; not dirty"
+            );
+        }
+    }
 
     // Credential rotation: re-mint comfortably before expiry (or on demand — the heartbeat
     // task nudges `remint` when the server rejects the current token), swap in place, and
@@ -701,7 +863,9 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 seen_epoch: overlay.epoch(),
                 recent_seals: Vec::new(),
                 chunk_cache: std::collections::HashMap::new(),
+                sealed: SealedIndex::load(state_dir),
             }),
+            mirror: std::sync::Mutex::new(SealerMirror::default()),
         })
     });
 
@@ -744,6 +908,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         let invalidate = invalidate.clone();
         let pending = pending.clone();
         let sealer = sealer.clone();
+        let control_state_dir = state_dir.to_path_buf();
         tokio::spawn(async move {
             loop {
                 let Ok((stream, _)) = listener.accept().await else {
@@ -755,6 +920,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 let invalidate = invalidate.clone();
                 let pending = pending.clone();
                 let sealer = sealer.clone();
+                let control_state_dir = control_state_dir.clone();
                 tokio::spawn(async move {
                     let mut reader = tokio::io::BufReader::new(stream);
                     let mut line = String::new();
@@ -772,6 +938,63 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         "ping" => {
                             serde_json::json!({ "ok": true, "commit": core.current_commit() })
                         }
+                        // The truthful dirty view: exactly what the next seal would publish
+                        // (`tl fs status`/`promote`/`sync`/`diff` all read this — one
+                        // definition of dirty). A read-only mount has no sealer and can hold
+                        // no dirt.
+                        "dirty" => match sealer.as_ref() {
+                            None => {
+                                let reply = DirtyReply {
+                                    commit: core.current_commit(),
+                                    ..Default::default()
+                                };
+                                match serde_json::to_value(&reply) {
+                                    Ok(mut v) => {
+                                        v["ok"] = serde_json::Value::Bool(true);
+                                        v
+                                    }
+                                    Err(e) => {
+                                        serde_json::json!({ "ok": false, "error": e.to_string() })
+                                    }
+                                }
+                            }
+                            Some(sealer) => match sealer.dirty_view().await {
+                                Ok(reply) => match serde_json::to_value(&reply) {
+                                    Ok(mut v) => {
+                                        v["ok"] = serde_json::Value::Bool(true);
+                                        v
+                                    }
+                                    Err(e) => {
+                                        serde_json::json!({ "ok": false, "error": e.to_string() })
+                                    }
+                                },
+                                Err(e) => {
+                                    serde_json::json!({ "ok": false, "error": e.to_string() })
+                                }
+                            },
+                        },
+                        // Drop retained (sealed-and-kept) overlay state — sync's pre-flight.
+                        // Unlike `clear_upper`, dirty and ignored files survive.
+                        "trim" => match sealer.as_ref() {
+                            None => serde_json::json!({
+                                "ok": false,
+                                "error": "read-only mount: nothing is retained",
+                            }),
+                            Some(sealer) => match sealer.trim_all().await {
+                                Ok(reply) => match serde_json::to_value(&reply) {
+                                    Ok(mut v) => {
+                                        v["ok"] = serde_json::Value::Bool(true);
+                                        v
+                                    }
+                                    Err(e) => {
+                                        serde_json::json!({ "ok": false, "error": e.to_string() })
+                                    }
+                                },
+                                Err(e) => {
+                                    serde_json::json!({ "ok": false, "error": e.to_string() })
+                                }
+                            },
+                        },
                         // Seal on demand: `tl fs snapshot` runs exactly one cycle of the same
                         // sealer auto-commit ticks, with the caller's message (and optional
                         // overlay clear). Streaming op — the handler writes its own event
@@ -818,15 +1041,25 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         "clear_upper" => match overlay.clear_upper() {
                             Ok(affected) => {
                                 invalidate(affected);
+                                // Nothing is retained anymore; the sealer's in-memory copy
+                                // dies at its next epoch check. Resetting the file NOW keeps
+                                // restore's follow-up reindex from absolving refilled paths
+                                // against records describing dropped content.
+                                SealedIndex::reset(&control_state_dir);
                                 serde_json::json!({ "ok": true })
                             }
                             Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
                         },
                         // The upper was mutated out-of-band (restore writes into the state dir
                         // from the CLI process); rebuild the dirty index from disk so an
-                        // auto-commit mount seals the new state.
+                        // auto-commit mount seals the new state. Then reconcile: whatever the
+                        // refill left byte-identical to sealed content (restore back to the
+                        // sealed snapshot) is retained, not dirt.
                         "reindex" => match overlay.rebuild_dirty_index() {
-                            Ok(()) => serde_json::json!({ "ok": true }),
+                            Ok(()) => {
+                                reconcile_sealed(&control_state_dir, &overlay);
+                                serde_json::json!({ "ok": true })
+                            }
                             Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
                         },
                         // Pending directory renames, expanded to the by-oid upserts a seal
@@ -1086,6 +1319,19 @@ struct Sealer {
     invalidate: InvalSink,
     pending: Arc<std::sync::Mutex<PendingProbe>>,
     state: tokio::sync::Mutex<SealerState>,
+    /// A lock-cheap copy of the dirty-relevant sealer state (`sealed_gen`, the resurrection
+    /// guard set), republished by [`Sealer::publish_mirror`] whenever the real state changes.
+    /// The `dirty` control op reads THIS: taking the state mutex would park status behind an
+    /// in-flight push for however long the upload takes.
+    mirror: std::sync::Mutex<SealerMirror>,
+}
+
+/// See [`Sealer::mirror`].
+#[cfg(unix)]
+#[derive(Default)]
+struct SealerMirror {
+    sealed_gen: u64,
+    recently: std::collections::HashSet<String>,
 }
 
 #[cfg(unix)]
@@ -1108,6 +1354,9 @@ struct SealerState {
     /// as a `StablePrefix` — only bytes past that boundary are re-read. Daemon-local; a
     /// restart just means one full-cost seal per file to re-learn.
     chunk_cache: std::collections::HashMap<String, ChunkList>,
+    /// The persisted seal record — see [`SealedIndex`]. Updated and saved after each
+    /// successful push; the durable half of what `recent_seals`/`sealed_gen` know in memory.
+    sealed: SealedIndex,
 }
 
 #[cfg(unix)]
@@ -1139,6 +1388,12 @@ impl Sealer {
             st.seen_epoch = epoch;
             st.chunk_cache.clear();
             st.recent_seals.clear();
+            // The sealed index describes the pre-rewrite world too. Restore's own reindex
+            // reconciles what genuinely survives; keeping records here would let a
+            // stat-coincident future file absolve against dropped content.
+            st.sealed = SealedIndex::default();
+            SealedIndex::reset(&self.state_dir);
+            self.publish_mirror(&st);
         }
         // Drop guard sets the lower has caught up with: the followed ref only moves along
         // this workspace's snapshots, so matching the current lower commit confirms it and
@@ -1150,6 +1405,7 @@ impl Sealer {
             .rposition(|(commit, _)| *commit == lower)
         {
             st.recent_seals.drain(..=i);
+            self.publish_mirror(&st);
         }
         // Renames a previous seal published but never consumed (crash, or the lower lagged
         // past our post-seal check) dangle once the lower advances; reap them before anything
@@ -1168,6 +1424,7 @@ impl Sealer {
         let watermark = delta.watermark;
         if delta.is_empty() && !self.overlay.has_redirects() {
             st.sealed_gen = watermark;
+            self.publish_mirror(&st);
             let cleared = clear.then(|| self.clear_overlay(&mut st)).transpose()?;
             return Ok(SealOutcome::Clean { cleared });
         }
@@ -1243,6 +1500,7 @@ impl Sealer {
             // and died between seals: sealed through, nothing to publish.
             st.sealed_gen = watermark;
             self.overlay.prune_dirty(watermark);
+            self.publish_mirror(&st);
             let cleared = clear.then(|| self.clear_overlay(&mut st)).transpose()?;
             return Ok(SealOutcome::Clean { cleared });
         }
@@ -1326,6 +1584,22 @@ impl Sealer {
         if st.chunk_cache.len() > 8192 {
             st.chunk_cache.clear();
         }
+        self.publish_mirror(&st);
+        // Record what this seal vouched for: each pushed upper file under its resolve-time
+        // stat, each published delete as an inert whiteout. The save failing costs nothing but
+        // a pessimistic restart.
+        for (path, stat) in &resolved.stats {
+            st.sealed.upserts.insert(path.clone(), *stat);
+            st.sealed.deletes.remove(path);
+        }
+        for path in &delete_paths {
+            st.sealed.upserts.remove(path);
+            st.sealed.deletes.insert(path.clone());
+        }
+        st.sealed.commit = report.commit.clone();
+        if let Err(e) = st.sealed.save(&self.state_dir) {
+            eprintln!("seal: persisting sealed index failed: {e}");
+        }
         // Advance the lower to the sealed commit now instead of waiting out the follow poll:
         // from here on, a delete of a just-sealed path sees lower presence and whiteouts
         // normally — and the mount serves the new commit before a manual `seal` replies.
@@ -1354,6 +1628,25 @@ impl Sealer {
                      recorded (next seal republishes them idempotently)",
                     report.commit
                 );
+            }
+        }
+        // Tombstone hygiene: once the lower serves the sealed commit, every published
+        // whiteout is inert (the tree it hides the path from no longer carries the path).
+        // Dropping the markers costs nothing kernel-visible and keeps wh/ from accumulating
+        // the workspace's whole deletion history. Retained upper FILES are deliberately NOT
+        // trimmed here: they double as the local byte cache — the next write to a sealed
+        // path copies up from the local file instead of re-reading pushed bytes back off the
+        // server. `tl fs sync` is the flow that needs them gone, and it asks via `trim`.
+        if self.core.current_commit() == report.commit && !st.sealed.deletes.is_empty() {
+            let tombstones: Vec<String> = st.sealed.deletes.iter().cloned().collect();
+            let outcome = self.overlay.trim_retained(&[], &tombstones).await;
+            if !outcome.tombstones_removed.is_empty() {
+                for path in &outcome.tombstones_removed {
+                    st.sealed.deletes.remove(path);
+                }
+                if let Err(e) = st.sealed.save(&self.state_dir) {
+                    eprintln!("seal: persisting sealed index failed: {e}");
+                }
             }
         }
         // The destructive opt-in, last: only after the seal published AND the lower refresh
@@ -1406,7 +1699,104 @@ impl Sealer {
         st.seen_epoch = self.overlay.epoch();
         st.chunk_cache.clear();
         st.recent_seals.clear();
+        // Nothing is retained anymore; a stale record would absolve a future upper file that
+        // happens to stat-match dropped content.
+        st.sealed = SealedIndex::default();
+        SealedIndex::reset(&self.state_dir);
+        self.publish_mirror(&st);
         Ok(cleared.into_iter().collect())
+    }
+
+    /// Republish the dirty-op mirror from the authoritative state. Call after every mutation
+    /// of `sealed_gen` or `recent_seals`.
+    fn publish_mirror(&self, st: &SealerState) {
+        let mut mirror = self.mirror.lock().expect("mirror lock");
+        mirror.sealed_gen = st.sealed_gen;
+        mirror.recently = st
+            .recent_seals
+            .iter()
+            .flat_map(|(_, set)| set)
+            .cloned()
+            .collect();
+    }
+
+    /// The truthful dirty view — exactly what the next seal would publish, resolved by the
+    /// dry-run twin of the seal walk. Reads the mirror, not the state lock, so it answers
+    /// instantly while a push is in flight.
+    async fn dirty_view(&self) -> Result<DirtyReply> {
+        let (sealed_gen, recently) = {
+            let mirror = self.mirror.lock().expect("mirror lock");
+            (mirror.sealed_gen, mirror.recently.clone())
+        };
+        let delta = self.overlay.dirty_since(sealed_gen);
+        let renames: Vec<(String, String)> = self
+            .overlay
+            .redirect_entries()
+            .into_iter()
+            .map(|(dst, src)| (src, dst))
+            .collect();
+        let commit = self.core.current_commit();
+        if delta.is_empty() {
+            return Ok(DirtyReply {
+                upserts: Vec::new(),
+                deletes: Vec::new(),
+                renames,
+                commit,
+            });
+        }
+        let (sd, mp) = (self.state_dir.clone(), self.mountpoint.clone());
+        // Same blocking-pool rule as resolve_seal: the ignore rules read through the
+        // mountpoint this very process serves.
+        let (upserts, deletes) =
+            tokio::task::spawn_blocking(move || resolve_dirty(&sd, &mp, &delta, &recently))
+                .await
+                .map_err(|e| CliError::usage(format!("dirty resolution task failed: {e}")))?
+                .map_err(|e| CliError::usage(format!("resolving the dirty view failed: {e}")))?;
+        Ok(DirtyReply {
+            upserts,
+            deletes,
+            renames,
+            commit,
+        })
+    }
+
+    /// Drop ALL retained overlay state (`trim` control op — `tl fs sync`'s pre-flight).
+    /// Everything dropped is sealed into workspace history, so nothing is lost; the mount just
+    /// stops shadowing the lower, which is exactly what a sync needs before it pulls content
+    /// the retained copies would mask. Dirty and ignored files are untouched.
+    async fn trim_all(&self) -> Result<TrimReply> {
+        let mut st = self.state.lock().await;
+        let epoch = self.overlay.epoch();
+        if epoch != st.seen_epoch {
+            // clear_upper/restore rewrote the world; the sealed index describes the old one.
+            st.seen_epoch = epoch;
+            st.chunk_cache.clear();
+            st.recent_seals.clear();
+            st.sealed = SealedIndex::default();
+            SealedIndex::reset(&self.state_dir);
+            self.publish_mirror(&st);
+            return Ok(TrimReply::default());
+        }
+        let candidates: Vec<String> = st.sealed.upserts.keys().cloned().collect();
+        let tombstones: Vec<String> = st.sealed.deletes.iter().cloned().collect();
+        if candidates.is_empty() && tombstones.is_empty() {
+            return Ok(TrimReply::default());
+        }
+        let outcome = self.overlay.trim_retained(&candidates, &tombstones).await;
+        (self.invalidate)(outcome.invals);
+        for path in &outcome.trimmed {
+            st.sealed.upserts.remove(path);
+        }
+        for path in &outcome.tombstones_removed {
+            st.sealed.deletes.remove(path);
+        }
+        if let Err(e) = st.sealed.save(&self.state_dir) {
+            eprintln!("trim: persisting sealed index failed: {e}");
+        }
+        Ok(TrimReply {
+            trimmed: (outcome.trimmed.len() + outcome.tombstones_removed.len()) as u64,
+            held_open: outcome.held_open,
+        })
     }
 }
 
@@ -1450,6 +1840,9 @@ struct ResolvedSeal {
     /// Vanished-but-recently-sealed paths that got a whiteout written here; their merged view
     /// flipped without a kernel-visible operation, so the kernel needs invalidations.
     tombstoned: Vec<String>,
+    /// Resolve-time [`SealedStat`] of every upper-backed upsert — what the sealed index
+    /// records for each path once the push succeeds.
+    stats: std::collections::HashMap<String, SealedStat>,
 }
 
 /// Resolve an event delta into upload-ready push files. The dirty index's kinds are routing
@@ -1521,6 +1914,16 @@ fn resolve_seal(
     upserts.dedup_by(|a, b| a.0 == b.0);
     deletes.sort();
     deletes.dedup();
+    // The sealed index's identity capture, stat'd here — before the push reads the bytes —
+    // so any later write mismatches the record (see [`SealedStat`]).
+    let stats: std::collections::HashMap<String, SealedStat> = upserts
+        .iter()
+        .filter_map(|(rel, abs, _)| {
+            std::fs::symlink_metadata(abs)
+                .ok()
+                .map(|meta| (rel.clone(), SealedStat::of(&meta)))
+        })
+        .collect();
     let mut files = super::overlay_push_files(&upserts, &deletes)?;
 
     // Append fast path: a file with a cached chunk list from its previous seal, whose writes
@@ -1569,7 +1972,63 @@ fn resolve_seal(
         sealed_upserts: upserts.iter().map(|(p, _, _)| p.clone()).collect(),
         files,
         tombstoned,
+        stats,
     })
+}
+
+/// The dry-run twin of [`resolve_seal`]: what WOULD the next seal publish. Same delta, same
+/// ignore rules, same directory-event expansion, but NO side effects — the tombstone arm
+/// reports the delete without writing the whiteout, and nothing chunk-related runs. This is
+/// what the `dirty` control op serves, so `tl fs status` and `tl fs snapshot` cannot disagree:
+/// they resolve the same state through the same walk.
+///
+/// Runs on the blocking pool for the same reason as [`resolve_seal`] (ignore files are read
+/// through the mountpoint this daemon serves).
+#[cfg(unix)]
+fn resolve_dirty(
+    state_dir: &Path,
+    mount_root: &Path,
+    delta: &super::overlay::DirtyDelta,
+    recently_sealed: &std::collections::HashSet<String>,
+) -> crate::error::Result<(Vec<String>, Vec<String>)> {
+    let mut ignore = super::SnapshotIgnore::new(mount_root);
+    let upper = state_dir.join("upper");
+    let wh = state_dir.join("wh");
+    let mut upserts: super::OverlayUpserts = Vec::new();
+    let mut deletes: Vec<String> = Vec::new();
+    let mut vanished: Vec<String> = Vec::new();
+    for (path, _) in &delta.upserts {
+        let abs = upper.join(path);
+        let Ok(meta) = std::fs::symlink_metadata(&abs) else {
+            vanished.push(path.clone());
+            continue;
+        };
+        if meta.is_dir() && !meta.file_type().is_symlink() {
+            collect_dir_upserts(&upper, path, &mut ignore, &mut upserts)?;
+            continue;
+        }
+        if ignore.is_ignored(path, false)? {
+            continue;
+        }
+        upserts.push((path.clone(), abs, git_mode(&meta)));
+    }
+    for path in delta.deletes.iter().chain(vanished.iter()) {
+        if upper.join(path).symlink_metadata().is_ok() {
+            continue;
+        }
+        if ignore.is_ignored(path, false)? {
+            continue;
+        }
+        if whited_out_on_disk(&wh, path) || recently_sealed.contains(path) {
+            deletes.push(path.clone());
+        }
+    }
+    let mut upserts: Vec<String> = upserts.into_iter().map(|(rel, _, _)| rel).collect();
+    upserts.sort();
+    upserts.dedup();
+    deletes.sort();
+    deletes.dedup();
+    Ok((upserts, deletes))
 }
 
 /// The git mode a local file publishes as (same policy as `enumerate_overlay`'s walk).
@@ -2105,5 +2564,189 @@ mod stable_prefix_tests {
         let resolved = resolve_with_cache(0);
         assert_eq!(stable_of(&resolved), None);
         assert!(matches!(resolved.files[0].source, PushSource::Path(_)));
+    }
+
+}
+
+/// The dirty view (dry-run resolution) and the sealed index: what `tl fs status` shows must
+/// be what a seal would publish, asking must never mutate overlay state, and seal records
+/// must survive restarts by exact stat identity.
+#[cfg(all(test, unix))]
+mod seal_tracking_tests {
+    use super::super::overlay::DirtyDelta;
+    use super::tests::state_with;
+    use super::*;
+
+    fn delta(upserts: &[&str], deletes: &[&str]) -> DirtyDelta {
+        DirtyDelta {
+            upserts: upserts.iter().map(|s| (s.to_string(), 0)).collect(),
+            deletes: deletes.iter().map(|s| s.to_string()).collect(),
+            watermark: 1,
+        }
+    }
+
+    fn no_cache() -> std::collections::HashMap<String, ChunkList> {
+        std::collections::HashMap::new()
+    }
+
+    #[test]
+    fn resolve_dirty_matches_what_a_seal_would_publish() {
+        let state = state_with(
+            &[("kept.txt", "hi"), ("dir/nested.txt", "deep")],
+            &["gone.txt"],
+        );
+        let mount = tempfile::tempdir().unwrap();
+        std::fs::write(mount.path().join(".gitignore"), "*.tmp\n").unwrap();
+        std::fs::write(state.path().join("upper/junk.tmp"), "x").unwrap();
+
+        let d = delta(&["kept.txt", "dir/nested.txt", "junk.tmp"], &["gone.txt"]);
+        let (upserts, deletes) = resolve_dirty(
+            state.path(),
+            mount.path(),
+            &d,
+            &std::collections::HashSet::new(),
+        )
+        .unwrap();
+        let sealed = resolve_seal(
+            state.path(),
+            mount.path(),
+            &d,
+            &std::collections::HashSet::new(),
+            &no_cache(),
+        )
+        .unwrap();
+
+        let mut published: Vec<String> = sealed
+            .files
+            .iter()
+            .filter(|f| !f.delete)
+            .map(|f| f.repo_path.clone())
+            .collect();
+        published.sort();
+        assert_eq!(upserts, published, "dry run and seal agree on upserts");
+        let mut sealed_deletes: Vec<String> = sealed
+            .files
+            .iter()
+            .filter(|f| f.delete)
+            .map(|f| f.repo_path.clone())
+            .collect();
+        sealed_deletes.sort();
+        assert_eq!(deletes, sealed_deletes, "dry run and seal agree on deletes");
+        assert!(!upserts.contains(&"junk.tmp".to_string()), "ignored paths never show");
+    }
+
+    #[test]
+    fn resolve_dirty_expands_directory_events() {
+        let state = state_with(
+            &[("moved/a.txt", "alpha"), ("moved/sub/b.txt", "beta")],
+            &[],
+        );
+        let mount = tempfile::tempdir().unwrap();
+        let (upserts, deletes) = resolve_dirty(
+            state.path(),
+            mount.path(),
+            &delta(&["moved"], &[]),
+            &std::collections::HashSet::new(),
+        )
+        .unwrap();
+        assert_eq!(upserts, vec!["moved/a.txt", "moved/sub/b.txt"]);
+        assert!(deletes.is_empty());
+    }
+
+    #[test]
+    fn resolve_dirty_reports_recently_sealed_vanished_without_writing_the_whiteout() {
+        // The seal's tombstone arm WRITES a whiteout for a vanished-but-recently-sealed path.
+        // The dry run must report the same delete but leave the overlay untouched — status
+        // runs must be idempotent and side-effect-free.
+        let state = state_with(&[], &[]);
+        let mount = tempfile::tempdir().unwrap();
+        let recently: std::collections::HashSet<String> =
+            [String::from("vanished.txt")].into_iter().collect();
+        let (upserts, deletes) = resolve_dirty(
+            state.path(),
+            mount.path(),
+            &delta(&["vanished.txt"], &[]),
+            &recently,
+        )
+        .unwrap();
+        assert!(upserts.is_empty());
+        assert_eq!(deletes, vec!["vanished.txt"]);
+        assert!(
+            !state.path().join("wh/vanished.txt").exists(),
+            "the dry run must not write the whiteout the real seal would"
+        );
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The sealed index: per-path seal records that survive daemon restarts.
+    // ---------------------------------------------------------------------------------------
+
+    #[test]
+    fn sealed_index_roundtrips_and_tolerates_corruption() {
+        let state = state_with(&[("a.txt", "alpha")], &[]);
+        let meta = std::fs::symlink_metadata(state.path().join("upper/a.txt")).unwrap();
+        let mut index = SealedIndex {
+            commit: "c1".into(),
+            ..Default::default()
+        };
+        index.upserts.insert("a.txt".into(), SealedStat::of(&meta));
+        index.deletes.insert("gone.txt".into());
+        index.save(state.path()).unwrap();
+
+        let loaded = SealedIndex::load(state.path());
+        assert_eq!(loaded.commit, "c1");
+        assert_eq!(loaded.upserts.get("a.txt"), Some(&SealedStat::of(&meta)));
+        assert!(loaded.deletes.contains("gone.txt"));
+
+        std::fs::write(state.path().join("sealed.json"), b"{not json").unwrap();
+        let corrupt = SealedIndex::load(state.path());
+        assert!(
+            corrupt.upserts.is_empty() && corrupt.deletes.is_empty(),
+            "corruption degrades to the pessimistic empty index, never an error"
+        );
+    }
+
+    #[test]
+    fn sealed_survivors_matches_by_exact_stat_identity() {
+        let state = state_with(&[("same.txt", "stable"), ("changed.txt", "old")], &["dead.txt"]);
+        let stat_of = |p: &str| {
+            SealedStat::of(&std::fs::symlink_metadata(state.path().join("upper").join(p)).unwrap())
+        };
+        let mut index = SealedIndex::default();
+        index.upserts.insert("same.txt".into(), stat_of("same.txt"));
+        index.upserts.insert("changed.txt".into(), stat_of("changed.txt"));
+        index.upserts.insert("missing.txt".into(), stat_of("same.txt"));
+        index.deletes.insert("dead.txt".into());
+        index.deletes.insert("reaped.txt".into());
+
+        // Rewrite one file with different content (size changes → identity breaks even if the
+        // filesystem's mtime granularity is coarse).
+        std::fs::write(state.path().join("upper/changed.txt"), "newer-bytes").unwrap();
+
+        let (upserts, deletes) = sealed_survivors(state.path(), &index);
+        assert_eq!(upserts, vec!["same.txt"], "only the untouched file survives");
+        assert_eq!(deletes, vec!["dead.txt"], "only the still-present whiteout survives");
+    }
+
+    #[test]
+    fn resolve_seal_captures_stats_for_every_upper_upsert() {
+        let state = state_with(&[("a.txt", "alpha"), ("dir/b.txt", "beta")], &[]);
+        let mount = tempfile::tempdir().unwrap();
+        let resolved = resolve_seal(
+            state.path(),
+            mount.path(),
+            &delta(&["a.txt", "dir/b.txt"], &[]),
+            &std::collections::HashSet::new(),
+            &no_cache(),
+        )
+        .unwrap();
+        for path in ["a.txt", "dir/b.txt"] {
+            let meta = std::fs::symlink_metadata(state.path().join("upper").join(path)).unwrap();
+            assert_eq!(
+                resolved.stats.get(path),
+                Some(&SealedStat::of(&meta)),
+                "resolve-time stat recorded for {path}"
+            );
+        }
     }
 }

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -865,6 +865,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 recent_seals: Vec::new(),
                 chunk_cache: std::collections::HashMap::new(),
                 sealed: SealedIndex::load(state_dir),
+                reindex_pending: false,
             }),
             mirror: std::sync::Mutex::new(SealerMirror::default()),
         })
@@ -1038,33 +1039,61 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                             Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
                         },
                         // The upper drop flips interned paths to their lower view with no
-                        // kernel-visible operation; push the implied invalidations.
-                        "clear_upper" => match overlay.clear_upper() {
-                            Ok(affected) => {
-                                invalidate(affected);
-                                // Nothing is retained anymore; the sealer's in-memory copy
-                                // dies at its next epoch check. Resetting the file NOW keeps
-                                // restore's follow-up reindex from absolving refilled paths
-                                // against records describing dropped content.
-                                SealedIndex::reset(&control_state_dir);
-                                serde_json::json!({ "ok": true })
+                        // kernel-visible operation; push the implied invalidations. Routed
+                        // through the sealer (state-lock serialized against in-flight seals,
+                        // arms the reindex-pending fail-closed guard) whenever one exists;
+                        // read-only mounts fall back to the bare drop.
+                        "clear_upper" => {
+                            let cleared = match sealer.as_ref() {
+                                Some(sealer) => sealer.clear_upper_control().await,
+                                None => {
+                                    SealedIndex::reset(&control_state_dir);
+                                    overlay.clear_upper().map_err(|e| {
+                                        CliError::usage(format!(
+                                            "clearing the overlay failed: {e}"
+                                        ))
+                                    })
+                                }
+                            };
+                            match cleared {
+                                Ok(affected) => {
+                                    invalidate(affected);
+                                    serde_json::json!({ "ok": true })
+                                }
+                                Err(e) => {
+                                    serde_json::json!({ "ok": false, "error": e.to_string() })
+                                }
                             }
-                            Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
-                        },
+                        }
                         // The upper was mutated out-of-band (restore writes into the state dir
                         // from the CLI process); rebuild the dirty index from disk so an
-                        // auto-commit mount seals the new state. The reconcile afterwards is a
-                        // correctness backstop, not an optimization: in the restore flow it
-                        // absolves nothing (clear_upper reset sealed.json, and refilled files
-                        // carry fresh mtimes), but any future out-of-band flow that preserves
-                        // seal records must not re-dirty retained content.
-                        "reindex" => match overlay.rebuild_dirty_index() {
-                            Ok(()) => {
-                                reconcile_sealed(&control_state_dir, &overlay);
-                                serde_json::json!({ "ok": true })
+                        // auto-commit mount seals the new state, and disarm the fail-closed
+                        // reindex-pending guard. The reconcile is a correctness backstop, not
+                        // an optimization: in the restore flow it absolves nothing
+                        // (clear_upper reset sealed.json, and refilled files carry fresh
+                        // mtimes), but any future out-of-band flow that preserves seal
+                        // records must not re-dirty retained content.
+                        "reindex" => {
+                            let reindexed = match sealer.as_ref() {
+                                Some(sealer) => sealer.reindex_control().await,
+                                None => overlay
+                                    .rebuild_dirty_index()
+                                    .map_err(|e| {
+                                        CliError::usage(format!(
+                                            "rebuilding the dirty index failed: {e}"
+                                        ))
+                                    })
+                                    .map(|()| {
+                                        reconcile_sealed(&control_state_dir, &overlay);
+                                    }),
+                            };
+                            match reindexed {
+                                Ok(()) => serde_json::json!({ "ok": true }),
+                                Err(e) => {
+                                    serde_json::json!({ "ok": false, "error": e.to_string() })
+                                }
                             }
-                            Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
-                        },
+                        }
                         // Pending directory renames, expanded to the by-oid upserts a seal
                         // must publish (`tl fs snapshot` merges these into its push).
                         "expand_redirects" => match overlay.expand_redirects().await {
@@ -1335,6 +1364,7 @@ struct Sealer {
 struct SealerMirror {
     sealed_gen: u64,
     recently: std::collections::HashSet<String>,
+    reindex_pending: bool,
 }
 
 #[cfg(unix)]
@@ -1360,6 +1390,12 @@ struct SealerState {
     /// The persisted seal record — see [`SealedIndex`]. Updated and saved after each
     /// successful push; the durable half of what `recent_seals`/`sealed_gen` know in memory.
     sealed: SealedIndex,
+    /// Restore has cleared the overlay and is refilling it out-of-band; until its follow-up
+    /// `reindex` rebuilds the dirty index, that index is EMPTY while the upper is in flux —
+    /// an unguarded dirty view would read as false-clean mid-refill (and a sync could pass
+    /// its dirty gate against a half-restored workspace). Seals, trims, and the dirty view
+    /// all fail closed while this is set.
+    reindex_pending: bool,
 }
 
 #[cfg(unix)]
@@ -1386,6 +1422,14 @@ impl Sealer {
     ) -> Result<SealOutcome> {
         use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
         let mut st = self.state.lock().await;
+        if st.reindex_pending {
+            // Restore is refilling the overlay out-of-band; the dirty index is not yet
+            // rebuilt, so a cycle here would seal (or worse, no-op through) a half-restored
+            // world. Retryable — the restore's reindex disarms this.
+            return Err(CliError::usage(
+                "the overlay is being restored (reindex pending); nothing was sealed",
+            ));
+        }
         let epoch = self.overlay.epoch();
         if epoch != st.seen_epoch {
             st.seen_epoch = epoch;
@@ -1729,6 +1773,7 @@ impl Sealer {
     fn publish_mirror(&self, st: &SealerState) {
         let mut mirror = self.mirror.lock().expect("mirror lock");
         mirror.sealed_gen = st.sealed_gen;
+        mirror.reindex_pending = st.reindex_pending;
         mirror.recently = st
             .recent_seals
             .iter()
@@ -1737,12 +1782,61 @@ impl Sealer {
             .collect();
     }
 
+    /// `clear_upper` routed through the sealer (adopted from the parallel #840 draft): the
+    /// state lock serializes the drop against in-flight seals — a clear can no longer land
+    /// inside a push window — and `reindex_pending` arms the fail-closed guard for the
+    /// out-of-band refill that follows.
+    async fn clear_upper_control(&self) -> Result<Vec<crate::commands::fs::overlay::OverlayInval>>
+    {
+        let mut st = self.state.lock().await;
+        let affected = self
+            .overlay
+            .clear_upper()
+            .map_err(|e| CliError::usage(format!("clearing the overlay failed: {e}")))?;
+        // The caches (and the sealed index) describe the dropped world; adopt the new epoch
+        // here so the next cycle doesn't double-clear.
+        st.seen_epoch = self.overlay.epoch();
+        st.chunk_cache.clear();
+        st.recent_seals.clear();
+        st.sealed = SealedIndex::default();
+        SealedIndex::reset(&self.state_dir);
+        st.reindex_pending = true;
+        self.publish_mirror(&st);
+        Ok(affected)
+    }
+
+    /// `reindex` routed through the sealer: rebuild the dirty index from the refilled
+    /// overlay, reconcile retained state, and disarm the fail-closed guard — under the same
+    /// lock that serializes seals, so no cycle observes the half-rebuilt index.
+    async fn reindex_control(&self) -> Result<()> {
+        let mut st = self.state.lock().await;
+        self.overlay
+            .rebuild_dirty_index()
+            .map_err(|e| CliError::usage(format!("rebuilding the dirty index failed: {e}")))?;
+        reconcile_sealed(&self.state_dir, &self.overlay);
+        st.seen_epoch = self.overlay.epoch();
+        st.chunk_cache.clear();
+        st.recent_seals.clear();
+        st.reindex_pending = false;
+        self.publish_mirror(&st);
+        Ok(())
+    }
+
     /// The truthful dirty view — exactly what the next seal would publish, resolved by the
     /// dry-run twin of the seal walk. Reads the mirror, not the state lock, so it answers
     /// instantly while a push is in flight.
     async fn dirty_view(&self) -> Result<DirtyReply> {
         let (sealed_gen, recently) = {
             let mirror = self.mirror.lock().expect("mirror lock");
+            if mirror.reindex_pending {
+                // Between restore's clear and its reindex the dirty index is empty while the
+                // upper is being refilled — answering would claim a half-restored workspace
+                // is clean.
+                return Err(CliError::usage(
+                    "the overlay is being restored (reindex pending); retry when the restore \
+                     completes",
+                ));
+            }
             (mirror.sealed_gen, mirror.recently.clone())
         };
         let delta = self.overlay.dirty_since(sealed_gen);
@@ -1783,6 +1877,12 @@ impl Sealer {
     /// the retained copies would mask. Dirty and ignored files are untouched.
     async fn trim_all(&self) -> Result<TrimReply> {
         let mut st = self.state.lock().await;
+        if st.reindex_pending {
+            return Err(CliError::usage(
+                "the overlay is being restored (reindex pending); retry when the restore \
+                 completes",
+            ));
+        }
         let epoch = self.overlay.epoch();
         if epoch != st.seen_epoch {
             // clear_upper/restore rewrote the world; the sealed index describes the old one.

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -1053,9 +1053,11 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         },
                         // The upper was mutated out-of-band (restore writes into the state dir
                         // from the CLI process); rebuild the dirty index from disk so an
-                        // auto-commit mount seals the new state. Then reconcile: whatever the
-                        // refill left byte-identical to sealed content (restore back to the
-                        // sealed snapshot) is retained, not dirt.
+                        // auto-commit mount seals the new state. The reconcile afterwards is a
+                        // correctness backstop, not an optimization: in the restore flow it
+                        // absolves nothing (clear_upper reset sealed.json, and refilled files
+                        // carry fresh mtimes), but any future out-of-band flow that preserves
+                        // seal records must not re-dirty retained content.
                         "reindex" => match overlay.rebuild_dirty_index() {
                             Ok(()) => {
                                 reconcile_sealed(&control_state_dir, &overlay);

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -356,6 +356,14 @@ pub struct OverlayFs {
     dirty: Mutex<HashMap<String, DirtyEntry>>,
     /// Out-of-band mutation epoch: see [`OverlayFs::epoch`].
     epoch: AtomicU64,
+    /// The trim fence. Mutating entry points hold it shared for their whole span (copy-up
+    /// through dirty-index record); [`OverlayFs::trim_retained`] holds it exclusively while it
+    /// drops sealed upper files. Without it, a trim could unlink an upper file between a
+    /// writer's copy-up and its open — the writer would then feed an unlinked inode whose
+    /// bytes no seal can ever read. Entry points take it exactly once and no private helper
+    /// re-acquires it (tokio's RwLock is write-preferring: a nested read behind a queued
+    /// writer deadlocks).
+    mutate: tokio::sync::RwLock<()>,
     /// Pending committed-directory renames: merged-namespace destination path -> lower source
     /// path in **true lower coordinates** (composed through existing entries at insert, so
     /// resolution is always one hop). A `rename(2)` of a lower-backed directory records here
@@ -463,6 +471,7 @@ impl OverlayFs {
             write_gen: AtomicU64::new(0),
             dirty: Mutex::new(HashMap::new()),
             epoch: AtomicU64::new(0),
+            mutate: tokio::sync::RwLock::new(()),
             redirects: Mutex::new(redirects),
             redirects_path,
             redirect_gen: AtomicU64::new(0),
@@ -561,6 +570,42 @@ impl OverlayFs {
             .lock()
             .expect("dirty lock")
             .retain(|_, entry| entry.generation > upto);
+    }
+
+    /// The mutation clock's current value — the generation ceiling for
+    /// [`OverlayFs::absolve_clean`].
+    pub fn current_generation(&self) -> u64 {
+        self.write_gen.load(Ordering::SeqCst)
+    }
+
+    /// Drop dirty entries whose on-disk state a persisted seal record has vouched for —
+    /// startup/reindex reconciliation, after [`OverlayFs::rebuild_dirty_index`] pessimistically
+    /// marked every upper file an upsert and every whiteout a delete. Only entries whose kind
+    /// matches are absolved: a path the sealed index calls an upsert but the rebuild calls a
+    /// delete (or vice versa) changed shape while the daemon was down and stays dirty.
+    ///
+    /// `upto` is the caller's clock snapshot from BEFORE it stat-matched the paths: an entry
+    /// with a newer generation was mutated by live kernel traffic after that snapshot, so the
+    /// stat match proves nothing about it and it stays dirty (reindex reconciliation runs on a
+    /// live mount).
+    pub fn absolve_clean(&self, upserts: &[String], deletes: &[String], upto: u64) {
+        let mut dirty = self.dirty.lock().expect("dirty lock");
+        for path in upserts {
+            if dirty
+                .get(path)
+                .is_some_and(|e| e.kind == DirtyKind::Upsert && e.generation <= upto)
+            {
+                dirty.remove(path);
+            }
+        }
+        for path in deletes {
+            if dirty
+                .get(path)
+                .is_some_and(|e| e.kind == DirtyKind::Delete && e.generation <= upto)
+            {
+                dirty.remove(path);
+            }
+        }
     }
 
     /// The path's current lowest written offset, if it is dirty. A sealer that built a stable
@@ -1126,9 +1171,15 @@ impl OverlayFs {
     /// never touched the path. Upper-backed opens always report false: local writes own the
     /// path from then on and the identity chain restarts.
     pub async fn open(&self, ino: u64, write: bool) -> Result<(u64, bool), MountError> {
-        if write {
+        let _fence = if write {
             self.write_guard()?;
-        }
+            // Held through handle registration: once the handle is in the table, trim skips
+            // the path; before that, the fence is what keeps trim from unlinking the upper
+            // file between copy-up and this open.
+            Some(self.mutate.read().await)
+        } else {
+            None
+        };
         let node = self.node(ino)?;
         // The kernel can open by cached inode without a fresh lookup; a node under a whiteout
         // (restore deleted it out-of-band) must not hand out its stale lower backing.
@@ -1365,6 +1416,7 @@ impl OverlayFs {
         exec: bool,
     ) -> Result<(OverlayAttr, u64), MountError> {
         self.write_guard()?;
+        let _fence = self.mutate.read().await;
         let parent_node = self.node(parent)?;
         let path = Self::child_path(&parent_node.path, name);
         if self
@@ -1408,6 +1460,7 @@ impl OverlayFs {
 
     pub async fn mkdir(&self, parent: u64, name: &str) -> Result<OverlayAttr, MountError> {
         self.write_guard()?;
+        let _fence = self.mutate.read().await;
         let parent_node = self.node(parent)?;
         let path = Self::child_path(&parent_node.path, name);
         if self
@@ -1432,6 +1485,7 @@ impl OverlayFs {
         target: &str,
     ) -> Result<OverlayAttr, MountError> {
         self.write_guard()?;
+        let _fence = self.mutate.read().await;
         let parent_node = self.node(parent)?;
         let path = Self::child_path(&parent_node.path, name);
         if self
@@ -1455,6 +1509,7 @@ impl OverlayFs {
 
     pub async fn unlink(&self, parent: u64, name: &str) -> Result<(), MountError> {
         self.write_guard()?;
+        let _fence = self.mutate.read().await;
         let parent_node = self.node(parent)?;
         let path = Self::child_path(&parent_node.path, name);
         let dest = self.upper_path(&path);
@@ -1473,6 +1528,7 @@ impl OverlayFs {
 
     pub async fn rmdir(&self, parent: u64, name: &str) -> Result<(), MountError> {
         self.write_guard()?;
+        let _fence = self.mutate.read().await;
         let parent_node = self.node(parent)?;
         let path = Self::child_path(&parent_node.path, name);
         // Merged-empty check: opendir the directory and require zero entries.
@@ -1585,6 +1641,7 @@ impl OverlayFs {
         new_name: &str,
     ) -> Result<(), MountError> {
         self.write_guard()?;
+        let _fence = self.mutate.read().await;
         let parent_node = self.node(parent)?;
         let new_parent_node = self.node(new_parent)?;
         let src = Self::child_path(&parent_node.path, name);
@@ -1698,6 +1755,7 @@ impl OverlayFs {
         mode: Option<u32>,
     ) -> Result<OverlayAttr, MountError> {
         self.write_guard()?;
+        let _fence = self.mutate.read().await;
         let node = self.node(ino)?;
         if size.is_some() || mode.is_some() {
             self.copy_up(&node).await?;
@@ -1922,6 +1980,84 @@ impl OverlayFs {
         Ok(affected)
     }
 
+    /// Drop retained upper files (and inert whiteouts) whose content a seal has published and
+    /// the lower now serves byte-identically — the incremental, non-destructive counterpart of
+    /// [`OverlayFs::clear_upper`]. The caller nominates candidates from its sealed index; this
+    /// method owns the liveness checks and skips, never deletes, anything it cannot prove
+    /// quiescent:
+    ///
+    /// - a path with an open upper handle is reported in `held_open` (a live writer's
+    ///   descriptor must keep resolving to the linked file);
+    /// - a path with a dirty-index entry was mutated after its seal and is silently skipped
+    ///   (it is not retained — the next seal owns it);
+    /// - a path under a pending rename is skipped (the redirect table is the authority there).
+    ///
+    /// Runs under the exclusive side of the trim fence, so no copy-up or open can interleave
+    /// with the unlinks. Empty parent directories are deliberately left in place: git has no
+    /// empty trees, so a directory emptied by trim may exist nowhere in the lower — removing
+    /// it would change the merged view.
+    ///
+    /// Dirty entries, sealer caches, and the epoch are untouched: logically nothing changed
+    /// (the lower serves the same bytes), the kernel just needs fresh lookups where an upper
+    /// inode was presenting (`invals`).
+    pub async fn trim_retained(&self, candidates: &[String], tombstones: &[String]) -> TrimOutcome {
+        let _fence = self.mutate.write().await;
+        let open_upper: std::collections::HashSet<String> = {
+            let handles = self.handles.lock().expect("handle lock");
+            handles
+                .values()
+                .filter_map(|h| match h {
+                    OHandle::Upper { path, .. } => Some(path.clone()),
+                    _ => None,
+                })
+                .collect()
+        };
+        let dirty: std::collections::HashSet<String> = {
+            let dirty = self.dirty.lock().expect("dirty lock");
+            dirty.keys().cloned().collect()
+        };
+        let mut out = TrimOutcome::default();
+        for path in candidates {
+            if dirty.contains(path) || self.redirect_covers(path) {
+                continue;
+            }
+            if open_upper.contains(path) {
+                out.held_open.push(path.clone());
+                continue;
+            }
+            let abs = self.upper_path(path);
+            if abs.symlink_metadata().is_err() {
+                // Already gone (an earlier trim, or a stale seal record) — report it trimmed
+                // so the caller drops the record.
+                out.trimmed.push(path.clone());
+                continue;
+            }
+            match std::fs::remove_file(&abs) {
+                Ok(()) => out.trimmed.push(path.clone()),
+                Err(e) => {
+                    eprintln!("trim: dropping retained {path} failed: {e}");
+                }
+            }
+        }
+        for path in tombstones {
+            if dirty.contains(path) {
+                continue;
+            }
+            // An inert whiteout: the sealed delete is in the lower's history, so the marker
+            // no longer hides anything — removing it does not change the merged view and
+            // needs no invalidation.
+            match std::fs::remove_file(self.wh_path(path)) {
+                Ok(()) => out.tombstones_removed.push(path.clone()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    out.tombstones_removed.push(path.clone());
+                }
+                Err(e) => eprintln!("trim: dropping whiteout {path} failed: {e}"),
+            }
+        }
+        out.invals = self.invals_for(&out.trimmed);
+        out
+    }
+
     /// Whether any pending directory renames await the next seal.
     pub fn has_redirects(&self) -> bool {
         !self.redirects.lock().expect("redirect lock").is_empty()
@@ -2140,6 +2276,17 @@ pub struct OverlayInval {
     pub parent_ino: Option<u64>,
     pub name: String,
     pub staled: bool,
+}
+
+/// What one [`OverlayFs::trim_retained`] pass did. `trimmed` includes candidates that were
+/// already gone from the upper (the caller drops their seal records either way); `held_open`
+/// names candidates a live upper handle pinned in place — retryable once the writer closes.
+#[derive(Default)]
+pub struct TrimOutcome {
+    pub trimmed: Vec<String>,
+    pub tombstones_removed: Vec<String>,
+    pub held_open: Vec<String>,
+    pub invals: Vec<OverlayInval>,
 }
 
 #[cfg(test)]
@@ -2849,6 +2996,149 @@ mod tests {
         assert_eq!(read_all(&fs, sub2.ino, "deep.txt").await, b"deep\n");
         let tool2 = fs.lookup(moved2.ino, "tool.sh").await.unwrap();
         assert_eq!(tool2.perm & 0o111, 0o111);
+
+        sdk.delete_workspace(PROJECT, &repo, "t", TOKEN, &ws.id)
+            .await
+            .unwrap();
+    }
+
+    /// Trim end to end: sealed-and-kept upper content drops in place — the merged view is
+    /// unchanged, now lower-served — while a dirty path is silently skipped and a path with a
+    /// live write handle is pinned and reported. This is `tl fs sync`'s pre-flight, so the
+    /// liveness checks are the whole point: trim must never delete bytes no snapshot holds.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "requires a local artifact-storage server on 127.0.0.1:8080"]
+    async fn trim_drops_retained_keeps_dirty_and_pins_open_files() {
+        if !server_up() {
+            eprintln!("skipping: no local artifact-storage server");
+            return;
+        }
+        let sdk = sdk();
+        let repo = format!(
+            "ofs-trim-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        sdk.create_repo_with_credential(PROJECT, &repo, None, "t", TOKEN)
+            .await
+            .unwrap();
+        sdk.push_files(
+            PROJECT,
+            &repo,
+            "t",
+            TOKEN,
+            vec![push_file("README.md", b"# seed\n", 0o100644)],
+            PushOptions {
+                message: "seed".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let ws = sdk
+            .create_workspace(
+                PROJECT,
+                &repo,
+                "t",
+                TOKEN,
+                &CreateWorkspaceRequest::default(),
+            )
+            .await
+            .unwrap()
+            .into_inner();
+        let client = FsClient::new(BASE, PROJECT, &repo, Some(TOKEN.to_string())).unwrap();
+        let core = MountCore::new(
+            client,
+            MountOptions {
+                reference: ws.ref_name.clone(),
+                follow: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let fs: Arc<OverlayFs> = OverlayFs::new(core.clone(), state.path(), false).unwrap();
+
+        // Three local files through the overlay.
+        for (name, content) in [
+            ("sealed.txt", &b"sealed\n"[..]),
+            ("held.txt", b"held\n"),
+            ("dirty.txt", b"dirty v1\n"),
+        ] {
+            let (attr, fh) = fs.create(ROOT_INO, name, false).await.unwrap();
+            fs.write(fh, 0, content).unwrap();
+            fs.release(fh);
+            fs.forget(attr.ino, 1);
+        }
+
+        // "Seal" all three the way the daemon's sealer does: push to the workspace ref,
+        // advance the lower, prune the dirty index to the watermark.
+        sdk.push_files(
+            PROJECT,
+            &repo,
+            "t",
+            TOKEN,
+            vec![
+                push_file("sealed.txt", b"sealed\n", 0o100644),
+                push_file("held.txt", b"held\n", 0o100644),
+                push_file("dirty.txt", b"dirty v1\n", 0o100644),
+            ],
+            PushOptions {
+                message: "seal".into(),
+                workspace_snapshot: Some(ws.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(core.poll_ref().await.unwrap().is_some());
+        fs.prune_dirty(fs.current_generation());
+
+        // Re-dirty one file and hold another open for write.
+        let dirty = fs.lookup(ROOT_INO, "dirty.txt").await.unwrap();
+        let (dfh, _) = fs.open(dirty.ino, true).await.unwrap();
+        fs.write(dfh, 0, b"dirty v2\n").unwrap();
+        fs.release(dfh);
+        fs.forget(dirty.ino, 1);
+        let held = fs.lookup(ROOT_INO, "held.txt").await.unwrap();
+        let (held_fh, _) = fs.open(held.ino, true).await.unwrap();
+
+        let candidates: Vec<String> = ["sealed.txt", "held.txt", "dirty.txt"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let outcome = fs.trim_retained(&candidates, &[]).await;
+        assert_eq!(outcome.trimmed, vec!["sealed.txt"]);
+        assert_eq!(outcome.held_open, vec!["held.txt"]);
+        assert!(
+            !state.path().join("upper/sealed.txt").exists(),
+            "retained file dropped from the upper"
+        );
+        assert!(
+            state.path().join("upper/dirty.txt").exists(),
+            "dirty file untouched"
+        );
+        assert!(
+            state.path().join("upper/held.txt").exists(),
+            "open file untouched"
+        );
+
+        // The merged view is unchanged: the trimmed path now serves from the lower,
+        // byte-identical; the dirty path still serves its unsealed content.
+        assert_eq!(read_all(&fs, ROOT_INO, "sealed.txt").await, b"sealed\n");
+        let sealed = fs.lookup(ROOT_INO, "sealed.txt").await.unwrap();
+        assert!(!sealed.upper, "trimmed content is lower-backed");
+        fs.forget(sealed.ino, 1);
+        assert_eq!(read_all(&fs, ROOT_INO, "dirty.txt").await, b"dirty v2\n");
+
+        // The pinned handle still reaches its linked file.
+        fs.write(held_fh, 5, b"more\n").unwrap();
+        fs.release(held_fh);
+        fs.forget(held.ino, 1);
+        assert_eq!(read_all(&fs, ROOT_INO, "held.txt").await, b"held\nmore\n");
 
         sdk.delete_workspace(PROJECT, &repo, "t", TOKEN, &ws.id)
             .await

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -1305,6 +1305,7 @@ impl OverlayFs {
                 }
                 std::os::unix::fs::symlink(String::from_utf8_lossy(&target).as_ref(), &dest)
                     .map_err(io_err)?;
+                self.record(&node.path, DirtyKind::Upsert);
                 return Ok(());
             }
             NodeKind::File => {}
@@ -1342,6 +1343,13 @@ impl OverlayFs {
             }
         }
         std::fs::rename(&tmp, &dest).map_err(io_err)?;
+        // The upper backs this path from here on, so the path is dirty NOW — not at the first
+        // write() through the handle. An open-for-write that never writes (or a `touch`, whose
+        // setattr carries neither size nor mode) would otherwise leave an upper file no dirty
+        // index, seal, or trim ever learns about: invisible to `status`, unpublishable, and
+        // silently shadowing every later sync of the path. Sealing it costs nothing — the
+        // bytes are lower-identical, so content dedup makes the push a by-reference no-op.
+        self.record(&node.path, DirtyKind::Upsert);
         Ok(())
     }
 
@@ -2002,6 +2010,24 @@ impl OverlayFs {
     /// inode was presenting (`invals`).
     pub async fn trim_retained(&self, candidates: &[String], tombstones: &[String]) -> TrimOutcome {
         let _fence = self.mutate.write().await;
+        self.trim_fenced(candidates, tombstones)
+    }
+
+    /// Non-blocking [`OverlayFs::trim_retained`]: `None` when the fence is contended. The
+    /// post-seal hygiene trim uses this — tokio's RwLock is write-preferring, so a BLOCKING
+    /// write acquisition behind one slow in-flight copy-up (a large lower file streaming from
+    /// the server) would stall every new mutating op mount-wide for the duration. Hygiene can
+    /// always wait for the next seal; mount liveness cannot.
+    pub fn try_trim_retained(
+        &self,
+        candidates: &[String],
+        tombstones: &[String],
+    ) -> Option<TrimOutcome> {
+        let _fence = self.mutate.try_write().ok()?;
+        Some(self.trim_fenced(candidates, tombstones))
+    }
+
+    fn trim_fenced(&self, candidates: &[String], tombstones: &[String]) -> TrimOutcome {
         let open_upper: std::collections::HashSet<String> = {
             let handles = self.handles.lock().expect("handle lock");
             handles
@@ -2035,12 +2061,19 @@ impl OverlayFs {
             match std::fs::remove_file(&abs) {
                 Ok(()) => out.trimmed.push(path.clone()),
                 Err(e) => {
+                    // A path that could not be dropped still shadows the lower; report it
+                    // like a pinned file so a sync pre-flight refuses instead of proceeding
+                    // over a silently retained copy.
                     eprintln!("trim: dropping retained {path} failed: {e}");
+                    out.held_open.push(path.clone());
                 }
             }
         }
         for path in tombstones {
-            if dirty.contains(path) {
+            // A whiteout under a pending rename can be load-bearing (it hides remapped lower
+            // content inside the renamed tree); the redirect table, not the sealed delete,
+            // is the authority there.
+            if dirty.contains(path) || self.redirect_covers(path) {
                 continue;
             }
             // An inert whiteout: the sealed delete is in the lower's history, so the marker
@@ -2280,7 +2313,8 @@ pub struct OverlayInval {
 
 /// What one [`OverlayFs::trim_retained`] pass did. `trimmed` includes candidates that were
 /// already gone from the upper (the caller drops their seal records either way); `held_open`
-/// names candidates a live upper handle pinned in place — retryable once the writer closes.
+/// names candidates that could NOT be dropped and still shadow the lower — pinned by a live
+/// upper handle, or an unlink failure — retryable once the pin clears.
 #[derive(Default)]
 pub struct TrimOutcome {
     pub trimmed: Vec<String>,
@@ -3106,7 +3140,19 @@ mod tests {
         let held = fs.lookup(ROOT_INO, "held.txt").await.unwrap();
         let (held_fh, _) = fs.open(held.ino, true).await.unwrap();
 
-        let candidates: Vec<String> = ["sealed.txt", "held.txt", "dirty.txt"]
+        // Open a LOWER-backed file for write and close it without writing: the copy-up alone
+        // must record dirt (an untracked upper copy would be invisible to every dirty view
+        // and silently shadow later syncs of the path) — and being dirty, trim must skip it.
+        let seeded = fs.lookup(ROOT_INO, "README.md").await.unwrap();
+        let (sfh, _) = fs.open(seeded.ino, true).await.unwrap();
+        fs.release(sfh);
+        fs.forget(seeded.ino, 1);
+        assert!(
+            state.path().join("upper/README.md").is_file(),
+            "copy-up materialized the upper copy"
+        );
+
+        let candidates: Vec<String> = ["sealed.txt", "held.txt", "dirty.txt", "README.md"]
             .iter()
             .map(|s| s.to_string())
             .collect();
@@ -3124,6 +3170,10 @@ mod tests {
         assert!(
             state.path().join("upper/held.txt").exists(),
             "open file untouched"
+        );
+        assert!(
+            state.path().join("upper/README.md").exists(),
+            "write-opened-but-never-written copy-up is dirty, not trimmable"
         );
 
         // The merged view is unchanged: the trimmed path now serves from the lower,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -326,10 +326,11 @@ enum FsCommands {
         #[arg(short, long)]
         message: Option<String>,
 
-        /// After sealing, drop the local overlay so the mount serves the snapshot commit
-        /// directly (required before `tl fs sync`). Destructive: also deletes ignored files
-        /// under the mount and any writes made while the snapshot was uploading — pause
-        /// writers first.
+        /// After sealing, drop the WHOLE local overlay so the mount serves the snapshot
+        /// commit directly. Rarely needed — `tl fs sync` trims sealed content by itself;
+        /// this is the disk-reclaim / reset-local-state escape hatch. Destructive: also
+        /// deletes ignored files under the mount and any writes made while the snapshot was
+        /// uploading — pause writers first.
         #[arg(long)]
         clear: bool,
     },


### PR DESCRIPTION
## Problem (live repro, prod sandbox 2026-07-11)

#834 shipped a documented temporary regression, and it bit immediately: after a snapshot, `tl fs status` reported **every sealed-but-retained overlay file as `M`** — a slatedb workspace showed *"496 change(s)"* forever while `tl fs snapshot` correctly answered *"Nothing to snapshot: workspace is clean."* Three commands held three different notions of dirty:

| Command | Source of truth | After a seal |
|---|---|---|
| `snapshot` | daemon sealer (dirty index + watermark) | correct |
| `status` / `promote` / `diff` | raw walk of `upper/` | **over-reports, forever** |
| `sync` | raw walk of `upper/` | refuses; only exit was destructive `--clear` |

Worse, the `--clear` guidance was a data-loss footgun: in the repro workspace it would have deleted a nested `.git` (~3,950 ignored-only files living nowhere but the overlay).

## Change

**One definition of dirty.** New `dirty` control op = the dry-run twin of seal resolution (same dirty index, same ignore rules, same dir-event expansion, no side effects — verified by a test that the tombstone arm does NOT write the whiteout). `status`/`promote`/`sync`/`diff` all consume it via one helper; the raw walk survives only as a labeled daemon-down fallback. It reads a lock-cheap mirror of sealer state, so `status` answers instantly mid-push. `status` now shows `retained:` and `ignored:` as their own categories (JSON: `dirty_exact`, `retained`, `ignored`).

**Seal records survive restarts.** The sealer persists `sealed.json` — per-path size/mtime/git-mode captured at *resolve* time (a racing write always mismatches the record; residual exposure is the classic racy-git same-size-same-ns window), deletes as inert-whiteout markers, plus the sealed commit. Startup and `reindex` reconcile the pessimistic rebuilt dirty index against it, with a generation ceiling so live kernel writes can't be absolved. `clear_upper`/restore/epoch changes reset the index.

**Sync stops needing `--clear`.** New `trim` control op drops retained overlay state in place (lower serves identical bytes; kernel gets invalidations). Dirty and ignored files are never touched; paths pinned by open write handles are reported, not deleted. `sync` pre-flight: refuse while dirty → fix is a plain `tl fs snapshot`; then trim; refuse by name on held-open files. Ignored files now *survive* sync. Trim safety comes from a mutation fence — a `tokio::sync::RwLock` held shared by every mutating overlay entry point and exclusively by trim — closing the copy-up/unlink race (a writer could otherwise be left feeding an unlinked inode no seal can read).

**Retained upper files are deliberately kept outside sync** — they're the local byte cache; background-trimming them would force the next edit of a sealed file to re-read just-pushed bytes off the server. Post-seal auto-trim covers inert whiteout tombstones only. `snapshot --clear` is demoted to the documented disk-reclaim escape hatch.

## Tests

- `resolve_dirty` == `resolve_seal` publication set; dir-event expansion; vanished-recently-sealed reports the delete **without** writing the whiteout.
- Sealed index round-trip + corrupt-file degradation to pessimistic-empty; survivor matching by exact stat identity; resolve-time stat capture.
- `local_changes` prefers the daemon view (retained/ignored accounting) and falls back labeled without a daemon.
- Server-backed overlay e2e (local gsvc-server): trim drops retained content in place (merged view byte-identical, lower-served), skips dirty paths, pins open write handles; existing overlay e2e passes under the new fence.
- Full suite: `cargo test -p tensorlake-cli --features mount` 262 passed; default features 199 passed.

Old daemons: a CLI talking to a pre-this-PR daemon gets the labeled fallback in `status`/`promote`/`diff`; `sync` asks for a remount (it needs the new ops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)