### PR TITLE
tl fs / tl git split: filesystems are the fs surface, mounts join git

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1,10 +1,15 @@
-//! `tl fs` — versioned filesystem workspaces on artifact storage, mounted over FUSE.
+//! `tl fs` — filesystems on artifact storage: create, mount, save, restore.
 //!
-//! Product model (artifact_storage issue #24): the *workspace* is the unit `tl fs` manages —
-//! `mount` creates or attaches one, `ls` lists them, `rm` deletes them. A *file system* is the
-//! artifact-storage repo backing them (managed with `tl git`); a mounted workspace (private
-//! leased ref) is served by a FUSE daemon — reads stream lazily from the server through the
-//! vendored `gsvc-mount` core's immutable caches, writes land in a local overlay.
+//! Product model (the fs/git split): the *filesystem* is the unit `tl fs` manages — `create`
+//! makes one (a `kind=filesystem` repo, born with a genesis empty save), `ls` lists them,
+//! `rm` deletes them, `mount` attaches one, `push` uploads a folder into one. The vocabulary
+//! is drives and saves: every mount is a publish-on-save session (shared-rw onto the default
+//! branch, autosave on), sessions survive crashes and auto-resume on remount, and the words
+//! branch/commit/workspace never surface. `tl git mount` is the branch-vocabulary sibling on
+//! the same engine (explicit checkpointing, promote/sync verbs, publish only with --publish);
+//! both are served by the same workspace machinery below and the same FUSE daemon — reads
+//! stream lazily from the server through the vendored `gsvc-mount` core's immutable caches,
+//! writes land in a local overlay.
 //! **The daemon's sealer owns the definition of dirty**: the overlay's dirty index resolves
 //! into incremental snapshot commits on the workspace ref (auto-commit ticks it; `tl fs
 //! snapshot` runs one cycle through the `seal` control op), and the mount's lower layer
@@ -455,6 +460,466 @@ pub async fn rm(ctx: &CliContext, workspace_id: &str) -> Result<()> {
         short_id(&ws.id)
     );
     Ok(())
+}
+
+// ---------------------------------------------------------------------------------------------
+// The filesystem product surface: create / ls / rm / mount / push / history. A filesystem is a
+// `kind=filesystem` repo; the vocabulary here is drives and saves — never branches, commits, or
+// workspaces (sessions at most). `tl git mount` is the branch-vocabulary sibling on the same
+// engine.
+// ---------------------------------------------------------------------------------------------
+
+/// How often an fs-surface mount autosaves when the user says nothing. A drive doesn't lose
+/// your work; `tl fs snapshot -m` remains the named save point.
+const FS_AUTOSAVE_DEFAULT_SECS: u64 = 30;
+
+/// `tl fs mount` options (the fs surface's defaults live in `mount_filesystem`, not here).
+pub struct FsMountOpts {
+    pub mode: Option<WritePolicy>,
+    pub legacy_shared_rw: bool,
+    pub autosave_secs: Option<u64>,
+    pub legacy_auto_commit_interval_secs: Option<u64>,
+    pub foreground: bool,
+    pub trace_ops: bool,
+    pub log_level: String,
+}
+
+/// `tl fs create <name>` — a new empty filesystem. Born with a genesis "empty" save
+/// server-side, so it mounts immediately.
+pub async fn create_filesystem(ctx: &CliContext, name: &str, output_json: bool) -> Result<()> {
+    let project_id = crate::commands::git::project_id(ctx)?;
+    let client = crate::commands::git::artifact_storage_client(ctx)?;
+    client
+        .create_repo_of_kind(&project_id, name, None, Some("filesystem"))
+        .await
+        .map_err(crate::commands::git::map_sdk_error)?;
+    if output_json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({ "filesystem": name }))?
+        );
+        return Ok(());
+    }
+    println!("Created filesystem {name}.");
+    println!("  mount it:        tl fs mount {name} <path>");
+    println!("  or push a folder: tl fs push <dir> {name}");
+    Ok(())
+}
+
+/// `tl fs ls` — the filesystems of this project, with where each is attached on this machine.
+pub async fn ls_filesystems(ctx: &CliContext, output_json: bool) -> Result<()> {
+    let project_id = crate::commands::git::project_id(ctx)?;
+    let client = crate::commands::git::artifact_storage_client(ctx)?;
+    let listing = client
+        .list_repos_of_kind(&project_id, Some("filesystem"))
+        .await
+        .map_err(crate::commands::git::map_sdk_error)?
+        .into_inner();
+    // Local attachments: kernel mounts and plain-directory bindings, keyed by backing repo.
+    let mounts = live_mounts();
+    let bound = plaindir::bound_binding_repos();
+    let attached = |fs: &str| -> Vec<String> {
+        let mut at: Vec<String> = mounts
+            .iter()
+            .filter(|(_, s)| s.repo == fs)
+            .map(|(m, _)| m.clone())
+            .collect();
+        at.extend(
+            bound
+                .iter()
+                .filter(|(repo, _)| repo == fs)
+                .map(|(_, root)| format!("{root} (bound)")),
+        );
+        at
+    };
+    if output_json {
+        let out: Vec<serde_json::Value> = listing
+            .repos
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "name": r.name,
+                    "status": r.status,
+                    "attached_at": attached(&r.name),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+    if listing.repos.is_empty() {
+        println!("No filesystems. Create one with: tl fs create <name>");
+        return Ok(());
+    }
+    let mut table = new_table(&["Filesystem", "Status", "Attached"]);
+    for r in &listing.repos {
+        let at = attached(&r.name);
+        table.add_row(vec![
+            Cell::new(&r.name),
+            Cell::new(&r.status),
+            Cell::new(if at.is_empty() {
+                "-".to_string()
+            } else {
+                at.join(", ")
+            }),
+        ]);
+    }
+    println!("{table}");
+    println!("Sessions of one filesystem: tl fs ls <filesystem>");
+    Ok(())
+}
+
+/// `tl fs rm <name>` — delete a filesystem and everything in it. A workspace/session id still
+/// works (deprecated) so existing scripts survive one release.
+pub async fn rm_filesystem(ctx: &CliContext, name: &str, force: bool) -> Result<()> {
+    let project_id = crate::commands::git::project_id(ctx)?;
+    let client = crate::commands::git::artifact_storage_client(ctx)?;
+    let listing = client
+        .list_repos(&project_id)
+        .await
+        .map_err(crate::commands::git::map_sdk_error)?
+        .into_inner();
+    let Some(repo) = listing.repos.iter().find(|r| r.name == name) else {
+        // Not a filesystem name: the pre-split `tl fs rm <workspace-id>` form. Keep it working
+        // behind a deprecation warning; sessions are otherwise managed via unmount --delete.
+        eprintln!(
+            "{} `tl fs rm <session-id>` is deprecated; `tl fs rm` deletes filesystems now",
+            style("deprecated:").yellow()
+        );
+        return rm(ctx, name).await;
+    };
+    if repo.kind != "filesystem" {
+        return Err(CliError::usage(format!(
+            "{name} is a repository, not a filesystem — delete it with: tl git rm {name}"
+        )));
+    }
+    let session = FsSession::open(ctx, None).await?;
+    let sessions = fleet_workspaces(&session, Some(name), None)
+        .await
+        .map(|rows| rows.len())
+        .unwrap_or(0);
+    if !force {
+        eprint!(
+            "Delete filesystem {name} and all its saves{}? [y/N] ",
+            if sessions > 0 {
+                format!(" ({sessions} session(s) die with it)")
+            } else {
+                String::new()
+            }
+        );
+        use std::io::BufRead;
+        let mut line = String::new();
+        std::io::stdin().lock().read_line(&mut line)?;
+        if !matches!(line.trim(), "y" | "Y" | "yes") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+    client
+        .delete_repo(&project_id, name)
+        .await
+        .map_err(crate::commands::git::map_sdk_error)?;
+    println!("Deleted filesystem {name}.");
+    Ok(())
+}
+
+/// `tl fs push <dir> <name>` — upload a folder into a filesystem as one save, no mount.
+pub async fn push_dir(
+    ctx: &CliContext,
+    dir: &Path,
+    name: &str,
+    message: Option<&str>,
+) -> Result<()> {
+    plaindir::push(ctx, dir, name, message).await
+}
+
+/// `tl fs history` — the save timeline of a filesystem (target: a filesystem name or a
+/// mounted/bound directory; default: the attachment containing the CWD).
+pub async fn history(
+    ctx: &CliContext,
+    target: Option<&str>,
+    limit: usize,
+    output_json: bool,
+) -> Result<()> {
+    // A target that is a known local attachment (or none, meaning the CWD's) names its backing
+    // filesystem; anything else is a filesystem name.
+    let fs_name = match target {
+        Some(t) if !is_registered_mount(Path::new(t)) => t.to_string(),
+        other => {
+            let path = other.map(PathBuf::from);
+            let (_, state_dir) = state_dir_for(&resolve_mount_path(path)?)?;
+            daemon::load_mount_state(&state_dir)?.repo
+        }
+    };
+    let session = FsSession::open(ctx, Some(&fs_name)).await?;
+    let (user, token) = session.creds();
+    let ops = session
+        .client
+        .list_operations_with_credential(&session.project_id, &fs_name, user, token)
+        .await
+        .map_err(|e| match e {
+            tensorlake::error::SdkError::ServerError { status, .. } if status.as_u16() == 403 => {
+                CliError::usage(
+                    "the save history is read from the operation log, which needs project \
+                     admin access on this project"
+                        .to_string(),
+                )
+            }
+            e => e.into(),
+        })?
+        .into_inner();
+    // Saves are the operations that landed content: pushes, publishes (shared-rw
+    // applications), and promotes. Lifecycle noise (create/fork/GC) is not history.
+    let saves: Vec<_> = ops
+        .operations
+        .iter()
+        .filter(|op| matches!(op.kind.as_str(), "push" | "reconcile" | "promote" | "merge"))
+        .take(limit)
+        .collect();
+    if output_json {
+        println!("{}", serde_json::to_string_pretty(&saves)?);
+        return Ok(());
+    }
+    if saves.is_empty() {
+        println!("No saves yet. Mount and `tl fs snapshot`, or `tl fs push <dir> {fs_name}`.");
+        return Ok(());
+    }
+    let mut table = new_table(&["When", "Who", "Via", "Save"]);
+    for op in &saves {
+        table.add_row(vec![
+            Cell::new(age_display(op.at_secs)),
+            Cell::new(if op.actor.is_empty() { "-" } else { &op.actor }),
+            Cell::new(&op.kind),
+            Cell::new(
+                op.refs
+                    .first()
+                    .and_then(|r| r.new.as_deref())
+                    .map(|oid| oid[..12.min(oid.len())].to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+            ),
+        ]);
+    }
+    println!("{table}");
+    Ok(())
+}
+
+/// `tl fs mount <name> <path>` — the filesystem-surface mount: publish-on-save, autosave on,
+/// detached local sessions auto-resume. Legacy forms (`<fs>:<ref>`, workspace ids, the old
+/// flags) keep working behind deprecation warnings for one release.
+pub async fn mount_filesystem(
+    ctx: &CliContext,
+    target: &str,
+    path: &Path,
+    opts: FsMountOpts,
+) -> Result<()> {
+    let deprecated = |what: &str, instead: &str| {
+        eprintln!("{} {what}; {instead}", style("deprecated:").yellow());
+    };
+    let mode = match opts.mode {
+        Some(m) => m,
+        None => WritePolicy::Auto,
+    };
+    // Legacy forms take the pre-split path unchanged: repo:ref targets and the old flags
+    // belong to `tl git mount` now.
+    let legacy_autosave = opts.legacy_auto_commit_interval_secs;
+    if legacy_autosave.is_some() {
+        deprecated(
+            "--auto-commit-interval-secs is now --autosave-secs",
+            "autosave is on by default for filesystem mounts",
+        );
+    }
+    if target.contains(':') || opts.legacy_shared_rw {
+        deprecated(
+            "`tl fs mount <repo>:<ref>` / --shared-rw mount repositories",
+            "use `tl git mount` for branch-addressed mounts",
+        );
+        let shared_target = opts.legacy_shared_rw.then(|| {
+            target
+                .split_once(':')
+                .map(|(_, base)| base.to_string())
+                .unwrap_or_default()
+        });
+        if opts.legacy_shared_rw && shared_target.as_deref() == Some("") {
+            return Err(CliError::usage(
+                "--shared-rw needs the branch to publish to: tl fs mount <file-system>:<branch> ...",
+            ));
+        }
+        return mount(
+            ctx,
+            target,
+            path,
+            mode,
+            shared_target,
+            legacy_autosave,
+            opts.foreground,
+            opts.trace_ops,
+            &opts.log_level,
+        )
+        .await;
+    }
+    // One listing answers everything the fs surface needs before mounting: does the target
+    // exist, what kind is it, and what is its default branch (the publish target).
+    let session = FsSession::open(ctx, None).await?;
+    let (user, token) = session.creds();
+    let listing = session
+        .client
+        .list_repos_with_credential(&session.project_id, None, user, token)
+        .await?
+        .into_inner();
+    let Some(repo) = listing.repos.iter().find(|r| r.name == target) else {
+        // Not a filesystem: a workspace/session id (auto-resume's explicit ancestor). The
+        // engine attaches it; sessions of repositories keep git-surface semantics.
+        return mount(
+            ctx,
+            target,
+            path,
+            mode,
+            None,
+            legacy_autosave,
+            opts.foreground,
+            opts.trace_ops,
+            &opts.log_level,
+        )
+        .await;
+    };
+    if repo.kind != "filesystem" {
+        deprecated(
+            &format!("{target} is a repository, not a filesystem"),
+            "mount it with `tl git mount` (this fallback will be removed)",
+        );
+        return mount(
+            ctx,
+            target,
+            path,
+            mode,
+            None,
+            legacy_autosave,
+            opts.foreground,
+            opts.trace_ops,
+            &opts.log_level,
+        )
+        .await;
+    }
+    // Auto-resume: a detached local session of this filesystem (mount state present, daemon
+    // dead) picks up where it left off — "run the same command again" is the crash recovery.
+    let resume = (mode != WritePolicy::Ro)
+        .then(|| detached_local_session(&repo.full_name, &repo.name))
+        .flatten();
+    let autosave = match opts.autosave_secs.or(legacy_autosave) {
+        Some(0) => None,
+        Some(secs) => Some(secs),
+        None => Some(FS_AUTOSAVE_DEFAULT_SECS),
+    };
+    match resume {
+        Some(workspace_id) => {
+            println!(
+                "Resuming detached session {} of filesystem {target}.",
+                short_id(&workspace_id)
+            );
+            mount(
+                ctx,
+                &workspace_id,
+                path,
+                mode,
+                None,
+                autosave,
+                opts.foreground,
+                opts.trace_ops,
+                &opts.log_level,
+            )
+            .await
+        }
+        None => {
+            // A fresh session publishes every save to the filesystem's current state. The
+            // shared-rw target is the default branch, which the genesis commit guarantees
+            // exists. Read-only mounts follow the branch instead.
+            let (target_spec, shared_target) = if mode == WritePolicy::Ro {
+                (format!("{target}:{}", repo.default_branch), None)
+            } else {
+                (target.to_string(), Some(repo.default_branch.clone()))
+            };
+            mount(
+                ctx,
+                &target_spec,
+                path,
+                mode,
+                shared_target,
+                autosave,
+                opts.foreground,
+                opts.trace_ops,
+                &opts.log_level,
+            )
+            .await
+        }
+    }
+}
+
+/// A detached local session of `repo`: registered mount state on this machine whose daemon is
+/// no longer alive. Newest state wins when several are detached.
+fn detached_local_session(_full_name: &str, repo: &str) -> Option<String> {
+    let mut candidates: Vec<(std::time::SystemTime, String)> = registry_load()
+        .iter()
+        .filter_map(|(_, v)| {
+            let state_dir = PathBuf::from(v.as_str()?);
+            let state = daemon::load_mount_state(&state_dir).ok()?;
+            if state.repo != repo || state.read_only() {
+                return None;
+            }
+            if daemon::daemon_pid(&state_dir).is_some_and(daemon_alive) {
+                return None;
+            }
+            let modified = std::fs::metadata(&state_dir)
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            Some((modified, state.workspace_id))
+        })
+        .collect();
+    candidates.sort_by_key(|(modified, _)| std::cmp::Reverse(*modified));
+    candidates.into_iter().next().map(|(_, id)| id)
+}
+
+/// `tl git mount <repo>[:<ref>]` — the repository-surface mount: explicit checkpointing, no
+/// autosave, publish only with --publish, --workspace reattaches an existing workspace.
+#[allow(clippy::too_many_arguments)]
+pub async fn mount_repo(
+    ctx: &CliContext,
+    target: &str,
+    workspace: Option<&str>,
+    path: &Path,
+    mode: WritePolicy,
+    publish: bool,
+    auto_snapshot_secs: Option<u64>,
+    foreground: bool,
+    trace_ops: bool,
+    log_level: &str,
+) -> Result<()> {
+    if publish && !target.contains(':') {
+        return Err(CliError::usage(
+            "--publish needs the branch to land on: tl git mount <repo>:<branch> ...",
+        ));
+    }
+    let shared_target = publish.then(|| {
+        target
+            .split_once(':')
+            .map(|(_, base)| base.to_string())
+            .expect("guarded above")
+    });
+    let target = match workspace {
+        Some(id) => id,
+        None => target,
+    };
+    mount(
+        ctx,
+        target,
+        path,
+        mode,
+        shared_target,
+        auto_snapshot_secs,
+        foreground,
+        trace_ops,
+        log_level,
+    )
+    .await
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -1693,7 +2158,7 @@ pub async fn mount(
     target: &str,
     path: &Path,
     mode: WritePolicy,
-    shared_rw: bool,
+    shared_target: Option<String>,
     auto_commit_interval_secs: Option<u64>,
     foreground: bool,
     trace_ops: bool,
@@ -1720,19 +2185,14 @@ pub async fn mount(
         Some((name, base)) => (name, Some(base.to_string())),
         None => (target, None),
     };
-    if shared_rw && mode == WritePolicy::Ro {
+    if shared_target.is_some() && mode == WritePolicy::Ro {
         return Err(CliError::usage(
-            "--shared-rw publishes every snapshot; it cannot be combined with --mode ro",
+            "publishing every snapshot cannot be combined with a read-only mount",
         ));
     }
     if auto_commit_interval_secs.is_some() && mode == WritePolicy::Ro {
         return Err(CliError::usage(
-            "--auto-commit-interval-secs seals local writes; a read-only mount has none",
-        ));
-    }
-    if shared_rw && base.is_none() {
-        return Err(CliError::usage(
-            "--shared-rw needs the branch to publish to: tl fs mount <file-system>:<branch> ...",
+            "automatic snapshots seal local writes; a read-only mount has none",
         ));
     }
     // A volume whose daemon died stays attached (on macOS the FSKit extension proxies to the
@@ -1827,7 +2287,7 @@ pub async fn mount(
     }
     let create_req = CreateWorkspaceRequest {
         base: base.clone(),
-        shared_target: shared_rw.then(|| base.clone().expect("guarded above")),
+        shared_target: shared_target.clone(),
         ..Default::default()
     };
     // One create call site for both the first attempt and the post-seed retry, so the two can
@@ -1867,7 +2327,7 @@ pub async fn mount(
             Some(CreateRecovery::BaseUnresolved) => {
                 let file_systems = session
                     .client
-                    .list_repos_with_credential(&session.project_id, user, token)
+                    .list_repos_with_credential(&session.project_id, None, user, token)
                     .await?
                     .into_inner();
                 let Some(fs) = file_systems.repos.iter().find(|r| r.name == name) else {
@@ -1900,10 +2360,10 @@ pub async fn mount(
     // resolves that one serially.
     let (repo, ws, attached, read_only, follow_ref, start_oid) = match resolved {
         Resolved::Attached(repo, ws) => {
-            if shared_rw {
+            if shared_target.is_some() {
                 return Err(CliError::usage(
-                    "--shared-rw is chosen when creating a workspace on a branch: tl fs mount \
-                     <file-system>:<branch> --shared-rw <path>",
+                    "publish-on-snapshot is chosen when the workspace is created; this attach \
+                     resumes an existing workspace, which keeps its original setting",
                 ));
             }
             // Single-writer by default: a workspace attached elsewhere — live mount OR
@@ -1955,12 +2415,8 @@ pub async fn mount(
             // reconciled branch rather than staying pinned to its own snapshots. A read-only
             // view follows the named branch (or the repo HEAD's branch) so new commits appear —
             // except a fixed commit base, which is a pinned view that never advances.
-            let follow_ref = if shared_rw {
-                Some(format!(
-                    "refs/heads/{}",
-                    base.clone()
-                        .expect("shared-rw requires <file-system>:<branch>")
-                ))
+            let follow_ref = if let Some(target) = &shared_target {
+                Some(format!("refs/heads/{target}"))
             } else if read_only {
                 match &base {
                     Some(b) if b.len() == 40 && b.bytes().all(|c| c.is_ascii_hexdigit()) => {
@@ -2089,7 +2545,7 @@ pub async fn mount(
                         ws.base_ref.as_deref().unwrap_or(&ws.base[..12]),
                         mountpoint,
                         short_id(&ws.id),
-                        if shared_rw {
+                        if shared_target.is_some() {
                             ", snapshots auto-publish to the branch"
                         } else if read_only {
                             ", read-only, follows the branch"
@@ -2264,9 +2720,7 @@ pub async fn unmount(
     // the normal post-snapshot state and must not gate). Anything TRULY losable — unsealed
     // changes, ignored files — needs the explicit flag. Checked before the shutdown so a
     // refusal leaves the mount fully intact.
-    if !discard_local
-        && let Some(losable) = overlay_losable_state(&state_dir, &mountpoint).await?
-    {
+    if !discard_local && let Some(losable) = overlay_losable_state(&state_dir, &mountpoint).await? {
         return Err(CliError::usage(format!(
             "the mount at {mountpoint} holds {losable}; unmounting would destroy that. Seal \
              unsealed changes first, then re-run:\n  tl fs snapshot {mountpoint}\n  tl fs \
@@ -2730,7 +3184,15 @@ async fn overlay_losable_state(state_dir: &Path, mountpoint: &str) -> Result<Opt
                 if check_ignored(ignore, &rel, true)? {
                     *ignored += strict_count_files(&abs)?;
                 } else {
-                    classify_upper(root, &abs, ignore, sealed, dirty_upserts, ignored, uncovered)?;
+                    classify_upper(
+                        root,
+                        &abs,
+                        ignore,
+                        sealed,
+                        dirty_upserts,
+                        ignored,
+                        uncovered,
+                    )?;
                 }
                 continue;
             }
@@ -2905,8 +3367,18 @@ fn overlay_fingerprint(state_dir: &Path) -> Result<u64> {
         Ok(())
     }
     let mut entries = Vec::new();
-    collect(&state_dir.join("upper"), &state_dir.join("upper"), "u/", &mut entries)?;
-    collect(&state_dir.join("wh"), &state_dir.join("wh"), "w/", &mut entries)?;
+    collect(
+        &state_dir.join("upper"),
+        &state_dir.join("upper"),
+        "u/",
+        &mut entries,
+    )?;
+    collect(
+        &state_dir.join("wh"),
+        &state_dir.join("wh"),
+        "w/",
+        &mut entries,
+    )?;
     entries.sort();
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     for (rel, len, mtime) in &entries {
@@ -3740,9 +4212,7 @@ pub async fn restore(
     // Restore's point of no return drops the ENTIRE overlay. Retained sealed content drops
     // loss-free (the restore refills the view it wants anyway); unsealed changes and ignored
     // files are truly losable and need the explicit flag.
-    if !discard_local
-        && let Some(losable) = overlay_losable_state(&state_dir, &mountpoint).await?
-    {
+    if !discard_local && let Some(losable) = overlay_losable_state(&state_dir, &mountpoint).await? {
         return Err(CliError::usage(format!(
             "the workspace holds {losable}; restoring would destroy that. Seal unsealed \
              changes first (`tl fs snapshot {path}`), or drop everything local (ignored \
@@ -4634,7 +5104,9 @@ mod tests {
         index.save(state.path()).unwrap();
         let _ops = fake_daemon_with_replies(
             state.path(),
-            [("dirty".to_string(), clean_dirty_reply())].into_iter().collect(),
+            [("dirty".to_string(), clean_dirty_reply())]
+                .into_iter()
+                .collect(),
         );
 
         let losable = overlay_losable_state(state.path(), &mount.path().to_string_lossy())
@@ -4679,7 +5151,9 @@ mod tests {
         upper_file(state.path(), "junk.tmp", "local only");
         let _ops = fake_daemon_with_replies(
             state.path(),
-            [("dirty".to_string(), clean_dirty_reply())].into_iter().collect(),
+            [("dirty".to_string(), clean_dirty_reply())]
+                .into_iter()
+                .collect(),
         );
         let losable = overlay_losable_state(state.path(), &mount.path().to_string_lossy())
             .await
@@ -4698,7 +5172,9 @@ mod tests {
         upper_file(state.path(), "mystery.txt", "whose is this");
         let _ops = fake_daemon_with_replies(
             state.path(),
-            [("dirty".to_string(), clean_dirty_reply())].into_iter().collect(),
+            [("dirty".to_string(), clean_dirty_reply())]
+                .into_iter()
+                .collect(),
         );
         let losable = overlay_losable_state(state.path(), &mount.path().to_string_lossy())
             .await
@@ -4782,7 +5258,9 @@ mod tests {
         std::fs::write(state.path().join("upper/kept.txt"), "newer, unsealed bytes").unwrap();
         let _ops = fake_daemon_with_replies(
             state.path(),
-            [("dirty".to_string(), clean_dirty_reply())].into_iter().collect(),
+            [("dirty".to_string(), clean_dirty_reply())]
+                .into_iter()
+                .collect(),
         );
         let losable = overlay_losable_state(state.path(), &mount.path().to_string_lossy())
             .await
@@ -4811,7 +5289,9 @@ mod tests {
         std::fs::write(mount.path().join(".gitignore"), "*.log\n").unwrap();
         let _ops = fake_daemon_with_replies(
             state.path(),
-            [("dirty".to_string(), clean_dirty_reply())].into_iter().collect(),
+            [("dirty".to_string(), clean_dirty_reply())]
+                .into_iter()
+                .collect(),
         );
         assert_eq!(
             overlay_losable_state(state.path(), &mount.path().to_string_lossy())
@@ -4836,7 +5316,9 @@ mod tests {
         std::fs::write(&wh, b"").unwrap();
         let _ops = fake_daemon_with_replies(
             state.path(),
-            [("dirty".to_string(), clean_dirty_reply())].into_iter().collect(),
+            [("dirty".to_string(), clean_dirty_reply())]
+                .into_iter()
+                .collect(),
         );
         let losable = overlay_losable_state(state.path(), &mount.path().to_string_lossy())
             .await

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -382,14 +382,14 @@ pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) 
         return Ok(());
     }
     if rows.is_empty() {
-        println!("No workspaces. Create and mount one with: tl fs mount <file-system> <path>");
+        println!("No sessions. Mount the filesystem to start one: tl fs mount <filesystem> <path>");
         return Ok(());
     }
     let mut table = new_table(&[
-        "Workspace",
-        "File system",
+        "Session",
+        "Filesystem",
         "Base",
-        "Snapshots",
+        "Saves",
         "Mode",
         "Mounted",
         "Age",
@@ -419,46 +419,7 @@ pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) 
         ]);
     }
     println!("{table}");
-    println!("Mount: tl fs mount <workspace> <path> — delete: tl fs rm <workspace>");
-    Ok(())
-}
-
-/// `tl fs rm <workspace-id>` — the one way a workspace dies. Its snapshots become unreachable
-/// (promoted work is unaffected).
-pub async fn rm(ctx: &CliContext, workspace_id: &str) -> Result<()> {
-    let session = FsSession::open(ctx, None).await?;
-    let Some((file_system, ws)) = resolve_workspace(&session, workspace_id).await? else {
-        return Err(CliError::usage(format!(
-            "no workspace matches {workspace_id:?} (see: tl fs ls)"
-        )));
-    };
-    if let Some(mountpoint) = live_mount_of(&ws.id) {
-        return Err(CliError::usage(format!(
-            "workspace {} is mounted at {mountpoint}; unmount and delete in one step: tl fs \
-             unmount {mountpoint} --delete",
-            short_id(&ws.id)
-        )));
-    }
-    // A plain-directory binding references the workspace exactly like a live mount does —
-    // deleting it out from under the binding would strand the local index (and every future
-    // snapshot) against a dead workspace. Fail-closed lookup: a corrupt binding.json aborts
-    // the delete instead of being skipped as if unbound.
-    if let Some(bound_at) = plaindir::binding_using_workspace(&ws.id)? {
-        return Err(CliError::usage(format!(
-            "workspace {} is bound to {bound_at}; unbind first (tl fs unbind {bound_at}), \
-             then delete",
-            short_id(&ws.id)
-        )));
-    }
-    let (user, token) = session.creds();
-    session
-        .client
-        .delete_workspace(&session.project_id, &file_system, user, token, &ws.id)
-        .await?;
-    println!(
-        "Deleted workspace {} (file system {file_system}).",
-        short_id(&ws.id)
-    );
+    println!("Remounting the filesystem resumes its newest detached session on this machine.");
     Ok(())
 }
 
@@ -472,17 +433,6 @@ pub async fn rm(ctx: &CliContext, workspace_id: &str) -> Result<()> {
 /// How often an fs-surface mount autosaves when the user says nothing. A drive doesn't lose
 /// your work; `tl fs snapshot -m` remains the named save point.
 const FS_AUTOSAVE_DEFAULT_SECS: u64 = 30;
-
-/// `tl fs mount` options (the fs surface's defaults live in `mount_filesystem`, not here).
-pub struct FsMountOpts {
-    pub mode: Option<WritePolicy>,
-    pub legacy_shared_rw: bool,
-    pub autosave_secs: Option<u64>,
-    pub legacy_auto_commit_interval_secs: Option<u64>,
-    pub foreground: bool,
-    pub trace_ops: bool,
-    pub log_level: String,
-}
 
 /// `tl fs create <name>` — a new empty filesystem. Born with a genesis "empty" save
 /// server-side, so it mounts immediately.
@@ -580,13 +530,9 @@ pub async fn rm_filesystem(ctx: &CliContext, name: &str, force: bool) -> Result<
         .map_err(crate::commands::git::map_sdk_error)?
         .into_inner();
     let Some(repo) = listing.repos.iter().find(|r| r.name == name) else {
-        // Not a filesystem name: the pre-split `tl fs rm <workspace-id>` form. Keep it working
-        // behind a deprecation warning; sessions are otherwise managed via unmount --delete.
-        eprintln!(
-            "{} `tl fs rm <session-id>` is deprecated; `tl fs rm` deletes filesystems now",
-            style("deprecated:").yellow()
-        );
-        return rm(ctx, name).await;
+        return Err(CliError::usage(format!(
+            "no filesystem named {name:?} (see: tl fs ls)"
+        )));
     };
     if repo.kind != "filesystem" {
         return Err(CliError::usage(format!(
@@ -704,59 +650,24 @@ pub async fn history(
 }
 
 /// `tl fs mount <name> <path>` — the filesystem-surface mount: publish-on-save, autosave on,
-/// detached local sessions auto-resume. Legacy forms (`<fs>:<ref>`, workspace ids, the old
-/// flags) keep working behind deprecation warnings for one release.
+/// detached local sessions auto-resume. Branch-addressed and repository mounts live on
+/// `tl git mount`.
 pub async fn mount_filesystem(
     ctx: &CliContext,
     target: &str,
     path: &Path,
-    opts: FsMountOpts,
+    ro: bool,
+    foreground: bool,
+    trace_ops: bool,
+    log_level: &str,
 ) -> Result<()> {
-    let deprecated = |what: &str, instead: &str| {
-        eprintln!("{} {what}; {instead}", style("deprecated:").yellow());
-    };
-    let mode = match opts.mode {
-        Some(m) => m,
-        None => WritePolicy::Auto,
-    };
-    // Legacy forms take the pre-split path unchanged: repo:ref targets and the old flags
-    // belong to `tl git mount` now.
-    let legacy_autosave = opts.legacy_auto_commit_interval_secs;
-    if legacy_autosave.is_some() {
-        deprecated(
-            "--auto-commit-interval-secs is now --autosave-secs",
-            "autosave is on by default for filesystem mounts",
-        );
+    if target.contains(':') {
+        return Err(CliError::usage(
+            "a filesystem mounts as a whole; branch-addressed mounts are `tl git mount \
+             <repo>:<ref> <path>`",
+        ));
     }
-    if target.contains(':') || opts.legacy_shared_rw {
-        deprecated(
-            "`tl fs mount <repo>:<ref>` / --shared-rw mount repositories",
-            "use `tl git mount` for branch-addressed mounts",
-        );
-        let shared_target = opts.legacy_shared_rw.then(|| {
-            target
-                .split_once(':')
-                .map(|(_, base)| base.to_string())
-                .unwrap_or_default()
-        });
-        if opts.legacy_shared_rw && shared_target.as_deref() == Some("") {
-            return Err(CliError::usage(
-                "--shared-rw needs the branch to publish to: tl fs mount <file-system>:<branch> ...",
-            ));
-        }
-        return mount(
-            ctx,
-            target,
-            path,
-            mode,
-            shared_target,
-            legacy_autosave,
-            opts.foreground,
-            opts.trace_ops,
-            &opts.log_level,
-        )
-        .await;
-    }
+    let mode = if ro { WritePolicy::Ro } else { WritePolicy::Rw };
     // One listing answers everything the fs surface needs before mounting: does the target
     // exist, what kind is it, and what is its default branch (the publish target).
     let session = FsSession::open(ctx, None).await?;
@@ -767,49 +678,21 @@ pub async fn mount_filesystem(
         .await?
         .into_inner();
     let Some(repo) = listing.repos.iter().find(|r| r.name == target) else {
-        // Not a filesystem: a workspace/session id (auto-resume's explicit ancestor). The
-        // engine attaches it; sessions of repositories keep git-surface semantics.
-        return mount(
-            ctx,
-            target,
-            path,
-            mode,
-            None,
-            legacy_autosave,
-            opts.foreground,
-            opts.trace_ops,
-            &opts.log_level,
-        )
-        .await;
+        return Err(CliError::usage(format!(
+            "no filesystem named {target:?} (see: tl fs ls; create one: tl fs create {target})"
+        )));
     };
     if repo.kind != "filesystem" {
-        deprecated(
-            &format!("{target} is a repository, not a filesystem"),
-            "mount it with `tl git mount` (this fallback will be removed)",
-        );
-        return mount(
-            ctx,
-            target,
-            path,
-            mode,
-            None,
-            legacy_autosave,
-            opts.foreground,
-            opts.trace_ops,
-            &opts.log_level,
-        )
-        .await;
+        return Err(CliError::usage(format!(
+            "{target} is a repository, not a filesystem — mount it with: tl git mount {target} \
+             <path>"
+        )));
     }
     // Auto-resume: a detached local session of this filesystem (mount state present, daemon
     // dead) picks up where it left off — "run the same command again" is the crash recovery.
-    let resume = (mode != WritePolicy::Ro)
-        .then(|| detached_local_session(&repo.full_name, &repo.name))
-        .flatten();
-    let autosave = match opts.autosave_secs.or(legacy_autosave) {
-        Some(0) => None,
-        Some(secs) => Some(secs),
-        None => Some(FS_AUTOSAVE_DEFAULT_SECS),
-    };
+    let resume = (!ro).then(|| detached_local_session(&repo.name)).flatten();
+    // A drive doesn't lose your work: writable filesystem mounts always autosave.
+    let autosave = (!ro).then_some(FS_AUTOSAVE_DEFAULT_SECS);
     match resume {
         Some(workspace_id) => {
             println!(
@@ -823,9 +706,9 @@ pub async fn mount_filesystem(
                 mode,
                 None,
                 autosave,
-                opts.foreground,
-                opts.trace_ops,
-                &opts.log_level,
+                foreground,
+                trace_ops,
+                log_level,
             )
             .await
         }
@@ -833,7 +716,7 @@ pub async fn mount_filesystem(
             // A fresh session publishes every save to the filesystem's current state. The
             // shared-rw target is the default branch, which the genesis commit guarantees
             // exists. Read-only mounts follow the branch instead.
-            let (target_spec, shared_target) = if mode == WritePolicy::Ro {
+            let (target_spec, shared_target) = if ro {
                 (format!("{target}:{}", repo.default_branch), None)
             } else {
                 (target.to_string(), Some(repo.default_branch.clone()))
@@ -845,9 +728,9 @@ pub async fn mount_filesystem(
                 mode,
                 shared_target,
                 autosave,
-                opts.foreground,
-                opts.trace_ops,
-                &opts.log_level,
+                foreground,
+                trace_ops,
+                log_level,
             )
             .await
         }
@@ -856,7 +739,7 @@ pub async fn mount_filesystem(
 
 /// A detached local session of `repo`: registered mount state on this machine whose daemon is
 /// no longer alive. Newest state wins when several are detached.
-fn detached_local_session(_full_name: &str, repo: &str) -> Option<String> {
+fn detached_local_session(repo: &str) -> Option<String> {
     let mut candidates: Vec<(std::time::SystemTime, String)> = registry_load()
         .iter()
         .filter_map(|(_, v)| {
@@ -886,9 +769,8 @@ pub async fn mount_repo(
     target: &str,
     workspace: Option<&str>,
     path: &Path,
-    mode: WritePolicy,
+    ro: bool,
     publish: bool,
-    auto_snapshot_secs: Option<u64>,
     foreground: bool,
     trace_ops: bool,
     log_level: &str,
@@ -898,6 +780,11 @@ pub async fn mount_repo(
             "--publish needs the branch to land on: tl git mount <repo>:<branch> ...",
         ));
     }
+    let mode = if ro {
+        WritePolicy::Ro
+    } else {
+        WritePolicy::Auto
+    };
     let shared_target = publish.then(|| {
         target
             .split_once(':')
@@ -914,7 +801,7 @@ pub async fn mount_repo(
         path,
         mode,
         shared_target,
-        auto_snapshot_secs,
+        None,
         foreground,
         trace_ops,
         log_level,
@@ -1948,7 +1835,7 @@ fn not_a_mount_error(message: String) -> CliError {
 }
 
 /// Whether `path` is a registered mountpoint or plain-directory binding root. Used to
-/// disambiguate optional positional args (`tl fs diff <a> <b>` vs `tl fs diff <path> <a>`) —
+/// disambiguate optional positional args (a path-addressed command's optional PATH) —
 /// a binding here resolves as the command's path, whose dispatch then answers with the
 /// binding-appropriate behavior (or a clear v1 "not supported").
 pub fn is_registered_mount(path: &Path) -> bool {
@@ -2012,38 +1899,7 @@ fn is_path_shaped(value: &Path) -> bool {
         || value.is_dir()
 }
 
-/// `tl fs diff` positionals are ambiguous once the mount path is optional: one leading arg can
-/// be either the mounted directory or the older snapshot. Treat it as the mount when it's a
-/// registered mountpoint; reject it when it's path-shaped but unregistered (a typo or stale
-/// mount, not a snapshot ref); otherwise shift everything right and infer the mount from the
-/// current directory.
-pub fn resolve_diff_args(
-    path: Option<PathBuf>,
-    a: Option<String>,
-    b: Option<String>,
-) -> Result<(PathBuf, Option<String>, Option<String>)> {
-    match path {
-        Some(path) if is_registered_mount(&path) => Ok((path, a, b)),
-        Some(not_a_mount) => {
-            if b.is_some() || is_path_shaped(&not_a_mount) {
-                // Three args, or a path-shaped first arg that isn't registered: surface the
-                // real problem instead of treating the path as a snapshot ref.
-                return Err(not_a_mount_error(format!(
-                    "{} is not a tl fs mount; run `tl fs mount` first",
-                    not_a_mount.display()
-                )));
-            }
-            Ok((
-                mount_containing_cwd()?,
-                Some(not_a_mount.to_string_lossy().into_owned()),
-                a,
-            ))
-        }
-        None => Ok((mount_containing_cwd()?, a, b)),
-    }
-}
-
-/// Guard for `tl fs promote <branch>` / `tl fs restore <version>` with the mount path omitted:
+/// Guard for `tl git promote <branch>` / `tl fs restore <version>` with the mount path omitted:
 /// when the sole positional is itself a mounted directory (or an explicit path), the user
 /// almost certainly forgot the branch/version — without this, promote would publish the CWD
 /// mount onto a branch literally named after the directory.
@@ -2367,8 +2223,8 @@ pub async fn mount(
                 ));
             }
             // Single-writer by default: a workspace attached elsewhere — live mount OR
-            // plain-directory binding (a binding is always a writer) — attaches read-only
-            // unless the user explicitly takes writes with --mode rw.
+            // plain-directory binding (a binding is always a writer) — attaches read-only.
+            // There is no override flag; release the other attachment to take writes.
             // Advisory only (write-policy default): unreadable binding state degrades to
             // "not attached" here — the destructive path (`tl fs rm`) stays fail-closed.
             let attached_at = live_mount_of(&ws.id).or_else(|| {
@@ -2384,8 +2240,8 @@ pub async fn mount(
             };
             match (&attached_at, mode) {
                 (Some(at), WritePolicy::Auto) => eprintln!(
-                    "{} workspace is already attached at {at}; mounting read-only (pass \
-                     --mode rw to mount it writable anyway)",
+                    "{} workspace is already attached at {at}; mounting read-only (unmount \
+                     it there to take writes)",
                     style("note:").yellow(),
                 ),
                 (Some(at), WritePolicy::Rw) => eprintln!(
@@ -2464,8 +2320,8 @@ pub async fn mount(
     // nothing server-side was created on that path, so erroring here leaks nothing.
     if auto_commit_interval_secs.is_some() && read_only {
         return Err(CliError::usage(
-            "--auto-commit-interval-secs needs a writable mount; this workspace is already \
-             mounted elsewhere and attached read-only (pass --mode rw to take writes)",
+            "automatic saves need a writable mount; this workspace is attached elsewhere and \
+             resolved read-only (unmount it there to take writes)",
         ));
     }
 
@@ -4617,65 +4473,6 @@ fn write_whiteout(wh: &Path, rel: &str) -> Result<()> {
     }
     std::fs::write(&marker, b"")?;
     Ok(())
-}
-
-/// `tl fs diff <path>` — overlay changes vs the last snapshot; `tl fs diff <path> <a> <b>` —
-/// server-side tree diff between two commits/refs.
-pub async fn diff(ctx: &CliContext, path: &Path, a: Option<&str>, b: Option<&str>) -> Result<()> {
-    if plaindir::binding_for_lenient(path).is_some() {
-        return Err(CliError::usage(
-            "diff is not supported for plain-directory bindings in v1; `tl fs status` lists \
-             the changed paths",
-        ));
-    }
-    let (mountpoint, state_dir) = state_dir_for(path)?;
-    let state = daemon::load_mount_state(&state_dir)?;
-    match (a, b) {
-        (None, None) => {
-            let changes = local_changes(&state_dir, &mountpoint).await?;
-            for (from, to) in &changes.renames {
-                println!("R {from} -> {to}");
-            }
-            for p in &changes.upserts {
-                println!("M {p}");
-            }
-            for p in changes
-                .deletes
-                .iter()
-                .filter(|p| !changes.renames.iter().any(|(from, _)| &from == p))
-            {
-                println!("D {p}");
-            }
-            if !changes.exact {
-                eprintln!(
-                    "note: the mount daemon did not answer the dirty query; this may include \
-                     files already sealed into a snapshot"
-                );
-            }
-            Ok(())
-        }
-        (Some(a), Some(b)) => {
-            let session = FsSession::open(ctx, Some(&state.repo)).await?;
-            let left = walk_remote_tree(&session, &state.repo, a).await?;
-            let right = walk_remote_tree(&session, &state.repo, b).await?;
-            for (p, entry) in &right {
-                match left.get(p) {
-                    None => println!("A {p}"),
-                    Some(prev) if prev.oid != entry.oid || prev.mode != entry.mode => {
-                        println!("M {p}")
-                    }
-                    Some(_) => {}
-                }
-            }
-            for p in left.keys().filter(|p| !right.contains_key(*p)) {
-                println!("D {p}");
-            }
-            Ok(())
-        }
-        _ => Err(CliError::usage(
-            "diff takes no versions (local vs snapshot) or two (snapshot vs snapshot)",
-        )),
-    }
 }
 
 /// Full recursive listing of `version`: repo path -> entry. Directories are traversed

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -437,12 +437,21 @@ const FS_AUTOSAVE_DEFAULT_SECS: u64 = 30;
 /// `tl fs create <name>` — a new empty filesystem. Born with a genesis "empty" save
 /// server-side, so it mounts immediately.
 pub async fn create_filesystem(ctx: &CliContext, name: &str, output_json: bool) -> Result<()> {
-    let project_id = crate::commands::git::project_id(ctx)?;
-    let client = crate::commands::git::artifact_storage_client(ctx)?;
-    client
-        .create_repo_of_kind(&project_id, name, None, Some("filesystem"))
-        .await
-        .map_err(crate::commands::git::map_sdk_error)?;
+    // FsSession caches the minted credential across invocations; the raw client would mint a
+    // fresh platform token on every call.
+    let session = FsSession::open(ctx, None).await?;
+    let (user, token) = session.creds();
+    session
+        .client
+        .create_repo_with_credential(
+            &session.project_id,
+            name,
+            None,
+            Some(tensorlake::artifact_storage::models::REPO_KIND_FILESYSTEM),
+            user,
+            token,
+        )
+        .await?;
     if output_json {
         println!(
             "{}",
@@ -456,14 +465,40 @@ pub async fn create_filesystem(ctx: &CliContext, name: &str, output_json: bool) 
     Ok(())
 }
 
+/// One kind-stamped listing, resolved to a filesystem by name. `replacement` names the
+/// `tl git` command shown when the name is actually a repository — the one line the two call
+/// sites differ in.
+fn resolve_filesystem<'a>(
+    listing: &'a tensorlake::artifact_storage::models::ListReposResponse,
+    name: &str,
+    replacement: &str,
+) -> Result<&'a tensorlake::artifact_storage::models::Repo> {
+    let Some(repo) = listing.repos.iter().find(|r| r.name == name) else {
+        return Err(CliError::usage(format!(
+            "no filesystem named {name:?} (see: tl fs ls; create one: tl fs create {name})"
+        )));
+    };
+    if !repo.is_filesystem() {
+        return Err(CliError::usage(format!(
+            "{name} is a repository, not a filesystem — use: {replacement}"
+        )));
+    }
+    Ok(repo)
+}
+
 /// `tl fs ls` — the filesystems of this project, with where each is attached on this machine.
 pub async fn ls_filesystems(ctx: &CliContext, output_json: bool) -> Result<()> {
-    let project_id = crate::commands::git::project_id(ctx)?;
-    let client = crate::commands::git::artifact_storage_client(ctx)?;
-    let listing = client
-        .list_repos_of_kind(&project_id, Some("filesystem"))
-        .await
-        .map_err(crate::commands::git::map_sdk_error)?
+    let session = FsSession::open(ctx, None).await?;
+    let (user, token) = session.creds();
+    let listing = session
+        .client
+        .list_repos_with_credential(
+            &session.project_id,
+            Some(tensorlake::artifact_storage::models::REPO_KIND_FILESYSTEM),
+            user,
+            token,
+        )
+        .await?
         .into_inner();
     // Local attachments: kernel mounts and plain-directory bindings, keyed by backing repo.
     let mounts = live_mounts();
@@ -519,52 +554,61 @@ pub async fn ls_filesystems(ctx: &CliContext, output_json: bool) -> Result<()> {
     Ok(())
 }
 
-/// `tl fs rm <name>` — delete a filesystem and everything in it. A workspace/session id still
-/// works (deprecated) so existing scripts survive one release.
+/// `tl fs rm <name>` — delete a filesystem and everything in it. Fail-closed against local
+/// attachments: a live mount or tracked directory of this filesystem on this machine must be
+/// detached first, or the delete would strand a running daemon (or a binding's future saves)
+/// against a dead repo.
 pub async fn rm_filesystem(ctx: &CliContext, name: &str, force: bool) -> Result<()> {
-    let project_id = crate::commands::git::project_id(ctx)?;
-    let client = crate::commands::git::artifact_storage_client(ctx)?;
-    let listing = client
-        .list_repos(&project_id)
-        .await
-        .map_err(crate::commands::git::map_sdk_error)?
+    let session = FsSession::open(ctx, None).await?;
+    let (user, token) = session.creds();
+    let listing = session
+        .client
+        .list_repos_with_credential(&session.project_id, None, user, token)
+        .await?
         .into_inner();
-    let Some(repo) = listing.repos.iter().find(|r| r.name == name) else {
+    resolve_filesystem(&listing, name, &format!("tl git rm {name}"))?;
+    if let Some((mountpoint, _)) = live_mounts().into_iter().find(|(_, s)| s.repo == name) {
         return Err(CliError::usage(format!(
-            "no filesystem named {name:?} (see: tl fs ls)"
-        )));
-    };
-    if repo.kind != "filesystem" {
-        return Err(CliError::usage(format!(
-            "{name} is a repository, not a filesystem — delete it with: tl git rm {name}"
+            "{name} is mounted at {mountpoint}; unmount first: tl fs unmount {mountpoint}"
         )));
     }
-    let session = FsSession::open(ctx, None).await?;
-    let sessions = fleet_workspaces(&session, Some(name), None)
-        .await
-        .map(|rows| rows.len())
-        .unwrap_or(0);
+    if let Some((_, root)) = plaindir::bound_binding_repos()
+        .into_iter()
+        .find(|(repo, _)| repo == name)
+    {
+        return Err(CliError::usage(format!(
+            "{name} is tracking {root}; stop first: tl fs unmount {root}"
+        )));
+    }
     if !force {
-        eprint!(
-            "Delete filesystem {name} and all its saves{}? [y/N] ",
+        // The session count is prompt garnish — skip the round trip entirely under --force
+        // and tolerate its absence.
+        let sessions = fleet_workspaces(&session, Some(name), None)
+            .await
+            .map(|rows| rows.len())
+            .unwrap_or(0);
+        let prompt = format!(
+            "Delete filesystem {name} and all its saves{}?",
             if sessions > 0 {
                 format!(" ({sessions} session(s) die with it)")
             } else {
                 String::new()
             }
         );
-        use std::io::BufRead;
-        let mut line = String::new();
-        std::io::stdin().lock().read_line(&mut line)?;
-        if !matches!(line.trim(), "y" | "Y" | "yes") {
+        let confirmed = dialoguer::Confirm::new()
+            .with_prompt(prompt)
+            .default(false)
+            .interact()
+            .unwrap_or(false);
+        if !confirmed {
             println!("Aborted.");
             return Ok(());
         }
     }
-    client
-        .delete_repo(&project_id, name)
-        .await
-        .map_err(crate::commands::git::map_sdk_error)?;
+    session
+        .client
+        .delete_repo_with_credential(&session.project_id, name, user, token)
+        .await?;
     println!("Deleted filesystem {name}.");
     Ok(())
 }
@@ -580,7 +624,7 @@ pub async fn push_dir(
 }
 
 /// `tl fs history` — the save timeline of a filesystem (target: a filesystem name or a
-/// mounted/bound directory; default: the attachment containing the CWD).
+/// mounted/tracked directory; default: the attachment containing the CWD).
 pub async fn history(
     ctx: &CliContext,
     target: Option<&str>,
@@ -588,13 +632,19 @@ pub async fn history(
     output_json: bool,
 ) -> Result<()> {
     // A target that is a known local attachment (or none, meaning the CWD's) names its backing
-    // filesystem; anything else is a filesystem name.
+    // filesystem; anything else is a filesystem name. Attachments are mounts OR tracked
+    // (pushed) directories — the latter have binding state, not daemon mount state.
     let fs_name = match target {
         Some(t) if !is_registered_mount(Path::new(t)) => t.to_string(),
         other => {
-            let path = other.map(PathBuf::from);
-            let (_, state_dir) = state_dir_for(&resolve_mount_path(path)?)?;
-            daemon::load_mount_state(&state_dir)?.repo
+            let path = resolve_mount_path(other.map(PathBuf::from))?;
+            match plaindir::binding_for_lenient(&path) {
+                Some((_, state_dir)) => plaindir::binding_repo(&state_dir)?,
+                None => {
+                    let (_, state_dir) = state_dir_for(&path)?;
+                    daemon::load_mount_state(&state_dir)?.repo
+                }
+            }
         }
     };
     let session = FsSession::open(ctx, Some(&fs_name)).await?;
@@ -614,14 +664,20 @@ pub async fn history(
             e => e.into(),
         })?
         .into_inner();
-    // Saves are the operations that landed content: pushes, publishes (shared-rw
-    // applications), and promotes. Lifecycle noise (create/fork/GC) is not history.
-    let saves: Vec<_> = ops
+    // Saves are the operations that LANDED content: committed pushes, publishes (shared-rw
+    // applications, kind "reconcile"), promotes, and merges. Failed/rejected operations are
+    // not saves, and lifecycle noise (create/fork/GC) is not history. Newest first regardless
+    // of the server's return order.
+    let mut saves: Vec<_> = ops
         .operations
         .iter()
-        .filter(|op| matches!(op.kind.as_str(), "push" | "reconcile" | "promote" | "merge"))
-        .take(limit)
+        .filter(|op| {
+            matches!(op.kind.as_str(), "push" | "reconcile" | "promote" | "merge")
+                && op.result == "committed"
+        })
         .collect();
+    saves.sort_by_key(|op| std::cmp::Reverse(op.at_secs));
+    saves.truncate(limit);
     if output_json {
         println!("{}", serde_json::to_string_pretty(&saves)?);
         return Ok(());
@@ -667,9 +723,35 @@ pub async fn mount_filesystem(
              <repo>:<ref> <path>`",
         ));
     }
-    let mode = if ro { WritePolicy::Ro } else { WritePolicy::Rw };
-    // One listing answers everything the fs surface needs before mounting: does the target
-    // exist, what kind is it, and what is its default branch (the publish target).
+    // A drive doesn't lose your work: writable filesystem mounts always autosave.
+    let autosave = (!ro).then_some(FS_AUTOSAVE_DEFAULT_SECS);
+    // Auto-resume first — it needs no server round trip. A detached local session of this
+    // filesystem (mount state present, daemon dead) picks up where it left off: "run the same
+    // command again" is the crash recovery. WritePolicy::Auto keeps the single-writer
+    // downgrade: a session attached writable elsewhere resumes read-only, never as a silent
+    // second writer.
+    if !ro && let Some(workspace_id) = detached_local_session(target) {
+        println!(
+            "Resuming detached session {} of filesystem {target}.",
+            short_id(&workspace_id)
+        );
+        return mount(
+            ctx,
+            &workspace_id,
+            path,
+            WritePolicy::Auto,
+            None,
+            autosave,
+            true,
+            foreground,
+            trace_ops,
+            log_level,
+        )
+        .await;
+    }
+    // Fresh session: one listing answers what the create needs — does the target exist, what
+    // kind is it, and what is its default branch (the publish target, which the genesis commit
+    // guarantees exists).
     let session = FsSession::open(ctx, None).await?;
     let (user, token) = session.creds();
     let listing = session
@@ -677,78 +759,42 @@ pub async fn mount_filesystem(
         .list_repos_with_credential(&session.project_id, None, user, token)
         .await?
         .into_inner();
-    let Some(repo) = listing.repos.iter().find(|r| r.name == target) else {
-        return Err(CliError::usage(format!(
-            "no filesystem named {target:?} (see: tl fs ls; create one: tl fs create {target})"
-        )));
+    let repo = resolve_filesystem(&listing, target, &format!("tl git mount {target} <path>"))?;
+    // A fresh session publishes every save to the filesystem's current state; read-only mounts
+    // follow it instead.
+    let (target_spec, shared_target) = if ro {
+        (format!("{target}:{}", repo.default_branch), None)
+    } else {
+        (target.to_string(), Some(repo.default_branch.clone()))
     };
-    if repo.kind != "filesystem" {
-        return Err(CliError::usage(format!(
-            "{target} is a repository, not a filesystem — mount it with: tl git mount {target} \
-             <path>"
-        )));
-    }
-    // Auto-resume: a detached local session of this filesystem (mount state present, daemon
-    // dead) picks up where it left off — "run the same command again" is the crash recovery.
-    let resume = (!ro).then(|| detached_local_session(&repo.name)).flatten();
-    // A drive doesn't lose your work: writable filesystem mounts always autosave.
-    let autosave = (!ro).then_some(FS_AUTOSAVE_DEFAULT_SECS);
-    match resume {
-        Some(workspace_id) => {
-            println!(
-                "Resuming detached session {} of filesystem {target}.",
-                short_id(&workspace_id)
-            );
-            mount(
-                ctx,
-                &workspace_id,
-                path,
-                mode,
-                None,
-                autosave,
-                foreground,
-                trace_ops,
-                log_level,
-            )
-            .await
-        }
-        None => {
-            // A fresh session publishes every save to the filesystem's current state. The
-            // shared-rw target is the default branch, which the genesis commit guarantees
-            // exists. Read-only mounts follow the branch instead.
-            let (target_spec, shared_target) = if ro {
-                (format!("{target}:{}", repo.default_branch), None)
-            } else {
-                (target.to_string(), Some(repo.default_branch.clone()))
-            };
-            mount(
-                ctx,
-                &target_spec,
-                path,
-                mode,
-                shared_target,
-                autosave,
-                foreground,
-                trace_ops,
-                log_level,
-            )
-            .await
-        }
-    }
+    mount(
+        ctx,
+        &target_spec,
+        path,
+        if ro {
+            WritePolicy::Ro
+        } else {
+            WritePolicy::Auto
+        },
+        shared_target,
+        autosave,
+        true,
+        foreground,
+        trace_ops,
+        log_level,
+    )
+    .await
 }
 
 /// A detached local session of `repo`: registered mount state on this machine whose daemon is
-/// no longer alive. Newest state wins when several are detached.
+/// no longer alive. Newest state-dir mtime wins when several are detached — a heuristic proxy
+/// for "the one you used last" (all fs sessions publish to the same target, so resuming an
+/// older sibling loses nothing published; only its local overlay differs).
 fn detached_local_session(repo: &str) -> Option<String> {
-    let mut candidates: Vec<(std::time::SystemTime, String)> = registry_load()
-        .iter()
-        .filter_map(|(_, v)| {
-            let state_dir = PathBuf::from(v.as_str()?);
-            let state = daemon::load_mount_state(&state_dir).ok()?;
-            if state.repo != repo || state.read_only() {
-                return None;
-            }
-            if daemon::daemon_pid(&state_dir).is_some_and(daemon_alive) {
+    let mut candidates: Vec<(std::time::SystemTime, String)> = local_mount_states()
+        .into_iter()
+        .filter_map(|(_, state_dir, state, alive)| {
+            if alive || state.repo != repo || state.read_only() {
                 return None;
             }
             let modified = std::fs::metadata(&state_dir)
@@ -802,6 +848,7 @@ pub async fn mount_repo(
         mode,
         shared_target,
         None,
+        false,
         foreground,
         trace_ops,
         log_level,
@@ -1955,16 +2002,26 @@ fn daemon_alive(_pid: i32) -> bool {
     false
 }
 
-/// Local mounts whose daemon is still running: `(mountpoint, state)`.
-fn live_mounts() -> Vec<(String, MountState)> {
+/// Every locally registered mount: `(mountpoint, state dir, state, daemon alive)`. The single
+/// scan behind both the live view (attachment columns, single-writer checks) and the detached
+/// view (auto-resume), so the two can never disagree on what "alive" means.
+fn local_mount_states() -> Vec<(String, PathBuf, MountState, bool)> {
     registry_load()
         .iter()
         .filter_map(|(mountpoint, state_dir)| {
             let state_dir = PathBuf::from(state_dir.as_str()?);
             let state = daemon::load_mount_state(&state_dir).ok()?;
             let alive = daemon::daemon_pid(&state_dir).is_some_and(daemon_alive);
-            alive.then(|| (mountpoint.clone(), state))
+            Some((mountpoint.clone(), state_dir, state, alive))
         })
+        .collect()
+}
+
+/// Local mounts whose daemon is still running: `(mountpoint, state)`.
+fn live_mounts() -> Vec<(String, MountState)> {
+    local_mount_states()
+        .into_iter()
+        .filter_map(|(mountpoint, _, state, alive)| alive.then_some((mountpoint, state)))
         .collect()
 }
 
@@ -2009,6 +2066,7 @@ fn alloc_state_dir(workspace_id: &str) -> PathBuf {
 /// `<workspace-id>` (or a unique prefix; see `tl fs ls`) mounts an existing one, resuming at
 /// its last snapshot. Reads stream lazily; nothing is copied to disk up front.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 pub async fn mount(
     ctx: &CliContext,
     target: &str,
@@ -2016,6 +2074,10 @@ pub async fn mount(
     mode: WritePolicy,
     shared_target: Option<String>,
     auto_commit_interval_secs: Option<u64>,
+    // The surface speaking: true = `tl fs` (drives, sessions, saves), false = `tl git`
+    // (workspaces, snapshots, branches). One engine, two vocabularies — the fs surface
+    // promises the words workspace/snapshot/branch never appear in its output.
+    fs_surface: bool,
     foreground: bool,
     trace_ops: bool,
     log_level: &str,
@@ -2032,6 +2094,13 @@ pub async fn mount(
     // through the same subscriber the daemon uses for daemon.log — pass `--log-level debug`
     // to see them; the default "info" keeps mount's stderr clean for scripts.
     daemon::init_logging(log_level)?;
+    // The two surfaces' words for the same machinery; every user-facing line below must use
+    // these (or branch on fs_surface) so `tl fs` never says workspace/snapshot/branch.
+    let (unit, saves) = if fs_surface {
+        ("session", "saves")
+    } else {
+        ("workspace", "snapshots")
+    };
     let started = std::time::Instant::now();
     #[cfg(target_os = "macos")]
     ensure_fskit_ready().await?;
@@ -2240,12 +2309,12 @@ pub async fn mount(
             };
             match (&attached_at, mode) {
                 (Some(at), WritePolicy::Auto) => eprintln!(
-                    "{} workspace is already attached at {at}; mounting read-only (unmount \
-                     it there to take writes)",
+                    "{} {unit} is already attached at {at}; mounting read-only (unmount it \
+                     there to take writes)",
                     style("note:").yellow(),
                 ),
                 (Some(at), WritePolicy::Rw) => eprintln!(
-                    "{} workspace is also writable at {at}; two writers race snapshots",
+                    "{} {unit} is also writable at {at}; two writers race {saves}",
                     style("warning:").yellow(),
                 ),
                 _ => {}
@@ -2384,14 +2453,28 @@ pub async fn mount(
                 );
                 if attached {
                     println!(
-                        "Mounted workspace {} ({}) at {}{}",
+                        "Mounted {unit} {} ({}) at {}{}",
                         short_id(&ws.id),
                         repo,
                         mountpoint,
-                        if read_only {
-                            ", read-only, follows its snapshots"
+                        match (read_only, fs_surface) {
+                            (true, _) => ", read-only",
+                            (false, true) => ", resumed at its last save",
+                            (false, false) => ", resumed at its last snapshot",
+                        },
+                    );
+                } else if fs_surface {
+                    println!(
+                        "Mounted filesystem {} at {} (session {}{})",
+                        repo,
+                        mountpoint,
+                        short_id(&ws.id),
+                        if shared_target.is_some() {
+                            ", saves publish automatically"
+                        } else if read_only {
+                            ", read-only, follows the filesystem"
                         } else {
-                            ", resumed at its last snapshot"
+                            ""
                         },
                     );
                 } else {
@@ -2411,21 +2494,40 @@ pub async fn mount(
                     );
                 }
                 if read_only {
+                    if fs_surface {
+                        println!(
+                            "Reading save {}; new saves appear as the filesystem advances.",
+                            resp.get("commit").and_then(|c| c.as_str()).unwrap_or("?"),
+                        );
+                    } else {
+                        println!(
+                            "Reading commit {}; new commits appear as the followed ref advances.",
+                            resp.get("commit").and_then(|c| c.as_str()).unwrap_or("?"),
+                        );
+                    }
+                } else if fs_surface {
                     println!(
-                        "Reading commit {}; new commits appear as the followed ref advances.",
+                        "At save {}. Changes save automatically; tl fs snapshot {} makes a \
+                         named save.",
                         resp.get("commit").and_then(|c| c.as_str()).unwrap_or("?"),
+                        mountpoint,
                     );
                 } else {
                     println!(
-                        "Lower commit {}. Work in the mount, then: tl fs snapshot {}",
+                        "Lower commit {}. Work in the mount, then: tl git snapshot {}",
                         resp.get("commit").and_then(|c| c.as_str()).unwrap_or("?"),
                         path.display()
                     );
                 }
                 if let Some(secs) = auto_commit_interval_secs {
-                    println!(
-                        "Auto-commit: local changes seal into a snapshot every {secs}s (async)."
-                    );
+                    if fs_surface {
+                        println!("Autosave: changes save every {secs}s (async).");
+                    } else {
+                        println!(
+                            "Auto-commit: local changes seal into a snapshot every {secs}s \
+                             (async)."
+                        );
+                    }
                 }
                 return Ok(());
             }
@@ -2581,7 +2683,7 @@ pub async fn unmount(
             "the mount at {mountpoint} holds {losable}; unmounting would destroy that. Seal \
              unsealed changes first, then re-run:\n  tl fs snapshot {mountpoint}\n  tl fs \
              unmount {mountpoint}\nIgnored files never enter a snapshot — dropping them (and \
-             everything else local) takes the flag:\n  tl fs unmount --discard-local \
+             everything else local) takes the flag:\n  tl fs unmount --discard \
              {mountpoint}"
         )));
     }
@@ -2680,7 +2782,7 @@ pub async fn unmount(
             "local changes landed while unmounting; the volume is detached but the local \
              state is kept at {}. Remount to recover and seal them (`tl fs mount \
              {mountpoint}`, then `tl fs snapshot {mountpoint}`), or re-run \
-             `tl fs unmount --discard-local {mountpoint}` to drop them.",
+             `tl fs unmount --discard {mountpoint}` to drop them.",
             state_dir.display()
         )));
     }
@@ -2864,7 +2966,7 @@ fn enumerate_overlay(state_dir: &Path, mount_root: &Path) -> Result<(OverlayUpse
 /// Fails CLOSED: this guards data destruction, so an overlay tree that cannot be read is an
 /// error, not "no state" — a permissions hiccup must never wave a destructive command
 /// through. Only a missing tree (never-written overlay side) is honestly empty. The explicit
-/// `--discard-local` flag bypasses the check entirely (callers short-circuit before calling).
+/// `--discard` flag bypasses the check entirely (callers short-circuit before calling).
 fn overlay_has_local_state(state_dir: &Path) -> Result<bool> {
     fn any_entry(dir: &Path) -> Result<bool> {
         let read = match std::fs::read_dir(dir) {
@@ -2900,7 +3002,7 @@ fn overlay_has_local_state(state_dir: &Path) -> Result<bool> {
 fn overlay_unreadable(path: &Path, err: &std::io::Error) -> CliError {
     CliError::usage(format!(
         "cannot verify local overlay state: {} is unreadable ({err}); fix permissions \
-         or pass --discard-local to drop the overlay without checking",
+         or pass --discard to drop the overlay without checking",
         path.display()
     ))
 }
@@ -2919,7 +3021,7 @@ fn overlay_rel_path(root: &Path, abs: &Path) -> String {
 }
 
 /// What dropping the overlay would actually destroy — the gate `unmount` and `restore` check
-/// before requiring `--discard-local`. `None` means everything the overlay holds is retained
+/// before requiring `--discard`. `None` means everything the overlay holds is retained
 /// sealed content (stat-verified against the sealed index, so byte-identical to workspace
 /// history — sealing keeps the overlay as the local byte cache, making this the DEFAULT
 /// state after every snapshot), which drops loss-free. `Some(reason)` names the truly-losable
@@ -2980,7 +3082,7 @@ async fn overlay_losable_state(state_dir: &Path, mountpoint: &str) -> Result<Opt
         ignore.is_ignored(rel, is_dir).map_err(|e| {
             CliError::usage(format!(
                 "cannot verify local overlay state: evaluating ignore rules failed ({e}); \
-                 fix the ignore file or pass --discard-local to drop the overlay without \
+                 fix the ignore file or pass --discard to drop the overlay without \
                  checking"
             ))
         })
@@ -3693,7 +3795,7 @@ pub async fn promote(
                             eprintln!("  {:<14} {}", style(&c.kind).yellow(), c.path);
                         }
                         return Err(CliError::usage(format!(
-                            "pull {branch} into the workspace, resolve, and promote again:\n  tl fs sync {}\n  # fix the conflict markers, then\n  tl fs snapshot {} && tl fs promote {} {branch} --merge",
+                            "pull {branch} into the working tree, resolve, and promote again:\n  tl git sync {}\n  # fix the conflict markers, then\n  tl git snapshot {} && tl git promote {} {branch} --merge",
                             path.display(),
                             path.display(),
                             path.display(),
@@ -4072,7 +4174,7 @@ pub async fn restore(
         return Err(CliError::usage(format!(
             "the workspace holds {losable}; restoring would destroy that. Seal unsealed \
              changes first (`tl fs snapshot {path}`), or drop everything local (ignored \
-             files included) with the flag:\n  tl fs restore --discard-local {path} \
+             files included) with the flag:\n  tl fs restore --discard {path} \
              {version}",
             path = path.display(),
         )));
@@ -4157,7 +4259,7 @@ pub async fn restore(
         return Err(CliError::usage(format!(
             "local changes landed while the restore was preparing; nothing was changed. \
              Seal them first (`tl fs snapshot {path}`) and re-run — or re-run with \
-             --discard-local to drop them. (Background seal housekeeping can also move the \
+             --discard to drop them. (Background seal housekeeping can also move the \
              overlay; if you made no local writes, simply retry.)",
             path = path.display(),
         )));
@@ -4877,7 +4979,7 @@ mod tests {
 
     /// The unmount/restore gate: a retained-only overlay — the DEFAULT state after every
     /// snapshot, since sealing keeps the overlay — is loss-free to drop and must not demand
-    /// --discard-local (the old raw-state gate did, and its own suggested remedy could never
+    /// --discard (the old raw-state gate did, and its own suggested remedy could never
     /// satisfy it). Sealed tombstones and bare directories don't block either: git cannot
     /// represent an empty tree, so no snapshot could ever cover one.
     #[cfg(unix)]
@@ -5101,7 +5203,7 @@ mod tests {
 
     /// An ignored whiteout is a local-only deletion of a committed file: it can never seal
     /// (the sealer's ignore filter skips it), so like an ignored file it refuses and only
-    /// --discard-local clears it. Silently passing it would resurrect the deleted file.
+    /// --discard clears it. Silently passing it would resurrect the deleted file.
     #[cfg(unix)]
     #[tokio::test]
     async fn losable_gate_refuses_ignored_whiteout() {
@@ -5338,10 +5440,7 @@ mod tests {
                 msg.contains("cannot verify local overlay state"),
                 "unexpected error: {msg}"
             );
-            assert!(
-                msg.contains("--discard-local"),
-                "names the escape hatch: {msg}"
-            );
+            assert!(msg.contains("--discard"), "names the escape hatch: {msg}");
         }
         // Restore so the tempdir can be cleaned up.
         std::fs::set_permissions(&upper, std::fs::Permissions::from_mode(0o755)).unwrap();

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -402,8 +402,8 @@ pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) 
             Cell::new(ws.base_ref.as_deref().unwrap_or(&ws.base[..12])),
             Cell::new(if ws.head == ws.base { "-" } else { "yes" }),
             Cell::new(match &ws.shared_target {
-                Some(target) => format!("shared-rw -> {target}"),
-                None => "workspace".to_string(),
+                Some(_) => "publishing".to_string(),
+                None => "private".to_string(),
             }),
             // Human output keeps the annotation; the JSON path/kind split serves machines.
             // A mount session on another machine (fleet liveness) shows as its host.
@@ -2543,7 +2543,7 @@ pub async fn unmount(
 ) -> Result<()> {
     if let Some((root, _)) = plaindir::binding_for_lenient(path) {
         return Err(CliError::usage(format!(
-            "{root} is a plain-directory binding, not a mount; detach it with: tl fs unbind \
+            "{root} is a pushed directory, not a mount; stop tracking it with: tl fs unmount \
              {root}"
         )));
     }

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -2654,6 +2654,26 @@ mod tests {
             .into_inner();
         assert_eq!(ws.base_ref.as_deref(), Some("refs/heads/main"));
         assert_eq!(ws.shared_target.as_deref(), Some("main"));
+        // Pin `tl fs history`'s save definition to the server's operation vocabulary: the
+        // genesis is a committed "push" op, i.e. exactly what the history filter
+        // (kind in {push, reconcile, promote, merge} AND result == "committed") must match.
+        // If the server ever renames these strings, this fails instead of history silently
+        // showing "No saves yet" for a live filesystem.
+        let ops = sdk
+            .list_operations_with_credential(PROJECT, &fs_name, "t", TOKEN)
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(
+            ops.operations
+                .iter()
+                .any(|op| op.kind == "push" && op.result == "committed"),
+            "genesis must appear as a committed push op; got kinds/results: {:?}",
+            ops.operations
+                .iter()
+                .map(|op| (op.kind.clone(), op.result.clone()))
+                .collect::<Vec<_>>()
+        );
         sdk.delete_workspace(PROJECT, &fs_name, "t", TOKEN, &ws.id)
             .await
             .unwrap();

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -2595,6 +2595,73 @@ mod tests {
         entries.into_iter().map(|e| e.name).collect()
     }
 
+    /// The `tl fs` product surface's wire contract (server >= repo-kinds): filesystems are
+    /// `kind=filesystem` repos, `?kind=` partitions the listing, and a fresh filesystem's
+    /// genesis commit lets a publish-on-save workspace be created with no push ever made.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "requires a local artifact-storage server on 127.0.0.1:8080"]
+    async fn filesystem_kind_contract_roundtrips() {
+        if !server_up() {
+            eprintln!("skipping: no local artifact-storage server");
+            return;
+        }
+        let sdk = sdk();
+        let fs_name = format!(
+            "fskind-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        sdk.create_repo_with_credential(PROJECT, &fs_name, None, Some("filesystem"), "t", TOKEN)
+            .await
+            .unwrap();
+        let filesystems = sdk
+            .list_repos_with_credential(PROJECT, Some("filesystem"), "t", TOKEN)
+            .await
+            .unwrap()
+            .into_inner();
+        let entry = filesystems
+            .repos
+            .iter()
+            .find(|r| r.name == fs_name)
+            .expect("created filesystem is in the kind=filesystem listing");
+        assert_eq!(entry.kind, "filesystem");
+        let repositories = sdk
+            .list_repos_with_credential(PROJECT, Some("repository"), "t", TOKEN)
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(
+            !repositories.repos.iter().any(|r| r.name == fs_name),
+            "a filesystem must not appear in the repository listing"
+        );
+        // The genesis commit is what makes `tl fs create` + mount work with no client push:
+        // a baseless, publish-on-save workspace resolves its base from the default branch.
+        let ws = sdk
+            .create_workspace(
+                PROJECT,
+                &fs_name,
+                "t",
+                TOKEN,
+                &CreateWorkspaceRequest {
+                    shared_target: Some(entry.default_branch.clone()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(ws.base_ref.as_deref(), Some("refs/heads/main"));
+        assert_eq!(ws.shared_target.as_deref(), Some("main"));
+        sdk.delete_workspace(PROJECT, &fs_name, "t", TOKEN, &ws.id)
+            .await
+            .unwrap();
+        sdk.delete_repo_with_credential(PROJECT, &fs_name, "t", TOKEN)
+            .await
+            .unwrap();
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[ignore = "requires a local artifact-storage server on 127.0.0.1:8080"]
     async fn overlay_merges_copies_up_whiteouts_and_snapshots() {
@@ -2612,7 +2679,7 @@ mod tests {
         );
         let project_repo = format!("{PROJECT}/{repo}");
         let _ = project_repo;
-        sdk.create_repo_with_credential(PROJECT, &repo, None, "t", TOKEN)
+        sdk.create_repo_with_credential(PROJECT, &repo, None, None, "t", TOKEN)
             .await
             .unwrap();
         sdk.push_files(
@@ -2842,7 +2909,7 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         );
-        sdk.create_repo_with_credential(PROJECT, &repo, None, "t", TOKEN)
+        sdk.create_repo_with_credential(PROJECT, &repo, None, None, "t", TOKEN)
             .await
             .unwrap();
         sdk.push_files(
@@ -3055,7 +3122,7 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         );
-        sdk.create_repo_with_credential(PROJECT, &repo, None, "t", TOKEN)
+        sdk.create_repo_with_credential(PROJECT, &repo, None, None, "t", TOKEN)
             .await
             .unwrap();
         sdk.push_files(

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -253,6 +253,21 @@ pub(crate) fn bound_workspaces() -> Vec<(String, String)> {
         .collect()
 }
 
+/// Every binding as (backing repo, bound root) — the filesystem listing's attachment column.
+pub(crate) fn bound_binding_repos() -> Vec<(String, String)> {
+    let Some(registry) = registry_lenient(registry_load()) else {
+        return Vec::new();
+    };
+    registry
+        .bindings
+        .iter()
+        .filter_map(|(root, state_dir)| {
+            let binding = load_binding(state_dir).ok()?;
+            Some((binding.repo, root.clone()))
+        })
+        .collect()
+}
+
 /// The bound directory attached to `workspace_id`, if any. Scans the binding state dirs
 /// themselves (not the registry): this guards destructive/attachment decisions (`tl fs rm`,
 /// mount write policy), and a binding missing from a damaged registry still owns its
@@ -1353,6 +1368,54 @@ pub async fn init(
     path: Option<PathBuf>,
     file_system: Option<&str>,
 ) -> Result<()> {
+    let (root, _state_dir, repo, ws_id) = bind(ctx, path, file_system, false).await?;
+    println!(
+        "Bound {root} to new workspace {} (file system {repo}).",
+        short_id(&ws_id)
+    );
+    println!("Work in the directory, then: tl fs snapshot {root}");
+    Ok(())
+}
+
+/// `tl fs push <dir> <filesystem>` — upload a directory into a filesystem as one save, no
+/// mount. First push binds the directory (publish-on-save workspace); later pushes reuse the
+/// binding's stat index, so only changed files upload.
+pub async fn push(
+    ctx: &CliContext,
+    dir: &Path,
+    file_system: &str,
+    message: Option<&str>,
+) -> Result<()> {
+    let (root, state_dir) = match binding_for_lenient(dir) {
+        Some((root, state_dir)) => {
+            let binding = load_binding(&state_dir)?;
+            if binding.repo != file_system {
+                return Err(CliError::usage(format!(
+                    "{root} is already bound to filesystem {} — push there, or pick another \
+                     directory for {file_system}",
+                    binding.repo
+                )));
+            }
+            (root, state_dir)
+        }
+        None => {
+            let (root, state_dir, _, _) =
+                bind(ctx, Some(dir.to_path_buf()), Some(file_system), true).await?;
+            (root, state_dir)
+        }
+    };
+    snapshot(ctx, &root, &state_dir, message).await
+}
+
+/// Bind a directory to a fresh workspace on a filesystem. `publish` arms shared-rw: every
+/// snapshot of the binding lands on the filesystem's default branch (the `tl fs push`
+/// contract). Returns (root, state dir, repo, workspace id).
+async fn bind(
+    ctx: &CliContext,
+    path: Option<PathBuf>,
+    file_system: Option<&str>,
+    publish: bool,
+) -> Result<(String, PathBuf, String, String)> {
     if cfg!(not(unix)) {
         return Err(CliError::usage(
             "plain-directory bindings are supported on unix only in v1",
@@ -1381,7 +1444,7 @@ pub async fn init(
     let (user, token) = session.creds();
     let file_systems = session
         .client
-        .list_repos_with_credential(&session.project_id, user, token)
+        .list_repos_with_credential(&session.project_id, None, user, token)
         .await?
         .into_inner();
     let repo = match file_system {
@@ -1430,7 +1493,10 @@ pub async fn init(
             &repo,
             user,
             token,
-            &CreateWorkspaceRequest::default(),
+            &CreateWorkspaceRequest {
+                shared_target: publish.then(|| default_branch.clone()),
+                ..Default::default()
+            },
         )
         .await?
         .into_inner();
@@ -1528,12 +1594,7 @@ pub async fn init(
             .await;
         return Err(e);
     }
-    println!(
-        "Bound {root} to new workspace {} (file system {repo}).",
-        short_id(&ws.id)
-    );
-    println!("Work in the directory, then: tl fs snapshot {root}");
-    Ok(())
+    Ok((root, state_dir, repo, ws.id))
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -1451,7 +1451,7 @@ async fn bind(
         Some(name) => {
             if !file_systems.repos.iter().any(|r| r.name == name) {
                 return Err(CliError::usage(format!(
-                    "no file system named {name:?}; create it first: tl git create {name}"
+                    "no filesystem named {name:?}; create it first: tl fs create {name}"
                 )));
             }
             name.to_string()
@@ -1461,7 +1461,7 @@ async fn bind(
             [only] => only.name.clone(),
             [] => {
                 return Err(CliError::usage(
-                    "this project has no file systems; create one first: tl git create <name>",
+                    "this project has no filesystems; create one first: tl fs create <name>",
                 ));
             }
             many => {

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -367,7 +367,7 @@ fn binding_overlap_error(root: &str, bindings: &BTreeMap<String, PathBuf>) -> Op
     bindings.keys().find_map(|bound| {
         let bound_path = Path::new(bound);
         (candidate.starts_with(bound_path) || bound_path.starts_with(candidate)).then(|| {
-            format!("{root} overlaps the existing binding at {bound} (see `tl fs unbind {bound}`)")
+            format!("{root} overlaps the tracked directory at {bound} (tl fs unmount {bound} stops tracking it)")
         })
     })
 }
@@ -379,8 +379,8 @@ pub fn assert_no_binding_overlap(mountpoint: &str) -> Result<()> {
         let bound_path = Path::new(bound);
         if candidate.starts_with(bound_path) || bound_path.starts_with(candidate) {
             return Err(CliError::usage(format!(
-                "{mountpoint} overlaps the plain-directory binding at {bound}; unbind it \
-                 first (tl fs unbind {bound}) or mount elsewhere"
+                "{mountpoint} overlaps the tracked directory at {bound}; stop tracking it \
+                 first (tl fs unmount {bound}) or mount elsewhere"
             )));
         }
     }
@@ -1363,20 +1363,6 @@ fn symlink_target_bytes(target: &Path) -> Vec<u8> {
 // tl fs init — bind a plain directory to a new (verified empty-base) workspace.
 // ---------------------------------------------------------------------------------------------
 
-pub async fn init(
-    ctx: &CliContext,
-    path: Option<PathBuf>,
-    file_system: Option<&str>,
-) -> Result<()> {
-    let (root, _state_dir, repo, ws_id) = bind(ctx, path, file_system, false).await?;
-    println!(
-        "Bound {root} to new workspace {} (file system {repo}).",
-        short_id(&ws_id)
-    );
-    println!("Work in the directory, then: tl fs snapshot {root}");
-    Ok(())
-}
-
 /// `tl fs push <dir> <filesystem>` — upload a directory into a filesystem as one save, no
 /// mount. First push binds the directory (publish-on-save workspace); later pushes reuse the
 /// binding's stat index, so only changed files upload.
@@ -2158,6 +2144,8 @@ fn orphan_state_dir_for(root: &str, state_root: &Path) -> Option<PathBuf> {
 /// `tl fs unbind` — remove the local binding and its state. Deliberately NOT `rm`: `tl fs rm`
 /// deletes the *workspace*; unbinding only forgets this directory's link to it, and the
 /// workspace (with every snapshot) survives on the server.
+/// `tl fs unmount` on a pushed directory: forget the local tracking state. The
+/// directory's files and the filesystem are untouched.
 pub async fn unbind(path: Option<PathBuf>) -> Result<()> {
     let (root, state_dir) = match path {
         Some(path) => match binding_for(&path)? {
@@ -2180,8 +2168,8 @@ pub async fn unbind(path: Option<PathBuf>) -> Result<()> {
                     return Ok(());
                 }
                 return Err(CliError::usage(format!(
-                    "{} is not a bound directory (see `tl fs status`, or bind one with \
-                     `tl fs init`)",
+                    "{} is not a tracked directory (see `tl fs status`, or start one with \
+                     `tl fs push <dir> <filesystem>`)",
                     path.display()
                 )));
             }

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -253,6 +253,11 @@ pub(crate) fn bound_workspaces() -> Vec<(String, String)> {
         .collect()
 }
 
+/// The backing repo of one binding state dir (for path-addressed reads like history).
+pub(crate) fn binding_repo(state_dir: &Path) -> Result<String> {
+    Ok(load_binding(state_dir)?.repo)
+}
+
 /// Every binding as (backing repo, bound root) — the filesystem listing's attachment column.
 pub(crate) fn bound_binding_repos() -> Vec<(String, String)> {
     let Some(registry) = registry_lenient(registry_load()) else {
@@ -400,6 +405,12 @@ pub(crate) struct Binding {
     /// Canonical bound directory.
     pub root: PathBuf,
     pub created_at_secs: u64,
+    /// Whether the binding's workspace publishes every save to the filesystem (shared-rw,
+    /// the `tl fs push` contract). `false` = a pre-split `tl fs init` binding whose saves
+    /// land on a private workspace only; push refuses those rather than reporting a save
+    /// nobody can see. Serde-defaulted so legacy binding.json reads as non-publishing.
+    #[serde(default)]
+    pub publish: bool,
 }
 
 pub(crate) fn load_binding(state_dir: &Path) -> Result<Binding> {
@@ -1382,6 +1393,16 @@ pub async fn push(
                     binding.repo
                 )));
             }
+            // A pre-split binding saves to a private workspace the filesystem never sees;
+            // "pushed" would be a lie. Re-binding fixes it (the private session's saves are
+            // superseded by the fresh upload).
+            if !binding.publish {
+                return Err(CliError::usage(format!(
+                    "{root} was bound without publish-on-save (created before `tl fs push` \
+                     existed); stop tracking it (tl fs unmount {root}) and push again to \
+                     re-bind"
+                )));
+            }
             (root, state_dir)
         }
         None => {
@@ -1543,6 +1564,7 @@ async fn bind(
         ref_name: ws.ref_name.clone(),
         root: PathBuf::from(&root),
         created_at_secs: now_secs(),
+        publish,
     };
     write_atomic(
         &state_dir.join("binding.json"),
@@ -2879,6 +2901,7 @@ mod tests {
             ref_name: format!("workspaces/{workspace_id}"),
             root: root.to_path_buf(),
             created_at_secs: 0,
+            publish: true,
         };
         std::fs::write(
             state_dir.join("binding.json"),

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -708,7 +708,7 @@ fn print_json<T: serde::Serialize>(value: &T) -> Result<()> {
     Ok(())
 }
 
-fn map_sdk_error(error: tensorlake::error::SdkError) -> CliError {
+pub(crate) fn map_sdk_error(error: tensorlake::error::SdkError) -> CliError {
     match error {
         tensorlake::error::SdkError::Authentication(_) => {
             CliError::auth("authentication failed. set TENSORLAKE_API_KEY or run 'tl login'.")

--- a/crates/cli/src/commands/git/fastclone.rs
+++ b/crates/cli/src/commands/git/fastclone.rs
@@ -1349,7 +1349,7 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         );
-        sdk.create_repo_with_credential("fastclonetest", &repo, None, "t", "devtoken")
+        sdk.create_repo_with_credential("fastclonetest", &repo, None, None, "t", "devtoken")
             .await
             .unwrap();
         let salt = repo.as_bytes().to_vec();

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2353,6 +2353,24 @@ async fn run_applications_command(
     }
 }
 
+/// A cached minted git credential can be revoked before its recorded expiry; purge the cache
+/// on an auth failure so the next invocation re-mints instead of retrying a dead token.
+/// Shared by both mount surfaces (`tl fs`, `tl git` mount family) so the behavior cannot
+/// drift between them.
+#[cfg(feature = "mount")]
+fn purge_credentials_on_auth_failure(result: &error::Result<()>) {
+    if let Err(
+        CliError::Auth(_)
+        | CliError::Sdk(
+            tensorlake::error::SdkError::Authentication(_)
+            | tensorlake::error::SdkError::Authorization(_),
+        ),
+    ) = result
+    {
+        crate::config::files::purge_git_credentials();
+    }
+}
+
 // `tl fs` drives the local FUSE/overlay mount stack, which is backed by the private gsvc-mount
 // core and therefore only compiled into `--features mount` release builds. The command surface
 // (FsCommands) is always parsed so `tl fs --help` documents it, but a build without the feature
@@ -2468,16 +2486,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
     // A cached minted git credential can be revoked before its recorded expiry; purge
     // the cache on an auth failure so the next invocation re-mints instead of retrying
     // a dead token.
-    if let Err(
-        CliError::Auth(_)
-        | CliError::Sdk(
-            tensorlake::error::SdkError::Authentication(_)
-            | tensorlake::error::SdkError::Authorization(_),
-        ),
-    ) = &result
-    {
-        crate::config::files::purge_git_credentials();
-    }
+    purge_credentials_on_auth_failure(&result);
     result
 }
 
@@ -2558,16 +2567,7 @@ async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> err
         } => commands::fs::unmount(ctx, &mount_dir(), delete, discard).await,
         _ => unreachable!("routed only for the mount family"),
     };
-    if let Err(
-        CliError::Auth(_)
-        | CliError::Sdk(
-            tensorlake::error::SdkError::Authentication(_)
-            | tensorlake::error::SdkError::Authorization(_),
-        ),
-    ) = &result
-    {
-        crate::config::files::purge_git_credentials();
-    }
+    purge_credentials_on_auth_failure(&result);
     result
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -204,14 +204,6 @@ enum Commands {
 
 use std::path::PathBuf;
 
-/// `--mode` for `tl fs mount`. Absent means writable, except a workspace already mounted
-/// elsewhere defaults to read-only.
-#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-enum MountWriteMode {
-    Ro,
-    Rw,
-}
-
 #[derive(Subcommand)]
 enum FsCommands {
     /// Install, enable, and diagnose the mount prerequisites (macOS FSKit extension; Linux
@@ -247,26 +239,8 @@ enum FsCommands {
         path: PathBuf,
 
         /// Read-only: look, don't touch (follows the filesystem's current state)
-        #[arg(long, conflicts_with = "mode")]
+        #[arg(long)]
         ro: bool,
-
-        /// (deprecated: use `tl git mount --ro/--rw` for repositories) Write policy
-        #[arg(long, value_enum, hide = true)]
-        mode: Option<MountWriteMode>,
-
-        /// (deprecated: publishing is the default for filesystems; use `tl git mount
-        /// --publish` for repositories)
-        #[arg(long, hide = true)]
-        shared_rw: bool,
-
-        /// Save automatically every N seconds (0 disables; on-demand `tl fs snapshot`
-        /// always works)
-        #[arg(long, hide = true, value_parser = clap::value_parser!(u64))]
-        autosave_secs: Option<u64>,
-
-        /// (deprecated: autosave is on by default; see --autosave-secs)
-        #[arg(long, hide = true, value_parser = clap::value_parser!(u64).range(1..))]
-        auto_commit_interval_secs: Option<u64>,
 
         /// Run the mount daemon in the foreground (debugging)
         #[arg(long, hide = true)]
@@ -381,48 +355,6 @@ enum FsCommands {
         clear: bool,
     },
 
-    /// (deprecated: use `tl git promote`) Publish the workspace's snapshot onto a real branch
-    #[command(allow_missing_positional = true, hide = true)]
-    Promote {
-        /// A mounted directory (default: the mount containing the current directory)
-        path: Option<PathBuf>,
-
-        /// Target branch
-        branch: String,
-
-        /// Land the full checkpoint chain instead of a single squashed commit
-        #[arg(long)]
-        full_history: bool,
-
-        /// Merge onto a moved target (two-parent merge commit); conflicts are reported
-        /// and nothing is published
-        #[arg(long, conflicts_with = "full_history")]
-        merge: bool,
-
-        /// Commit message for the squashed promote
-        #[arg(short, long)]
-        message: Option<String>,
-    },
-
-    /// (deprecated: use `tl git sync`) Pull the target branch into the workspace
-    #[command(hide = true)]
-    Sync {
-        /// A mounted directory (default: the mount containing the current directory)
-        path: Option<PathBuf>,
-
-        /// Branch to pull from (default: the branch the workspace was created from)
-        #[arg(long)]
-        target: Option<String>,
-
-        /// Fail on conflicts instead of materializing diff3 markers into the workspace
-        #[arg(long)]
-        fail_on_conflict: bool,
-
-        /// Commit message for the sync merge commit
-        #[arg(short, long)]
-        message: Option<String>,
-    },
-
     /// Show workspace, lease, and local-change status for a mount
     Status {
         /// A mounted directory (default: the mount containing the current directory)
@@ -442,23 +374,10 @@ enum FsCommands {
         /// Snapshot/commit hex, branch, or ref to restore to
         version: String,
 
-        /// Drop the local overlay to apply the restore. Destructive: local changes not yet in
-        /// a snapshot AND ignored files under the mount are deleted — `tl fs snapshot` first
-        /// to keep the changes.
-        #[arg(long)]
-        discard_local: bool,
-    },
-
-    /// List changed paths: local vs last snapshot, or between two snapshots
-    Diff {
-        /// A mounted directory (default: the mount containing the current directory)
-        path: Option<PathBuf>,
-
-        /// Older snapshot/commit (omit both for local vs last snapshot)
-        a: Option<String>,
-
-        /// Newer snapshot/commit
-        b: Option<String>,
+        /// Drop the local overlay to apply the restore. Destructive: unsaved changes AND
+        /// ignored files under the mount are deleted — `tl fs snapshot` first to keep them
+        #[arg(long, alias = "discard-local")]
+        discard: bool,
     },
 
     /// Unmount: detach; the session survives and remounting the filesystem resumes it
@@ -473,7 +392,7 @@ enum FsCommands {
         /// Throw away unsaved changes (and ignored files under the mount) with the mount.
         /// Without it, unmount refuses when unsaved work would be lost — `tl fs snapshot`
         /// first to keep it
-        #[arg(long, alias = "discard-local")]
+        #[arg(long)]
         discard: bool,
     },
 }
@@ -679,10 +598,6 @@ enum GitCommands {
         #[arg(long, conflicts_with = "publish")]
         ro: bool,
 
-        /// Force writable even though this workspace is mounted live elsewhere
-        #[arg(long, conflicts_with = "ro", hide = true)]
-        rw: bool,
-
         /// Every snapshot lands on the mounted branch automatically (server-ordered, merged,
         /// one attributed commit per snapshot). Requires `<repo>:<branch>`
         #[arg(long)]
@@ -691,11 +606,6 @@ enum GitCommands {
         /// Reattach an existing workspace instead of forking a new one
         #[arg(long, conflicts_with = "publish")]
         workspace: Option<String>,
-
-        /// Checkpoint local changes as a snapshot commit every N seconds (async, in the
-        /// mount daemon)
-        #[arg(long, hide = true, value_parser = clap::value_parser!(u64).range(1..))]
-        auto_snapshot_secs: Option<u64>,
 
         /// Run the mount daemon in the foreground (debugging)
         #[arg(long, hide = true)]
@@ -745,18 +655,6 @@ enum GitCommands {
     Sync {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
-
-        /// Branch to pull from (default: the branch the workspace was created from)
-        #[arg(long, hide = true)]
-        target: Option<String>,
-
-        /// Report conflicts and change nothing instead of materializing markers
-        #[arg(long, hide = true)]
-        fail_on_conflict: bool,
-
-        /// Message for the sync commit
-        #[arg(short, long, hide = true)]
-        message: Option<String>,
     },
 
     /// Land the mounted working tree's checkpoint on a branch (squash by default)
@@ -772,14 +670,6 @@ enum GitCommands {
         /// publish nothing
         #[arg(long)]
         merge: bool,
-
-        /// Land the full checkpoint chain instead of one squashed commit
-        #[arg(long, conflicts_with = "merge", hide = true)]
-        full_history: bool,
-
-        /// Message for the squashed/merge commit
-        #[arg(short, long, hide = true)]
-        message: Option<String>,
     },
 
     /// Show workspace and local-change status for a mounted working tree
@@ -2510,19 +2400,6 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
     let mut subcmd = subcmd;
     let mut mount_dir: Option<std::path::PathBuf> = None;
     match &mut subcmd {
-        FsCommands::Promote { path, branch, .. } => {
-            if path.is_none() {
-                // With the path omitted, a sole positional that is itself a mounted
-                // directory is a forgotten branch — reject it before it becomes a publish
-                // onto a branch named after the directory.
-                commands::fs::reject_mount_like_positional(
-                    branch,
-                    "branch",
-                    "tl fs promote [PATH] <BRANCH>",
-                )?;
-            }
-            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
-        }
         FsCommands::Restore { path, version, .. } => {
             if path.is_none() {
                 commands::fs::reject_mount_like_positional(
@@ -2533,14 +2410,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             }
             mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
         }
-        FsCommands::Diff { path, a, b } => {
-            let (path, ra, rb) = commands::fs::resolve_diff_args(path.take(), a.take(), b.take())?;
-            *a = ra;
-            *b = rb;
-            mount_dir = Some(path);
-        }
         FsCommands::Snapshot { path, .. }
-        | FsCommands::Sync { path, .. }
         | FsCommands::Status { path, .. }
         | FsCommands::Unmount { path, .. } => {
             mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
@@ -2583,35 +2453,12 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             target,
             path,
             ro,
-            mode,
-            shared_rw,
-            autosave_secs,
-            auto_commit_interval_secs,
             foreground,
             trace_ops,
             log_level,
         } => {
-            let mode = if ro {
-                Some(commands::fs::WritePolicy::Ro)
-            } else {
-                mode.map(|m| match m {
-                    MountWriteMode::Ro => commands::fs::WritePolicy::Ro,
-                    MountWriteMode::Rw => commands::fs::WritePolicy::Rw,
-                })
-            };
             commands::fs::mount_filesystem(
-                ctx,
-                &target,
-                &path,
-                commands::fs::FsMountOpts {
-                    mode,
-                    legacy_shared_rw: shared_rw,
-                    autosave_secs,
-                    legacy_auto_commit_interval_secs: auto_commit_interval_secs,
-                    foreground,
-                    trace_ops,
-                    log_level,
-                },
+                ctx, &target, &path, ro, foreground, trace_ops, &log_level,
             )
             .await
         }
@@ -2622,55 +2469,10 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
         FsCommands::Snapshot { message, clear, .. } => {
             commands::fs::snapshot(ctx, &mount_dir(), message.as_deref(), clear).await
         }
-        FsCommands::Promote {
-            branch,
-            full_history,
-            merge,
-            message,
-            ..
-        } => {
-            eprintln!(
-                "deprecated: `tl fs promote` moved to `tl git promote` (same arguments); \
-                 this alias will be removed in a future release"
-            );
-            commands::fs::promote(
-                ctx,
-                &mount_dir(),
-                &branch,
-                full_history,
-                merge,
-                message.as_deref(),
-            )
-            .await
-        }
-        FsCommands::Sync {
-            target,
-            fail_on_conflict,
-            message,
-            ..
-        } => {
-            eprintln!(
-                "deprecated: `tl fs sync` moved to `tl git sync` (same arguments); this \
-                 alias will be removed in a future release"
-            );
-            commands::fs::sync(
-                ctx,
-                &mount_dir(),
-                target.as_deref(),
-                fail_on_conflict,
-                message.as_deref(),
-            )
-            .await
-        }
         FsCommands::Status { json, .. } => commands::fs::status(ctx, &mount_dir(), json).await,
         FsCommands::Restore {
-            version,
-            discard_local,
-            ..
-        } => commands::fs::restore(ctx, &mount_dir(), &version, discard_local).await,
-        FsCommands::Diff { a, b, .. } => {
-            commands::fs::diff(ctx, &mount_dir(), a.as_deref(), b.as_deref()).await
-        }
+            version, discard, ..
+        } => commands::fs::restore(ctx, &mount_dir(), &version, discard).await,
         FsCommands::Unmount {
             delete, discard, ..
         } => commands::fs::unmount(ctx, &mount_dir(), delete, discard).await,
@@ -2736,29 +2538,19 @@ async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> err
             target,
             path,
             ro,
-            rw,
             publish,
             workspace,
-            auto_snapshot_secs,
             foreground,
             trace_ops,
             log_level,
         } => {
-            let mode = if ro {
-                commands::fs::WritePolicy::Ro
-            } else if rw {
-                commands::fs::WritePolicy::Rw
-            } else {
-                commands::fs::WritePolicy::Auto
-            };
             commands::fs::mount_repo(
                 ctx,
                 &target,
                 workspace.as_deref(),
                 &path,
-                mode,
+                ro,
                 publish,
-                auto_snapshot_secs,
                 foreground,
                 trace_ops,
                 &log_level,
@@ -2768,37 +2560,9 @@ async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> err
         GitCommands::Snapshot { message, clear, .. } => {
             commands::fs::snapshot(ctx, &mount_dir(), message.as_deref(), clear).await
         }
-        GitCommands::Sync {
-            target,
-            fail_on_conflict,
-            message,
-            ..
-        } => {
-            commands::fs::sync(
-                ctx,
-                &mount_dir(),
-                target.as_deref(),
-                fail_on_conflict,
-                message.as_deref(),
-            )
-            .await
-        }
-        GitCommands::Promote {
-            branch,
-            full_history,
-            merge,
-            message,
-            ..
-        } => {
-            commands::fs::promote(
-                ctx,
-                &mount_dir(),
-                &branch,
-                full_history,
-                merge,
-                message.as_deref(),
-            )
-            .await
+        GitCommands::Sync { .. } => commands::fs::sync(ctx, &mount_dir(), None, false, None).await,
+        GitCommands::Promote { branch, merge, .. } => {
+            commands::fs::promote(ctx, &mount_dir(), &branch, false, merge, None).await
         }
         GitCommands::Status { json, .. } => commands::fs::status(ctx, &mount_dir(), json).await,
         GitCommands::Unmount {
@@ -3303,17 +3067,12 @@ mod tests {
 
     #[test]
     fn fs_commands_are_filesystem_centric() {
-        // The filesystem surface: a bare name plus --ro. The legacy repo:ref form still
-        // parses (deprecation alias, warned at dispatch).
+        // The filesystem surface: a bare name plus --ro. Nothing else.
         match parse_command(["tl", "fs", "mount", "scratch", "./w", "--ro"]) {
             Commands::Fs(FsCommands::Mount {
                 target,
                 path,
                 ro,
-                mode,
-                shared_rw,
-                autosave_secs,
-                auto_commit_interval_secs,
                 foreground,
                 trace_ops,
                 log_level,
@@ -3321,20 +3080,28 @@ mod tests {
                 assert_eq!(target, "scratch");
                 assert_eq!(path, PathBuf::from("./w"));
                 assert!(ro);
-                assert_eq!(mode, None);
-                assert!(!shared_rw);
-                assert_eq!(autosave_secs, None);
-                assert_eq!(auto_commit_interval_secs, None);
                 assert!(!foreground);
                 assert!(!trace_ops);
                 assert_eq!(log_level, "info");
             }
             _ => panic!("expected fs mount command"),
         }
-        // --ro and the deprecated --mode are mutually exclusive.
-        assert!(
-            Cli::try_parse_from(["tl", "fs", "mount", "s", "./w", "--ro", "--mode", "rw"]).is_err()
-        );
+        // The pre-split flags are gone, not hidden.
+        for legacy in [
+            vec!["tl", "fs", "mount", "s", "./w", "--mode", "rw"],
+            vec!["tl", "fs", "mount", "s", "./w", "--shared-rw"],
+            vec![
+                "tl",
+                "fs",
+                "mount",
+                "s",
+                "./w",
+                "--auto-commit-interval-secs",
+                "30",
+            ],
+        ] {
+            assert!(Cli::try_parse_from(legacy).is_err());
+        }
 
         match parse_command(["tl", "fs", "create", "scratch"]) {
             Commands::Fs(FsCommands::Create { name, json: false }) => {
@@ -3363,47 +3130,6 @@ mod tests {
             }
             _ => panic!("expected fs history command"),
         }
-
-        // A bare workspace id mounts an existing workspace; --mode rw forces writes.
-        match parse_command(["tl", "fs", "mount", "0a1b2c3d", "./w", "--mode", "rw"]) {
-            Commands::Fs(FsCommands::Mount { target, mode, .. }) => {
-                assert_eq!(target, "0a1b2c3d");
-                assert_eq!(mode, Some(MountWriteMode::Rw));
-            }
-            _ => panic!("expected fs mount command"),
-        }
-
-        match parse_command([
-            "tl",
-            "fs",
-            "mount",
-            "data",
-            "./w",
-            "--auto-commit-interval-secs",
-            "30",
-        ]) {
-            Commands::Fs(FsCommands::Mount {
-                auto_commit_interval_secs,
-                ..
-            }) => {
-                assert_eq!(auto_commit_interval_secs, Some(30));
-            }
-            _ => panic!("expected fs mount command"),
-        }
-
-        // Zero is rejected at parse time: an interval of 0 is not a debounce, it's a busy loop.
-        assert!(
-            Cli::try_parse_from([
-                "tl",
-                "fs",
-                "mount",
-                "data",
-                "./w",
-                "--auto-commit-interval-secs",
-                "0",
-            ])
-            .is_err()
-        );
 
         match parse_command(["tl", "fs", "ls"]) {
             Commands::Fs(FsCommands::Ls {
@@ -3466,44 +3192,29 @@ mod tests {
             _ => panic!("expected fs snapshot --clear command"),
         }
 
-        // Promote/restore have a required positional after the optional path; with a single
-        // value the path is the one skipped (allow_missing_positional).
-        match parse_command(["tl", "fs", "promote", "main"]) {
-            Commands::Fs(FsCommands::Promote { path, branch, .. }) => {
-                assert_eq!(path, None);
-                assert_eq!(branch, "main");
-            }
-            _ => panic!("expected fs promote command"),
-        }
-
-        match parse_command(["tl", "fs", "promote", "./w", "main"]) {
-            Commands::Fs(FsCommands::Promote { path, branch, .. }) => {
-                assert_eq!(path, Some(PathBuf::from("./w")));
-                assert_eq!(branch, "main");
-            }
-            _ => panic!("expected fs promote command"),
-        }
+        // Promote, sync, and diff left the fs surface entirely (promote/sync live on
+        // `tl git`; diff was cut).
+        assert!(Cli::try_parse_from(["tl", "fs", "promote", "main"]).is_err());
+        assert!(Cli::try_parse_from(["tl", "fs", "sync"]).is_err());
+        assert!(Cli::try_parse_from(["tl", "fs", "diff"]).is_err());
 
         match parse_command(["tl", "fs", "restore", "0a1b2c3d"]) {
             Commands::Fs(FsCommands::Restore {
                 path,
                 version,
-                discard_local,
+                discard,
             }) => {
                 assert_eq!(path, None);
                 assert_eq!(version, "0a1b2c3d");
-                assert!(!discard_local, "overlay-dropping restore is opt-in");
+                assert!(!discard, "overlay-dropping restore is opt-in");
             }
             _ => panic!("expected fs restore command"),
         }
 
-        // The overlay-destroying flags are explicit opt-ins on both destructive commands.
-        match parse_command(["tl", "fs", "restore", "--discard-local", "0a1b2c3d"]) {
-            Commands::Fs(FsCommands::Restore {
-                discard_local: true,
-                ..
-            }) => {}
-            _ => panic!("expected fs restore --discard-local command"),
+        // The overlay-destroying flag is an explicit opt-in.
+        match parse_command(["tl", "fs", "restore", "--discard", "0a1b2c3d"]) {
+            Commands::Fs(FsCommands::Restore { discard: true, .. }) => {}
+            _ => panic!("expected fs restore --discard command"),
         }
         match parse_command(["tl", "fs", "unmount", "./w"]) {
             Commands::Fs(FsCommands::Unmount {
@@ -3513,17 +3224,12 @@ mod tests {
             }) => {}
             _ => panic!("expected fs unmount command"),
         }
-        // --discard is the flag; --discard-local survives as a hidden alias.
-        match parse_command(["tl", "fs", "unmount", "--discard-local", "--delete", "./w"]) {
+        match parse_command(["tl", "fs", "unmount", "--discard", "--delete", "./w"]) {
             Commands::Fs(FsCommands::Unmount {
                 delete: true,
                 discard: true,
                 ..
             }) => {}
-            _ => panic!("expected fs unmount --discard command"),
-        }
-        match parse_command(["tl", "fs", "unmount", "--discard", "./w"]) {
-            Commands::Fs(FsCommands::Unmount { discard: true, .. }) => {}
             _ => panic!("expected fs unmount --discard command"),
         }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -227,47 +227,89 @@ enum FsCommands {
         check: bool,
     },
 
-    /// Create and mount a workspace, or mount an existing one (FUSE): reads stream lazily,
-    /// writes stay local until snapshotted
+    /// Create a new filesystem (starts empty; mount it or push a folder into it)
+    Create {
+        /// Filesystem name
+        name: String,
+
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Mount a filesystem (FUSE): reads stream lazily, saves publish to the filesystem.
+    /// Remounting a filesystem this machine has a detached session for resumes that session
     Mount {
-        /// `<file-system>[:<ref-or-commit>]` to create a new workspace, or a workspace id
-        /// from `tl fs ls` to mount an existing one (resumes at its last snapshot)
+        /// Filesystem name (see `tl fs ls`)
         target: String,
 
         /// Mountpoint directory (created; must be empty)
         path: PathBuf,
 
-        /// Write policy. Defaults to `rw`, but a workspace already mounted elsewhere defaults
-        /// to `ro` — pass `--mode rw` to mount it writable anyway. With a
-        /// `<file-system>[:<branch>]` target, `ro` is a read-only view that follows the branch
-        #[arg(long, value_enum)]
+        /// Read-only: look, don't touch (follows the filesystem's current state)
+        #[arg(long, conflicts_with = "mode")]
+        ro: bool,
+
+        /// (deprecated: use `tl git mount --ro/--rw` for repositories) Write policy
+        #[arg(long, value_enum, hide = true)]
         mode: Option<MountWriteMode>,
 
-        /// Every snapshot automatically publishes to the mounted branch (server-ordered,
-        /// one attributed commit per snapshot). Requires `<file-system>:<branch>`
-        #[arg(long)]
+        /// (deprecated: publishing is the default for filesystems; use `tl git mount
+        /// --publish` for repositories)
+        #[arg(long, hide = true)]
         shared_rw: bool,
 
-        /// Automatically seal local changes into a snapshot commit every N seconds (async,
-        /// in the mount daemon). Local overlay state is kept; `tl fs snapshot` remains the
-        /// on-demand seal. Requires a writable mount
-        #[arg(long, value_parser = clap::value_parser!(u64).range(1..))]
+        /// Save automatically every N seconds (0 disables; on-demand `tl fs snapshot`
+        /// always works)
+        #[arg(long, hide = true, value_parser = clap::value_parser!(u64))]
+        autosave_secs: Option<u64>,
+
+        /// (deprecated: autosave is on by default; see --autosave-secs)
+        #[arg(long, hide = true, value_parser = clap::value_parser!(u64).range(1..))]
         auto_commit_interval_secs: Option<u64>,
 
         /// Run the mount daemon in the foreground (debugging)
-        #[arg(long)]
+        #[arg(long, hide = true)]
         foreground: bool,
 
         /// Log every VFS operation the mount serves to stderr (macOS; requires --foreground)
-        #[arg(long, requires = "foreground")]
+        #[arg(long, requires = "foreground", hide = true)]
         trace_ops: bool,
 
         /// Log level (off, error, warn, info, debug, trace) for the mount daemon AND this
         /// command's own stderr diagnostics. Detached daemons log to `daemon.log` in the
         /// mount's state directory; foreground runs log to the terminal. `debug` also prints
         /// the CLI's `mount timing` phase lines.
-        #[arg(long, default_value = "info")]
+        #[arg(long, default_value = "info", hide = true)]
         log_level: String,
+    },
+
+    /// Upload a folder into a filesystem as one save (no mount needed)
+    Push {
+        /// Local directory to upload
+        dir: PathBuf,
+
+        /// Filesystem name
+        name: String,
+
+        /// Save message
+        #[arg(short, long)]
+        message: Option<String>,
+    },
+
+    /// Show the save history of a filesystem
+    History {
+        /// Filesystem name, or a mounted directory (default: the mount containing the
+        /// current directory)
+        target: Option<String>,
+
+        /// Show at most N entries
+        #[arg(short = 'n', long, default_value_t = 20)]
+        limit: usize,
+
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Bind a plain directory (no mount) to a new workspace; `tl fs snapshot` then scans and
@@ -288,22 +330,26 @@ enum FsCommands {
         path: Option<PathBuf>,
     },
 
-    /// List workspaces (all file systems, or one)
+    /// List filesystems (with a name: that filesystem's sessions and mounts)
     #[command(name = "ls")]
     Ls {
-        /// Limit the listing to one file system
+        /// Show one filesystem's sessions instead of the filesystem listing
         file_system: Option<String>,
 
-        /// Print workspaces as JSON
+        /// Output JSON
         #[arg(long)]
         json: bool,
     },
 
-    /// Delete a workspace (the only way a workspace dies)
+    /// Delete a filesystem and everything in it
     #[command(name = "rm")]
     Rm {
-        /// Workspace id or unique prefix (see `tl fs ls`)
-        workspace_id: String,
+        /// Filesystem name (a session id from `tl fs ls <filesystem>` still works, deprecated)
+        name: String,
+
+        /// Skip the confirmation
+        #[arg(short, long)]
+        force: bool,
     },
 
     /// (internal) Run a mount daemon for an existing state directory
@@ -335,8 +381,8 @@ enum FsCommands {
         clear: bool,
     },
 
-    /// Publish the workspace's snapshot onto a real branch (squash by default)
-    #[command(allow_missing_positional = true)]
+    /// (deprecated: use `tl git promote`) Publish the workspace's snapshot onto a real branch
+    #[command(allow_missing_positional = true, hide = true)]
     Promote {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
@@ -358,7 +404,8 @@ enum FsCommands {
         message: Option<String>,
     },
 
-    /// Pull the target branch into the workspace (server-side rebase-style merge)
+    /// (deprecated: use `tl git sync`) Pull the target branch into the workspace
+    #[command(hide = true)]
     Sync {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
@@ -414,20 +461,20 @@ enum FsCommands {
         b: Option<String>,
     },
 
-    /// Unmount: detach and forget local state; the workspace stays until deleted
+    /// Unmount: detach; the session survives and remounting the filesystem resumes it
     Unmount {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
 
-        /// Also delete the server-side workspace
-        #[arg(long)]
+        /// Also delete the server-side session (its unpublished saves become unreachable)
+        #[arg(long, hide = true)]
         delete: bool,
 
-        /// Drop the local overlay with the mount. Destructive: local changes not yet in a
-        /// snapshot AND ignored files under the mount are deleted — `tl fs snapshot` first to
-        /// keep the changes.
-        #[arg(long)]
-        discard_local: bool,
+        /// Throw away unsaved changes (and ignored files under the mount) with the mount.
+        /// Without it, unmount refuses when unsaved work would be lost — `tl fs snapshot`
+        /// first to keep it
+        #[arg(long, alias = "discard-local")]
+        discard: bool,
     },
 }
 
@@ -618,8 +665,135 @@ enum GitCommands {
         /// Operation requested by git: get, store, or erase
         operation: String,
     },
+    /// Mount a repo branch as a working tree (FUSE), without cloning: reads stream lazily,
+    /// writes stay local until `tl git snapshot`
+    Mount {
+        /// `<repo>[:<ref-or-commit>]` — forks a private workspace off the tip (default: the
+        /// repo's default branch)
+        target: String,
+
+        /// Mountpoint directory (created; must be empty)
+        path: PathBuf,
+
+        /// A live read-only view that follows the branch
+        #[arg(long, conflicts_with = "publish")]
+        ro: bool,
+
+        /// Force writable even though this workspace is mounted live elsewhere
+        #[arg(long, conflicts_with = "ro", hide = true)]
+        rw: bool,
+
+        /// Every snapshot lands on the mounted branch automatically (server-ordered, merged,
+        /// one attributed commit per snapshot). Requires `<repo>:<branch>`
+        #[arg(long)]
+        publish: bool,
+
+        /// Reattach an existing workspace instead of forking a new one
+        #[arg(long, conflicts_with = "publish")]
+        workspace: Option<String>,
+
+        /// Checkpoint local changes as a snapshot commit every N seconds (async, in the
+        /// mount daemon)
+        #[arg(long, hide = true, value_parser = clap::value_parser!(u64).range(1..))]
+        auto_snapshot_secs: Option<u64>,
+
+        /// Run the mount daemon in the foreground (debugging)
+        #[arg(long, hide = true)]
+        foreground: bool,
+
+        /// Log every VFS operation the mount serves to stderr (macOS; requires --foreground)
+        #[arg(long, requires = "foreground", hide = true)]
+        trace_ops: bool,
+
+        /// Daemon + CLI log level (off, error, warn, info, debug, trace)
+        #[arg(long, default_value = "info", hide = true)]
+        log_level: String,
+    },
+
+    /// Unmount a repo working tree; the workspace survives unless --delete
+    Unmount {
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
+
+        /// Also delete the server-side workspace (promoted work is unaffected)
+        #[arg(long)]
+        delete: bool,
+
+        /// Drop unsealed local changes (and ignored files) with the mount; without it,
+        /// unmount refuses when unsealed work would be lost
+        #[arg(long, alias = "discard-local")]
+        discard: bool,
+    },
+
+    /// Checkpoint the mounted working tree as a commit on its private workspace line
+    Snapshot {
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
+
+        /// Commit message
+        #[arg(short, long)]
+        message: Option<String>,
+
+        /// Drop the WHOLE local overlay after sealing (disk-reclaim escape hatch;
+        /// destructive to ignored files and concurrent writes)
+        #[arg(long, hide = true)]
+        clear: bool,
+    },
+
+    /// Pull the branch into the mounted working tree (server-side three-way merge;
+    /// conflicts materialize as diff3 markers in your files)
+    Sync {
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
+
+        /// Branch to pull from (default: the branch the workspace was created from)
+        #[arg(long, hide = true)]
+        target: Option<String>,
+
+        /// Report conflicts and change nothing instead of materializing markers
+        #[arg(long, hide = true)]
+        fail_on_conflict: bool,
+
+        /// Message for the sync commit
+        #[arg(short, long, hide = true)]
+        message: Option<String>,
+    },
+
+    /// Land the mounted working tree's checkpoint on a branch (squash by default)
+    #[command(allow_missing_positional = true)]
+    Promote {
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
+
+        /// Target branch
+        branch: String,
+
+        /// If the branch moved, land a two-parent merge instead of failing; conflicts
+        /// publish nothing
+        #[arg(long)]
+        merge: bool,
+
+        /// Land the full checkpoint chain instead of one squashed commit
+        #[arg(long, conflicts_with = "merge", hide = true)]
+        full_history: bool,
+
+        /// Message for the squashed/merge commit
+        #[arg(short, long, hide = true)]
+        message: Option<String>,
+    },
+
+    /// Show workspace and local-change status for a mounted working tree
+    Status {
+        /// A mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
+
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Print repo information (remote URL, branches, refs)
-    #[command(aliases = ["status", "url"])]
+    #[command(aliases = ["url"])]
     Info {
         /// Repo name
         repo: String,
@@ -1809,6 +1983,20 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
             run_ssh_keys_command(ctx, subcmd).await
         }
         Commands::Git(subcmd) => {
+            // The mount family resolves auth AFTER hydrating project scope from the mount's
+            // own state (so the commands work from any CWD), exactly like `tl fs` — route it
+            // before the eager auth guard below.
+            if matches!(
+                subcmd,
+                GitCommands::Mount { .. }
+                    | GitCommands::Unmount { .. }
+                    | GitCommands::Snapshot { .. }
+                    | GitCommands::Sync { .. }
+                    | GitCommands::Promote { .. }
+                    | GitCommands::Status { .. }
+            ) {
+                return run_git_mount_command(ctx, subcmd).await;
+            }
             // The credential helper is invoked by git itself, often non-interactively; it must
             // never start a login/init flow. It degrades softly (prints nothing, so git falls
             // through to prompting) when auth or project context is missing.
@@ -2375,35 +2563,55 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
         FsCommands::Init { path, file_system } => {
             commands::fs::plaindir::init(ctx, path, file_system.as_deref()).await
         }
-        FsCommands::Ls { file_system, json } => {
-            commands::fs::ls(ctx, file_system.as_deref(), json).await
+        FsCommands::Create { name, json } => {
+            commands::fs::create_filesystem(ctx, &name, json).await
         }
-        FsCommands::Rm { workspace_id } => commands::fs::rm(ctx, &workspace_id).await,
+        FsCommands::Ls { file_system, json } => match file_system {
+            None => commands::fs::ls_filesystems(ctx, json).await,
+            Some(fs) => commands::fs::ls(ctx, Some(&fs), json).await,
+        },
+        FsCommands::Rm { name, force } => commands::fs::rm_filesystem(ctx, &name, force).await,
+        FsCommands::Push { dir, name, message } => {
+            commands::fs::push_dir(ctx, &dir, &name, message.as_deref()).await
+        }
+        FsCommands::History {
+            target,
+            limit,
+            json,
+        } => commands::fs::history(ctx, target.as_deref(), limit, json).await,
         FsCommands::Mount {
             target,
             path,
+            ro,
             mode,
             shared_rw,
+            autosave_secs,
             auto_commit_interval_secs,
             foreground,
             trace_ops,
             log_level,
         } => {
-            let mode = match mode {
-                Some(MountWriteMode::Ro) => commands::fs::WritePolicy::Ro,
-                Some(MountWriteMode::Rw) => commands::fs::WritePolicy::Rw,
-                None => commands::fs::WritePolicy::Auto,
+            let mode = if ro {
+                Some(commands::fs::WritePolicy::Ro)
+            } else {
+                mode.map(|m| match m {
+                    MountWriteMode::Ro => commands::fs::WritePolicy::Ro,
+                    MountWriteMode::Rw => commands::fs::WritePolicy::Rw,
+                })
             };
-            commands::fs::mount(
+            commands::fs::mount_filesystem(
                 ctx,
                 &target,
                 &path,
-                mode,
-                shared_rw,
-                auto_commit_interval_secs,
-                foreground,
-                trace_ops,
-                &log_level,
+                commands::fs::FsMountOpts {
+                    mode,
+                    legacy_shared_rw: shared_rw,
+                    autosave_secs,
+                    legacy_auto_commit_interval_secs: auto_commit_interval_secs,
+                    foreground,
+                    trace_ops,
+                    log_level,
+                },
             )
             .await
         }
@@ -2421,6 +2629,10 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             message,
             ..
         } => {
+            eprintln!(
+                "deprecated: `tl fs promote` moved to `tl git promote` (same arguments); \
+                 this alias will be removed in a future release"
+            );
             commands::fs::promote(
                 ctx,
                 &mount_dir(),
@@ -2437,6 +2649,10 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             message,
             ..
         } => {
+            eprintln!(
+                "deprecated: `tl fs sync` moved to `tl git sync` (same arguments); this \
+                 alias will be removed in a future release"
+            );
             commands::fs::sync(
                 ctx,
                 &mount_dir(),
@@ -2456,10 +2672,8 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             commands::fs::diff(ctx, &mount_dir(), a.as_deref(), b.as_deref()).await
         }
         FsCommands::Unmount {
-            delete,
-            discard_local,
-            ..
-        } => commands::fs::unmount(ctx, &mount_dir(), delete, discard_local).await,
+            delete, discard, ..
+        } => commands::fs::unmount(ctx, &mount_dir(), delete, discard).await,
     };
     // A cached minted git credential can be revoked before its recorded expiry; purge
     // the cache on an auth failure so the next invocation re-mints instead of retrying
@@ -2485,6 +2699,134 @@ async fn run_fs_command(_ctx: &mut CliContext, _subcmd: FsCommands) -> error::Re
     ))
 }
 
+/// The `tl git` mount family: the same battle-tested engine as `tl fs`, with git vocabulary
+/// and git defaults (explicit checkpointing, no autosave, no publish unless asked).
+#[cfg(feature = "mount")]
+async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> error::Result<()> {
+    // Path-addressed commands carry their scope in the mount state; resolve it before auth so
+    // they work from any CWD (mirrors run_fs_command).
+    let mut subcmd = subcmd;
+    let mut mount_dir: Option<std::path::PathBuf> = None;
+    match &mut subcmd {
+        GitCommands::Promote { path, branch, .. } => {
+            if path.is_none() {
+                commands::fs::reject_mount_like_positional(
+                    branch,
+                    "branch",
+                    "tl git promote [PATH] <BRANCH>",
+                )?;
+            }
+            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
+        }
+        GitCommands::Snapshot { path, .. }
+        | GitCommands::Sync { path, .. }
+        | GitCommands::Status { path, .. }
+        | GitCommands::Unmount { path, .. } => {
+            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
+        }
+        _ => {}
+    }
+    if let Some(mount_dir) = &mount_dir {
+        commands::fs::hydrate_scope_from_mount(ctx, mount_dir);
+    }
+    ensure_auth_and_project(ctx).await?;
+    let mount_dir = move || mount_dir.expect("resolved for every path-addressed command above");
+    let result = match subcmd {
+        GitCommands::Mount {
+            target,
+            path,
+            ro,
+            rw,
+            publish,
+            workspace,
+            auto_snapshot_secs,
+            foreground,
+            trace_ops,
+            log_level,
+        } => {
+            let mode = if ro {
+                commands::fs::WritePolicy::Ro
+            } else if rw {
+                commands::fs::WritePolicy::Rw
+            } else {
+                commands::fs::WritePolicy::Auto
+            };
+            commands::fs::mount_repo(
+                ctx,
+                &target,
+                workspace.as_deref(),
+                &path,
+                mode,
+                publish,
+                auto_snapshot_secs,
+                foreground,
+                trace_ops,
+                &log_level,
+            )
+            .await
+        }
+        GitCommands::Snapshot { message, clear, .. } => {
+            commands::fs::snapshot(ctx, &mount_dir(), message.as_deref(), clear).await
+        }
+        GitCommands::Sync {
+            target,
+            fail_on_conflict,
+            message,
+            ..
+        } => {
+            commands::fs::sync(
+                ctx,
+                &mount_dir(),
+                target.as_deref(),
+                fail_on_conflict,
+                message.as_deref(),
+            )
+            .await
+        }
+        GitCommands::Promote {
+            branch,
+            full_history,
+            merge,
+            message,
+            ..
+        } => {
+            commands::fs::promote(
+                ctx,
+                &mount_dir(),
+                &branch,
+                full_history,
+                merge,
+                message.as_deref(),
+            )
+            .await
+        }
+        GitCommands::Status { json, .. } => commands::fs::status(ctx, &mount_dir(), json).await,
+        GitCommands::Unmount {
+            delete, discard, ..
+        } => commands::fs::unmount(ctx, &mount_dir(), delete, discard).await,
+        _ => unreachable!("routed only for the mount family"),
+    };
+    if let Err(
+        CliError::Auth(_)
+        | CliError::Sdk(
+            tensorlake::error::SdkError::Authentication(_)
+            | tensorlake::error::SdkError::Authorization(_),
+        ),
+    ) = &result
+    {
+        crate::config::files::purge_git_credentials();
+    }
+    result
+}
+
+#[cfg(not(feature = "mount"))]
+async fn run_git_mount_command(_ctx: &mut CliContext, _subcmd: GitCommands) -> error::Result<()> {
+    Err(CliError::usage(
+        "`tl git` mounts are not available in this build. Install the official `tl` release, \
+         which is compiled with mount support.",
+    ))
+}
+
 async fn run_ssh_keys_command(ctx: &CliContext, subcmd: SshKeysCommands) -> error::Result<()> {
     match subcmd {
         SshKeysCommands::Ls => commands::ssh_keys::list(ctx).await,
@@ -2497,6 +2839,14 @@ async fn run_ssh_keys_command(ctx: &CliContext, subcmd: SshKeysCommands) -> erro
 
 async fn run_git_command(ctx: &CliContext, subcmd: GitCommands) -> error::Result<()> {
     match subcmd {
+        GitCommands::Mount { .. }
+        | GitCommands::Unmount { .. }
+        | GitCommands::Snapshot { .. }
+        | GitCommands::Sync { .. }
+        | GitCommands::Promote { .. }
+        | GitCommands::Status { .. } => {
+            unreachable!("the mount family is routed to run_git_mount_command before auth")
+        }
         GitCommands::Clone {
             repo,
             dest,
@@ -2851,12 +3201,14 @@ mod tests {
             _ => panic!("expected git info command"),
         }
 
-        match parse_command(["tl", "git", "status", "demo", "--json"]) {
-            Commands::Git(GitCommands::Info { repo, json }) => {
-                assert_eq!(repo, "demo");
+        // `tl git status` is the mount-status command now (the old Info alias is gone);
+        // a positional parses as the mounted path, not a repo name.
+        match parse_command(["tl", "git", "status", "./w", "--json"]) {
+            Commands::Git(GitCommands::Status { path, json }) => {
+                assert_eq!(path, Some(PathBuf::from("./w")));
                 assert!(json);
             }
-            _ => panic!("expected git status alias"),
+            _ => panic!("expected git mount-status command"),
         }
 
         // `tl git url` merged into `tl git info` (which prints the remote URL).
@@ -2950,28 +3302,66 @@ mod tests {
     }
 
     #[test]
-    fn fs_commands_are_workspace_centric() {
-        match parse_command(["tl", "fs", "mount", "data:main", "./w", "--mode", "ro"]) {
+    fn fs_commands_are_filesystem_centric() {
+        // The filesystem surface: a bare name plus --ro. The legacy repo:ref form still
+        // parses (deprecation alias, warned at dispatch).
+        match parse_command(["tl", "fs", "mount", "scratch", "./w", "--ro"]) {
             Commands::Fs(FsCommands::Mount {
                 target,
                 path,
+                ro,
                 mode,
                 shared_rw,
+                autosave_secs,
                 auto_commit_interval_secs,
                 foreground,
                 trace_ops,
                 log_level,
             }) => {
-                assert_eq!(target, "data:main");
+                assert_eq!(target, "scratch");
                 assert_eq!(path, PathBuf::from("./w"));
-                assert_eq!(mode, Some(MountWriteMode::Ro));
+                assert!(ro);
+                assert_eq!(mode, None);
                 assert!(!shared_rw);
+                assert_eq!(autosave_secs, None);
                 assert_eq!(auto_commit_interval_secs, None);
                 assert!(!foreground);
                 assert!(!trace_ops);
                 assert_eq!(log_level, "info");
             }
             _ => panic!("expected fs mount command"),
+        }
+        // --ro and the deprecated --mode are mutually exclusive.
+        assert!(
+            Cli::try_parse_from(["tl", "fs", "mount", "s", "./w", "--ro", "--mode", "rw"]).is_err()
+        );
+
+        match parse_command(["tl", "fs", "create", "scratch"]) {
+            Commands::Fs(FsCommands::Create { name, json: false }) => {
+                assert_eq!(name, "scratch");
+            }
+            _ => panic!("expected fs create command"),
+        }
+
+        match parse_command(["tl", "fs", "push", "./data", "scratch", "-m", "bulk load"]) {
+            Commands::Fs(FsCommands::Push { dir, name, message }) => {
+                assert_eq!(dir, PathBuf::from("./data"));
+                assert_eq!(name, "scratch");
+                assert_eq!(message.as_deref(), Some("bulk load"));
+            }
+            _ => panic!("expected fs push command"),
+        }
+
+        match parse_command(["tl", "fs", "history", "scratch", "-n", "5"]) {
+            Commands::Fs(FsCommands::History {
+                target,
+                limit,
+                json: false,
+            }) => {
+                assert_eq!(target.as_deref(), Some("scratch"));
+                assert_eq!(limit, 5);
+            }
+            _ => panic!("expected fs history command"),
         }
 
         // A bare workspace id mounts an existing workspace; --mode rw forces writes.
@@ -3031,9 +3421,9 @@ mod tests {
             _ => panic!("expected fs ls command"),
         }
 
-        match parse_command(["tl", "fs", "rm", "0a1b2c3d"]) {
-            Commands::Fs(FsCommands::Rm { workspace_id }) => {
-                assert_eq!(workspace_id, "0a1b2c3d");
+        match parse_command(["tl", "fs", "rm", "scratch", "-f"]) {
+            Commands::Fs(FsCommands::Rm { name, force: true }) => {
+                assert_eq!(name, "scratch");
             }
             _ => panic!("expected fs rm command"),
         }
@@ -3118,18 +3508,59 @@ mod tests {
         match parse_command(["tl", "fs", "unmount", "./w"]) {
             Commands::Fs(FsCommands::Unmount {
                 delete: false,
-                discard_local: false,
+                discard: false,
                 ..
             }) => {}
             _ => panic!("expected fs unmount command"),
         }
+        // --discard is the flag; --discard-local survives as a hidden alias.
         match parse_command(["tl", "fs", "unmount", "--discard-local", "--delete", "./w"]) {
             Commands::Fs(FsCommands::Unmount {
                 delete: true,
-                discard_local: true,
+                discard: true,
                 ..
             }) => {}
-            _ => panic!("expected fs unmount --discard-local command"),
+            _ => panic!("expected fs unmount --discard command"),
+        }
+        match parse_command(["tl", "fs", "unmount", "--discard", "./w"]) {
+            Commands::Fs(FsCommands::Unmount { discard: true, .. }) => {}
+            _ => panic!("expected fs unmount --discard command"),
+        }
+
+        // The git mount family parses with git vocabulary.
+        match parse_command(["tl", "git", "mount", "demo:main", "./w", "--publish"]) {
+            Commands::Git(GitCommands::Mount {
+                target,
+                path,
+                ro: false,
+                publish: true,
+                workspace: None,
+                ..
+            }) => {
+                assert_eq!(target, "demo:main");
+                assert_eq!(path, PathBuf::from("./w"));
+            }
+            _ => panic!("expected git mount command"),
+        }
+        match parse_command(["tl", "git", "promote", "main", "--merge"]) {
+            Commands::Git(GitCommands::Promote {
+                path: None,
+                branch,
+                merge: true,
+                ..
+            }) => {
+                assert_eq!(branch, "main");
+            }
+            _ => panic!("expected git promote command"),
+        }
+        match parse_command(["tl", "git", "sync"]) {
+            Commands::Git(GitCommands::Sync { path: None, .. }) => {}
+            _ => panic!("expected git sync command"),
+        }
+        // `tl git status` is the mount status now; repo info keeps its `url` alias only.
+        match parse_command(["tl", "git", "status"]) {
+            Commands::Git(GitCommands::Status { path: None, .. }) => {}
+            _ => panic!("expected git status command"),
         }
 
         assert!(Cli::try_parse_from(["tl", "fs", "promote"]).is_err());

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -286,24 +286,6 @@ enum FsCommands {
         json: bool,
     },
 
-    /// Bind a plain directory (no mount) to a new workspace; `tl fs snapshot` then scans and
-    /// pushes it directly — v1 requires the file system's head to be empty
-    Init {
-        /// Directory to bind (default: the current directory; created if missing)
-        path: Option<PathBuf>,
-
-        /// File system to create the workspace on (default: the project's only file system)
-        #[arg(long)]
-        file_system: Option<String>,
-    },
-
-    /// Remove a plain-directory binding and its local state; the workspace and its snapshots
-    /// survive on the server (delete them with `tl fs rm`)
-    Unbind {
-        /// A bound directory (default: the binding containing the current directory)
-        path: Option<PathBuf>,
-    },
-
     /// List filesystems (with a name: that filesystem's sessions and mounts)
     #[command(name = "ls")]
     Ls {
@@ -318,7 +300,7 @@ enum FsCommands {
     /// Delete a filesystem and everything in it
     #[command(name = "rm")]
     Rm {
-        /// Filesystem name (a session id from `tl fs ls <filesystem>` still works, deprecated)
+        /// Filesystem name
         name: String,
 
         /// Skip the confirmation
@@ -337,22 +319,15 @@ enum FsCommands {
         log_level: String,
     },
 
-    /// Seal local changes into a snapshot on the workspace ref (the local overlay is kept)
+    /// Save the current state of the filesystem (a clean tree is a quiet no-op)
     Snapshot {
-        /// A mounted directory (default: the mount containing the current directory)
+        /// A mounted or pushed directory (default: the attachment containing the current
+        /// directory)
         path: Option<PathBuf>,
 
-        /// Snapshot message
+        /// Save message
         #[arg(short, long)]
         message: Option<String>,
-
-        /// After sealing, drop the WHOLE local overlay so the mount serves the snapshot
-        /// commit directly. Rarely needed — `tl fs sync` trims sealed content by itself;
-        /// this is the disk-reclaim / reset-local-state escape hatch. Destructive: also
-        /// deletes ignored files under the mount and any writes made while the snapshot was
-        /// uploading — pause writers first.
-        #[arg(long)]
-        clear: bool,
     },
 
     /// Show workspace, lease, and local-change status for a mount
@@ -376,11 +351,12 @@ enum FsCommands {
 
         /// Drop the local overlay to apply the restore. Destructive: unsaved changes AND
         /// ignored files under the mount are deleted — `tl fs snapshot` first to keep them
-        #[arg(long, alias = "discard-local")]
+        #[arg(long)]
         discard: bool,
     },
 
-    /// Unmount: detach; the session survives and remounting the filesystem resumes it
+    /// Detach a mounted filesystem (the session survives; remounting resumes it) or stop
+    /// tracking a pushed directory
     Unmount {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
@@ -631,7 +607,7 @@ enum GitCommands {
 
         /// Drop unsealed local changes (and ignored files) with the mount; without it,
         /// unmount refuses when unsealed work would be lost
-        #[arg(long, alias = "discard-local")]
+        #[arg(long)]
         discard: bool,
     },
 
@@ -2384,17 +2360,34 @@ async fn run_applications_command(
 #[cfg(feature = "mount")]
 async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Result<()> {
     // Setup installs a local app bundle; it must work before the user has logged in.
-    // Unbind only removes local binding state (the workspace survives server-side), so it
-    // must work even when auth is unavailable.
     let subcmd = match subcmd {
         FsCommands::Setup { from, check } => {
             return commands::fs::setup(from.as_deref(), check).await;
         }
-        FsCommands::Unbind { path } => {
-            return commands::fs::plaindir::unbind(path).await;
-        }
         other => other,
     };
+    // Unmounting a pushed (bound) directory only removes local tracking state — the directory
+    // and the filesystem are untouched — so, like setup, it works without auth.
+    if let FsCommands::Unmount {
+        path,
+        delete,
+        discard,
+    } = &subcmd
+    {
+        let probe = match path {
+            Some(p) => p.clone(),
+            None => std::env::current_dir()?,
+        };
+        if commands::fs::plaindir::binding_for_lenient(&probe).is_some() {
+            if *delete || *discard {
+                return Err(CliError::usage(
+                    "a pushed directory is your own files; unmount just stops tracking it \
+                     (--discard/--delete do not apply)",
+                ));
+            }
+            return commands::fs::plaindir::unbind(path.clone()).await;
+        }
+    }
     // Path-addressed commands default their mounted-directory argument to the mount containing
     // the CWD; resolve it up front so scope hydration and the command agree on the path.
     let mut subcmd = subcmd;
@@ -2427,12 +2420,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
     // Set for exactly the path-addressed commands, whose dispatch arms are the only readers.
     let mount_dir = move || mount_dir.expect("resolved for every path-addressed command above");
     let result = match subcmd {
-        FsCommands::Setup { .. } | FsCommands::Unbind { .. } => {
-            unreachable!("handled before the auth guard")
-        }
-        FsCommands::Init { path, file_system } => {
-            commands::fs::plaindir::init(ctx, path, file_system.as_deref()).await
-        }
+        FsCommands::Setup { .. } => unreachable!("handled before the auth guard"),
         FsCommands::Create { name, json } => {
             commands::fs::create_filesystem(ctx, &name, json).await
         }
@@ -2466,8 +2454,8 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             state_dir,
             log_level,
         } => commands::fs::daemon::run(ctx, &state_dir, &log_level).await,
-        FsCommands::Snapshot { message, clear, .. } => {
-            commands::fs::snapshot(ctx, &mount_dir(), message.as_deref(), clear).await
+        FsCommands::Snapshot { message, .. } => {
+            commands::fs::snapshot(ctx, &mount_dir(), message.as_deref(), false).await
         }
         FsCommands::Status { json, .. } => commands::fs::status(ctx, &mount_dir(), json).await,
         FsCommands::Restore {
@@ -3168,35 +3156,32 @@ mod tests {
             Commands::Fs(FsCommands::Snapshot {
                 path: None,
                 message: None,
-                clear: false,
             }) => {}
             _ => panic!("expected fs snapshot command"),
         }
 
         match parse_command(["tl", "fs", "snapshot", "./w", "-m", "wip"]) {
-            Commands::Fs(FsCommands::Snapshot {
-                path,
-                message,
-                clear,
-            }) => {
+            Commands::Fs(FsCommands::Snapshot { path, message }) => {
                 assert_eq!(path, Some(PathBuf::from("./w")));
                 assert_eq!(message.as_deref(), Some("wip"));
-                assert!(!clear, "clear is opt-in");
             }
             _ => panic!("expected fs snapshot command"),
         }
 
-        // The destructive seal-and-clear is an explicit flag.
-        match parse_command(["tl", "fs", "snapshot", "--clear"]) {
-            Commands::Fs(FsCommands::Snapshot { clear: true, .. }) => {}
-            _ => panic!("expected fs snapshot --clear command"),
-        }
-
-        // Promote, sync, and diff left the fs surface entirely (promote/sync live on
-        // `tl git`; diff was cut).
+        // Promote, sync, diff, init, and the overlay-clearing snapshot left the fs surface
+        // entirely (promote/sync/--clear live on `tl git`; diff and init were cut — push
+        // binds a directory, unmount forgets it).
         assert!(Cli::try_parse_from(["tl", "fs", "promote", "main"]).is_err());
         assert!(Cli::try_parse_from(["tl", "fs", "sync"]).is_err());
         assert!(Cli::try_parse_from(["tl", "fs", "diff"]).is_err());
+        assert!(Cli::try_parse_from(["tl", "fs", "init"]).is_err());
+        assert!(Cli::try_parse_from(["tl", "fs", "unbind"]).is_err());
+        assert!(Cli::try_parse_from(["tl", "fs", "snapshot", "--clear"]).is_err());
+        // `tl git snapshot --clear` keeps the disk-reclaim hatch (hidden).
+        match parse_command(["tl", "git", "snapshot", "--clear"]) {
+            Commands::Git(GitCommands::Snapshot { clear: true, .. }) => {}
+            _ => panic!("expected git snapshot --clear command"),
+        }
 
         match parse_command(["tl", "fs", "restore", "0a1b2c3d"]) {
             Commands::Fs(FsCommands::Restore {

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -2445,7 +2445,7 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         );
-        sdk.create_repo_with_credential("ingesttest", &repo, None, "t", "devtoken")
+        sdk.create_repo_with_credential("ingesttest", &repo, None, None, "t", "devtoken")
             .await
             .unwrap();
 

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -117,11 +117,25 @@ impl ArtifactStorageClient {
         repo: &str,
         default_branch: Option<&str>,
     ) -> Result<Traced<()>, SdkError> {
+        self.create_repo_of_kind(project_id, repo, default_branch, None)
+            .await
+    }
+
+    /// Create a repo of an explicit kind ("repository" | "filesystem"). `None` omits the field
+    /// entirely, which pre-kind servers require.
+    pub async fn create_repo_of_kind(
+        &self,
+        project_id: &str,
+        repo: &str,
+        default_branch: Option<&str>,
+        kind: Option<&str>,
+    ) -> Result<Traced<()>, SdkError> {
         let credential = self.git_credential_for_project(project_id).await?;
         self.create_repo_with_credential(
             project_id,
             repo,
             default_branch,
+            kind,
             &credential.git_username,
             &credential.token,
         )
@@ -133,11 +147,13 @@ impl ArtifactStorageClient {
         project_id: &str,
         repo: &str,
         default_branch: Option<&str>,
+        kind: Option<&str>,
         git_username: &str,
         git_token: &str,
     ) -> Result<Traced<()>, SdkError> {
         let request = CreateRepoRequest {
             default_branch: default_branch.unwrap_or("main").to_string(),
+            kind: kind.map(str::to_string),
         };
         let (request_builder, trace_id) = self.git_request(
             Method::POST,
@@ -272,22 +288,41 @@ impl ArtifactStorageClient {
         &self,
         project_id: &str,
     ) -> Result<Traced<ListReposResponse>, SdkError> {
+        self.list_repos_of_kind(project_id, None).await
+    }
+
+    /// List repos restricted to one kind ("repository" | "filesystem"). `None` lists all kinds
+    /// and sends no filter, which pre-kind servers require.
+    pub async fn list_repos_of_kind(
+        &self,
+        project_id: &str,
+        kind: Option<&str>,
+    ) -> Result<Traced<ListReposResponse>, SdkError> {
         let credential = self.git_credential_for_project(project_id).await?;
-        self.list_repos_with_credential(project_id, &credential.git_username, &credential.token)
-            .await
+        self.list_repos_with_credential(
+            project_id,
+            kind,
+            &credential.git_username,
+            &credential.token,
+        )
+        .await
     }
 
     pub async fn list_repos_with_credential(
         &self,
         project_id: &str,
+        kind: Option<&str>,
         git_username: &str,
         git_token: &str,
     ) -> Result<Traced<ListReposResponse>, SdkError> {
-        let url = format!(
+        let mut url = format!(
             "{}/project/{}/repos",
             self.git_base_url,
             encode_path_segment(project_id)
         );
+        if let Some(kind) = kind {
+            url.push_str(&format!("?kind={}", urlencoding::encode(kind)));
+        }
         let (request, trace_id) = self.git_request_url(Method::GET, url, git_username, git_token);
         let response = request.send().await?;
         decode_json(response, trace_id).await

--- a/crates/cloud-sdk/src/artifact_storage/models.rs
+++ b/crates/cloud-sdk/src/artifact_storage/models.rs
@@ -49,7 +49,18 @@ pub struct Repo {
 }
 
 fn default_repo_kind() -> String {
-    "repository".to_string()
+    REPO_KIND_REPOSITORY.to_string()
+}
+
+/// The wire names for repo kinds — defined once; every construction and comparison goes
+/// through these (a typo'd bare literal would compile and silently misroute).
+pub const REPO_KIND_REPOSITORY: &str = "repository";
+pub const REPO_KIND_FILESYSTEM: &str = "filesystem";
+
+impl Repo {
+    pub fn is_filesystem(&self) -> bool {
+        self.kind == REPO_KIND_FILESYSTEM
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/cloud-sdk/src/artifact_storage/models.rs
+++ b/crates/cloud-sdk/src/artifact_storage/models.rs
@@ -10,12 +10,17 @@ pub struct MintGitTokenRequest {
 pub struct CreateRepoRequest {
     #[serde(rename = "default_branch")]
     pub default_branch: String,
+    /// "repository" (default) or "filesystem". Omitted (not sent) when `None` so the request
+    /// stays valid against servers that predate repo kinds (`deny_unknown_fields`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
 }
 
 impl Default for CreateRepoRequest {
     fn default() -> Self {
         Self {
             default_branch: "main".to_string(),
+            kind: None,
         }
     }
 }
@@ -37,6 +42,14 @@ pub struct Repo {
     pub full_name: String,
     pub default_branch: String,
     pub status: String,
+    /// "repository" or "filesystem". Defaults to "repository" when the server predates repo
+    /// kinds and omits the field.
+    #[serde(default = "default_repo_kind")]
+    pub kind: String,
+}
+
+fn default_repo_kind() -> String {
+    "repository".to_string()
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
The CLI half of the fs/git decoupling. `tl fs` becomes the filesystem product (the create → copy → save mental model users arrive with); branch-vocabulary mounts move under `tl git`. One engine — workspaces, the mount daemon, plaindir bindings — under both surfaces; they differ in vocabulary and defaults only. **No back-compat layer: the old forms are gone, not deprecated** (second commit).

**Depends on [artifact_storage#102](https://github.com/tensorlakeai/artifact_storage/pull/102)** (repo kinds + genesis snapshots) being merged and deployed: `tl fs create` sends `kind: "filesystem"`, `tl fs ls` filters with `?kind=`, and mounting a fresh filesystem needs the server-minted genesis commit.

## tl fs (filesystem vocabulary — "workspace" never surfaces)

| Command | Behavior |
|---|---|
| `create <name>` | New filesystem, born mountable (genesis save server-side) |
| `ls` | Filesystems + where each is attached locally; `ls <fs>` shows its sessions |
| `mount <name> <path> [--ro]` | Publish-on-save session (shared-rw onto the default branch, materialize), autosave always on for writable mounts, detached local session auto-resumes. A filesystem name and `--ro` are the whole surface: `repo:ref` targets and repositories error with a pointer to `tl git mount` |
| `push <dir> <name> [-m]` | Upload a folder as one save, no mount; re-push reuses the binding's stat index so only changes upload |
| `history [target] [-n]` | Save timeline (operation log; 403 degrades with clear guidance) |
| `rm <name> [-f]` | Deletes the filesystem after a confirm |
| `unmount [--discard] [--delete]` | `--discard` overrides the unsaved-work gate; hidden `--delete` also drops the session |
| `snapshot -m / status / restore [--discard] / setup` | Core verbs; clean snapshot = quiet no-op |

Removed outright (was: deprecated aliases): `promote`, `sync`, `diff`, `rm <session-id>`, `mount <repo>:<ref>`, `--mode`, `--shared-rw`, `--auto-commit-interval-secs`.

Third commit (review round): `init`/`unbind` folded away — `push` is the one way a plain directory enters a filesystem (binds on first use) and `unmount` detaches any attachment (mount or pushed directory); fs `snapshot --clear` removed (hatch stays hidden on `tl git snapshot`); sessions view says publishing/private instead of workspace vocabulary.

## tl git gains the mount family (git vocabulary, git defaults)

`mount <repo>[:<ref>] <path>` (`--ro`, `--publish`, `--workspace <id>`), `unmount` (`--delete`), `snapshot -m`, `sync` (flagless; conflicts materialize as diff3 markers), `promote [path] <branch>` (`--merge` only), `status`. Explicit checkpointing — no autosave, no publish unless asked, and **no `--rw` override**: a workspace attached elsewhere mounts read-only until the other attachment is released. `tl git info` loses its `status` alias to the mount status command (`url` alias stays).

Every surviving flag is either a guard override (`--discard`, `--delete`, `-f`) or the answer to an error (`--merge`, `--workspace`, `--publish`, `--check`); `-m` and `--ro` are the only preference flags.

## Mechanics

- Engine: `fs::mount()` takes an explicit `shared_target` publish branch (replaces the `shared_rw` flag); `plaindir::init` split into a reusable `bind` core so `push` gets a publish-on-save binding; the dead workspace-level `rm()` and `MountWriteMode` are deleted.
- SDK: `create_repo_of_kind` / `list_repos_of_kind`, `kind` on the `Repo` model (serde-defaulted for pre-kind servers, omitted from create when unset).
- Auto-resume: the mounts registry is scanned for a dead-daemon session of the same filesystem; newest wins; read-only mounts never resume a writer session.

## Validation

- Live e2e against a local artifact_storage server built at the #102 commit: new ignored `filesystem_kind_contract_roundtrips` (kind create → listing partition → genesis-backed publish-on-save workspace) plus the full ignored overlay suite — all green, re-run after the back-compat removal.
- 279 unit tests pass; the parse tests now assert the legacy forms **fail** to parse.
- `cargo check` clean for the plain build and `--features mount,git-clone --all-targets`; clippy adds no new warnings.
- gsvc-mount/gsvc-codec placeholders untouched (vendored sources swapped in only for local builds, restored before committing).

## Follow-ups

- `history` reads the admin-gated operation log; a product commits-log endpoint would remove the project-admin requirement.
- Release notes for the removed commands/flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)