### PR TITLE
tl fs status: report the sealer's dirty set

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -5,12 +5,13 @@
 //! artifact-storage repo backing them (managed with `tl git`); a mounted workspace (private
 //! leased ref) is served by a FUSE daemon — reads stream lazily from the server through the
 //! vendored `gsvc-mount` core's immutable caches, writes land in a local overlay.
-//! **The overlay is the dirty set**: the daemon's sealer resolves its dirty index into
-//! incremental snapshot commits on the workspace ref (auto-commit ticks it; `tl fs snapshot`
-//! runs one cycle through the `seal` control op), and the mount's lower layer follows the ref
-//! to the new snapshot. The overlay is **kept** after sealing —
-//! the upper keeps serving the byte-identical sealed content; `snapshot --clear` is the
-//! explicit, destructive opt-in that drops it (required before `sync`). `promote`
+//! The daemon's dirty index is the snapshot source of truth: its sealer resolves that index
+//! into incremental snapshot commits on the workspace ref (auto-commit ticks it; `tl fs
+//! snapshot` runs one cycle through the `seal` control op), and the mount's lower layer follows
+//! the ref to the new snapshot. The overlay is **kept** after sealing, so a raw upper walk is
+//! only an approximate fallback when the daemon cannot report the exact next-snapshot set.
+//! `snapshot --clear` is the explicit, destructive opt-in that drops the upper (required before
+//! `sync`). `promote`
 //! CAS-advances a real branch (squash by default); `restore` refills the overlay from any
 //! snapshot. FUSE is the only mount path — Linux builds
 //! carry it unconditionally, macOS requires macFUSE and the `macfuse` build feature.
@@ -2246,7 +2247,7 @@ pub async fn unmount(
 }
 
 // ---------------------------------------------------------------------------------------------
-// Snapshot: the overlay is the dirty set.
+// Snapshot: the daemon sealer's dirty index is the dirty set.
 // ---------------------------------------------------------------------------------------------
 
 /// Walk the overlay state dir: `(upserts, deletes)` as repo paths. Ignored names (built-ins +
@@ -2463,6 +2464,225 @@ fn pending_renames(state_dir: &Path) -> Vec<(String, String)> {
     let mut entries: Vec<(String, String)> = map.into_iter().collect();
     entries.sort();
     entries
+}
+
+/// Where a local-change view came from. Only the daemon can report the exact set the next
+/// snapshot would seal; walking the retained upper is deliberately labelled approximate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DirtySource {
+    Daemon,
+    OverlayDaemonDown,
+}
+
+impl DirtySource {
+    fn approximate(self) -> bool {
+        self != Self::Daemon
+    }
+
+    fn json_name(self) -> &'static str {
+        match self {
+            Self::Daemon => "daemon",
+            Self::OverlayDaemonDown => "overlay_fallback_daemon_down",
+        }
+    }
+
+    fn warning(self) -> Option<&'static str> {
+        match self {
+            Self::Daemon => None,
+            Self::OverlayDaemonDown => {
+                Some("daemon not running; showing approximate local changes")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct LocalChanges {
+    dirty: Vec<daemon::DirtyPath>,
+    lower_commit: Option<String>,
+    daemon_running: bool,
+    source: DirtySource,
+}
+
+/// Parse and semantically validate the daemon's exact next-snapshot view. Serde makes every
+/// top-level field required; the checks below also prevent malformed rename rows (or paths) from
+/// being rendered as ordinary changes. A rename source delete is redundant with the R row and is
+/// suppressed even if a transition-version daemon includes both.
+fn parse_dirty_reply(
+    response: serde_json::Value,
+) -> std::result::Result<(Vec<daemon::DirtyPath>, String), String> {
+    fn valid_repo_path(path: &str) -> bool {
+        !path.is_empty()
+            && !path.contains('\0')
+            && path
+                .split('/')
+                .all(|component| !component.is_empty() && component != "." && component != "..")
+    }
+
+    let reply: daemon::DirtyReply =
+        serde_json::from_value(response).map_err(|e| format!("invalid reply shape: {e}"))?;
+    if reply.lower_commit.trim().is_empty() {
+        return Err("lower_commit is empty".to_string());
+    }
+    for entry in &reply.dirty {
+        if !valid_repo_path(&entry.path) {
+            return Err(format!("invalid dirty path {:?}", entry.path));
+        }
+        match (&entry.kind, &entry.from) {
+            (daemon::DirtyPathKind::Renamed, Some(from))
+                if valid_repo_path(from) && from != &entry.path => {}
+            (daemon::DirtyPathKind::Renamed, _) => {
+                return Err(format!(
+                    "rename destination {:?} has no valid, distinct source",
+                    entry.path
+                ));
+            }
+            (daemon::DirtyPathKind::Modified | daemon::DirtyPathKind::Deleted, None) => {}
+            (daemon::DirtyPathKind::Modified | daemon::DirtyPathKind::Deleted, Some(_)) => {
+                return Err(format!(
+                    "non-rename dirty path {:?} unexpectedly has a source",
+                    entry.path
+                ));
+            }
+        }
+    }
+
+    let rename_sources: std::collections::HashSet<String> = reply
+        .dirty
+        .iter()
+        .filter_map(|entry| {
+            (entry.kind == daemon::DirtyPathKind::Renamed)
+                .then_some(entry.from.as_deref())
+                .flatten()
+        })
+        .map(str::to_string)
+        .collect();
+    let dirty = reply
+        .dirty
+        .into_iter()
+        .filter(|entry| {
+            entry.kind != daemon::DirtyPathKind::Deleted
+                || !rename_sources.contains(entry.path.as_str())
+        })
+        .collect();
+    Ok((dirty, reply.lower_commit))
+}
+
+fn approximate_overlay_changes(
+    state_dir: &Path,
+    mount_root: &Path,
+) -> Result<Vec<daemon::DirtyPath>> {
+    let (upserts, deletes) = enumerate_overlay(state_dir, mount_root)?;
+    let renames = pending_renames(state_dir); // (destination, source)
+    let rename_sources: std::collections::HashSet<String> =
+        renames.iter().map(|(_, from)| from.clone()).collect();
+    let mut dirty = Vec::with_capacity(upserts.len() + deletes.len() + renames.len());
+    for (path, from) in renames {
+        dirty.push(daemon::DirtyPath {
+            path,
+            kind: daemon::DirtyPathKind::Renamed,
+            from: Some(from),
+        });
+    }
+    for (path, _, _) in upserts {
+        dirty.push(daemon::DirtyPath {
+            path,
+            kind: daemon::DirtyPathKind::Modified,
+            from: None,
+        });
+    }
+    for path in deletes {
+        if !rename_sources.contains(path.as_str()) {
+            dirty.push(daemon::DirtyPath {
+                path,
+                kind: daemon::DirtyPathKind::Deleted,
+                from: None,
+            });
+        }
+    }
+    Ok(dirty)
+}
+
+/// Ask the running sealer for its exact dirty set. Only an unreachable daemon falls back to the
+/// raw overlay walk, and the caller must surface that approximation. A live daemon that is busy,
+/// old, or malformed fails closed: raw upper state can miss dirty-index-only delete events, so it
+/// is not a safe substitute while the authoritative in-memory index still exists.
+async fn query_local_changes(state_dir: &Path, mount_root: &Path) -> Result<LocalChanges> {
+    fn is_connect_failure(error: &CliError) -> bool {
+        // `daemon::control` uses this prefix only when UnixStream::connect fails. Operation
+        // errors use `daemon <op> failed`, so a live/busy daemon cannot enter the raw fallback.
+        matches!(
+            error,
+            CliError::Usage(message) if message.starts_with("mount daemon is not running (")
+        )
+    }
+
+    fn daemon_down_changes(state_dir: &Path, mount_root: &Path) -> Result<LocalChanges> {
+        Ok(LocalChanges {
+            dirty: approximate_overlay_changes(state_dir, mount_root)?,
+            lower_commit: None,
+            daemon_running: false,
+            source: DirtySource::OverlayDaemonDown,
+        })
+    }
+
+    enum DirtyFailure {
+        Outdated,
+        Unavailable,
+        Malformed,
+    }
+
+    let failure = match daemon::control(state_dir, "dirty").await {
+        Ok(response) => match parse_dirty_reply(response) {
+            Ok((dirty, lower_commit)) => {
+                return Ok(LocalChanges {
+                    dirty,
+                    lower_commit: Some(lower_commit),
+                    daemon_running: true,
+                    source: DirtySource::Daemon,
+                });
+            }
+            Err(_) => DirtyFailure::Malformed,
+        },
+        Err(error) if is_connect_failure(&error) => {
+            return daemon_down_changes(state_dir, mount_root);
+        }
+        Err(error)
+            if error.to_string().contains("unknown op")
+                || error.to_string().contains("unknown_op") =>
+        {
+            DirtyFailure::Outdated
+        }
+        Err(_) => DirtyFailure::Unavailable,
+    };
+
+    match daemon::control(state_dir, "ping").await {
+        Err(error) if is_connect_failure(&error) => daemon_down_changes(state_dir, mount_root),
+        Ok(_) => {
+            let message = match failure {
+                DirtyFailure::Outdated => {
+                    "the mount daemon predates exact local status; remount this workspace with \
+                     the current tl version, then retry"
+                        .to_string()
+                }
+                DirtyFailure::Malformed => {
+                    "the mount daemon returned invalid local status; remount to upgrade it, then \
+                     retry"
+                        .to_string()
+                }
+                DirtyFailure::Unavailable => {
+                    "the mount daemon is busy or could not provide exact local status; retry \
+                     after the current snapshot or restore finishes"
+                        .to_string()
+                }
+            };
+            Err(CliError::usage(message))
+        }
+        Err(_) => Err(CliError::usage(
+            "could not verify exact local status with the mount daemon; retry or inspect the \
+             daemon log",
+        )),
+    }
 }
 
 /// An enumerated dirty set as push files, used by the daemon's sealer (`tl fs snapshot`
@@ -2726,14 +2946,27 @@ pub async fn promote(
     }
     let session = FsSession::open(ctx, Some(&state.repo)).await?;
     heartbeat(&session, &state).await?;
-    let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
-    let renames = pending_renames(&state_dir);
-    if !upserts.is_empty() || !deletes.is_empty() || !renames.is_empty() {
-        eprintln!(
-            "{} {} local change(s) that may not be in a snapshot; promoting the last snapshot only. Run `tl fs snapshot` first to be sure they are included.",
-            style("note:").yellow(),
-            upserts.len() + deletes.len() + renames.len()
-        );
+    let local = query_local_changes(&state_dir, Path::new(&mountpoint)).await?;
+    if let Some(warning) = local.source.warning() {
+        eprintln!("{} {warning}", style("note:").yellow());
+    }
+    if !local.dirty.is_empty() {
+        if local.source.approximate() {
+            eprintln!(
+                "{} approximate overlay scan found {} local change(s) that may not be in a \
+                 snapshot; promoting the last snapshot only. Run `tl fs snapshot` first to be \
+                 sure they are included.",
+                style("note:").yellow(),
+                local.dirty.len(),
+            );
+        } else {
+            eprintln!(
+                "{} {} unsealed local change(s); promoting the last snapshot only. Run `tl fs \
+                 snapshot` first to include them.",
+                style("note:").yellow(),
+                local.dirty.len(),
+            );
+        }
     }
     let (user, token) = session.creds();
     let request = PromoteWorkspaceRequest {
@@ -2986,26 +3219,36 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         .await?
         .into_inner();
     let _ = heartbeat(&session, &state).await;
-    let daemon_commit = daemon::control(&state_dir, "ping")
-        .await
-        .ok()
-        .and_then(|r| r.get("commit").and_then(|c| c.as_str().map(str::to_string)));
-    let (upserts, deletes) = enumerate_overlay(&state_dir, Path::new(&mountpoint))?;
+    let local = query_local_changes(&state_dir, Path::new(&mountpoint)).await?;
 
     if output_json {
+        let pending_renames = local
+            .dirty
+            .iter()
+            .filter(|entry| entry.kind == daemon::DirtyPathKind::Renamed)
+            .map(|entry| {
+                serde_json::json!({
+                    "from": entry.from.as_deref().expect("validated rename source"),
+                    "to": entry.path,
+                })
+            })
+            .collect::<Vec<_>>();
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
                 "workspace": ws,
-                "mounted": daemon_commit.is_some(),
-                "lower_commit": daemon_commit,
+                "mounted": local.daemon_running,
+                "lower_commit": local.lower_commit,
                 "log": state_dir.join("daemon.log"),
-                "dirty": upserts.iter().map(|(p, _, _)| p.clone())
-                    .chain(deletes.iter().cloned()).collect::<Vec<_>>(),
-                "pending_renames": pending_renames(&state_dir)
-                    .into_iter()
-                    .map(|(to, from)| serde_json::json!({ "from": from, "to": to }))
+                // Preserve the legacy JSON split: M/D paths live in `dirty`; renames live in
+                // `pending_renames` and are not duplicated here.
+                "dirty": local.dirty.iter()
+                    .filter(|entry| entry.kind != daemon::DirtyPathKind::Renamed)
+                    .map(|entry| entry.path.clone())
                     .collect::<Vec<_>>(),
+                "pending_renames": pending_renames,
+                "dirty_approximate": local.source.approximate(),
+                "dirty_source": local.source.json_name(),
             }))?
         );
         return Ok(());
@@ -3027,14 +3270,18 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
     }
     if let Some(secs) = state.auto_commit_interval_secs {
         println!(
-            "{} local changes seal into a snapshot every {secs}s (local: below is the kept \
-             overlay, sealed content included; `tl fs snapshot --clear` drops it)",
+            "{} local changes seal into a snapshot every {secs}s (local status shows only \
+             changes pending for the next snapshot)",
             style("auto-commit:").dim()
         );
     }
-    match &daemon_commit {
-        Some(commit) => println!("{} mounted at {commit}", style("daemon:").dim()),
-        None => println!(
+    match (&local.lower_commit, local.daemon_running) {
+        (Some(commit), true) => println!("{} mounted at {commit}", style("daemon:").dim()),
+        (None, true) => println!(
+            "{} running (lower commit unavailable)",
+            style("daemon:").dim()
+        ),
+        (_, false) => println!(
             "{} not running (remount with tl fs mount)",
             style("daemon:").dim()
         ),
@@ -3044,26 +3291,46 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         style("log:").dim(),
         state_dir.join("daemon.log").display()
     );
-    let renames = pending_renames(&state_dir);
-    // A pending rename's source whiteout is a real delete, but showing it next to the R line
-    // would read as two changes; the R line carries both sides.
-    let deletes: Vec<String> = deletes
-        .into_iter()
-        .filter(|p| !renames.iter().any(|(_, from)| from == p))
-        .collect();
-    let dirty = upserts.len() + deletes.len() + renames.len();
+    if let Some(warning) = local.source.warning() {
+        println!("{} {warning}", style("note:").yellow());
+    }
+    let dirty = local.dirty.len();
     if dirty == 0 {
-        println!("{} clean", style("local:").dim());
+        if local.source.approximate() {
+            println!("{} no changes found (approximate)", style("local:").dim());
+        } else {
+            println!("{} clean", style("local:").dim());
+        }
     } else {
         println!("{} {} change(s):", style("local:").dim(), dirty);
-        for (to, from) in renames.iter().take(20) {
-            println!("  {} {from} -> {to}", style("R").cyan());
+        for entry in local
+            .dirty
+            .iter()
+            .filter(|entry| entry.kind == daemon::DirtyPathKind::Renamed)
+            .take(20)
+        {
+            println!(
+                "  {} {} -> {}",
+                style("R").cyan(),
+                entry.from.as_deref().expect("validated rename source"),
+                entry.path,
+            );
         }
-        for (p, _, _) in upserts.iter().take(20) {
-            println!("  {} {p}", style("M").yellow());
+        for entry in local
+            .dirty
+            .iter()
+            .filter(|entry| entry.kind == daemon::DirtyPathKind::Modified)
+            .take(20)
+        {
+            println!("  {} {}", style("M").yellow(), entry.path);
         }
-        for p in deletes.iter().take(20) {
-            println!("  {} {p}", style("D").red());
+        for entry in local
+            .dirty
+            .iter()
+            .filter(|entry| entry.kind == daemon::DirtyPathKind::Deleted)
+            .take(20)
+        {
+            println!("  {} {}", style("D").red(), entry.path);
         }
         if dirty > 60 {
             println!("  … and more");
@@ -3693,16 +3960,27 @@ mod tests {
         assert!(deletes.is_empty());
     }
 
-    /// A fake daemon control endpoint: records the op sequence and replies `{"ok":true}` to
-    /// every op except `seal`, which replies like a real sealer that minted a commit — so the
-    /// snapshot control flow can be exercised without a mount. `seal` honors the new framing:
+    /// A fake daemon control endpoint: records the op sequence, returns the supplied `dirty`
+    /// reply, and makes `seal` reply like a real sealer that minted a commit — so the snapshot
+    /// and local-status control flows can be exercised without a mount. `seal` honors framing:
     /// each string in `events` is written as an `{"event": ...}` progress line before the
     /// final reply (pass none for the plain single-line reply older tests exercise), and a
     /// `clear:true` request gets a `cleared` list back.
     #[cfg(unix)]
+    fn clean_dirty_reply() -> serde_json::Value {
+        serde_json::json!({
+            "ok": true,
+            "dirty": [],
+            "lower_commit": "cafe0000",
+            "watermark": 7,
+        })
+    }
+
+    #[cfg(unix)]
     fn fake_daemon_with_events(
         state_dir: &Path,
         events: Vec<String>,
+        dirty_reply: serde_json::Value,
     ) -> std::sync::Arc<std::sync::Mutex<Vec<String>>> {
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
         let ops = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
@@ -3715,6 +3993,7 @@ mod tests {
             while let Ok((stream, _)) = listener.accept().await {
                 let recorded = recorded.clone();
                 let events = events.clone();
+                let dirty_reply = dirty_reply.clone();
                 tokio::spawn(async move {
                     let mut reader = tokio::io::BufReader::new(stream);
                     let mut line = String::new();
@@ -3745,6 +4024,8 @@ mod tests {
                                 serde_json::json!(["keep.txt", "target/build.o", "raced.txt"]);
                         }
                         resp
+                    } else if op == "dirty" {
+                        dirty_reply
                     } else {
                         serde_json::json!({ "ok": true })
                     };
@@ -3757,7 +4038,117 @@ mod tests {
 
     #[cfg(unix)]
     fn fake_daemon(state_dir: &Path) -> std::sync::Arc<std::sync::Mutex<Vec<String>>> {
-        fake_daemon_with_events(state_dir, Vec::new())
+        fake_daemon_with_events(state_dir, Vec::new(), clean_dirty_reply())
+    }
+
+    /// Retained upper files are not dirty after a seal. The exact daemon reply must therefore
+    /// win over the raw overlay walk, and the fast path must not pay a second ping round-trip.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_changes_use_daemon_view_instead_of_retained_upper() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(state.path().join("upper")).unwrap();
+        std::fs::write(state.path().join("upper/already-sealed.txt"), "sealed").unwrap();
+        let ops = fake_daemon(state.path());
+
+        let changes = query_local_changes(state.path(), mount.path())
+            .await
+            .unwrap();
+
+        assert_eq!(changes.source, DirtySource::Daemon);
+        assert!(!changes.source.approximate());
+        assert_eq!(changes.lower_commit.as_deref(), Some("cafe0000"));
+        assert!(changes.dirty.is_empty(), "retained upper is not dirty");
+        assert_eq!(*ops.lock().unwrap(), vec!["dirty"], "no ping on success");
+    }
+
+    /// A live old daemon still owns dirty-index-only events that a raw upper walk cannot see.
+    /// Fail closed and require a remount instead of presenting that walk as approximate truth.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_changes_do_not_raw_fallback_for_live_old_daemon() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(state.path().join("upper")).unwrap();
+        std::fs::write(state.path().join("upper/retained.txt"), "sealed").unwrap();
+        let ops = fake_daemon_with_events(
+            state.path(),
+            Vec::new(),
+            serde_json::json!({
+                "ok": false,
+                "code": "unknown_op",
+                "error": "unknown op \"dirty\"",
+            }),
+        );
+
+        let error = query_local_changes(state.path(), mount.path())
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("predates exact local status"));
+        assert_eq!(*ops.lock().unwrap(), vec!["dirty", "ping"]);
+    }
+
+    /// With no daemon, compatibility falls back to the overlay and says so explicitly. A
+    /// pending rename is rendered source -> destination, without a duplicate source delete.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_changes_label_daemon_down_fallback_and_dedupe_rename_delete() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(state.path().join("upper")).unwrap();
+        std::fs::create_dir_all(state.path().join("wh/old-dir")).unwrap();
+        std::fs::write(state.path().join("upper/changed.txt"), "changed").unwrap();
+        std::fs::write(state.path().join("wh/old-dir/file.txt"), "").unwrap();
+        std::fs::write(
+            state.path().join("redirects.json"),
+            serde_json::to_vec(&serde_json::json!({ "new-dir": "old-dir/file.txt" })).unwrap(),
+        )
+        .unwrap();
+
+        let changes = query_local_changes(state.path(), mount.path())
+            .await
+            .unwrap();
+
+        assert_eq!(changes.source, DirtySource::OverlayDaemonDown);
+        assert!(changes.source.approximate());
+        assert_eq!(
+            changes.source.warning(),
+            Some("daemon not running; showing approximate local changes")
+        );
+        assert!(!changes.daemon_running);
+        assert_eq!(changes.dirty.len(), 2);
+        assert_eq!(changes.dirty[0].kind, daemon::DirtyPathKind::Renamed);
+        assert_eq!(changes.dirty[0].from.as_deref(), Some("old-dir/file.txt"));
+        assert_eq!(changes.dirty[0].path, "new-dir");
+        assert_eq!(changes.dirty[1].kind, daemon::DirtyPathKind::Modified);
+        assert_eq!(changes.dirty[1].path, "changed.txt");
+    }
+
+    #[test]
+    fn dirty_reply_requires_semantically_valid_renames() {
+        let malformed = serde_json::json!({
+            "ok": true,
+            "dirty": [{ "path": "new-dir", "kind": "R" }],
+            "lower_commit": "cafe0000",
+            "watermark": 7,
+        });
+        assert!(parse_dirty_reply(malformed).is_err());
+
+        let transitional = serde_json::json!({
+            "ok": true,
+            "dirty": [
+                { "path": "new-dir", "kind": "R", "from": "old-dir" },
+                { "path": "old-dir", "kind": "D" }
+            ],
+            "lower_commit": "cafe0000",
+            "watermark": 7,
+        });
+        let (dirty, commit) = parse_dirty_reply(transitional).unwrap();
+        assert_eq!(commit, "cafe0000");
+        assert_eq!(dirty.len(), 1, "rename source delete is redundant");
+        assert_eq!(dirty[0].kind, daemon::DirtyPathKind::Renamed);
     }
 
     /// Regression for the snapshot data-loss bug: sealing must KEEP the overlay, and the seal
@@ -3855,6 +4246,7 @@ mod tests {
                 "hashing 1/2 files (1 KiB)...".to_string(),
                 "uploaded 3 chunks (2 KiB)...".to_string(),
             ],
+            clean_dirty_reply(),
         );
 
         let bar = indicatif::ProgressBar::hidden();

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -8,6 +8,12 @@
 //!
 //! ```text
 //! {"op":"ping"}        -> {"ok":true,"commit":"<hex>"}
+//! {"op":"dirty"}       -> the sealer's exact next-snapshot view:
+//!                         {ok, dirty: [{path, kind: M|D|R, from?}], lower_commit,
+//!                         watermark}. `R.path` is the destination and `R.from` its source.
+//!                         Inspection applies the same ignore/directory/delete resolution as
+//!                         `seal` without materializing whiteouts; it may reconcile rename
+//!                         bookkeeping already made obsolete by the served lower commit.
 //! {"op":"refresh"}     -> poll the workspace ref now; reply with the (possibly new) commit
 //!                         plus every probe expectation banked since the last drain
 //!                         ("changed": [{path, present, size?}], "complete": bool) so callers
@@ -188,6 +194,22 @@ pub fn control_socket(state_dir: &Path) -> PathBuf {
     state_dir.join("control.sock")
 }
 
+#[cfg(unix)]
+fn control_connect_error(sock: &Path, error: std::io::Error) -> CliError {
+    let message = match error.kind() {
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused => {
+            format!("mount daemon is not running ({}): {error}", sock.display())
+        }
+        // Permission/resource failures do not prove the daemon is down. Keep a distinct
+        // prefix so callers that contemplate a raw fallback can fail closed.
+        _ => format!(
+            "could not connect to mount daemon ({}): {error}",
+            sock.display()
+        ),
+    };
+    CliError::usage(message)
+}
+
 /// The daemon's pid, written at startup so `unmount` can wait for the process to actually die
 /// before tearing down the state dir (a shutdown fired into the socket alone races the exit).
 pub fn pid_file(state_dir: &Path) -> PathBuf {
@@ -243,6 +265,39 @@ pub(crate) struct SealReply {
     pub cleared: Option<Vec<String>>,
 }
 
+/// One path in the sealer's exact next-snapshot view.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DirtyPath {
+    pub path: String,
+    pub kind: DirtyPathKind,
+    /// Required for renames (source path); absent for modifications and deletions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<String>,
+}
+
+/// Compact status kind used by the daemon control protocol.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum DirtyPathKind {
+    #[serde(rename = "M")]
+    Modified,
+    #[serde(rename = "D")]
+    Deleted,
+    #[serde(rename = "R")]
+    Renamed,
+}
+
+/// Final reply of the `dirty` control op. Every field is required intentionally: an older or
+/// malformed daemon reply must never deserialize as a false-clean workspace.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DirtyReply {
+    pub dirty: Vec<DirtyPath>,
+    /// The commit the lower layer currently serves. This is not necessarily a locally sealed
+    /// commit (shared mounts can advance for other reasons), hence the deliberately precise name.
+    pub lower_commit: String,
+    /// Dirty-index generation captured for this view.
+    pub watermark: u64,
+}
+
 /// One control round-trip from a CLI command to the daemon. Mounts (and so daemons) exist
 /// only on unix; elsewhere every control call reports the daemon as not running.
 #[cfg(not(unix))]
@@ -293,12 +348,9 @@ pub async fn control_with(
     args: serde_json::Value,
 ) -> Result<serde_json::Value> {
     let sock = control_socket(state_dir);
-    let mut stream = tokio::net::UnixStream::connect(&sock).await.map_err(|e| {
-        CliError::usage(format!(
-            "mount daemon is not running ({}): {e}",
-            sock.display()
-        ))
-    })?;
+    let mut stream = tokio::net::UnixStream::connect(&sock)
+        .await
+        .map_err(|e| control_connect_error(&sock, e))?;
     let mut request = serde_json::json!({ "op": op });
     if let serde_json::Value::Object(fields) = args {
         let obj = request.as_object_mut().expect("request is an object");
@@ -340,12 +392,9 @@ pub async fn control_streaming(
     mut on_event: impl FnMut(&str),
 ) -> Result<serde_json::Value> {
     let sock = control_socket(state_dir);
-    let mut stream = tokio::net::UnixStream::connect(&sock).await.map_err(|e| {
-        CliError::usage(format!(
-            "mount daemon is not running ({}): {e}",
-            sock.display()
-        ))
-    })?;
+    let mut stream = tokio::net::UnixStream::connect(&sock)
+        .await
+        .map_err(|e| control_connect_error(&sock, e))?;
     let mut request = serde_json::json!({ "op": op });
     if let serde_json::Value::Object(fields) = args {
         let obj = request.as_object_mut().expect("request is an object");
@@ -699,6 +748,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
             state: tokio::sync::Mutex::new(SealerState {
                 sealed_gen: 0,
                 seen_epoch: overlay.epoch(),
+                overlay_reindex_pending: false,
                 recent_seals: Vec::new(),
                 chunk_cache: std::collections::HashMap::new(),
             }),
@@ -772,6 +822,48 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         "ping" => {
                             serde_json::json!({ "ok": true, "commit": core.current_commit() })
                         }
+                        // One authoritative definition of local dirt: ask the same sealer
+                        // state and path resolver that the next `seal` cycle will use. A
+                        // read-only mount has no sealer and cannot accept local mutations.
+                        "dirty" => {
+                            let reply = match sealer.as_ref() {
+                                Some(sealer) => sealer.dirty_view().await,
+                                None => {
+                                    let delta = overlay.dirty_since(0);
+                                    if delta.is_empty() && !overlay.has_redirects() {
+                                        Ok(DirtyReply {
+                                            dirty: Vec::new(),
+                                            lower_commit: core.current_commit(),
+                                            watermark: delta.watermark,
+                                        })
+                                    } else {
+                                        // A read-only mount normally has no upper state. If
+                                        // stale/local state does exist, there is no sealer
+                                        // watermark capable of classifying it exactly; force
+                                        // the CLI to fail closed rather than claim it is clean.
+                                        Err(CliError::usage(
+                                            "read-only mount has local overlay state but no sealer",
+                                        ))
+                                    }
+                                }
+                            };
+                            match reply {
+                                Ok(reply) => match serde_json::to_value(reply) {
+                                    Ok(mut reply) => {
+                                        reply["ok"] = serde_json::Value::Bool(true);
+                                        reply
+                                    }
+                                    Err(e) => serde_json::json!({
+                                        "ok": false,
+                                        "error": e.to_string(),
+                                    }),
+                                },
+                                Err(e) => serde_json::json!({
+                                    "ok": false,
+                                    "error": e.to_string(),
+                                }),
+                            }
+                        }
                         // Seal on demand: `tl fs snapshot` runs exactly one cycle of the same
                         // sealer auto-commit ticks, with the caller's message (and optional
                         // overlay clear). Streaming op — the handler writes its own event
@@ -815,20 +907,38 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                         },
                         // The upper drop flips interned paths to their lower view with no
                         // kernel-visible operation; push the implied invalidations.
-                        "clear_upper" => match overlay.clear_upper() {
-                            Ok(affected) => {
-                                invalidate(affected);
-                                serde_json::json!({ "ok": true })
+                        "clear_upper" => {
+                            let result = match sealer.as_ref() {
+                                Some(sealer) => sealer.clear_upper_control().await,
+                                None => overlay
+                                    .clear_upper()
+                                    .map(|affected| invalidate(affected))
+                                    .map_err(|e| CliError::usage(e.to_string())),
+                            };
+                            match result {
+                                Ok(()) => serde_json::json!({ "ok": true }),
+                                Err(e) => {
+                                    serde_json::json!({ "ok": false, "error": e.to_string() })
+                                }
                             }
-                            Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
-                        },
+                        }
                         // The upper was mutated out-of-band (restore writes into the state dir
                         // from the CLI process); rebuild the dirty index from disk so an
                         // auto-commit mount seals the new state.
-                        "reindex" => match overlay.rebuild_dirty_index() {
-                            Ok(()) => serde_json::json!({ "ok": true }),
-                            Err(e) => serde_json::json!({ "ok": false, "error": e.to_string() }),
-                        },
+                        "reindex" => {
+                            let result = match sealer.as_ref() {
+                                Some(sealer) => sealer.reindex_control().await,
+                                None => overlay
+                                    .rebuild_dirty_index()
+                                    .map_err(|e| CliError::usage(e.to_string())),
+                            };
+                            match result {
+                                Ok(()) => serde_json::json!({ "ok": true }),
+                                Err(e) => {
+                                    serde_json::json!({ "ok": false, "error": e.to_string() })
+                                }
+                            }
+                        }
                         // Pending directory renames, expanded to the by-oid upserts a seal
                         // must publish (`tl fs snapshot` merges these into its push).
                         "expand_redirects" => match overlay.expand_redirects().await {
@@ -1096,12 +1206,15 @@ struct SealerState {
     /// restore) and rebuild_dirty_index rewrite the overlay's world out-of-band; every cache
     /// below is a claim about the old world and dies with it.
     seen_epoch: u64,
+    /// Restore has cleared the overlay and may be refilling it out-of-band; until its reindex
+    /// completes, neither dirty inspection nor sealing may claim the event index is complete.
+    overlay_reindex_pending: bool,
     /// Upserts of not-yet-confirmed seals, in seal order, each tagged with its commit: the
     /// guard set for deletes racing the lower's advance past their seal (see resolve_seal's
     /// tombstone arm). Confirmation-based — a set is only dropped once the lower is observed
-    /// at (or past) its seal — because eviction-by-count expires the guard exactly when index
-    /// materialization lags behind hot pushes. Memory is bounded by the unconfirmed window,
-    /// not a fixed depth.
+    /// at (or past) its seal and the pending delta has resolved against the guard — because
+    /// eviction-by-count expires it exactly when index materialization lags behind hot pushes.
+    /// Memory is bounded by the unconfirmed window, not a fixed depth.
     recent_seals: Vec<(String, std::collections::HashSet<String>)>,
     /// Chunk lists from previous seals (path -> the pushed CDC chunk list): the append fast
     /// path's memory. A re-touched file whose writes never went below a cached boundary seals
@@ -1112,6 +1225,126 @@ struct SealerState {
 
 #[cfg(unix)]
 impl Sealer {
+    /// Inspect exactly what the next seal would publish without materializing whiteouts or
+    /// other dirty filesystem changes. The sealer-state lock gives this query one linearization
+    /// point with manual/automatic seal cycles; writes after the captured watermark remain
+    /// visible to the following query.
+    async fn dirty_view(&self) -> Result<DirtyReply> {
+        let mut st = self.state.try_lock().map_err(|_| {
+            CliError::usage("the sealer is busy; exact local changes are temporarily unavailable")
+        })?;
+        if st.overlay_reindex_pending {
+            return Err(CliError::usage(
+                "the overlay is awaiting reindex after an out-of-band rewrite",
+            ));
+        }
+        let epoch = self.overlay.epoch();
+        if epoch != st.seen_epoch {
+            // restore/reindex/clear replaced the overlay world. Match seal_once's cache reset
+            // before interpreting the rebuilt dirty index.
+            st.seen_epoch = epoch;
+            st.chunk_cache.clear();
+            st.recent_seals.clear();
+        }
+        // Match seal_once's prelude: a rename already present in lower was published by an
+        // earlier seal and is no longer dirty. Reaping only removes consumed redirect
+        // bookkeeping; it never drops upper/local-only content.
+        if self.overlay.has_redirects() {
+            self.overlay
+                .reap_sealed_redirects()
+                .await
+                .map_err(|e| CliError::usage(format!("reaping sealed renames failed: {e}")))?;
+        }
+        let delta = self.overlay.dirty_since(st.sealed_gen);
+        let watermark = delta.watermark;
+        let recently: std::collections::HashSet<String> = st
+            .recent_seals
+            .iter()
+            .flat_map(|(_, set)| set)
+            .cloned()
+            .collect();
+        let (sd, mp) = (self.state_dir.clone(), self.mountpoint.clone());
+        let resolved =
+            tokio::task::spawn_blocking(move || resolve_dirty_paths(&sd, &mp, &delta, &recently))
+                .await
+                .map_err(|e| CliError::usage(format!("dirty resolution task failed: {e}")))?
+                .map_err(|e| CliError::usage(format!("resolving local changes failed: {e}")))?;
+        if self.overlay.epoch() != epoch {
+            // Never present a mixed-world answer as exact; a live-daemon client fails closed.
+            return Err(CliError::usage(
+                "the overlay was rewritten while inspecting local changes",
+            ));
+        }
+
+        let redirects = self.overlay.redirect_entries(); // (destination, source)
+        let rename_sources: std::collections::HashSet<String> =
+            redirects.iter().map(|(_, source)| source.clone()).collect();
+        let mut dirty =
+            Vec::with_capacity(redirects.len() + resolved.upserts.len() + resolved.deletes.len());
+        for (path, from) in redirects {
+            dirty.push(DirtyPath {
+                path,
+                kind: DirtyPathKind::Renamed,
+                from: Some(from),
+            });
+        }
+        for (path, _, _) in resolved.upserts {
+            dirty.push(DirtyPath {
+                path,
+                kind: DirtyPathKind::Modified,
+                from: None,
+            });
+        }
+        // A pending rename's source whiteout is represented by the R row. Reporting the
+        // matching D as well would count the same operation twice.
+        for path in resolved.deletes {
+            if !rename_sources.contains(path.as_str()) {
+                dirty.push(DirtyPath {
+                    path,
+                    kind: DirtyPathKind::Deleted,
+                    from: None,
+                });
+            }
+        }
+        Ok(DirtyReply {
+            dirty,
+            lower_commit: self.core.current_commit(),
+            watermark,
+        })
+    }
+
+    /// Serialize restore's out-of-band overlay drop with seal/dirty inspection. Without this,
+    /// a concurrent `dirty` query could observe a half-cleared tree before `clear_upper` bumps
+    /// the overlay epoch and incorrectly present it as exact.
+    async fn clear_upper_control(&self) -> Result<()> {
+        let mut st = self.state.lock().await;
+        let affected = self
+            .overlay
+            .clear_upper()
+            .map_err(|e| CliError::usage(format!("clearing the overlay failed: {e}")))?;
+        (self.invalidate)(affected);
+        st.seen_epoch = self.overlay.epoch();
+        st.chunk_cache.clear();
+        st.recent_seals.clear();
+        st.overlay_reindex_pending = true;
+        Ok(())
+    }
+
+    /// Serialize dirty-index rebuild with seal/dirty inspection. `rebuild_dirty_index` bumps
+    /// its epoch before repopulating the map, so an epoch-only before/after check cannot detect
+    /// a query that otherwise lands in the middle of that walk.
+    async fn reindex_control(&self) -> Result<()> {
+        let mut st = self.state.lock().await;
+        self.overlay
+            .rebuild_dirty_index()
+            .map_err(|e| CliError::usage(format!("reindexing the overlay failed: {e}")))?;
+        st.seen_epoch = self.overlay.epoch();
+        st.chunk_cache.clear();
+        st.recent_seals.clear();
+        st.overlay_reindex_pending = false;
+        Ok(())
+    }
+
     /// Run ONE seal cycle: resolve the dirty delta since the sealed watermark (plus pending
     /// renames) against the on-disk overlay, push it as a snapshot commit carrying `message`,
     /// and advance the lower to the sealed commit. Errors are retryable — nothing was
@@ -1134,23 +1367,26 @@ impl Sealer {
     ) -> Result<SealOutcome> {
         use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
         let mut st = self.state.lock().await;
+        if st.overlay_reindex_pending {
+            return Err(CliError::usage(
+                "the overlay is awaiting reindex after an out-of-band rewrite",
+            ));
+        }
         let epoch = self.overlay.epoch();
         if epoch != st.seen_epoch {
             st.seen_epoch = epoch;
             st.chunk_cache.clear();
             st.recent_seals.clear();
         }
-        // Drop guard sets the lower has caught up with: the followed ref only moves along
-        // this workspace's snapshots, so matching the current lower commit confirms it and
-        // everything sealed before it.
+        // Remember which guard sets the lower has confirmed, but do not drop them until this
+        // cycle has resolved its pending delta. An unlink can land while its upsert push is in
+        // flight, before lower serves the new file and therefore without writing a whiteout;
+        // that pending delete still needs the just-confirmed guard to avoid resurrection.
         let lower = self.core.current_commit();
-        if let Some(i) = st
+        let confirmed_through = st
             .recent_seals
             .iter()
-            .rposition(|(commit, _)| *commit == lower)
-        {
-            st.recent_seals.drain(..=i);
-        }
+            .rposition(|(commit, _)| *commit == lower);
         // Renames a previous seal published but never consumed (crash, or the lower lagged
         // past our post-seal check) dangle once the lower advances; reap them before anything
         // resolves through the table.
@@ -1167,6 +1403,9 @@ impl Sealer {
         let delta = self.overlay.dirty_since(st.sealed_gen);
         let watermark = delta.watermark;
         if delta.is_empty() && !self.overlay.has_redirects() {
+            if let Some(i) = confirmed_through {
+                st.recent_seals.drain(..=i);
+            }
             st.sealed_gen = watermark;
             let cleared = clear.then(|| self.clear_overlay(&mut st)).transpose()?;
             return Ok(SealOutcome::Clean { cleared });
@@ -1223,6 +1462,12 @@ impl Sealer {
             // until TTL if the push fails (the retry routes through the plain-deletes arm and
             // never re-lists these).
             (self.invalidate)(self.overlay.invals_for(&resolved.tombstoned));
+        }
+        // The pending delta has now consumed any resurrection guards it needed. Confirmed
+        // sets can be retired without losing a raced delete; materialized tombstones remain
+        // ordinary whiteout-backed deletes even if the subsequent push must retry.
+        if let Some(i) = confirmed_through {
+            st.recent_seals.drain(..=i);
         }
         // Pending directory renames seal as by-oid references: every file the destination
         // serves from the lower commits by blob oid (nothing uploads), alongside the source
@@ -1452,31 +1697,36 @@ struct ResolvedSeal {
     tombstoned: Vec<String>,
 }
 
-/// Resolve an event delta into upload-ready push files. The dirty index's kinds are routing
-/// hints; the on-disk overlay is the authority — a path is an upsert if the upper serves it,
-/// a delete if a whiteout covers it, and skipped when it is a bare directory or ignored.
-///
-/// The subtle arm is the tombstone: a path sealed by a recent commit, then deleted before the
-/// lower advanced to that commit. The unlink saw no lower presence, so no whiteout was written
-/// — once the lower catches up the path would silently resurrect. Recognize it by membership
-/// in the recent seals, write the whiteout the unlink would have, and publish the delete.
-///
-/// Runs on the blocking pool: the ignore rules read `.gitignore` files through the mountpoint,
-/// which this very daemon serves.
+/// Side-effect-free path classification shared by `dirty` inspection and seal materialization.
 #[cfg(unix)]
-fn resolve_seal(
+struct ResolvedDirtyPaths {
+    upserts: super::OverlayUpserts,
+    deletes: Vec<String>,
+    /// Deletes that need a resurrection whiteout when a seal actually runs.
+    tombstones: Vec<String>,
+}
+
+/// Resolve an event delta into the paths a seal would publish. The dirty index's kinds are
+/// routing hints; the on-disk overlay is the authority — a path is an upsert if upper serves
+/// it, a delete if a whiteout covers it, and skipped when it is bare, ignored, or was born and
+/// deleted locally between seals.
+///
+/// This function is deliberately pure. A vanished recently-sealed path is returned in both
+/// `deletes` and `tombstones`; only `resolve_seal` materializes its whiteout. That lets the
+/// `dirty` control op use the exact same classification without changing filesystem state.
+#[cfg(unix)]
+fn resolve_dirty_paths(
     state_dir: &Path,
     mount_root: &Path,
     delta: &super::overlay::DirtyDelta,
     recently_sealed: &std::collections::HashSet<String>,
-    chunk_cache: &std::collections::HashMap<String, ChunkList>,
-) -> crate::error::Result<ResolvedSeal> {
+) -> crate::error::Result<ResolvedDirtyPaths> {
     let mut ignore = super::SnapshotIgnore::new(mount_root);
     let upper = state_dir.join("upper");
     let wh = state_dir.join("wh");
     let mut upserts: super::OverlayUpserts = Vec::new();
     let mut deletes: Vec<String> = Vec::new();
-    let mut tombstoned: Vec<String> = Vec::new();
+    let mut tombstones: Vec<String> = Vec::new();
     let mut vanished: Vec<String> = Vec::new();
 
     for (path, _) in &delta.upserts {
@@ -1488,10 +1738,8 @@ fn resolve_seal(
             continue;
         };
         if meta.is_dir() && !meta.file_type().is_symlink() {
-            // A directory upsert names a subtree (a directory rename lands one alongside its
-            // per-child events; future bulk ops may not): publish its files so nothing under
-            // it can be missed. The sort+dedup below collapses overlap with child events.
-            // Empty directories still publish nothing — git has no empty trees.
+            // A directory event names a subtree. Empty directories still publish nothing —
+            // git has no empty trees — and sort+dedup collapses child-event overlap.
             collect_dir_upserts(&upper, path, &mut ignore, &mut upserts)?;
             continue;
         }
@@ -1511,9 +1759,8 @@ fn resolve_seal(
         if whited_out_on_disk(&wh, path) {
             deletes.push(path.clone());
         } else if recently_sealed.contains(path) {
-            super::write_whiteout(&wh, path)?;
             deletes.push(path.clone());
-            tombstoned.push(path.clone());
+            tombstones.push(path.clone());
         }
         // Neither: born and died locally between seals — nothing was ever published.
     }
@@ -1521,6 +1768,43 @@ fn resolve_seal(
     upserts.dedup_by(|a, b| a.0 == b.0);
     deletes.sort();
     deletes.dedup();
+    tombstones.sort();
+    tombstones.dedup();
+    Ok(ResolvedDirtyPaths {
+        upserts,
+        deletes,
+        tombstones,
+    })
+}
+
+/// Resolve an event delta into upload-ready push files. The dirty index's kinds are routing
+/// hints; the on-disk overlay is the authority — a path is an upsert if the upper serves it,
+/// a delete if a whiteout covers it, and skipped when it is a bare directory or ignored.
+///
+/// The subtle arm is the tombstone: a path sealed by a recent commit, then deleted before the
+/// lower advanced to that commit. The unlink saw no lower presence, so no whiteout was written
+/// — once the lower catches up the path would silently resurrect. Recognize it by membership
+/// in the recent seals, write the whiteout the unlink would have, and publish the delete.
+///
+/// Runs on the blocking pool: the ignore rules read `.gitignore` files through the mountpoint,
+/// which this very daemon serves.
+#[cfg(unix)]
+fn resolve_seal(
+    state_dir: &Path,
+    mount_root: &Path,
+    delta: &super::overlay::DirtyDelta,
+    recently_sealed: &std::collections::HashSet<String>,
+    chunk_cache: &std::collections::HashMap<String, ChunkList>,
+) -> crate::error::Result<ResolvedSeal> {
+    let wh = state_dir.join("wh");
+    let ResolvedDirtyPaths {
+        upserts,
+        deletes,
+        tombstones: tombstoned,
+    } = resolve_dirty_paths(state_dir, mount_root, delta, recently_sealed)?;
+    for path in &tombstoned {
+        super::write_whiteout(&wh, path)?;
+    }
     let mut files = super::overlay_push_files(&upserts, &deletes)?;
 
     // Append fast path: a file with a cached chunk list from its previous seal, whose writes
@@ -2016,6 +2300,79 @@ mod tests {
         assert!(
             state.path().join("wh/sealed-then-deleted.txt").is_file(),
             "the whiteout the unlink would have written"
+        );
+    }
+
+    #[test]
+    fn dirty_inspection_reports_raced_delete_without_materializing_whiteout() {
+        let state = state_with(&[], &[]);
+        let mount = tempfile::tempdir().unwrap();
+        let recently: std::collections::HashSet<String> = ["sealed-then-deleted.txt".to_string()]
+            .into_iter()
+            .collect();
+
+        let resolved = resolve_dirty_paths(
+            state.path(),
+            mount.path(),
+            &delta(&[], &["sealed-then-deleted.txt", "never-sealed.txt"]),
+            &recently,
+        )
+        .unwrap();
+
+        assert_eq!(resolved.deletes, vec!["sealed-then-deleted.txt"]);
+        assert_eq!(resolved.tombstones, vec!["sealed-then-deleted.txt"]);
+        assert!(
+            !state.path().join("wh/sealed-then-deleted.txt").exists(),
+            "status inspection must not mutate the overlay"
+        );
+    }
+
+    #[test]
+    fn dirty_reply_requires_every_wire_field() {
+        let valid = serde_json::json!({
+            "dirty": [{"path": "file.txt", "kind": "M"}],
+            "lower_commit": "cafe",
+            "watermark": 7,
+        });
+        assert!(serde_json::from_value::<DirtyReply>(valid).is_ok());
+        assert!(
+            serde_json::from_value::<DirtyReply>(serde_json::json!({
+                "dirty": [],
+                "lower_commit": "cafe",
+            }))
+            .is_err(),
+            "a missing watermark must not decode as a clean workspace"
+        );
+        assert!(
+            serde_json::from_value::<DirtyReply>(serde_json::json!({
+                "dirty": [],
+                "watermark": 7,
+            }))
+            .is_err(),
+            "a missing lower commit must not decode as a clean workspace"
+        );
+    }
+
+    #[test]
+    fn control_connect_errors_only_call_absence_not_running() {
+        let sock = Path::new("/tmp/control.sock");
+        for kind in [
+            std::io::ErrorKind::NotFound,
+            std::io::ErrorKind::ConnectionRefused,
+        ] {
+            assert!(
+                control_connect_error(sock, std::io::Error::from(kind))
+                    .to_string()
+                    .starts_with("mount daemon is not running (")
+            );
+        }
+        assert!(
+            control_connect_error(
+                sock,
+                std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+            )
+            .to_string()
+            .starts_with("could not connect to mount daemon (")
         );
     }
 


### PR DESCRIPTION
## Summary

- add a typed dirty daemon control op backed by the same dirty watermark and path classification used by seal
- make fs status and promote consume that authoritative view, so retained sealed upper files no longer appear as unsealed changes
- use a visibly approximate raw-overlay fallback only when the daemon socket is absent/refused; live old, busy, or malformed daemons fail closed
- serialize restore clear/reindex bookkeeping with seal inspection and preserve raced-delete resurrection guards until pending dirt is resolved

## Scope

This is Phase 1 only. It does not add the persisted sealed index, retained/ignored accounting, overlay trimming, or sync changes. After a daemon restart, the current in-memory design can still conservatively re-report retained upper files until the next seal; persistence is Phase 2.

## Validation

- cargo fmt --all -- --check
- just test-rust
- just build-cli-full --tests
- mount-enabled tl test harness: 266 passed, 4 ignored
- focused coverage for retained upper content, daemon-down fallback, live-old-daemon fail-closed behavior, strict wire parsing, rename deduplication, and side-effect-free raced-delete inspection

Workspace-wide Clippy remains blocked by existing warnings in untouched cloud-sdk/CLI files; the changed mount code introduced no additional Clippy diagnostics.

## Follow-up verification

Before merge, run the live mounted-workspace sequence with the built Linux CLI: write -> status M -> snapshot -> status clean while upper remains -> touch -> status M.