### PR TITLE
fs/git split: fixes from live e2e against the deployed server

### DIFF
--- a/crates/cli/src/auth/context.rs
+++ b/crates/cli/src/auth/context.rs
@@ -231,3 +231,18 @@ impl CliContext {
             .and_then(|r| r.project_id.clone())
     }
 }
+
+/// The project a pre-provisioned git credential is scoped to, read from the JWT `iss` claim
+/// (artifact-storage mints carry `iss: "project_..."`). `None` for opaque dev tokens and
+/// malformed payloads — callers fall back to configured scope.
+pub(crate) fn project_from_git_token() -> Option<String> {
+    use base64::Engine;
+    let token = std::env::var("TENSORLAKE_GIT_TOKEN").ok()?;
+    let payload = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let iss = claims.get("iss")?.as_str()?;
+    iss.starts_with("project_").then(|| iss.to_string())
+}

--- a/crates/cli/src/auth/guard.rs
+++ b/crates/cli/src/auth/guard.rs
@@ -44,6 +44,24 @@ pub async fn ensure_auth(ctx: &mut CliContext) -> Result<()> {
 /// Ensure authentication and org/project are available.
 /// Triggers login and/or init flows as needed.
 pub async fn ensure_auth_and_project(ctx: &mut CliContext) -> Result<()> {
+    // Sandbox attach path (issue #103): a pre-provisioned repo-scoped git credential IS the
+    // authentication for the fs surface, and its JWT carries the project claim. Never start
+    // an interactive login/init flow here — the guest is headless, and the browser-approval
+    // poll would hang forever.
+    if std::env::var("TENSORLAKE_GIT_TOKEN").is_ok() {
+        if ctx.effective_project_id().is_none()
+            && let Some(project) = crate::auth::context::project_from_git_token()
+        {
+            ctx.project_id = Some(project);
+        }
+        if ctx.effective_project_id().is_some() {
+            return Ok(());
+        }
+        return Err(CliError::auth(
+            "TENSORLAKE_GIT_TOKEN is set but carries no project claim; \
+             re-mint it with `tl fs token <filesystem>` or configure a project",
+        ));
+    }
     if !ctx.has_authentication() {
         eprintln!("It seems like you're not logged in. Let's log you in...\n");
         let login_result = match run_login_flow(ctx, true).await {

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -647,7 +647,9 @@ pub async fn history(
             }
         }
     };
-    let session = FsSession::open(ctx, Some(&fs_name)).await?;
+    // Project-wide session: the operation log is project-scoped, and repo-scoped mints
+    // deliberately omit that scope (a repo credential would 403 here).
+    let session = FsSession::open(ctx, None).await?;
     let (user, token) = session.creds();
     let ops = session
         .client
@@ -1782,6 +1784,18 @@ fn create_recovery(e: &tensorlake::error::SdkError) -> Option<CreateRecovery> {
 /// still succeeds.
 async fn ensure_seeded(session: &FsSession, default_branch: &str, repo: &str) -> Result<()> {
     let (user, token) = session.creds();
+    // Filesystems are born with a genesis save (server-minted, kind=filesystem) and legacy
+    // repos may have real history — seeding those would stack a pointless empty commit on
+    // every first bind. Only a genuinely unborn default branch needs the seed.
+    let refs = session
+        .client
+        .list_refs_with_credential(&session.project_id, repo, user, token)
+        .await?
+        .into_inner();
+    let full_ref = format!("refs/heads/{default_branch}");
+    if refs.refs.iter().any(|r| r.name == full_ref) {
+        return Ok(());
+    }
     session
         .client
         .push_files(
@@ -2790,14 +2804,16 @@ pub async fn unmount(
     registry_remove(&mountpoint)?;
     if delete {
         println!(
-            "Unmounted {mountpoint} (workspace {} deleted).",
+            "Unmounted {mountpoint} (session {} deleted).",
             short_id(&state.workspace_id)
         );
     } else {
         println!(
-            "Unmounted {mountpoint}. Workspace {} kept — mount it again with: tl fs mount {} \
-             <path>",
+            "Unmounted {mountpoint}. Session {} kept — `tl fs mount {} <path>` resumes it \
+             (repositories: tl git mount {} <path> --workspace {}).",
             short_id(&state.workspace_id),
+            state.repo,
+            state.repo,
             short_id(&state.workspace_id),
         );
     }
@@ -3087,6 +3103,20 @@ async fn overlay_losable_state(state_dir: &Path, mountpoint: &str) -> Result<Opt
             ))
         })
     }
+    // Files the OS strews into every volume it touches (AppleDouble resource forks,
+    // Finder/Spotlight/Trash state). They are ignored-by-rule and mechanically recreated, so
+    // they are not user work and must not make a clean unmount demand --discard — on macOS
+    // every mount acquires them within seconds of being browsed.
+    fn is_os_junk(rel: &str) -> bool {
+        let base = rel.rsplit('/').next().unwrap_or(rel);
+        base == ".DS_Store"
+            || base == ".Spotlight-V100"
+            || base == ".fseventsd"
+            || base == ".Trashes"
+            || base == ".TemporaryItems"
+            || base == ".apdisk"
+            || base.starts_with("._")
+    }
     fn strict_count_files(dir: &Path) -> Result<usize> {
         let mut n = 0;
         let read = match std::fs::read_dir(dir) {
@@ -3140,7 +3170,9 @@ async fn overlay_losable_state(state_dir: &Path, mountpoint: &str) -> Result<Opt
             let rel = overlay_rel_path(root, &abs);
             if meta.is_dir() && !meta.file_type().is_symlink() {
                 if check_ignored(ignore, &rel, true)? {
-                    *ignored += strict_count_files(&abs)?;
+                    if !is_os_junk(&rel) {
+                        *ignored += strict_count_files(&abs)?;
+                    }
                 } else {
                     classify_upper(
                         root,
@@ -3165,7 +3197,9 @@ async fn overlay_losable_state(state_dir: &Path, mountpoint: &str) -> Result<Opt
                 continue; // retained: stat-verified sealed content
             }
             if check_ignored(ignore, &rel, false)? {
-                *ignored += 1;
+                if !is_os_junk(&rel) {
+                    *ignored += 1;
+                }
                 continue;
             }
             *uncovered += 1;
@@ -4061,26 +4095,31 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         );
         return Ok(());
     }
-    println!("{} {}", style("file system:").dim(), state.repo);
+    println!("{} {}", style("filesystem:").dim(), state.repo);
     println!(
         "{} {} (created {} ago)",
-        style("workspace:").dim(),
+        style("session:").dim(),
         short_id(&ws.id),
         age_display(ws.created_at_secs)
     );
-    if let Some(followed) = &state.follow_ref {
+    // A publish-on-save mount follows its target branch for convergence but is writable —
+    // read_only() (not follow_ref presence) decides which mode the user is in.
+    if state.read_only() {
+        let followed = state.follow_ref.as_deref().unwrap_or("the current state");
         println!("{} read-only, follows {followed}", style("mode:").dim());
     } else if let Some(target) = &ws.shared_target {
         println!(
-            "{} shared-rw, snapshots auto-publish to {target}",
+            "{} publishing — every save lands on {target} (view follows it)",
             style("mode:").dim()
         );
+    } else {
+        println!("{} private (publish with promote)", style("mode:").dim());
     }
     if let Some(secs) = state.auto_commit_interval_secs {
         println!(
-            "{} local changes seal into a snapshot every {secs}s (local: below is the kept \
-             overlay, sealed content included; `tl fs snapshot --clear` drops it)",
-            style("auto-commit:").dim()
+            "{} local changes seal into a save every {secs}s (sealed content below is kept \
+             locally as the byte cache)",
+            style("autosave:").dim()
         );
     }
     match &daemon_commit {

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -4736,7 +4736,7 @@ fn parse_refresh_probes(
 
 /// Write a whiteout marker file, superseding any container of child markers at the same path
 /// (mirrors OverlayFs::set_whiteout).
-fn write_whiteout(wh: &Path, rel: &str) -> Result<()> {
+pub(crate) fn write_whiteout(wh: &Path, rel: &str) -> Result<()> {
     let marker = wh.join(rel);
     if let Some(parent) = marker.parent() {
         std::fs::create_dir_all(parent)?;

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1880,16 +1880,28 @@ fn registry_load() -> toml::map::Map<String, toml::Value> {
         .unwrap_or_default()
 }
 
+/// Serialize registry mutations across processes. Every writer is load-modify-save; without
+/// this, two concurrent `tl fs mount`s read the same table and the last save silently drops
+/// the other's entry — stranding a LIVE mount outside ls/status/unmount. Readers stay
+/// lock-free: [`plaindir::write_atomic`]'s rename means they see a complete document or the
+/// previous one, never a torn write (which `registry_load` would misread as an empty
+/// registry). Blocking acquire — the critical section is a small file rewrite.
+fn registry_lock() -> Result<std::fs::File> {
+    std::fs::create_dir_all(crate::config::files::config_dir())?;
+    plaindir::flock_exclusive(&crate::config::files::config_dir().join("mounts.lock"), true)?
+        .ok_or_else(|| CliError::usage("could not lock the mount registry"))
+}
+
 fn registry_save(table: &toml::map::Map<String, toml::Value>) -> Result<()> {
     std::fs::create_dir_all(crate::config::files::config_dir())?;
-    std::fs::write(
-        mounts_registry_path(),
-        toml::to_string_pretty(&toml::Value::Table(table.clone()))?,
-    )?;
-    Ok(())
+    plaindir::write_atomic(
+        &mounts_registry_path(),
+        toml::to_string_pretty(&toml::Value::Table(table.clone()))?.as_bytes(),
+    )
 }
 
 fn registry_add(mountpoint: &str, state_dir: &Path) -> Result<()> {
+    let _lock = registry_lock()?;
     let mut table = registry_load();
     // One state dir, one mountpoint: resuming a detached session at a NEW path must retire
     // the old path's binding, or management commands against the stale mountpoint report
@@ -1901,6 +1913,7 @@ fn registry_add(mountpoint: &str, state_dir: &Path) -> Result<()> {
 }
 
 fn registry_remove(mountpoint: &str) -> Result<()> {
+    let _lock = registry_lock()?;
     let mut table = registry_load();
     table.remove(mountpoint);
     registry_save(&table)

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -762,7 +762,7 @@ pub async fn mount_filesystem(
     // Auto-resume first — no server round trip. A detached local session of this filesystem
     // (mount state present, daemon dead) picks up where it left off: "run the same command
     // again" is the crash recovery. WritePolicy::Auto keeps the single-writer downgrade.
-    if !ro && let Some(workspace_id) = detached_local_session(target) {
+    if !ro && let Some((workspace_id, state_dir)) = detached_local_session(target) {
         println!(
             "Resuming detached session {} of filesystem {target}.",
             short_id(&workspace_id)
@@ -770,6 +770,9 @@ pub async fn mount_filesystem(
         // The repo is KNOWN from the local mount state: attach through the per-repo
         // endpoint so the whole path works under a repo-scoped credential (the sandbox
         // recipe) — never through name resolution, which would treat the id as a repo.
+        // The SELECTED state dir travels with the id: recomputing it via allocation
+        // could pick a different dead registration of the same workspace (the canonical
+        // dir when the newest overlay lives in a suffixed one) and strand unsealed work.
         return mount(
             ctx,
             target,
@@ -778,7 +781,10 @@ pub async fn mount_filesystem(
             None,
             autosave,
             true,
-            Some(&workspace_id),
+            Some(Resume {
+                workspace_id: &workspace_id,
+                state_dir: Some(state_dir),
+            }),
             foreground,
             trace_ops,
             log_level,
@@ -805,12 +811,19 @@ pub async fn mount_filesystem(
     .await
 }
 
+/// A known-repo workspace attach for [`mount`]: skip name resolution entirely, and — when a
+/// crash-resume selected a specific detached overlay — reopen exactly that state dir.
+pub(crate) struct Resume<'a> {
+    pub(crate) workspace_id: &'a str,
+    pub(crate) state_dir: Option<PathBuf>,
+}
+
 /// A detached local session of `repo`: registered mount state on this machine whose daemon is
 /// no longer alive. Newest state-dir mtime wins when several are detached — a heuristic proxy
 /// for "the one you used last" (all fs sessions publish to the same target, so resuming an
 /// older sibling loses nothing published; only its local overlay differs).
-fn detached_local_session(repo: &str) -> Option<String> {
-    let mut candidates: Vec<(std::time::SystemTime, String)> = local_mount_states()
+fn detached_local_session(repo: &str) -> Option<(String, PathBuf)> {
+    let mut candidates: Vec<(std::time::SystemTime, String, PathBuf)> = local_mount_states()
         .into_iter()
         .filter_map(|(_, state_dir, state, alive)| {
             if alive || state.repo != repo || state.read_only() {
@@ -819,11 +832,11 @@ fn detached_local_session(repo: &str) -> Option<String> {
             let modified = std::fs::metadata(&state_dir)
                 .and_then(|m| m.modified())
                 .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-            Some((modified, state.workspace_id))
+            Some((modified, state.workspace_id, state_dir))
         })
         .collect();
-    candidates.sort_by_key(|(modified, _)| std::cmp::Reverse(*modified));
-    candidates.into_iter().next().map(|(_, id)| id)
+    candidates.sort_by_key(|(modified, ..)| std::cmp::Reverse(*modified));
+    candidates.into_iter().next().map(|(_, id, dir)| (id, dir))
 }
 
 /// `tl git mount <repo>[:<ref>]` — the repository-surface mount: explicit checkpointing, no
@@ -865,7 +878,10 @@ pub async fn mount_repo(
         None,
         false,
         // --workspace names an id inside `target`'s repo: per-repo attach, repo-scoped-safe.
-        workspace,
+        workspace.map(|id| Resume {
+            workspace_id: id,
+            state_dir: None,
+        }),
         foreground,
         trace_ops,
         log_level,
@@ -2113,12 +2129,12 @@ pub async fn mount(
     // (workspaces, snapshots, branches). One engine, two vocabularies — the fs surface
     // promises the words workspace/snapshot/branch never appear in its output.
     fs_surface: bool,
-    // A workspace id KNOWN to live in `target`'s repo (auto-resume, `--workspace`): attach
+    // A workspace KNOWN to live in `target`'s repo (auto-resume, `--workspace`): attach
     // through the per-repo, principal-checked endpoint directly. Never routed through name
     // resolution — that path treats the id as a repo name and then falls back to a
     // project-wide fleet search, both of which a repo-scoped credential (the sandbox attach
     // recipe) rightly 403s.
-    resume: Option<&str>,
+    resume: Option<Resume<'_>>,
     foreground: bool,
     trace_ops: bool,
     log_level: &str,
@@ -2293,7 +2309,8 @@ pub async fn mount(
             .client
             .create_workspace(&session.project_id, name, user, token, &create_req)
     };
-    let resolved = if let Some(id) = resume {
+    let resume_state_dir = resume.as_ref().and_then(|r| r.state_dir.clone());
+    let resolved = if let Some(id) = resume.map(|r| r.workspace_id) {
         let ws = session
             .client
             .get_workspace(&session.project_id, name, user, token, id)
@@ -2502,7 +2519,9 @@ pub async fn mount(
     }
 
     let mountpoint = canonical_mountpoint(path)?;
-    let state_dir = alloc_state_dir(&ws.id);
+    // A resume reopens EXACTLY the state dir it selected (the newest detached overlay);
+    // re-allocating could land on a different dead registration of the same workspace.
+    let state_dir = resume_state_dir.unwrap_or_else(|| alloc_state_dir(&ws.id));
     let (owner_uid, owner_gid) = mount_owner();
     daemon::save_mount_state(
         &state_dir,

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -2089,7 +2089,7 @@ fn live_mount_of(workspace_id: &str) -> Option<String> {
 /// registry entry survives the crash, and treating it as a hold pushed the crash-resume onto
 /// a fresh suffixed dir — stranding the unsealed local overlay in the old one, which is the
 /// exact loss "run the same command again" recovery exists to prevent.
-fn alloc_state_dir(workspace_id: &str) -> PathBuf {
+fn alloc_state_dir(workspace_id: &str, skip: &std::collections::HashSet<PathBuf>) -> PathBuf {
     let registered: std::collections::HashSet<PathBuf> = registry_load()
         .values()
         .filter_map(|v| v.as_str().map(PathBuf::from))
@@ -2103,11 +2103,43 @@ fn alloc_state_dir(workspace_id: &str) -> PathBuf {
         } else {
             root.join(format!("{workspace_id}.{n}"))
         };
-        if !registered.contains(&candidate) {
+        if !registered.contains(&candidate) && !skip.contains(&candidate) {
             return candidate;
         }
         n += 1;
     }
+}
+
+/// Stake `dir` for THIS mount, atomically, before any state lands in it. The aliveness
+/// probe alone is racy: a daemon writes its pid only after credentials, server round
+/// trips, and the FUSE attach — a multi-second window in which a second mount of the same
+/// workspace sees the dir as free and two daemons end up sharing one overlay. The claim
+/// is an exclusive flock on `daemon.pid` holding the CLI's OWN pid; the daemon overwrites
+/// it once serving, and the caller keeps the returned guard (and its lock) until then.
+/// `None` = another process holds the claim or a live daemon owns the dir.
+fn claim_state_dir(dir: &Path) -> Result<Option<std::fs::File>> {
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
+    std::fs::create_dir_all(dir)?;
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(dir.join("daemon.pid"))?;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return Ok(None);
+    }
+    // The lock arbitrates concurrent CLAIMS; a running daemon holds no flock, so its
+    // liveness is checked separately (its pid is what the file holds).
+    if daemon::daemon_pid(dir).is_some_and(daemon_alive) {
+        return Ok(None);
+    }
+    let mut file = file;
+    file.set_len(0)?;
+    write!(file, "{}", std::process::id())?;
+    file.sync_all()?;
+    Ok(Some(file))
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -2523,7 +2555,32 @@ pub async fn mount(
     let mountpoint = canonical_mountpoint(path)?;
     // A resume reopens EXACTLY the state dir it selected (the newest detached overlay);
     // re-allocating could land on a different dead registration of the same workspace.
-    let state_dir = resume_state_dir.unwrap_or_else(|| alloc_state_dir(&ws.id));
+    // `_state_claim` holds the exclusive claim (see claim_state_dir) until this function
+    // returns — by which point the daemon is serving and its own pid holds the dir.
+    let (state_dir, _state_claim) = match resume_state_dir {
+        Some(dir) => match claim_state_dir(&dir)? {
+            Some(guard) => (dir, guard),
+            None => {
+                return Err(CliError::usage(format!(
+                    "{unit} {} is already being mounted or served by another process",
+                    short_id(&ws.id)
+                )));
+            }
+        },
+        None => {
+            let mut skip: std::collections::HashSet<PathBuf> = Default::default();
+            loop {
+                let candidate = alloc_state_dir(&ws.id, &skip);
+                match claim_state_dir(&candidate)? {
+                    Some(guard) => break (candidate, guard),
+                    // Raced by a concurrent mount mid-claim: take the next dir.
+                    None => {
+                        skip.insert(candidate);
+                    }
+                }
+            }
+        }
+    };
     let (owner_uid, owner_gid) = mount_owner();
     daemon::save_mount_state(
         &state_dir,

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -767,14 +767,18 @@ pub async fn mount_filesystem(
             "Resuming detached session {} of filesystem {target}.",
             short_id(&workspace_id)
         );
+        // The repo is KNOWN from the local mount state: attach through the per-repo
+        // endpoint so the whole path works under a repo-scoped credential (the sandbox
+        // recipe) — never through name resolution, which would treat the id as a repo.
         return mount(
             ctx,
-            &workspace_id,
+            target,
             path,
             WritePolicy::Auto,
             None,
             autosave,
             true,
+            Some(&workspace_id),
             foreground,
             trace_ops,
             log_level,
@@ -793,6 +797,7 @@ pub async fn mount_filesystem(
         None,
         autosave,
         true,
+        None,
         foreground,
         trace_ops,
         log_level,
@@ -851,10 +856,6 @@ pub async fn mount_repo(
             .map(|(_, base)| base.to_string())
             .expect("guarded above")
     });
-    let target = match workspace {
-        Some(id) => id,
-        None => target,
-    };
     mount(
         ctx,
         target,
@@ -863,6 +864,8 @@ pub async fn mount_repo(
         shared_target,
         None,
         false,
+        // --workspace names an id inside `target`'s repo: per-repo attach, repo-scoped-safe.
+        workspace,
         foreground,
         trace_ops,
         log_level,
@@ -2063,10 +2066,16 @@ fn live_mount_of(workspace_id: &str) -> Option<String> {
 /// free (that's what lets a plain re-mount resume its local cache); when another registered
 /// mount of the same workspace holds it, pick a fresh suffixed dir — concurrent second mounts
 /// (read-only views especially) must never share overlay state with the writer.
+///
+/// A registration only HOLDS its dir while its daemon is alive: a crashed mount's on-disk
+/// registry entry survives the crash, and treating it as a hold pushed the crash-resume onto
+/// a fresh suffixed dir — stranding the unsealed local overlay in the old one, which is the
+/// exact loss "run the same command again" recovery exists to prevent.
 fn alloc_state_dir(workspace_id: &str) -> PathBuf {
     let registered: std::collections::HashSet<PathBuf> = registry_load()
         .values()
         .filter_map(|v| v.as_str().map(PathBuf::from))
+        .filter(|dir| daemon::daemon_pid(dir).is_some_and(daemon_alive))
         .collect();
     let root = daemon::state_dir_root();
     let mut n = 1u32;
@@ -2104,6 +2113,12 @@ pub async fn mount(
     // (workspaces, snapshots, branches). One engine, two vocabularies — the fs surface
     // promises the words workspace/snapshot/branch never appear in its output.
     fs_surface: bool,
+    // A workspace id KNOWN to live in `target`'s repo (auto-resume, `--workspace`): attach
+    // through the per-repo, principal-checked endpoint directly. Never routed through name
+    // resolution — that path treats the id as a repo name and then falls back to a
+    // project-wide fleet search, both of which a repo-scoped credential (the sandbox attach
+    // recipe) rightly 403s.
+    resume: Option<&str>,
     foreground: bool,
     trace_ops: bool,
     log_level: &str,
@@ -2131,7 +2146,32 @@ pub async fn mount(
     #[cfg(target_os = "macos")]
     ensure_fskit_ready().await?;
     #[cfg(target_os = "linux")]
-    ensure_fuse_ready()?;
+    {
+        ensure_fuse_ready()?;
+        // A crashed mount leaves its dead FUSE attachment in place; the kernel answers the
+        // mountpoint with ENOTCONN forever. Detach it lazily before mounting — otherwise the
+        // new mount stacks over the corpse, and unmounting later resurfaces it.
+        if std::fs::metadata(path).is_err()
+            && matches!(
+                std::fs::symlink_metadata(path),
+                Err(ref e) if matches!(
+                    e.raw_os_error(),
+                    Some(libc::ENOTCONN) | Some(libc::EIO) | Some(libc::ENXIO)
+                )
+            )
+        {
+            for cmd in ["fusermount3", "fusermount"] {
+                if std::process::Command::new(cmd)
+                    .args(["-uz", &path.to_string_lossy()])
+                    .status()
+                    .is_ok_and(|st| st.success())
+                {
+                    eprintln!("detached a dead previous mount at {}", path.display());
+                    break;
+                }
+            }
+        }
+    }
     let (name, base) = match target.split_once(':') {
         Some((name, base)) => (name, Some(base.to_string())),
         None => (target, None),
@@ -2253,67 +2293,85 @@ pub async fn mount(
             .client
             .create_workspace(&session.project_id, name, user, token, &create_req)
     };
-    let resolved = match try_create().await {
-        Ok(ws) => Resolved::Created(ws.into_inner()),
-        Err(e) => match create_recovery(&e) {
-            // No file system by this name and no branch was named: try it as a workspace id.
-            Some(CreateRecovery::RepoMissing) if base.is_none() => {
-                match resolve_workspace(&session, name).await? {
-                    Some((repo, ws)) => Resolved::Attached(repo, ws),
-                    None if fs_surface => {
-                        return Err(CliError::usage(format!(
-                            "no filesystem named {name:?} (see: tl fs ls; create one: tl fs \
+    let resolved = if let Some(id) = resume {
+        let ws = session
+            .client
+            .get_workspace(&session.project_id, name, user, token, id)
+            .await
+            .map_err(|e| {
+                CliError::usage(format!(
+                    "resuming {} {} of {name} failed: {e} (start fresh: tl fs mount {name} \
+                     <path>)",
+                    unit,
+                    short_id(id),
+                ))
+            })?
+            .into_inner();
+        Resolved::Attached(name.to_string(), ws)
+    } else {
+        match try_create().await {
+            Ok(ws) => Resolved::Created(ws.into_inner()),
+            Err(e) => match create_recovery(&e) {
+                // No file system by this name and no branch was named: try it as a workspace id.
+                Some(CreateRecovery::RepoMissing) if base.is_none() => {
+                    match resolve_workspace(&session, name).await? {
+                        Some((repo, ws)) => Resolved::Attached(repo, ws),
+                        None if fs_surface => {
+                            return Err(CliError::usage(format!(
+                                "no filesystem named {name:?} (see: tl fs ls; create one: tl fs \
                              create {name})"
-                        )));
-                    }
-                    None => {
-                        return Err(CliError::usage(format!(
-                            "no repo or workspace matches {name:?}. See `tl git ls`, or \
+                            )));
+                        }
+                        None => {
+                            return Err(CliError::usage(format!(
+                                "no repo or workspace matches {name:?}. See `tl git ls`, or \
                              create the repo first: tl git create {name}"
-                        )));
+                            )));
+                        }
                     }
                 }
-            }
-            Some(CreateRecovery::RepoMissing) if fs_surface => {
-                return Err(CliError::usage(format!(
-                    "no filesystem named {name:?} (see: tl fs ls; create one: tl fs create \
+                Some(CreateRecovery::RepoMissing) if fs_surface => {
+                    return Err(CliError::usage(format!(
+                        "no filesystem named {name:?} (see: tl fs ls; create one: tl fs create \
                      {name})"
-                )));
-            }
-            Some(CreateRecovery::RepoMissing) => {
-                return Err(CliError::usage(format!(
-                    "no repo named {name:?}; create it first: tl git create {name}"
-                )));
-            }
-            // Seed an unborn default branch whether it is implied OR named (either spelling):
-            // a fresh `tl git create` repo has no commits, and `tl fs mount repo:main` used to
-            // fail with `base "main" does not resolve to a commit` while plain
-            // `tl fs mount repo` worked. Writable mounts only — a read-only view must never
-            // write to the server (and with read-scoped credentials the seed push would fail
-            // opaquely); ro keeps the clear server error. Other branch names stay strict —
-            // seeding cannot conjure them.
-            Some(CreateRecovery::BaseUnresolved) if fs_surface => return Err(e.into()),
-            Some(CreateRecovery::BaseUnresolved) => {
-                let file_systems = session
-                    .client
-                    .list_repos_with_credential(&session.project_id, None, user, token)
-                    .await?
-                    .into_inner();
-                let Some(fs) = file_systems.repos.iter().find(|r| r.name == name) else {
-                    return Err(e.into());
-                };
-                let default_branch = fs.default_branch.clone();
-                let names_default = base.as_deref().is_none_or(|b| {
-                    b == default_branch || b.strip_prefix("refs/heads/") == Some(&default_branch)
-                });
-                if !names_default || mode == WritePolicy::Ro {
-                    return Err(e.into());
+                    )));
                 }
-                ensure_seeded(&session, &default_branch, name).await?;
-                Resolved::Created(try_create().await?.into_inner())
-            }
-            None => return Err(e.into()),
-        },
+                Some(CreateRecovery::RepoMissing) => {
+                    return Err(CliError::usage(format!(
+                        "no repo named {name:?}; create it first: tl git create {name}"
+                    )));
+                }
+                // Seed an unborn default branch whether it is implied OR named (either spelling):
+                // a fresh `tl git create` repo has no commits, and `tl fs mount repo:main` used to
+                // fail with `base "main" does not resolve to a commit` while plain
+                // `tl fs mount repo` worked. Writable mounts only — a read-only view must never
+                // write to the server (and with read-scoped credentials the seed push would fail
+                // opaquely); ro keeps the clear server error. Other branch names stay strict —
+                // seeding cannot conjure them.
+                Some(CreateRecovery::BaseUnresolved) if fs_surface => return Err(e.into()),
+                Some(CreateRecovery::BaseUnresolved) => {
+                    let file_systems = session
+                        .client
+                        .list_repos_with_credential(&session.project_id, None, user, token)
+                        .await?
+                        .into_inner();
+                    let Some(fs) = file_systems.repos.iter().find(|r| r.name == name) else {
+                        return Err(e.into());
+                    };
+                    let default_branch = fs.default_branch.clone();
+                    let names_default = base.as_deref().is_none_or(|b| {
+                        b == default_branch
+                            || b.strip_prefix("refs/heads/") == Some(&default_branch)
+                    });
+                    if !names_default || mode == WritePolicy::Ro {
+                        return Err(e.into());
+                    }
+                    ensure_seeded(&session, &default_branch, name).await?;
+                    Resolved::Created(try_create().await?.into_inner())
+                }
+                None => return Err(e.into()),
+            },
+        }
     };
     tracing::debug!(
         phase = "workspace",
@@ -3152,34 +3210,6 @@ async fn overlay_losable_state(state_dir: &Path, mountpoint: &str) -> Result<Opt
             || base == ".apdisk"
             || base.starts_with("._")
     }
-    fn strict_count_files(dir: &Path) -> Result<usize> {
-        let mut n = 0;
-        let read = match std::fs::read_dir(dir) {
-            Ok(read) => read,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-            Err(e) => return Err(overlay_unreadable(dir, &e)),
-        };
-        for entry in read {
-            let entry = entry.map_err(|e| overlay_unreadable(dir, &e))?;
-            let meta = match entry.path().symlink_metadata() {
-                Ok(meta) => meta,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-                Err(e) => return Err(overlay_unreadable(&entry.path(), &e)),
-            };
-            if meta.is_dir() && !meta.file_type().is_symlink() {
-                n += strict_count_files(&entry.path())?;
-            } else {
-                n += 1;
-            }
-        }
-        Ok(n)
-    }
-    // One strict pass per tree, classified inline. Upper files: dirty (already counted) →
-    // stat-verified sealed (retained; path membership alone would vouch for bytes modified
-    // out-of-band or racing the dirty reply) → ignored → uncovered. Ignored directories
-    // prune the descent: the whole subtree is ignored, count it without per-file rule
-    // evaluation.
-    #[allow(clippy::too_many_arguments)]
     fn classify_upper(
         root: &Path,
         dir: &Path,
@@ -3203,11 +3233,21 @@ async fn overlay_losable_state(state_dir: &Path, mountpoint: &str) -> Result<Opt
                 Err(e) => return Err(overlay_unreadable(&abs, &e)),
             };
             let rel = overlay_rel_path(root, &abs);
+            // OS junk first, BEFORE gitignore classification: `.Spotlight-V100`,
+            // `.fseventsd` and friends are not inherently gitignored, and letting them fall
+            // through to the recursive walk classified their children as uncovered — which
+            // refused the very unmounts this allowlist exists to permit. Junk never counts
+            // and is never descended into.
+            if is_os_junk(&rel) {
+                continue;
+            }
             if meta.is_dir() && !meta.file_type().is_symlink() {
                 if check_ignored(ignore, &rel, true)? {
-                    if !is_os_junk(&rel) {
-                        *ignored += strict_count_files(&abs)?;
-                    }
+                    // One ignored SUBTREE, not a recursive file count: walking a large
+                    // node_modules merely to report an exact number could dominate unmount
+                    // latency, and the decision (ignored content never seals, user keeps or
+                    // discards it knowingly) is per-subtree anyway.
+                    *ignored += 1;
                 } else {
                     classify_upper(
                         root,
@@ -3232,9 +3272,7 @@ async fn overlay_losable_state(state_dir: &Path, mountpoint: &str) -> Result<Opt
                 continue; // retained: stat-verified sealed content
             }
             if check_ignored(ignore, &rel, false)? {
-                if !is_os_junk(&rel) {
-                    *ignored += 1;
-                }
+                *ignored += 1;
                 continue;
             }
             *uncovered += 1;

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -465,27 +465,6 @@ pub async fn create_filesystem(ctx: &CliContext, name: &str, output_json: bool) 
     Ok(())
 }
 
-/// One kind-stamped listing, resolved to a filesystem by name. `replacement` names the
-/// `tl git` command shown when the name is actually a repository — the one line the two call
-/// sites differ in.
-fn resolve_filesystem<'a>(
-    listing: &'a tensorlake::artifact_storage::models::ListReposResponse,
-    name: &str,
-    replacement: &str,
-) -> Result<&'a tensorlake::artifact_storage::models::Repo> {
-    let Some(repo) = listing.repos.iter().find(|r| r.name == name) else {
-        return Err(CliError::usage(format!(
-            "no filesystem named {name:?} (see: tl fs ls; create one: tl fs create {name})"
-        )));
-    };
-    if !repo.is_filesystem() {
-        return Err(CliError::usage(format!(
-            "{name} is a repository, not a filesystem — use: {replacement}"
-        )));
-    }
-    Ok(repo)
-}
-
 /// `tl fs ls` — the filesystems of this project, with where each is attached on this machine.
 pub async fn ls_filesystems(ctx: &CliContext, output_json: bool) -> Result<()> {
     let session = FsSession::open(ctx, None).await?;
@@ -561,12 +540,26 @@ pub async fn ls_filesystems(ctx: &CliContext, output_json: bool) -> Result<()> {
 pub async fn rm_filesystem(ctx: &CliContext, name: &str, force: bool) -> Result<()> {
     let session = FsSession::open(ctx, None).await?;
     let (user, token) = session.creds();
-    let listing = session
+    // Authoritative point-read: read-your-writes for a just-created filesystem, and the
+    // 404/kind answers never come from a stale listing.
+    let meta = match session
         .client
-        .list_repos_with_credential(&session.project_id, None, user, token)
-        .await?
-        .into_inner();
-    resolve_filesystem(&listing, name, &format!("tl git rm {name}"))?;
+        .repo_meta_with_credential(&session.project_id, name, user, token)
+        .await
+    {
+        Ok(meta) => meta.into_inner(),
+        Err(tensorlake::error::SdkError::ServerError { status, .. }) if status.as_u16() == 404 => {
+            return Err(CliError::usage(format!(
+                "no filesystem named {name:?} (see: tl fs ls)"
+            )));
+        }
+        Err(e) => return Err(e.into()),
+    };
+    if !meta.is_filesystem() {
+        return Err(CliError::usage(format!(
+            "{name} is a repository, not a filesystem — use: tl git rm {name}"
+        )));
+    }
     if let Some((mountpoint, _)) = live_mounts().into_iter().find(|(_, s)| s.repo == name) {
         return Err(CliError::usage(format!(
             "{name} is mounted at {mountpoint}; unmount first: tl fs unmount {mountpoint}"
@@ -610,6 +603,33 @@ pub async fn rm_filesystem(ctx: &CliContext, name: &str, force: bool) -> Result<
         .delete_repo_with_credential(&session.project_id, name, user, token)
         .await?;
     println!("Deleted filesystem {name}.");
+    Ok(())
+}
+
+/// `tl fs token <name>` — mint the narrow credential a sandbox (or any remote environment)
+/// needs to attach this one filesystem. Everything on the attach path — mount, saves,
+/// history-by-follow — works under it; project-scope surfaces (ls, history, rm) do not.
+pub async fn token(ctx: &CliContext, name: &str, output_json: bool) -> Result<()> {
+    let project_id = crate::commands::git::project_id(ctx)?;
+    let client = crate::commands::git::artifact_storage_client(ctx)?;
+    let credential = client
+        .mint_token_for_repo(&project_id, Some(name))
+        .await
+        .map_err(crate::commands::git::map_sdk_error)?
+        .into_inner();
+    if output_json {
+        println!("{}", serde_json::to_string_pretty(&credential)?);
+        return Ok(());
+    }
+    println!(
+        "Scoped credential for filesystem {name} (expires {}):",
+        credential.expires_at
+    );
+    println!("  {}", credential.token);
+    println!();
+    println!("Attach from any sandbox with FUSE:");
+    println!("  export TENSORLAKE_GIT_TOKEN={}", credential.token);
+    println!("  tl fs mount {name} <path>");
     Ok(())
 }
 
@@ -693,7 +713,11 @@ pub async fn history(
         table.add_row(vec![
             Cell::new(age_display(op.at_secs)),
             Cell::new(if op.actor.is_empty() { "-" } else { &op.actor }),
-            Cell::new(&op.kind),
+            Cell::new(if op.conflicted {
+                format!("{} (collision)", op.kind)
+            } else {
+                op.kind.clone()
+            }),
             Cell::new(
                 op.refs
                     .first()
@@ -704,12 +728,20 @@ pub async fn history(
         ]);
     }
     println!("{table}");
+    if saves.iter().any(|op| op.conflicted) {
+        println!(
+            "Collision saves kept both sides; markers are in the affected files (`tl fs \
+             status` lists unresolved ones)."
+        );
+    }
     Ok(())
 }
 
 /// `tl fs mount <name> <path>` — the filesystem-surface mount: publish-on-save, autosave on,
-/// detached local sessions auto-resume. Branch-addressed and repository mounts live on
-/// `tl git mount`.
+/// detached local sessions auto-resume. One server round trip: the create carries
+/// `surface=filesystem` and the SERVER applies the semantics (publish target, kind check)
+/// from the repo's authoritative kind — no listing, so a filesystem created milliseconds ago
+/// mounts, and a repo-scoped credential suffices (the sandbox story).
 pub async fn mount_filesystem(
     ctx: &CliContext,
     target: &str,
@@ -727,11 +759,9 @@ pub async fn mount_filesystem(
     }
     // A drive doesn't lose your work: writable filesystem mounts always autosave.
     let autosave = (!ro).then_some(FS_AUTOSAVE_DEFAULT_SECS);
-    // Auto-resume first — it needs no server round trip. A detached local session of this
-    // filesystem (mount state present, daemon dead) picks up where it left off: "run the same
-    // command again" is the crash recovery. WritePolicy::Auto keeps the single-writer
-    // downgrade: a session attached writable elsewhere resumes read-only, never as a silent
-    // second writer.
+    // Auto-resume first — no server round trip. A detached local session of this filesystem
+    // (mount state present, daemon dead) picks up where it left off: "run the same command
+    // again" is the crash recovery. WritePolicy::Auto keeps the single-writer downgrade.
     if !ro && let Some(workspace_id) = detached_local_session(target) {
         println!(
             "Resuming detached session {} of filesystem {target}.",
@@ -751,34 +781,16 @@ pub async fn mount_filesystem(
         )
         .await;
     }
-    // Fresh session: one listing answers what the create needs — does the target exist, what
-    // kind is it, and what is its default branch (the publish target, which the genesis commit
-    // guarantees exists).
-    let session = FsSession::open(ctx, None).await?;
-    let (user, token) = session.creds();
-    let listing = session
-        .client
-        .list_repos_with_credential(&session.project_id, None, user, token)
-        .await?
-        .into_inner();
-    let repo = resolve_filesystem(&listing, target, &format!("tl git mount {target} <path>"))?;
-    // A fresh session publishes every save to the filesystem's current state; read-only mounts
-    // follow it instead.
-    let (target_spec, shared_target) = if ro {
-        (format!("{target}:{}", repo.default_branch), None)
-    } else {
-        (target.to_string(), Some(repo.default_branch.clone()))
-    };
     mount(
         ctx,
-        &target_spec,
+        target,
         path,
         if ro {
             WritePolicy::Ro
         } else {
             WritePolicy::Auto
         },
-        shared_target,
+        None,
         autosave,
         true,
         foreground,
@@ -2227,6 +2239,11 @@ pub async fn mount(
     let create_req = CreateWorkspaceRequest {
         base: base.clone(),
         shared_target: shared_target.clone(),
+        // The server applies product semantics from the repo's authoritative kind: an
+        // fs-surface create gets its publish target filled server-side (and a repository is
+        // rejected with the right command). Clients never pre-read listings to decide this.
+        surface: fs_surface.then(|| "filesystem".to_string()),
+        read_only: mode == WritePolicy::Ro,
         ..Default::default()
     };
     // One create call site for both the first attempt and the post-seed retry, so the two can
@@ -2243,17 +2260,29 @@ pub async fn mount(
             Some(CreateRecovery::RepoMissing) if base.is_none() => {
                 match resolve_workspace(&session, name).await? {
                     Some((repo, ws)) => Resolved::Attached(repo, ws),
+                    None if fs_surface => {
+                        return Err(CliError::usage(format!(
+                            "no filesystem named {name:?} (see: tl fs ls; create one: tl fs \
+                             create {name})"
+                        )));
+                    }
                     None => {
                         return Err(CliError::usage(format!(
-                            "no file system or workspace matches {name:?}. See `tl fs ls`, or \
-                             create the file system first: tl git create {name}"
+                            "no repo or workspace matches {name:?}. See `tl git ls`, or \
+                             create the repo first: tl git create {name}"
                         )));
                     }
                 }
             }
+            Some(CreateRecovery::RepoMissing) if fs_surface => {
+                return Err(CliError::usage(format!(
+                    "no filesystem named {name:?} (see: tl fs ls; create one: tl fs create \
+                     {name})"
+                )));
+            }
             Some(CreateRecovery::RepoMissing) => {
                 return Err(CliError::usage(format!(
-                    "no file system named {name:?}; create it first: tl git create {name}"
+                    "no repo named {name:?}; create it first: tl git create {name}"
                 )));
             }
             // Seed an unborn default branch whether it is implied OR named (either spelling):
@@ -2263,6 +2292,7 @@ pub async fn mount(
             // write to the server (and with read-scoped credentials the seed push would fail
             // opaquely); ro keeps the clear server error. Other branch names stay strict —
             // seeding cannot conjure them.
+            Some(CreateRecovery::BaseUnresolved) if fs_surface => return Err(e.into()),
             Some(CreateRecovery::BaseUnresolved) => {
                 let file_systems = session
                     .client
@@ -2351,11 +2381,16 @@ pub async fn mount(
             let read_only = mode == WritePolicy::Ro;
             // What the view follows. Writable workspaces follow their own ref; shared-rw
             // follows the branch it publishes to, so every writer's view converges on the
-            // reconciled branch rather than staying pinned to its own snapshots. A read-only
-            // view follows the named branch (or the repo HEAD's branch) so new commits appear —
-            // except a fixed commit base, which is a pinned view that never advances.
-            let follow_ref = if let Some(target) = &shared_target {
+            // reconciled branch rather than staying pinned to its own snapshots. The publish
+            // target comes from the CREATE RESPONSE — for fs-surface sessions the server
+            // filled it from the repo's stored default branch. A read-only view follows the
+            // named branch (fs surface: HEAD itself, resolved per poll) so new commits
+            // appear — except a fixed commit base, which is a pinned view that never
+            // advances.
+            let follow_ref = if let Some(target) = &ws.shared_target {
                 Some(format!("refs/heads/{target}"))
+            } else if read_only && fs_surface {
+                Some("HEAD".to_string())
             } else if read_only {
                 match &base {
                     Some(b) if b.len() == 40 && b.bytes().all(|c| c.is_ascii_hexdigit()) => {
@@ -2483,7 +2518,7 @@ pub async fn mount(
                         repo,
                         mountpoint,
                         short_id(&ws.id),
-                        if shared_target.is_some() {
+                        if ws.shared_target.is_some() {
                             ", saves publish automatically"
                         } else if read_only {
                             ", read-only, follows the filesystem"
@@ -2498,7 +2533,7 @@ pub async fn mount(
                         ws.base_ref.as_deref().unwrap_or(&ws.base[..12]),
                         mountpoint,
                         short_id(&ws.id),
-                        if shared_target.is_some() {
+                        if ws.shared_target.is_some() {
                             ", snapshots auto-publish to the branch"
                         } else if read_only {
                             ", read-only, follows the branch"
@@ -4071,6 +4106,25 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         .ok()
         .and_then(|r| r.get("commit").and_then(|c| c.as_str().map(str::to_string)));
     let changes = local_changes(&state_dir, &mountpoint).await?;
+    // Collisions the followed state materialized that no later save has overwritten. Absent
+    // daemon (or a pre-visibility daemon) reads as none — the section only ever adds signal.
+    let collisions: Vec<(String, String, String)> = daemon::control(&state_dir, "conflicts")
+        .await
+        .ok()
+        .and_then(|r| r.get("conflicts").cloned())
+        .and_then(|v| serde_json::from_value::<Vec<serde_json::Value>>(v).ok())
+        .map(|list| {
+            list.into_iter()
+                .filter_map(|c| {
+                    Some((
+                        c.get("path")?.as_str()?.to_string(),
+                        c.get("kind")?.as_str()?.to_string(),
+                        c.get("commit")?.as_str()?.to_string(),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
 
     if output_json {
         println!(
@@ -4090,6 +4144,12 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
                 "pending_renames": changes.renames
                     .iter()
                     .map(|(from, to)| serde_json::json!({ "from": from, "to": to }))
+                    .collect::<Vec<_>>(),
+                "unresolved_collisions": collisions
+                    .iter()
+                    .map(|(path, kind, commit)| serde_json::json!({
+                        "path": path, "kind": kind, "commit": commit,
+                    }))
                     .collect::<Vec<_>>(),
             }))?
         );
@@ -4134,6 +4194,21 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         style("log:").dim(),
         state_dir.join("daemon.log").display()
     );
+    if !collisions.is_empty() {
+        println!(
+            "{} {} path(s) — both saves were kept; markers are in the files. Edit and save \
+             to resolve:",
+            style("unresolved collisions:").yellow(),
+            collisions.len(),
+        );
+        for (path, kind, commit) in &collisions {
+            println!(
+                "  {:<14} {path} (save {})",
+                style(kind).yellow(),
+                short_id(commit)
+            );
+        }
+    }
     // A pending rename's source whiteout is a real delete, but showing it next to the R line
     // would read as two changes; the R line carries both sides.
     let deletes: Vec<&String> = changes

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1891,10 +1891,12 @@ fn registry_save(table: &toml::map::Map<String, toml::Value>) -> Result<()> {
 
 fn registry_add(mountpoint: &str, state_dir: &Path) -> Result<()> {
     let mut table = registry_load();
-    table.insert(
-        mountpoint.to_string(),
-        toml::Value::String(state_dir.to_string_lossy().into_owned()),
-    );
+    // One state dir, one mountpoint: resuming a detached session at a NEW path must retire
+    // the old path's binding, or management commands against the stale mountpoint report
+    // the live session twice — and can shut down or delete the new mount's state.
+    let dir = state_dir.to_string_lossy().into_owned();
+    table.retain(|_, v| v.as_str() != Some(dir.as_str()));
+    table.insert(mountpoint.to_string(), toml::Value::String(dir));
     registry_save(&table)
 }
 

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -1888,8 +1888,11 @@ fn registry_load() -> toml::map::Map<String, toml::Value> {
 /// registry). Blocking acquire — the critical section is a small file rewrite.
 fn registry_lock() -> Result<std::fs::File> {
     std::fs::create_dir_all(crate::config::files::config_dir())?;
-    plaindir::flock_exclusive(&crate::config::files::config_dir().join("mounts.lock"), true)?
-        .ok_or_else(|| CliError::usage("could not lock the mount registry"))
+    plaindir::flock_exclusive(
+        &crate::config::files::config_dir().join("mounts.lock"),
+        true,
+    )?
+    .ok_or_else(|| CliError::usage("could not lock the mount registry"))
 }
 
 fn registry_save(table: &toml::map::Map<String, toml::Value>) -> Result<()> {

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -882,10 +882,13 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 chunk_cache: std::collections::HashMap::new(),
                 sealed: {
                     let index = SealedIndex::load(state_dir);
-                    // Retained upper files from before this restart have seal records but
-                    // no recorded oids: seed them so divergence eviction still covers them
-                    // (unknown oid = divergent whenever the branch touches the path).
-                    overlay.seed_retained(index.upserts.keys().cloned());
+                    // Retained upper files AND sealed-delete whiteouts from before this
+                    // restart have seal records but no recorded oids: seed both so
+                    // divergence eviction still covers them (unknown oid = divergent
+                    // whenever the branch touches the path — for a whiteout, that is what
+                    // lets a remote re-add surface instead of staying hidden forever).
+                    overlay
+                        .seed_retained(index.upserts.keys().chain(index.deletes.iter()).cloned());
                     index
                 },
                 reindex_pending: false,

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -1551,15 +1551,12 @@ impl Sealer {
             .heal_replaced_files(delta.upserts.iter().map(|(p, _)| p.as_str()))
             .await
             .map_err(|e| CliError::usage(format!("{e} (nothing was sealed; will retry)")))?;
-        for path in &healed.newly_healed {
-            eprintln!("seal: healed dir-over-file at {path} (whiteout written)");
-        }
-        // EVERY boundary — including markers written by an earlier seal whose push failed —
-        // forces its delete into this change set: the boundary path may no longer be in the
-        // delta (its mkdir record was pruned by an earlier empty seal), and the delete arm
-        // skips paths with upper presence.
+        // Freshly healed boundaries are recorded in the dirty index (they ride every FUTURE
+        // delta natively — retries re-derive nothing), but their record generation is past
+        // THIS delta's watermark, so this one seal carries the delete by hand.
         let mut delta = delta;
-        for path in &healed.boundaries {
+        for path in &healed {
+            eprintln!("seal: healed dir-over-file at {path} (whiteout written)");
             if !delta.deletes.contains(path) {
                 delta.deletes.push(path.clone());
             }

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -880,7 +880,14 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 seen_epoch: overlay.epoch(),
                 recent_seals: Vec::new(),
                 chunk_cache: std::collections::HashMap::new(),
-                sealed: SealedIndex::load(state_dir),
+                sealed: {
+                    let index = SealedIndex::load(state_dir);
+                    // Retained upper files from before this restart have seal records but
+                    // no recorded oids: seed them so divergence eviction still covers them
+                    // (unknown oid = divergent whenever the branch touches the path).
+                    overlay.seed_retained(index.upserts.keys().cloned());
+                    index
+                },
                 reindex_pending: false,
             }),
             mirror: std::sync::Mutex::new(SealerMirror::default()),

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -54,7 +54,7 @@ use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
 
 #[cfg(unix)]
-use super::overlay::{KernelExpectation, OverlayFs, OverlayInval};
+use super::overlay::{KernelExpectation, OverlayFs, OverlayInval, TrimBoundaries};
 #[cfg(unix)]
 use std::sync::Arc;
 
@@ -1540,8 +1540,7 @@ impl Sealer {
                 eprintln!("seal: reaped {} sealed rename(s)", consumed.len());
             }
         }
-        let delta = self.overlay.dirty_since(st.sealed_gen);
-        let watermark = delta.watermark;
+        let mut delta = self.overlay.dirty_since(st.sealed_gen);
         // Dir-over-file self-heal: a mkdir that raced another session's same-named FILE
         // landing has an upper directory shadowing a lower file with no whiteout. Write
         // the missing marker now so this seal publishes the replacement's delete half and
@@ -1551,16 +1550,18 @@ impl Sealer {
             .heal_replaced_files(delta.upserts.iter().map(|(p, _)| p.as_str()))
             .await
             .map_err(|e| CliError::usage(format!("{e} (nothing was sealed; will retry)")))?;
-        // Freshly healed boundaries are recorded in the dirty index (they ride every FUTURE
-        // delta natively — retries re-derive nothing), but their record generation is past
-        // THIS delta's watermark, so this one seal carries the delete by hand.
-        let mut delta = delta;
-        for path in &healed {
-            eprintln!("seal: healed dir-over-file at {path} (whiteout written)");
-            if !delta.deletes.contains(path) {
-                delta.deletes.push(path.clone());
+        if !healed.is_empty() {
+            for path in &healed {
+                eprintln!("seal: healed dir-over-file at {path} (whiteout written)");
             }
+            // Healing records each boundary as a dirty dir upsert whose generation is past
+            // the delta just taken. Re-snapshot so THIS seal carries the boundary natively
+            // (the dir-upsert arm publishes the whiteout-delete plus children) AND so the
+            // watermark covers the heal record — pruning to the pre-heal watermark would
+            // leave the boundary dirty and re-publish the same delete every following seal.
+            delta = self.overlay.dirty_since(st.sealed_gen);
         }
+        let watermark = delta.watermark;
         if delta.is_empty() && !self.overlay.has_redirects() {
             st.sealed_gen = watermark;
             // Nothing to seal: close the mutation clocks (and batch base) so the autosave
@@ -1811,7 +1812,9 @@ impl Sealer {
             // try, not wait: hygiene must never park the seal (and, transitively, every new
             // mutating op queued behind the write-preferring fence) behind one slow in-flight
             // copy-up. A contended fence just leaves the markers for the next seal.
-            if let Some(outcome) = self.overlay.try_trim_retained(&[], &tombstones)
+            if let Some(outcome) =
+                self.overlay
+                    .try_trim_retained(&[], &tombstones, TrimBoundaries::RetireInert)
                 && !outcome.tombstones_removed.is_empty()
             {
                 for path in &outcome.tombstones_removed {

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -90,7 +90,14 @@ fn absorb_refresh(
     pending: &std::sync::Mutex<PendingProbe>,
     delta: &gsvc_mount::RefreshDelta,
 ) {
-    let outputs = overlay.refresh_outputs(delta);
+    // Divergence first: retained upper copies the branch moved past stop shadowing, so the
+    // shadow filter inside refresh_outputs sees them gone and their invalidations flow.
+    let divergence = overlay.absorb_divergence(delta);
+    if !divergence.invals.is_empty() {
+        invalidate(divergence.invals);
+    }
+    let mut outputs = overlay.refresh_outputs(delta);
+    outputs.expectations.extend(divergence.expectations);
     {
         let mut p = pending.lock().expect("pending probe lock");
         if delta.appeared.is_none() {
@@ -271,7 +278,10 @@ impl SealedIndex {
 
     pub(crate) fn save(&self, state_dir: &Path) -> std::io::Result<()> {
         let tmp = state_dir.join("sealed.json.tmp");
-        std::fs::write(&tmp, serde_json::to_vec(self).expect("plain data serializes"))?;
+        std::fs::write(
+            &tmp,
+            serde_json::to_vec(self).expect("plain data serializes"),
+        )?;
         std::fs::rename(&tmp, Self::file(state_dir))
     }
 
@@ -888,17 +898,84 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     if let Some(secs) = state.auto_commit_interval_secs
         && let Some(sealer) = sealer.clone()
     {
+        // Event-driven autosave (issue #103 step 5): seal when the overlay has been dirty AND
+        // quiet for `QUIET_SECS`, or dirty for `secs` regardless — bounded time-to-published
+        // instead of "some tick after". Quiet is measured from the dirty files' real mtimes
+        // in the upper (no write hooks needed); very large dirty sets skip the stat pass and
+        // ride the max-latency bound alone. The old behavior was one blind seal every `secs`,
+        // which let a write land right after a tick and wait the whole interval.
+        const POLL: Duration = Duration::from_secs(2);
+        const QUIET_SECS: u64 = 10;
+        const MTIME_SCAN_CAP: usize = 256;
+        let upper = state_dir.join("upper");
         tokio::spawn(async move {
+            let mut dirty_since: Option<std::time::Instant> = None;
             loop {
-                tokio::time::sleep(Duration::from_secs(secs.max(1))).await;
+                tokio::time::sleep(POLL).await;
+                let view = match sealer.dirty_view().await {
+                    Ok(view) => view,
+                    Err(e) => {
+                        eprintln!("autosave: dirty view failed: {e}");
+                        continue;
+                    }
+                };
+                let dirty_paths: Vec<&String> =
+                    view.upserts.iter().chain(view.deletes.iter()).collect();
+                let renames = view.renames.len();
+                if dirty_paths.is_empty() && renames == 0 {
+                    dirty_since = None;
+                    continue;
+                }
+                let now = std::time::Instant::now();
+                let since = *dirty_since.get_or_insert(now);
+                let dirty_for = now.duration_since(since);
+                // Quiet = no dirty file touched within QUIET_SECS. Deletes/renames have no
+                // mtime to consult; they count as quiet (their "write" was the operation
+                // itself, already at least one poll old by the time we see it twice).
+                let quiet = if view.upserts.len() > MTIME_SCAN_CAP {
+                    false // too many to stat cheaply; the max-latency bound owns this seal
+                } else {
+                    let quiet_floor =
+                        std::time::SystemTime::now() - Duration::from_secs(QUIET_SECS);
+                    view.upserts.iter().all(|rel| {
+                        match upper
+                            .join(rel)
+                            .symlink_metadata()
+                            .and_then(|m| m.modified())
+                        {
+                            Ok(mtime) => mtime <= quiet_floor,
+                            Err(_) => true, // vanished/unstattable: nothing left to wait on
+                        }
+                    })
+                };
+                if !quiet && dirty_for < Duration::from_secs(secs.max(1)) {
+                    continue;
+                }
                 // eprintln, not tracing: the daemon's stderr is the state dir's daemon.log —
-                // the one place a user can see an async flush fail.
+                // the one place a user can see an async flush fail. One structured line per
+                // stage so a slow save localizes to seal vs publish (server landing times
+                // come from the ops log).
+                let reason = if quiet { "quiet" } else { "max-latency" };
+                eprintln!(
+                    "autosave: sealing reason={reason} dirty_for_s={} files={} renames={renames}",
+                    dirty_for.as_secs(),
+                    dirty_paths.len(),
+                );
+                let seal_started = std::time::Instant::now();
                 match sealer.seal_once("tl fs auto-commit", false, None).await {
                     Ok(SealOutcome::Sealed(report)) => {
-                        eprintln!("auto-commit sealed snapshot {}", report.commit);
+                        eprintln!(
+                            "autosave: sealed snapshot {} seal_ms={} push_ms={:?}",
+                            report.commit,
+                            seal_started.elapsed().as_millis(),
+                            report.push_ms,
+                        );
+                        dirty_since = None;
                     }
-                    Ok(SealOutcome::Clean { .. }) => {}
-                    Err(e) => eprintln!("auto-commit: {e}"),
+                    Ok(SealOutcome::Clean { .. }) => {
+                        dirty_since = None;
+                    }
+                    Err(e) => eprintln!("autosave: {e}"),
                 }
             }
         });
@@ -981,6 +1058,23 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 }
                             },
                         },
+                        // The still-unresolved collisions on the followed branch (issue
+                        // #103 step 4b): fed by refresh deltas inside the mount core,
+                        // cleared when a later save changes the path again.
+                        "conflicts" => {
+                            let list: Vec<serde_json::Value> = core
+                                .open_conflicts()
+                                .into_iter()
+                                .map(|(path, c)| {
+                                    serde_json::json!({
+                                        "path": path,
+                                        "commit": c.commit,
+                                        "kind": c.kind,
+                                    })
+                                })
+                                .collect();
+                            serde_json::json!({ "ok": true, "conflicts": list })
+                        }
                         // Drop retained (sealed-and-kept) overlay state — sync's pre-flight.
                         // Unlike `clear_upper`, dirty and ignored files survive.
                         "trim" => match sealer.as_ref() {
@@ -1055,9 +1149,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 None => {
                                     SealedIndex::reset(&control_state_dir);
                                     overlay.clear_upper().map_err(|e| {
-                                        CliError::usage(format!(
-                                            "clearing the overlay failed: {e}"
-                                        ))
+                                        CliError::usage(format!("clearing the overlay failed: {e}"))
                                     })
                                 }
                             };
@@ -1613,6 +1705,20 @@ impl Sealer {
                 PushOptions {
                     message: message.to_string(),
                     workspace_snapshot: Some(self.workspace.clone()),
+                    // The view this delta's edits were made against: the lower at the
+                    // batch's FIRST write (not at seal time — the branch can move during
+                    // the quiet window, and claiming the later view would turn a genuine
+                    // concurrent write into a silent overwrite). The server parents the
+                    // snapshot here, so the shared-rw application three-ways against what
+                    // the writer saw: overwriting another session's file is a clean write,
+                    // concurrent writes collide visibly, and resolving a collision
+                    // converges instead of nesting markers. Servers that predate the field
+                    // ignore it (old behavior).
+                    base: Some(
+                        self.overlay
+                            .dirty_base()
+                            .unwrap_or_else(|| lower.to_string()),
+                    ),
                     collect_file_chunks: true,
                     progress,
                     ..Default::default()
@@ -1624,6 +1730,9 @@ impl Sealer {
         st.sealed_gen = watermark;
         self.overlay.prune_dirty(watermark);
         let report = report.into_inner();
+        self.overlay
+            .record_sealed_oids(report.file_blob_oids.iter().cloned());
+        self.overlay.close_dirty_base_if_clean();
         st.recent_seals
             .push((report.commit.clone(), resolved.sealed_upserts));
         // Remember what each file's content chunked to; a blunt cap bounds daemon memory (a
@@ -1792,8 +1901,7 @@ impl Sealer {
     /// state lock serializes the drop against in-flight seals — a clear can no longer land
     /// inside a push window — and `reindex_pending` arms the fail-closed guard for the
     /// out-of-band refill that follows.
-    async fn clear_upper_control(&self) -> Result<Vec<crate::commands::fs::overlay::OverlayInval>>
-    {
+    async fn clear_upper_control(&self) -> Result<Vec<crate::commands::fs::overlay::OverlayInval>> {
         let mut st = self.state.lock().await;
         let affected = self
             .overlay
@@ -2697,7 +2805,6 @@ mod stable_prefix_tests {
         assert_eq!(stable_of(&resolved), None);
         assert!(matches!(resolved.files[0].source, PushSource::Path(_)));
     }
-
 }
 
 /// The dirty view (dry-run resolution) and the sealed index: what `tl fs status` shows must
@@ -2764,7 +2871,10 @@ mod seal_tracking_tests {
             .collect();
         sealed_deletes.sort();
         assert_eq!(deletes, sealed_deletes, "dry run and seal agree on deletes");
-        assert!(!upserts.contains(&"junk.tmp".to_string()), "ignored paths never show");
+        assert!(
+            !upserts.contains(&"junk.tmp".to_string()),
+            "ignored paths never show"
+        );
     }
 
     #[test]
@@ -2840,14 +2950,21 @@ mod seal_tracking_tests {
 
     #[test]
     fn sealed_survivors_matches_by_exact_stat_identity() {
-        let state = state_with(&[("same.txt", "stable"), ("changed.txt", "old")], &["dead.txt"]);
+        let state = state_with(
+            &[("same.txt", "stable"), ("changed.txt", "old")],
+            &["dead.txt"],
+        );
         let stat_of = |p: &str| {
             SealedStat::of(&std::fs::symlink_metadata(state.path().join("upper").join(p)).unwrap())
         };
         let mut index = SealedIndex::default();
         index.upserts.insert("same.txt".into(), stat_of("same.txt"));
-        index.upserts.insert("changed.txt".into(), stat_of("changed.txt"));
-        index.upserts.insert("missing.txt".into(), stat_of("same.txt"));
+        index
+            .upserts
+            .insert("changed.txt".into(), stat_of("changed.txt"));
+        index
+            .upserts
+            .insert("missing.txt".into(), stat_of("same.txt"));
         index.deletes.insert("dead.txt".into());
         index.deletes.insert("reaped.txt".into());
 
@@ -2856,8 +2973,16 @@ mod seal_tracking_tests {
         std::fs::write(state.path().join("upper/changed.txt"), "newer-bytes").unwrap();
 
         let (upserts, deletes) = sealed_survivors(state.path(), &index);
-        assert_eq!(upserts, vec!["same.txt"], "only the untouched file survives");
-        assert_eq!(deletes, vec!["dead.txt"], "only the still-present whiteout survives");
+        assert_eq!(
+            upserts,
+            vec!["same.txt"],
+            "only the untouched file survives"
+        );
+        assert_eq!(
+            deletes,
+            vec!["dead.txt"],
+            "only the still-present whiteout survives"
+        );
     }
 
     #[test]

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -1549,15 +1549,17 @@ impl Sealer {
         let healed = self
             .overlay
             .heal_replaced_files(delta.upserts.iter().map(|(p, _)| p.as_str()))
-            .await;
-        for path in &healed {
+            .await
+            .map_err(|e| CliError::usage(format!("{e} (nothing was sealed; will retry)")))?;
+        for path in &healed.newly_healed {
             eprintln!("seal: healed dir-over-file at {path} (whiteout written)");
         }
-        // The healed path may no longer be in this delta (its mkdir record was pruned by an
-        // earlier empty seal), and the delete arm skips paths with upper presence — force
-        // the replacement's delete half into the change set explicitly.
+        // EVERY boundary — including markers written by an earlier seal whose push failed —
+        // forces its delete into this change set: the boundary path may no longer be in the
+        // delta (its mkdir record was pruned by an earlier empty seal), and the delete arm
+        // skips paths with upper presence.
         let mut delta = delta;
-        for path in &healed {
+        for path in &healed.boundaries {
             if !delta.deletes.contains(path) {
                 delta.deletes.push(path.clone());
             }

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -2260,6 +2260,12 @@ fn resolve_dirty(
             continue;
         };
         if meta.is_dir() && !meta.file_type().is_symlink() {
+            // Parity with resolve_seal's replacement arm: a whiteout under a directory
+            // upsert is the delete half of a file→directory replacement, and status must
+            // report what the next seal will publish.
+            if whited_out_on_disk(&wh, path) {
+                deletes.push(path.clone());
+            }
             collect_dir_upserts(&upper, path, &mut ignore, &mut upserts)?;
             continue;
         }
@@ -2269,7 +2275,14 @@ fn resolve_dirty(
         upserts.push((path.clone(), abs, git_mode(&meta)));
     }
     for path in delta.deletes.iter().chain(vanished.iter()) {
-        if upper.join(path).symlink_metadata().is_ok() {
+        // Parity with resolve_seal: an upper DIRECTORY over the deleted name is a
+        // file→directory replacement whose delete still publishes; only re-created
+        // CONTENT covers the event via its own upsert.
+        if upper
+            .join(path)
+            .symlink_metadata()
+            .is_ok_and(|m| !m.is_dir() || m.file_type().is_symlink())
+        {
             continue;
         }
         if ignore.is_ignored(path, false)? {

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -913,49 +913,21 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
         // which let a write land right after a tick and wait the whole interval.
         const POLL: Duration = Duration::from_secs(2);
         const QUIET_SECS: u64 = 10;
-        const MTIME_SCAN_CAP: usize = 256;
-        let upper = state_dir.join("upper");
+        let overlay_clock = sealer.overlay.clone();
         tokio::spawn(async move {
-            let mut dirty_since: Option<std::time::Instant> = None;
             loop {
                 tokio::time::sleep(POLL).await;
-                let view = match sealer.dirty_view().await {
-                    Ok(view) => view,
-                    Err(e) => {
-                        eprintln!("autosave: dirty view failed: {e}");
-                        continue;
-                    }
-                };
-                let dirty_paths: Vec<&String> =
-                    view.upserts.iter().chain(view.deletes.iter()).collect();
-                let renames = view.renames.len();
-                if dirty_paths.is_empty() && renames == 0 {
-                    dirty_since = None;
+                // The idle tick is a pair of atomic loads — no dirty-set resolution, no
+                // file stats. The write hooks stamp the clock at mutation time, which is
+                // strictly more accurate than statting: deletes and renames have no mtime,
+                // and same-second writes hide inside filesystem timestamp granularity.
+                let Some((first, last)) = overlay_clock.dirty_clock() else {
                     continue;
-                }
-                let now = std::time::Instant::now();
-                let since = *dirty_since.get_or_insert(now);
-                let dirty_for = now.duration_since(since);
-                // Quiet = no dirty file touched within QUIET_SECS. Deletes/renames have no
-                // mtime to consult; they count as quiet (their "write" was the operation
-                // itself, already at least one poll old by the time we see it twice).
-                let quiet = if view.upserts.len() > MTIME_SCAN_CAP {
-                    false // too many to stat cheaply; the max-latency bound owns this seal
-                } else {
-                    let quiet_floor =
-                        std::time::SystemTime::now() - Duration::from_secs(QUIET_SECS);
-                    view.upserts.iter().all(|rel| {
-                        match upper
-                            .join(rel)
-                            .symlink_metadata()
-                            .and_then(|m| m.modified())
-                        {
-                            Ok(mtime) => mtime <= quiet_floor,
-                            Err(_) => true, // vanished/unstattable: nothing left to wait on
-                        }
-                    })
                 };
-                if !quiet && dirty_for < Duration::from_secs(secs.max(1)) {
+                let now = overlay_clock.clock_ms();
+                let quiet = now.saturating_sub(last) >= QUIET_SECS * 1000;
+                let dirty_for_s = now.saturating_sub(first) / 1000;
+                if !quiet && dirty_for_s < secs.max(1) {
                     continue;
                 }
                 // eprintln, not tracing: the daemon's stderr is the state dir's daemon.log —
@@ -963,11 +935,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                 // stage so a slow save localizes to seal vs publish (server landing times
                 // come from the ops log).
                 let reason = if quiet { "quiet" } else { "max-latency" };
-                eprintln!(
-                    "autosave: sealing reason={reason} dirty_for_s={} files={} renames={renames}",
-                    dirty_for.as_secs(),
-                    dirty_paths.len(),
-                );
+                eprintln!("autosave: sealing reason={reason} dirty_for_s={dirty_for_s}");
                 let seal_started = std::time::Instant::now();
                 match sealer.seal_once("tl fs auto-commit", false, None).await {
                     Ok(SealOutcome::Sealed(report)) => {
@@ -977,11 +945,8 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                             seal_started.elapsed().as_millis(),
                             report.push_ms,
                         );
-                        dirty_since = None;
                     }
-                    Ok(SealOutcome::Clean { .. }) => {
-                        dirty_since = None;
-                    }
+                    Ok(SealOutcome::Clean { .. }) => {}
                     Err(e) => eprintln!("autosave: {e}"),
                 }
             }
@@ -1576,6 +1541,9 @@ impl Sealer {
         let watermark = delta.watermark;
         if delta.is_empty() && !self.overlay.has_redirects() {
             st.sealed_gen = watermark;
+            // Nothing to seal: close the mutation clocks (and batch base) so the autosave
+            // tick goes back to its idle path instead of re-entering every poll.
+            self.overlay.close_dirty_base_if_clean();
             self.publish_mirror(&st);
             let cleared = clear.then(|| self.clear_overlay(&mut st)).transpose()?;
             return Ok(SealOutcome::Clean { cleared });

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -2103,6 +2103,15 @@ fn resolve_seal(
             // per-child events; future bulk ops may not): publish its files so nothing under
             // it can be missed. The sort+dedup below collapses overlap with child events.
             // Empty directories still publish nothing — git has no empty trees.
+            //
+            // A whiteout at the same name is the other half of a file→directory replacement
+            // (`rm file; mkdir file`): the mkdir's dirty record overwrote the rm's, but the
+            // marker survives. Publish the delete alongside the children — without it the
+            // application reads the adds as a kind conflict against the still-present file
+            // and keeps the file.
+            if whited_out_on_disk(&wh, path) {
+                deletes.push(path.clone());
+            }
             collect_dir_upserts(&upper, path, &mut ignore, &mut upserts)?;
             continue;
         }

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -1542,6 +1542,26 @@ impl Sealer {
         }
         let delta = self.overlay.dirty_since(st.sealed_gen);
         let watermark = delta.watermark;
+        // Dir-over-file self-heal: a mkdir that raced another session's same-named FILE
+        // landing has an upper directory shadowing a lower file with no whiteout. Write
+        // the missing marker now so this seal publishes the replacement's delete half and
+        // the merged view stays coherent (upper-first reads already shadow the file).
+        let healed = self
+            .overlay
+            .heal_replaced_files(delta.upserts.iter().map(|(p, _)| p.as_str()))
+            .await;
+        for path in &healed {
+            eprintln!("seal: healed dir-over-file at {path} (whiteout written)");
+        }
+        // The healed path may no longer be in this delta (its mkdir record was pruned by an
+        // earlier empty seal), and the delete arm skips paths with upper presence — force
+        // the replacement's delete half into the change set explicitly.
+        let mut delta = delta;
+        for path in &healed {
+            if !delta.deletes.contains(path) {
+                delta.deletes.push(path.clone());
+            }
+        }
         if delta.is_empty() && !self.overlay.has_redirects() {
             st.sealed_gen = watermark;
             // Nothing to seal: close the mutation clocks (and batch base) so the autosave
@@ -2121,8 +2141,15 @@ fn resolve_seal(
         upserts.push((path.clone(), abs, git_mode(&meta)));
     }
     for path in delta.deletes.iter().chain(vanished.iter()) {
-        if upper.join(path).symlink_metadata().is_ok() {
-            // Re-created since the event; its own upsert event covers it.
+        if upper
+            .join(path)
+            .symlink_metadata()
+            .is_ok_and(|m| !m.is_dir() || m.file_type().is_symlink())
+        {
+            // Re-created as CONTENT since the event; its own upsert event covers it. An
+            // upper DIRECTORY over the deleted name is different — a file→directory
+            // replacement, whose children ride their own upserts while this delete is the
+            // other half — and falls through to publish via its whiteout.
             continue;
         }
         if ignore.is_ignored(path, false)? {

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -356,6 +356,16 @@ pub struct OverlayFs {
     dirty: Mutex<HashMap<String, DirtyEntry>>,
     /// Out-of-band mutation epoch: see [`OverlayFs::epoch`].
     epoch: AtomicU64,
+    /// Monotonic clock origin for the mutation timestamps below (process-local millis).
+    started: std::time::Instant,
+    /// When the current dirty batch began / when the overlay was last mutated, in
+    /// [`OverlayFs::clock_ms`] millis; `0` = clean. Stamped by every write hook (content,
+    /// namespace, committed-dir renames), which makes the autosave quiet test a pair of
+    /// atomic loads instead of resolving the dirty set and statting files every tick — and
+    /// strictly more accurate: deletes and renames have no mtime to consult, and same-second
+    /// writes hide inside filesystem timestamp granularity.
+    first_dirty_ms: AtomicU64,
+    last_mutation_ms: AtomicU64,
     /// Published blob oid per retained upper path, recorded after each seal from the push
     /// report. A branch refresh compares these against the delta's new oids: equal means the
     /// change is this mount's own save echoing back (the retained copy stays — it IS the
@@ -498,6 +508,9 @@ impl OverlayFs {
             divergent_pending: Mutex::new(std::collections::HashSet::new()),
             dirty_base: Mutex::new(None),
             epoch: AtomicU64::new(0),
+            started: std::time::Instant::now(),
+            first_dirty_ms: AtomicU64::new(0),
+            last_mutation_ms: AtomicU64::new(0),
             mutate: tokio::sync::RwLock::new(()),
             redirects: Mutex::new(redirects),
             redirects_path,
@@ -538,6 +551,7 @@ impl OverlayFs {
         // both covered by a watermark and invisible to that watermark's delta, which is what
         // made a racing write silently unsealable forever.
         let generation = self.write_gen.fetch_add(1, Ordering::SeqCst) + 1;
+        self.stamp_mutation();
         match dirty.get_mut(path) {
             Some(entry) => {
                 entry.generation = generation;
@@ -666,6 +680,8 @@ impl OverlayFs {
     /// straight into the state dir and then asks for a reindex).
     pub fn rebuild_dirty_index(&self) -> Result<(), MountError> {
         self.epoch.fetch_add(1, Ordering::SeqCst);
+        self.first_dirty_ms.store(0, Ordering::SeqCst);
+        self.last_mutation_ms.store(0, Ordering::SeqCst);
         self.sealed_oids.lock().expect("sealed oid lock").clear();
         self.divergent_pending
             .lock()
@@ -1617,6 +1633,7 @@ impl OverlayFs {
             self.persist_redirects(&redirects)?;
         }
         self.redirect_gen.fetch_add(1, Ordering::SeqCst);
+        self.stamp_mutation();
         // Stale deletion markers at the destination belong to whatever the replace displaced.
         let dst_wh = self.wh_path(dst);
         if dst_wh
@@ -2023,12 +2040,37 @@ impl OverlayFs {
         // resolutions) describe a dead world too.
         self.dirty.lock().expect("dirty lock").clear();
         self.epoch.fetch_add(1, Ordering::SeqCst);
+        self.first_dirty_ms.store(0, Ordering::SeqCst);
+        self.last_mutation_ms.store(0, Ordering::SeqCst);
         self.sealed_oids.lock().expect("sealed oid lock").clear();
         self.divergent_pending
             .lock()
             .expect("divergence lock")
             .clear();
         Ok(affected)
+    }
+
+    /// Millis on this overlay's private monotonic clock (never 0 — 0 is the clean sentinel
+    /// in the mutation stamps).
+    pub fn clock_ms(&self) -> u64 {
+        self.started.elapsed().as_millis() as u64 + 1
+    }
+
+    fn stamp_mutation(&self) {
+        let now = self.clock_ms();
+        self.last_mutation_ms.store(now, Ordering::SeqCst);
+        // First write of the batch; racing writers can both lose to an earlier stamp,
+        // which is exactly right.
+        let _ = self
+            .first_dirty_ms
+            .compare_exchange(0, now, Ordering::SeqCst, Ordering::SeqCst);
+    }
+
+    /// `(first dirty, last mutation)` clock stamps of the current dirty batch, or `None`
+    /// when the overlay is clean — the autosave tick's entire cost on the idle path.
+    pub fn dirty_clock(&self) -> Option<(u64, u64)> {
+        let first = self.first_dirty_ms.load(Ordering::SeqCst);
+        (first != 0).then(|| (first, self.last_mutation_ms.load(Ordering::SeqCst)))
     }
 
     /// The lower commit the current dirty batch was started against — the merge base a seal
@@ -2045,6 +2087,13 @@ impl OverlayFs {
         let dirty = self.dirty.lock().expect("dirty lock");
         if dirty.is_empty() {
             *self.dirty_base.lock().expect("dirty base lock") = None;
+            if !self.has_redirects() {
+                // Batch fully sealed: the clocks re-arm on the next write. Pending
+                // redirects keep them running — they are unsealed work the dirty map
+                // never sees.
+                self.first_dirty_ms.store(0, Ordering::SeqCst);
+                self.last_mutation_ms.store(0, Ordering::SeqCst);
+            }
         }
     }
 
@@ -2086,14 +2135,18 @@ impl OverlayFs {
     pub fn absorb_divergence(&self, delta: &gsvc_mount::RefreshDelta) -> RefreshOutputs {
         let mut candidates: std::collections::HashSet<String> =
             std::mem::take(&mut *self.divergent_pending.lock().expect("divergence lock"));
+        // Everything intersects the sealed-record map IN MEMORY first: rows that no seal of
+        // ours ever touched (the overwhelming majority of a branch-jump delta) cost zero
+        // syscalls — dirty and ignored upper content is never even considered, and the only
+        // per-row filesystem work left is the whiteout probe for map hits.
         match &delta.changed {
             Some(rows) => {
                 let sealed = self.sealed_oids.lock().expect("sealed oid lock");
-                // Prefixes under which every retained path is implicitly changed — the same
-                // rule the core applies to its own inodes: a removed directory row implies
-                // its subtree, and a modified non-directory row means whatever was under
-                // that name as a directory is gone.
                 for row in rows {
+                    // Boundary rows expand — the same rule the core applies to its own
+                    // inodes: a removed directory row implies its subtree, and a modified
+                    // non-directory row means whatever was under that name as a directory
+                    // is gone.
                     let erases_subtree = match row.change {
                         gsvc_mount::ChangeKind::Removed => row.is_dir,
                         gsvc_mount::ChangeKind::Modified => !row.is_dir,
@@ -2106,22 +2159,23 @@ impl OverlayFs {
                         }
                     }
                     let path = row.path.as_str();
-                    if self.upper_meta(path).is_none() || self.whited_out(path) {
+                    let Some(sealed_oid) = sealed.get(path) else {
+                        continue; // not sealed by this mount: never ours to evict
+                    };
+                    let own_echo = matches!((sealed_oid, row.oid.as_deref()),
+                        (Some(sealed_oid), Some(new)) if sealed_oid == new);
+                    if own_echo {
                         continue;
                     }
-                    let own_echo = matches!((sealed.get(path), row.oid.as_deref()),
-                        (Some(Some(sealed_oid)), Some(new)) if sealed_oid == new);
-                    if !own_echo {
-                        candidates.insert(path.to_string());
-                    }
+                    candidates.insert(path.to_string());
                 }
             }
             None => {
-                // Divergence unknown: nominate every recorded retained shadow (trim skips
-                // dirty and pinned ones). Restart-lost records are re-seeded from the
-                // persisted seal index at daemon startup, so the map is the complete set —
-                // and an upper file OUTSIDE it is dirty or ignored content that must never
-                // be nominated.
+                // Divergence unknown (stat-walk fallback): nominate every recorded retained
+                // shadow AND sealed whiteout (trim skips dirty, pinned, and redirect-covered
+                // ones). Restart-lost records are re-seeded from the persisted seal index at
+                // daemon startup, so the map is the complete set — and an upper file OUTSIDE
+                // it is dirty or ignored content that must never be nominated.
                 let sealed = self.sealed_oids.lock().expect("sealed oid lock");
                 candidates.extend(sealed.keys().cloned());
             }
@@ -2129,12 +2183,24 @@ impl OverlayFs {
         if candidates.is_empty() {
             return RefreshOutputs::default();
         }
+        // A divergent candidate that carries a whiteout is a sealed DELETE the branch moved
+        // past — usually a remote (re-)add over it. The whiteout was masking lower content
+        // the branch now carries; keeping it would hide the other session's file
+        // indefinitely (the delivering application commit differs from the snapshot commit,
+        // so the seal-echo hygiene never matched). Derived from the final candidate set so
+        // pending retries re-probe too; retiring an actually-inert whiteout (branch also
+        // deleted) is the trim's original no-op.
         let candidates: Vec<String> = candidates.into_iter().collect();
-        match self.try_trim_retained(&candidates, &[]) {
+        let tombstones: Vec<String> = candidates
+            .iter()
+            .filter(|p| self.whited_out(p))
+            .cloned()
+            .collect();
+        match self.try_trim_retained(&candidates, &tombstones) {
             Some(outcome) => {
                 {
                     let mut sealed = self.sealed_oids.lock().expect("sealed oid lock");
-                    for path in &outcome.trimmed {
+                    for path in outcome.trimmed.iter().chain(&outcome.tombstones_removed) {
                         sealed.remove(path);
                     }
                 }
@@ -2149,8 +2215,17 @@ impl OverlayFs {
                 // supply the lower's new size when known; boundary-expanded and
                 // fallback-dropped paths get bare present-probes (the prober re-opens,
                 // which revalidates content through the overlay).
-                let trimmed: std::collections::HashSet<&str> =
-                    outcome.trimmed.iter().map(String::as_str).collect();
+                // A retired whiteout here is NOT inert — it was hiding content the branch
+                // re-added — so the merged path needs the same kernel convergence as a
+                // dropped shadow.
+                let mut invals = outcome.invals;
+                invals.extend(self.invals_for(&outcome.tombstones_removed));
+                let trimmed: std::collections::HashSet<&str> = outcome
+                    .trimmed
+                    .iter()
+                    .chain(&outcome.tombstones_removed)
+                    .map(String::as_str)
+                    .collect();
                 let mut expectations: Vec<KernelExpectation> = Vec::new();
                 let mut covered: std::collections::HashSet<&str> = std::collections::HashSet::new();
                 if let Some(rows) = &delta.changed {
@@ -2175,16 +2250,17 @@ impl OverlayFs {
                     }
                 }
                 RefreshOutputs {
-                    invals: outcome.invals,
+                    invals,
                     expectations,
                 }
             }
-            // Fence contended (a copy-up mid-flight): retry the whole set next time.
+            // Fence contended (a copy-up mid-flight): retry the whole set next time (the
+            // whiteout probe re-derives tombstones from these same paths).
             None => {
                 self.divergent_pending
                     .lock()
                     .expect("divergence lock")
-                    .extend(candidates);
+                    .extend(candidates.into_iter().chain(tombstones));
                 RefreshOutputs::default()
             }
         }

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -362,9 +362,12 @@ pub struct OverlayFs {
     /// byte cache), different means another session moved the path and the retained copy
     /// must stop shadowing the lower. Unknown (never recorded, or the push skipped hashing
     /// on the stable-prefix fast path) reads as divergent — dropping costs a refetch,
-    /// keeping costs serving stale bytes. In-memory only: after a restart every retained
-    /// path re-arms as unknown and the first branch change to touch it refetches.
-    sealed_oids: Mutex<HashMap<String, String>>,
+    /// keeping costs serving stale bytes. `None` values mark retained paths whose oid is
+    /// unknown (seeded from the persisted seal index after a restart, or stable-prefix
+    /// fast-path files that never hashed) — divergent by default. Only paths in this map
+    /// are ever nominated for eviction: an upper file without a seal record is dirty or
+    /// ignored content the trim must never touch.
+    sealed_oids: Mutex<HashMap<String, Option<String>>>,
     /// Divergent retained paths a trim could not drop yet (open handle, contended fence).
     /// Retried on every subsequent refresh absorption.
     divergent_pending: Mutex<std::collections::HashSet<String>>,
@@ -2051,40 +2054,76 @@ impl OverlayFs {
     pub fn record_sealed_oids(&self, oids: impl IntoIterator<Item = (String, String)>) {
         let mut map = self.sealed_oids.lock().expect("sealed oid lock");
         for (path, oid) in oids {
-            if !oid.is_empty() {
-                map.insert(path, oid);
-            }
+            map.insert(path, (!oid.is_empty()).then_some(oid));
+        }
+    }
+
+    /// Seed retained paths whose seal oids are unknown (the persisted seal index after a
+    /// daemon restart): they stay eligible for divergence eviction — treated as divergent
+    /// whenever the branch touches them, and on a divergence-unknown fallback — without
+    /// exposing dirty or ignored upper content to the trim.
+    pub fn seed_retained(&self, paths: impl IntoIterator<Item = String>) {
+        let mut map = self.sealed_oids.lock().expect("sealed oid lock");
+        for path in paths {
+            map.entry(path).or_insert(None);
         }
     }
 
     /// Drop retained upper copies the branch has moved past, so the merged view converges to
     /// what the branch actually says instead of serving this mount's stale byte cache. For
-    /// every delta path shadowed by the upper: a dirty path is the user's in-flight edit and
+    /// every delta row shadowed by the upper: a dirty path is the user's in-flight edit and
     /// keeps shadowing (the next seal owns it); a retained path whose recorded seal oid
-    /// equals the delta's new oid is this mount's own save echoing back and stays (byte
-    /// cache); anything else — different oid, unknown oid, or branch-side deletion — stops
-    /// shadowing via the trim fence (which pins open handles and skips redirects). Paths a
-    /// trim could not drop are retried on the next absorption. Returns the kernel
-    /// invalidations for everything dropped.
+    /// equals the row's new oid is this mount's own save echoing back and stays (byte
+    /// cache); anything else — different oid, unknown oid, branch-side deletion — stops
+    /// shadowing via the trim fence (which pins open handles and skips redirects). Rows sit
+    /// at the server's change boundary, so a removed directory (or a directory that became a
+    /// file) expands against every retained path under it. A `None` delta (stat-walk
+    /// fallback: older server, pruned base, transient diff failure) means divergence is
+    /// UNKNOWN — every retained shadow is dropped rather than risk serving stale bytes; the
+    /// cost is refetching content that usually matches. Paths a trim could not drop are
+    /// retried on the next absorption. Returns kernel invalidations and probe expectations
+    /// for everything dropped.
     pub fn absorb_divergence(&self, delta: &gsvc_mount::RefreshDelta) -> RefreshOutputs {
         let mut candidates: std::collections::HashSet<String> =
             std::mem::take(&mut *self.divergent_pending.lock().expect("divergence lock"));
-        {
-            let sealed = self.sealed_oids.lock().expect("sealed oid lock");
-            // The raw diff rows, not rebound/staled: a retained upper shadow means the
-            // kernel never looked the path up through the core, so no live inode exists
-            // and the inval lists skip it — but the branch change is exactly what must
-            // evict the shadow.
-            for row in &delta.changed {
-                let path = row.path.as_str();
-                if self.upper_meta(path).is_none() || self.whited_out(path) {
-                    continue;
+        match &delta.changed {
+            Some(rows) => {
+                let sealed = self.sealed_oids.lock().expect("sealed oid lock");
+                // Prefixes under which every retained path is implicitly changed — the same
+                // rule the core applies to its own inodes: a removed directory row implies
+                // its subtree, and a modified non-directory row means whatever was under
+                // that name as a directory is gone.
+                for row in rows {
+                    let erases_subtree = match row.change {
+                        gsvc_mount::ChangeKind::Removed => row.is_dir,
+                        gsvc_mount::ChangeKind::Modified => !row.is_dir,
+                        gsvc_mount::ChangeKind::Added => false,
+                    };
+                    if erases_subtree {
+                        let prefix = format!("{}/", row.path);
+                        for path in sealed.keys().filter(|p| p.starts_with(&prefix)) {
+                            candidates.insert(path.clone());
+                        }
+                    }
+                    let path = row.path.as_str();
+                    if self.upper_meta(path).is_none() || self.whited_out(path) {
+                        continue;
+                    }
+                    let own_echo = matches!((sealed.get(path), row.oid.as_deref()),
+                        (Some(Some(sealed_oid)), Some(new)) if sealed_oid == new);
+                    if !own_echo {
+                        candidates.insert(path.to_string());
+                    }
                 }
-                let own_echo = matches!((sealed.get(path), row.oid.as_deref()),
-                    (Some(sealed_oid), Some(new)) if sealed_oid == new);
-                if !own_echo {
-                    candidates.insert(path.to_string());
-                }
+            }
+            None => {
+                // Divergence unknown: nominate every recorded retained shadow (trim skips
+                // dirty and pinned ones). Restart-lost records are re-seeded from the
+                // persisted seal index at daemon startup, so the map is the complete set —
+                // and an upper file OUTSIDE it is dirty or ignored content that must never
+                // be nominated.
+                let sealed = self.sealed_oids.lock().expect("sealed oid lock");
+                candidates.extend(sealed.keys().cloned());
             }
         }
         if candidates.is_empty() {
@@ -2106,20 +2145,35 @@ impl OverlayFs {
                         .extend(outcome.held_open.iter().cloned());
                 }
                 // Bindings without a notify channel (FSKit) converge via probe
-                // expectations; a dropped shadow must purge cached pages and attrs, so
-                // carry the lower's new size (or absence) for every trimmed path.
+                // expectations; a dropped shadow must purge cached pages and attrs. Rows
+                // supply the lower's new size when known; boundary-expanded and
+                // fallback-dropped paths get bare present-probes (the prober re-opens,
+                // which revalidates content through the overlay).
                 let trimmed: std::collections::HashSet<&str> =
                     outcome.trimmed.iter().map(String::as_str).collect();
-                let expectations = delta
-                    .changed
-                    .iter()
-                    .filter(|row| trimmed.contains(row.path.as_str()))
-                    .map(|row| KernelExpectation {
-                        path: row.path.clone(),
-                        present: row.oid.is_some(),
-                        size: row.size,
-                    })
-                    .collect();
+                let mut expectations: Vec<KernelExpectation> = Vec::new();
+                let mut covered: std::collections::HashSet<&str> = std::collections::HashSet::new();
+                if let Some(rows) = &delta.changed {
+                    for row in rows {
+                        if trimmed.contains(row.path.as_str()) {
+                            covered.insert(row.path.as_str());
+                            expectations.push(KernelExpectation {
+                                path: row.path.clone(),
+                                present: row.oid.is_some(),
+                                size: row.size,
+                            });
+                        }
+                    }
+                }
+                for path in &outcome.trimmed {
+                    if !covered.contains(path.as_str()) {
+                        expectations.push(KernelExpectation {
+                            path: path.clone(),
+                            present: true,
+                            size: None,
+                        });
+                    }
+                }
                 RefreshOutputs {
                     invals: outcome.invals,
                     expectations,

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -2180,9 +2180,10 @@ impl OverlayFs {
     /// consumed by an earlier empty seal BEFORE the racing file lands, leaving only child
     /// upserts to name the boundary.
     ///
-    /// Returns the paths healed THIS pass (for the daemon log and the current seal's
-    /// forced delete — the fresh record's generation is past the in-flight delta's
-    /// watermark, so this one seal injects it by hand).
+    /// Returns the paths healed THIS pass (for the daemon log, and so the sealer knows to
+    /// re-snapshot its delta: the fresh record's generation is past the delta it already
+    /// took, and both the current seal and its success-pruning watermark must cover it —
+    /// otherwise the boundary stays dirty and re-publishes every following seal).
     ///
     /// Errors abort the seal (retryable): a transient index error or a failed marker write
     /// swallowed here would let the seal publish the children WITHOUT the delete half.
@@ -2357,7 +2358,10 @@ impl OverlayFs {
         // APPLIED yet (reconcile lag, a start-hint mount behind the branch), and removing
         // the marker would resurface the very files the user deleted. A whiteout under an
         // upper DIRECTORY is a live file→directory replacement boundary and is never
-        // retired here — the seal owns it.
+        // retired while the directory stands — but this very trim can unwind the directory
+        // (the branch moved past the replacement, so the dir is itself a candidate), so
+        // the liveness check runs inside the fenced trim AFTER candidate removal, where it
+        // sees the post-trim upper.
         let candidates: Vec<String> = candidates.into_iter().collect();
         let branch_carries: std::collections::HashSet<&str> = match &delta.changed {
             Some(rows) => rows
@@ -2369,17 +2373,10 @@ impl OverlayFs {
         };
         let tombstones: Vec<String> = candidates
             .iter()
-            .filter(|p| {
-                branch_carries.contains(p.as_str())
-                    && self.whited_out(p)
-                    && !self
-                        .upper_path(p)
-                        .symlink_metadata()
-                        .is_ok_and(|m| m.is_dir() && !m.file_type().is_symlink())
-            })
+            .filter(|p| branch_carries.contains(p.as_str()) && self.whited_out(p))
             .cloned()
             .collect();
-        match self.try_trim_retained(&candidates, &tombstones) {
+        match self.try_trim_retained(&candidates, &tombstones, TrimBoundaries::KeepLive) {
             Some(outcome) => {
                 {
                     let mut sealed = self.sealed_oids.lock().expect("sealed oid lock");
@@ -2467,7 +2464,7 @@ impl OverlayFs {
     /// inode was presenting (`invals`).
     pub async fn trim_retained(&self, candidates: &[String], tombstones: &[String]) -> TrimOutcome {
         let _fence = self.mutate.write().await;
-        self.trim_fenced(candidates, tombstones)
+        self.trim_fenced(candidates, tombstones, TrimBoundaries::RetireInert)
     }
 
     /// Non-blocking [`OverlayFs::trim_retained`]: `None` when the fence is contended. The
@@ -2479,12 +2476,18 @@ impl OverlayFs {
         &self,
         candidates: &[String],
         tombstones: &[String],
+        boundaries: TrimBoundaries,
     ) -> Option<TrimOutcome> {
         let _fence = self.mutate.try_write().ok()?;
-        Some(self.trim_fenced(candidates, tombstones))
+        Some(self.trim_fenced(candidates, tombstones, boundaries))
     }
 
-    fn trim_fenced(&self, candidates: &[String], tombstones: &[String]) -> TrimOutcome {
+    fn trim_fenced(
+        &self,
+        candidates: &[String],
+        tombstones: &[String],
+        boundaries: TrimBoundaries,
+    ) -> TrimOutcome {
         let open_upper: std::collections::HashSet<String> = {
             let handles = self.handles.lock().expect("handle lock");
             handles
@@ -2500,6 +2503,11 @@ impl OverlayFs {
             dirty.keys().cloned().collect()
         };
         let mut out = TrimOutcome::default();
+        // Child-first: a sealed file→directory replacement nominates the directory AND its
+        // sealed children when the branch moves past it; the directory can only fall once
+        // its children have.
+        let mut candidates: Vec<&String> = candidates.iter().collect();
+        candidates.sort_by_key(|p| std::cmp::Reverse(p.matches('/').count()));
         for path in candidates {
             if dirty.contains(path) || self.redirect_covers(path) {
                 continue;
@@ -2509,13 +2517,22 @@ impl OverlayFs {
                 continue;
             }
             let abs = self.upper_path(path);
-            if abs.symlink_metadata().is_err() {
+            let Ok(meta) = abs.symlink_metadata() else {
                 // Already gone (an earlier trim, or a stale seal record) — report it trimmed
                 // so the caller drops the record.
                 out.trimmed.push(path.clone());
                 continue;
-            }
-            match std::fs::remove_file(&abs) {
+            };
+            // A retained upper DIRECTORY (a sealed file→dir replacement the branch moved
+            // past) drops with remove_dir; remove_file would EISDIR and requeue the path
+            // forever. A non-empty directory still holds live children (dirty, held-open,
+            // or ignored content) and genuinely shadows the lower — that is held_open.
+            let removed = if meta.is_dir() && !meta.file_type().is_symlink() {
+                std::fs::remove_dir(&abs)
+            } else {
+                std::fs::remove_file(&abs)
+            };
+            match removed {
                 Ok(()) => out.trimmed.push(path.clone()),
                 Err(e) => {
                     // A path that could not be dropped still shadows the lower; report it
@@ -2531,6 +2548,21 @@ impl OverlayFs {
             // content inside the renamed tree); the redirect table, not the sealed delete,
             // is the authority there.
             if dirty.contains(path) || self.redirect_covers(path) {
+                continue;
+            }
+            // A whiteout whose own name still carries an upper directory is a LIVE
+            // file→directory replacement boundary — the delete half of an unsealed (or
+            // un-applied) swap; retiring it would resurface the replaced lower file. The
+            // check runs here, after the candidate pass, so a directory this same trim
+            // unwound releases its whiteout in one pass. The post-seal hygiene callers
+            // assert inertness differently (the lower already serves the sealed commit)
+            // and retire regardless of upper kind.
+            if boundaries == TrimBoundaries::KeepLive
+                && self
+                    .upper_path(path)
+                    .symlink_metadata()
+                    .is_ok_and(|m| m.is_dir() && !m.file_type().is_symlink())
+            {
                 continue;
             }
             // An inert whiteout: the sealed delete is in the lower's history, so the marker
@@ -2766,6 +2798,18 @@ pub struct OverlayInval {
     pub parent_ino: Option<u64>,
     pub name: String,
     pub staled: bool,
+}
+
+/// How a trim treats a whiteout whose name still carries an upper directory — the delete
+/// half of a file→directory replacement. `KeepLive` (the divergence path) skips it while
+/// the directory stands: the swap may be unsealed or not yet applied, and retiring the
+/// marker would resurface the replaced lower file. `RetireInert` (the post-seal callers)
+/// removes it regardless: those callers only pass tombstones once the lower serves the
+/// sealed commit, so the marker hides nothing.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum TrimBoundaries {
+    KeepLive,
+    RetireInert,
 }
 
 /// What one [`OverlayFs::trim_retained`] pass did. `trimmed` includes candidates that were
@@ -3916,6 +3960,20 @@ mod tests {
             .await
             .unwrap();
         assert!(via_child.is_empty(), "marker present: nothing to re-heal");
+        // The sealer re-snapshots its delta after a heal, so the SECOND snapshot's
+        // watermark covers the heal record — success-pruning to it must leave the boundary
+        // clean. (Pruning to the pre-heal watermark would leave the record dirty and
+        // re-publish the same delete on every following seal.)
+        assert!(
+            gen_before < delta.watermark,
+            "the heal record advanced the clock past the pre-heal watermark"
+        );
+        let resnap = fs.dirty_since(gen_before);
+        fs.prune_dirty(resnap.watermark);
+        assert!(
+            fs.dirty_since(resnap.watermark).is_empty(),
+            "a success that prunes to the re-snapshotted watermark consumes the heal record"
+        );
         let attr = fs.getattr(dir_attr.ino).await.unwrap();
         assert_eq!(
             attr.kind,
@@ -3959,5 +4017,120 @@ mod tests {
         );
         fs.forget(rev.ino, 1);
         fs.forget(dir_attr.ino, 1);
+    }
+
+    /// A sealed file→directory replacement the branch later moves PAST (the directory swaps
+    /// back to a file remotely) must unwind in one divergence pass: the retained upper
+    /// directory drops via `remove_dir`, children first (`remove_file` would EISDIR and
+    /// requeue the path forever, permanently shadowing the branch's file), and the boundary
+    /// whiteout retires in the same pass once the directory is gone.
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "needs a local artifact-storage server"]
+    async fn divergence_unwinds_sealed_file_to_dir_replacement() {
+        if !server_up() {
+            eprintln!("skipping: no local artifact-storage server");
+            return;
+        }
+        let sdk = sdk();
+        let repo = format!(
+            "unwind-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        sdk.create_repo_with_credential(PROJECT, &repo, None, None, "t", TOKEN)
+            .await
+            .unwrap();
+        sdk.push_files(
+            PROJECT,
+            &repo,
+            "t",
+            TOKEN,
+            vec![push_file("swap", b"lower file\n", 0o100644)],
+            PushOptions {
+                message: "seed".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let client = FsClient::new(BASE, PROJECT, &repo, Some(TOKEN.to_string())).unwrap();
+        let core = MountCore::new(
+            client,
+            MountOptions {
+                reference: "main".to_string(),
+                follow: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let fs: Arc<OverlayFs> = OverlayFs::new(core.clone(), state.path(), false).unwrap();
+
+        // The local file→dir replacement a previous seal would have published: whiteout at
+        // the name, upper directory over it, a child file inside.
+        fs.unlink(ROOT_INO, "swap").await.unwrap();
+        let dir_attr = fs.mkdir(ROOT_INO, "swap").await.unwrap();
+        let (kept, kfh) = fs.create(dir_attr.ino, "kept.txt", false).await.unwrap();
+        fs.release(kfh);
+        fs.forget(kept.ino, 1);
+        fs.forget(dir_attr.ino, 1);
+        assert!(state.path().join("wh/swap").is_file());
+        assert!(state.path().join("upper/swap").is_dir());
+        // "The seal published and pruned": records exist for the retained shapes, nothing
+        // is dirty (trim skips dirty paths by design).
+        fs.prune_dirty(fs.dirty_since(0).watermark);
+        fs.record_sealed_oids([
+            ("swap".to_string(), "0".repeat(40)),
+            ("swap/kept.txt".to_string(), "1".repeat(40)),
+        ]);
+
+        // The branch moves past the replacement: a Modified NON-directory row at the name
+        // (dir→file remotely) implies everything sealed under `swap/` is gone.
+        let delta = gsvc_mount::RefreshDelta {
+            changed: Some(vec![gsvc_mount::ChangedRow {
+                path: "swap".to_string(),
+                change: gsvc_mount::ChangeKind::Modified,
+                is_dir: false,
+                oid: Some("2".repeat(40)),
+                size: Some(11),
+            }]),
+            appeared: Some(Vec::new()),
+            ..Default::default()
+        };
+        let outputs = fs.absorb_divergence(&delta);
+        assert!(
+            !state.path().join("upper/swap").exists(),
+            "the retained upper directory dropped (remove_dir, child-first)"
+        );
+        assert!(
+            !state.path().join("wh/swap").exists(),
+            "the boundary whiteout retired in the same pass the directory fell"
+        );
+        assert!(
+            outputs
+                .expectations
+                .iter()
+                .any(|e| e.path == "swap" && e.present),
+            "the delta-covered path converges via a present-probe: {:?}",
+            outputs
+                .expectations
+                .iter()
+                .map(|e| e.path.as_str())
+                .collect::<Vec<_>>()
+        );
+        // Nothing requeued: a second pass with the same delta has no candidates left.
+        let again = fs.absorb_divergence(&delta);
+        assert!(
+            again.expectations.is_empty() && again.invals.is_empty(),
+            "no held_open requeue loop"
+        );
+        // The branch's file resurfaces through the merged view (the lower still serves the
+        // seed commit here; kind is what matters — no dir, no whiteout in the way).
+        let looked = fs.lookup(ROOT_INO, "swap").await.unwrap();
+        assert_eq!(looked.kind, NodeKind::File);
+        fs.forget(looked.ino, 1);
     }
 }

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -356,6 +356,27 @@ pub struct OverlayFs {
     dirty: Mutex<HashMap<String, DirtyEntry>>,
     /// Out-of-band mutation epoch: see [`OverlayFs::epoch`].
     epoch: AtomicU64,
+    /// Published blob oid per retained upper path, recorded after each seal from the push
+    /// report. A branch refresh compares these against the delta's new oids: equal means the
+    /// change is this mount's own save echoing back (the retained copy stays — it IS the
+    /// byte cache), different means another session moved the path and the retained copy
+    /// must stop shadowing the lower. Unknown (never recorded, or the push skipped hashing
+    /// on the stable-prefix fast path) reads as divergent — dropping costs a refetch,
+    /// keeping costs serving stale bytes. In-memory only: after a restart every retained
+    /// path re-arms as unknown and the first branch change to touch it refetches.
+    sealed_oids: Mutex<HashMap<String, String>>,
+    /// Divergent retained paths a trim could not drop yet (open handle, contended fence).
+    /// Retried on every subsequent refresh absorption.
+    divergent_pending: Mutex<std::collections::HashSet<String>>,
+    /// The lower commit the CURRENT dirty batch's edits were made against: stamped when the
+    /// dirty set goes empty→nonempty (under the dirty lock), cleared only when a seal leaves
+    /// the set empty. This — not the lower at seal time — is the merge base a seal declares:
+    /// the lower can advance during the quiet window between a write and its autosave, and a
+    /// base captured at seal time would claim the writer saw content that landed AFTER their
+    /// edit, turning a genuine concurrent write into a silent overwrite. A too-old base costs
+    /// at worst a spurious conflict (both sides kept, visibly); a too-new base loses a write
+    /// invisibly — always err old.
+    dirty_base: Mutex<Option<String>>,
     /// The trim fence. Mutating entry points hold it shared for their whole span (copy-up
     /// through dirty-index record); [`OverlayFs::trim_retained`] holds it exclusively while it
     /// drops sealed upper files. Without it, a trim could unlink an upper file between a
@@ -470,6 +491,9 @@ impl OverlayFs {
             lower_times: Mutex::new(HashMap::new()),
             write_gen: AtomicU64::new(0),
             dirty: Mutex::new(HashMap::new()),
+            sealed_oids: Mutex::new(HashMap::new()),
+            divergent_pending: Mutex::new(std::collections::HashSet::new()),
+            dirty_base: Mutex::new(None),
             epoch: AtomicU64::new(0),
             mutate: tokio::sync::RwLock::new(()),
             redirects: Mutex::new(redirects),
@@ -499,6 +523,12 @@ impl OverlayFs {
 
     fn record_at(&self, path: &str, kind: DirtyKind, offset: u64) {
         let mut dirty = self.dirty.lock().expect("dirty lock");
+        if dirty.is_empty() {
+            // First write of a new batch: remember which view these edits are against.
+            // Stamped under the dirty lock so a sealer that empties the set and clears the
+            // base can never interleave mid-transition.
+            *self.dirty_base.lock().expect("dirty base lock") = Some(self.core.current_commit());
+        }
         // The clock bump happens UNDER the map lock: a sealer that loaded watermark W is then
         // guaranteed to either see this entry (we inserted before it acquired the lock) or to
         // have loaded W < generation (we bumped after its load) — a generation can never be
@@ -633,6 +663,11 @@ impl OverlayFs {
     /// straight into the state dir and then asks for a reindex).
     pub fn rebuild_dirty_index(&self) -> Result<(), MountError> {
         self.epoch.fetch_add(1, Ordering::SeqCst);
+        self.sealed_oids.lock().expect("sealed oid lock").clear();
+        self.divergent_pending
+            .lock()
+            .expect("divergence lock")
+            .clear();
         fn walk(root: &Path, dir: &Path, out: &mut dyn FnMut(String)) -> std::io::Result<()> {
             let Ok(read) = std::fs::read_dir(dir) else {
                 return Ok(());
@@ -1985,7 +2020,120 @@ impl OverlayFs {
         // resolutions) describe a dead world too.
         self.dirty.lock().expect("dirty lock").clear();
         self.epoch.fetch_add(1, Ordering::SeqCst);
+        self.sealed_oids.lock().expect("sealed oid lock").clear();
+        self.divergent_pending
+            .lock()
+            .expect("divergence lock")
+            .clear();
         Ok(affected)
+    }
+
+    /// The lower commit the current dirty batch was started against — the merge base a seal
+    /// must declare. `None` when nothing has been written since the last clean seal (callers
+    /// fall back to the current lower).
+    pub fn dirty_base(&self) -> Option<String> {
+        self.dirty_base.lock().expect("dirty base lock").clone()
+    }
+
+    /// After a successful seal: if no write raced in during the push (the dirty set is
+    /// empty), the batch is closed — the next write stamps a fresh base. A non-empty set
+    /// keeps the old (older-than-necessary, therefore safe) base for the writes it covers.
+    pub fn close_dirty_base_if_clean(&self) {
+        let dirty = self.dirty.lock().expect("dirty lock");
+        if dirty.is_empty() {
+            *self.dirty_base.lock().expect("dirty base lock") = None;
+        }
+    }
+
+    /// Record the published blob oid for each sealed path (from the push report). Empty oids
+    /// (deletes, stable-prefix fast-path files that never hashed) are dropped — those paths
+    /// read as divergence-unknown and err toward refetching.
+    pub fn record_sealed_oids(&self, oids: impl IntoIterator<Item = (String, String)>) {
+        let mut map = self.sealed_oids.lock().expect("sealed oid lock");
+        for (path, oid) in oids {
+            if !oid.is_empty() {
+                map.insert(path, oid);
+            }
+        }
+    }
+
+    /// Drop retained upper copies the branch has moved past, so the merged view converges to
+    /// what the branch actually says instead of serving this mount's stale byte cache. For
+    /// every delta path shadowed by the upper: a dirty path is the user's in-flight edit and
+    /// keeps shadowing (the next seal owns it); a retained path whose recorded seal oid
+    /// equals the delta's new oid is this mount's own save echoing back and stays (byte
+    /// cache); anything else — different oid, unknown oid, or branch-side deletion — stops
+    /// shadowing via the trim fence (which pins open handles and skips redirects). Paths a
+    /// trim could not drop are retried on the next absorption. Returns the kernel
+    /// invalidations for everything dropped.
+    pub fn absorb_divergence(&self, delta: &gsvc_mount::RefreshDelta) -> RefreshOutputs {
+        let mut candidates: std::collections::HashSet<String> =
+            std::mem::take(&mut *self.divergent_pending.lock().expect("divergence lock"));
+        {
+            let sealed = self.sealed_oids.lock().expect("sealed oid lock");
+            // The raw diff rows, not rebound/staled: a retained upper shadow means the
+            // kernel never looked the path up through the core, so no live inode exists
+            // and the inval lists skip it — but the branch change is exactly what must
+            // evict the shadow.
+            for row in &delta.changed {
+                let path = row.path.as_str();
+                if self.upper_meta(path).is_none() || self.whited_out(path) {
+                    continue;
+                }
+                let own_echo = matches!((sealed.get(path), row.oid.as_deref()),
+                    (Some(sealed_oid), Some(new)) if sealed_oid == new);
+                if !own_echo {
+                    candidates.insert(path.to_string());
+                }
+            }
+        }
+        if candidates.is_empty() {
+            return RefreshOutputs::default();
+        }
+        let candidates: Vec<String> = candidates.into_iter().collect();
+        match self.try_trim_retained(&candidates, &[]) {
+            Some(outcome) => {
+                {
+                    let mut sealed = self.sealed_oids.lock().expect("sealed oid lock");
+                    for path in &outcome.trimmed {
+                        sealed.remove(path);
+                    }
+                }
+                if !outcome.held_open.is_empty() {
+                    self.divergent_pending
+                        .lock()
+                        .expect("divergence lock")
+                        .extend(outcome.held_open.iter().cloned());
+                }
+                // Bindings without a notify channel (FSKit) converge via probe
+                // expectations; a dropped shadow must purge cached pages and attrs, so
+                // carry the lower's new size (or absence) for every trimmed path.
+                let trimmed: std::collections::HashSet<&str> =
+                    outcome.trimmed.iter().map(String::as_str).collect();
+                let expectations = delta
+                    .changed
+                    .iter()
+                    .filter(|row| trimmed.contains(row.path.as_str()))
+                    .map(|row| KernelExpectation {
+                        path: row.path.clone(),
+                        present: row.oid.is_some(),
+                        size: row.size,
+                    })
+                    .collect();
+                RefreshOutputs {
+                    invals: outcome.invals,
+                    expectations,
+                }
+            }
+            // Fence contended (a copy-up mid-flight): retry the whole set next time.
+            None => {
+                self.divergent_pending
+                    .lock()
+                    .expect("divergence lock")
+                    .extend(candidates);
+                RefreshOutputs::default()
+            }
+        }
     }
 
     /// Drop retained upper files (and inert whiteouts) whose content a seal has published and
@@ -2636,8 +2784,9 @@ mod tests {
             !repositories.repos.iter().any(|r| r.name == fs_name),
             "a filesystem must not appear in the repository listing"
         );
-        // The genesis commit is what makes `tl fs create` + mount work with no client push:
-        // a baseless, publish-on-save workspace resolves its base from the default branch.
+        // The genesis commit is what makes `tl fs create` + mount work with no client push,
+        // and `surface` is what makes it ONE round trip: the SERVER fills the publish target
+        // from the repo's stored default branch — the client never reads a listing.
         let ws = sdk
             .create_workspace(
                 PROJECT,
@@ -2645,7 +2794,7 @@ mod tests {
                 "t",
                 TOKEN,
                 &CreateWorkspaceRequest {
-                    shared_target: Some(entry.default_branch.clone()),
+                    surface: Some("filesystem".to_string()),
                     ..Default::default()
                 },
             )
@@ -2654,6 +2803,42 @@ mod tests {
             .into_inner();
         assert_eq!(ws.base_ref.as_deref(), Some("refs/heads/main"));
         assert_eq!(ws.shared_target.as_deref(), Some("main"));
+
+        // The authoritative meta point-read answers immediately after create — this is the
+        // rm/validation path's read-your-writes guarantee.
+        let meta = sdk
+            .repo_meta_with_credential(PROJECT, &fs_name, "t", TOKEN)
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(meta.is_filesystem());
+        assert_eq!(meta.default_branch, "main");
+
+        // An fs-surface session on a repository fails closed with the right command.
+        let repo_name = format!("{fs_name}-repo");
+        sdk.create_repo_with_credential(PROJECT, &repo_name, None, None, "t", TOKEN)
+            .await
+            .unwrap();
+        let err = sdk
+            .create_workspace(
+                PROJECT,
+                &repo_name,
+                "t",
+                TOKEN,
+                &CreateWorkspaceRequest {
+                    surface: Some("filesystem".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err}").contains("tl git mount"),
+            "kind mismatch must name the replacement, got: {err}"
+        );
+        sdk.delete_repo_with_credential(PROJECT, &repo_name, "t", TOKEN)
+            .await
+            .unwrap();
         // Pin `tl fs history`'s save definition to the server's operation vocabulary: the
         // genesis is a committed "push" op, i.e. exactly what the history filter
         // (kind in {push, reconcile, promote, merge} AND result == "committed") must match.

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -23,6 +23,29 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use bytes::Bytes;
 use gsvc_mount::{MountCore, MountError, NodeAttr, NodeKind, ROOT_INO};
 
+/// Nominate one retained path plus the upper directories that can become empty after it is
+/// removed. `stop_at` bounds a server-declared subtree erase; without one (the divergence-unknown
+/// fallback), walking to the top-level directory is still safe because trim uses `remove_dir`,
+/// never `remove_dir_all`: dirty or ignored children keep every non-empty ancestor in place.
+fn nominate_retained_path_and_parents(
+    candidates: &mut std::collections::HashSet<String>,
+    path: &str,
+    stop_at: Option<&str>,
+) {
+    candidates.insert(path.to_string());
+    let mut child = path;
+    while let Some((parent, _)) = child.rsplit_once('/') {
+        if parent.is_empty() {
+            break;
+        }
+        candidates.insert(parent.to_string());
+        if stop_at == Some(parent) {
+            break;
+        }
+        child = parent;
+    }
+}
+
 /// One merged-namespace node. Path-keyed: the same repo-relative path keeps the same ino for as
 /// long as the kernel references it, regardless of which layer currently backs it.
 struct ONode {
@@ -2322,7 +2345,15 @@ impl OverlayFs {
                     if erases_subtree {
                         let prefix = format!("{}/", row.path);
                         for path in sealed.keys().filter(|p| p.starts_with(&prefix)) {
-                            candidates.insert(path.clone());
+                            // Git records files, not their directory objects. Nominate every
+                            // intermediate upper directory too, through the changed boundary, so
+                            // child-first trim does not strand `swap/sub/` after removing
+                            // `swap/sub/file` and then retry `remove_dir("swap")` forever.
+                            nominate_retained_path_and_parents(
+                                &mut candidates,
+                                path,
+                                Some(row.path.as_str()),
+                            );
                         }
                     }
                     let path = row.path.as_str();
@@ -2344,7 +2375,9 @@ impl OverlayFs {
                 // daemon startup, so the map is the complete set — and an upper file OUTSIDE
                 // it is dirty or ignored content that must never be nominated.
                 let sealed = self.sealed_oids.lock().expect("sealed oid lock");
-                candidates.extend(sealed.keys().cloned());
+                for path in sealed.keys() {
+                    nominate_retained_path_and_parents(&mut candidates, path, None);
+                }
             }
         }
         if candidates.is_empty() {
@@ -2455,9 +2488,9 @@ impl OverlayFs {
     /// - a path under a pending rename is skipped (the redirect table is the authority there).
     ///
     /// Runs under the exclusive side of the trim fence, so no copy-up or open can interleave
-    /// with the unlinks. Empty parent directories are deliberately left in place: git has no
-    /// empty trees, so a directory emptied by trim may exist nowhere in the lower — removing
-    /// it would change the merged view.
+    /// with the unlinks. Parent directories are left in place unless the caller explicitly
+    /// nominates them from a sealed descendant; those nominated parents use `remove_dir`, so an
+    /// unrelated dirty or ignored child safely keeps the directory and its merged view.
     ///
     /// Dirty entries, sealer caches, and the epoch are untouched: logically nothing changed
     /// (the lower serves the same bytes), the kernel just needs fresh lookups where an upper
@@ -2852,6 +2885,28 @@ mod tests {
     use tensorlake::artifact_storage::ArtifactStorageClient;
     use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
     use tensorlake::artifact_storage::workspaces::CreateWorkspaceRequest;
+
+    #[test]
+    fn retained_candidates_include_every_directory_to_the_changed_boundary() {
+        let mut candidates = std::collections::HashSet::new();
+        nominate_retained_path_and_parents(
+            &mut candidates,
+            "swap/sub/deeper/file.txt",
+            Some("swap"),
+        );
+        assert_eq!(
+            candidates,
+            [
+                "swap".to_string(),
+                "swap/sub".to_string(),
+                "swap/sub/deeper".to_string(),
+                "swap/sub/deeper/file.txt".to_string(),
+            ]
+            .into_iter()
+            .collect(),
+            "child-first trim receives the intermediate directories Git never records"
+        );
+    }
 
     // ---------------------------------------------------------------------------------------
     // Inode-table re-keying (pure, no server): the rename fix that lets `git init`/`git clone`
@@ -4070,21 +4125,24 @@ mod tests {
         let fs: Arc<OverlayFs> = OverlayFs::new(core.clone(), state.path(), false).unwrap();
 
         // The local file→dir replacement a previous seal would have published: whiteout at
-        // the name, upper directory over it, a child file inside.
+        // the name, upper directory over it, and a file below an intermediate directory Git
+        // never records as a sealed path.
         fs.unlink(ROOT_INO, "swap").await.unwrap();
         let dir_attr = fs.mkdir(ROOT_INO, "swap").await.unwrap();
-        let (kept, kfh) = fs.create(dir_attr.ino, "kept.txt", false).await.unwrap();
+        let sub_attr = fs.mkdir(dir_attr.ino, "sub").await.unwrap();
+        let (kept, kfh) = fs.create(sub_attr.ino, "kept.txt", false).await.unwrap();
         fs.release(kfh);
         fs.forget(kept.ino, 1);
+        fs.forget(sub_attr.ino, 1);
         fs.forget(dir_attr.ino, 1);
         assert!(state.path().join("wh/swap").is_file());
-        assert!(state.path().join("upper/swap").is_dir());
+        assert!(state.path().join("upper/swap/sub").is_dir());
         // "The seal published and pruned": records exist for the retained shapes, nothing
         // is dirty (trim skips dirty paths by design).
         fs.prune_dirty(fs.dirty_since(0).watermark);
         fs.record_sealed_oids([
             ("swap".to_string(), "0".repeat(40)),
-            ("swap/kept.txt".to_string(), "1".repeat(40)),
+            ("swap/sub/kept.txt".to_string(), "1".repeat(40)),
         ]);
 
         // The branch moves past the replacement: a Modified NON-directory row at the name

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -928,7 +928,7 @@ impl OverlayFs {
         if self.whited_out(&path) {
             return Err(not_found());
         }
-        let Ok(parent_core) = self.lower_binding(&parent_node).await else {
+        let Ok(parent_core) = self.lower_dir_binding(&parent_node).await else {
             return Err(not_found());
         };
         // Always a fresh core lookup: after a snapshot the workspace ref moved, and the node's
@@ -982,6 +982,27 @@ impl OverlayFs {
         Ok(leaf)
     }
 
+    /// A node's lower binding FOR CHILD RESOLUTION: only a lower directory can have lower
+    /// children. An upper directory shadowing a lower non-directory — a concurrent
+    /// dir-vs-file collision (mkdir raced another session's file landing), or the window
+    /// between `rm file; mkdir file` and its seal — resolves as "no lower children"
+    /// instead of probing a file as a tree, which reads as `IndexNotReady` in the core and
+    /// spins the settle loop for its full deadline (the silently-stalled seals).
+    async fn lower_dir_binding(&self, node: &ONode) -> Result<u64, MountError> {
+        // The reverse shadow: an upper NON-directory at this name hides the lower entirely,
+        // so a lower directory gained by refresh underneath it must not leak children.
+        if let Some(meta) = self.upper_meta(&node.path)
+            && !(meta.is_dir() && !meta.file_type().is_symlink())
+        {
+            return Err(not_found());
+        }
+        let ino = self.lower_binding(node).await?;
+        match self.core.getattr(ino) {
+            Ok(attr) if attr.kind == NodeKind::Dir => Ok(ino),
+            _ => Err(not_found()),
+        }
+    }
+
     /// Walk a merged path component-by-component through the core, following any pending
     /// rename remap. Returns the leaf's attributes holding **one counted core reference**
     /// (on `attr.ino`) that the caller must own or repay.
@@ -996,6 +1017,17 @@ impl OverlayFs {
         let mut cur = ROOT_INO;
         let mut chain: Vec<NodeAttr> = Vec::new();
         for component in lower.split('/') {
+            // A non-directory intermediate means the path does not exist as spelled —
+            // answer that directly instead of asking the core to list a file as a tree
+            // (which reads as IndexNotReady and spins the settle loop).
+            if let Some(parent) = chain.last()
+                && parent.kind != NodeKind::Dir
+            {
+                for attr in chain {
+                    self.core.forget(attr.ino, 1);
+                }
+                return Err(not_found());
+            }
             match settle_lower!(self.core.lookup(cur, component).await) {
                 Ok(attr) => {
                     cur = attr.ino;
@@ -1102,7 +1134,7 @@ impl OverlayFs {
         }
 
         let lower = if !self.whited_out(&node.path) || node.path.is_empty() {
-            self.lower_binding(&node).await.ok()
+            self.lower_dir_binding(&node).await.ok()
         } else {
             None
         };
@@ -1462,6 +1494,11 @@ impl OverlayFs {
         let Some(core_parent) = parent_core else {
             return false;
         };
+        // A cached parent binding can point at a lower non-directory (the upper dir shadows
+        // it): no lower children exist, and probing would spin the settle loop.
+        if !matches!(self.core.getattr(core_parent), Ok(attr) if attr.kind == NodeKind::Dir) {
+            return false;
+        }
         match self.core.lookup(core_parent, name).await {
             Ok(attr) => {
                 self.core.forget(attr.ino, 1);
@@ -2117,6 +2154,54 @@ impl OverlayFs {
                 self.last_mutation_ms.store(0, Ordering::SeqCst);
             }
         }
+    }
+
+    /// Self-heal dir-over-file states before a seal: for every dirty upsert whose UPPER is
+    /// a directory while the LOWER holds a non-directory at the same path, write the
+    /// missing whiteout. `rm file; mkdir file` writes it naturally, but a mkdir that raced
+    /// another session's file LANDING never saw the file (merged_exists answered before
+    /// delivery) — the marker converts that state into the coherent replaced-file shape,
+    /// and the seal's directory-upsert arm then publishes the delete half of the
+    /// replacement. Returns the healed paths (for the daemon log).
+    pub(crate) async fn heal_replaced_files<'a>(
+        &self,
+        upserts: impl Iterator<Item = &'a str>,
+    ) -> Vec<String> {
+        // Each upsert's ANCESTOR directories are candidates too: after the race, the mkdir's
+        // own dirty record can be pruned by an earlier (empty) seal, leaving only child
+        // upserts in this delta while the dir still shadows the lower file.
+        let mut candidates: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for path in upserts {
+            let mut prefix = String::with_capacity(path.len());
+            for component in path.split('/') {
+                if !prefix.is_empty() {
+                    prefix.push('/');
+                }
+                prefix.push_str(component);
+                candidates.insert(prefix.clone());
+            }
+        }
+        let mut healed = Vec::new();
+        for path in candidates {
+            let is_upper_dir = self
+                .upper_path(&path)
+                .symlink_metadata()
+                .is_ok_and(|m| m.is_dir() && !m.file_type().is_symlink());
+            if !is_upper_dir || self.whited_out(&path) {
+                continue;
+            }
+            match self.walk_lower(&path).await {
+                Ok(attr) => {
+                    let non_dir = attr.kind != NodeKind::Dir;
+                    self.core.forget(attr.ino, 1);
+                    if non_dir && super::write_whiteout(&self.wh, &path).is_ok() {
+                        healed.push(path);
+                    }
+                }
+                Err(_) => {}
+            }
+        }
+        healed
     }
 
     /// Record the published blob oid for each sealed path (from the push report). Empty oids
@@ -3617,5 +3702,169 @@ mod tests {
         sdk.delete_workspace(PROJECT, &repo, "t", TOKEN, &ws.id)
             .await
             .unwrap();
+    }
+
+    /// The concurrent dir-vs-file collision: a `mkdir` lands while another writer's
+    /// same-named FILE is being delivered to the followed ref (`merged_exists` answered
+    /// before delivery, so no whiteout exists). The upper directory must consistently
+    /// shadow the lower file — getattr, child create, child lookup, and readdir all answer
+    /// upper-side, in bounded time (the old behavior probed the lower FILE as a tree,
+    /// which reads as IndexNotReady and spins the settle loop 10s per probe: the silently
+    /// stalled seals). The pre-seal heal then writes the missing whiteout, turning the
+    /// state into a plain file→directory replacement. The reverse shape (upper FILE at a
+    /// name where the lower gains a directory) stays upper-shadowed too.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "requires a local artifact-storage server on 127.0.0.1:8080"]
+    async fn upper_dir_shadows_lower_file_gained_by_refresh() {
+        if !server_up() {
+            eprintln!("skipping: no local artifact-storage server");
+            return;
+        }
+        let sdk = sdk();
+        let repo = format!(
+            "dirfile-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        sdk.create_repo_with_credential(PROJECT, &repo, None, None, "t", TOKEN)
+            .await
+            .unwrap();
+        sdk.push_files(
+            PROJECT,
+            &repo,
+            "t",
+            TOKEN,
+            vec![push_file("README.md", b"# seed\n", 0o100644)],
+            PushOptions {
+                message: "seed".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let client = FsClient::new(BASE, PROJECT, &repo, Some(TOKEN.to_string())).unwrap();
+        let core = MountCore::new(
+            client,
+            MountOptions {
+                reference: "main".to_string(),
+                follow: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let state = tempfile::tempdir().unwrap();
+        let fs: Arc<OverlayFs> = OverlayFs::new(core.clone(), state.path(), false).unwrap();
+
+        // The race: the local mkdir wins the local view before the remote file exists.
+        let dir_attr = fs.mkdir(ROOT_INO, "swap").await.unwrap();
+        assert_eq!(dir_attr.kind, NodeKind::Dir);
+
+        // Another writer lands FILE `swap` on the followed branch; deliver it.
+        sdk.push_files(
+            PROJECT,
+            &repo,
+            "t",
+            TOKEN,
+            vec![push_file("swap", b"remote file\n", 0o100644)],
+            PushOptions {
+                message: "remote file at the mkdir name".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let mut delivered = false;
+        for _ in 0..100 {
+            if core.poll_ref().await.unwrap().is_some() {
+                delivered = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(delivered, "the remote file's refresh never arrived");
+
+        // Coherence, in bounded time — no settle-loop stalls.
+        let bounded = std::time::Duration::from_secs(3);
+        let attr = fs.getattr(dir_attr.ino).await.unwrap();
+        assert_eq!(attr.kind, NodeKind::Dir, "upper dir keeps shadowing");
+        let (inner, ifh) =
+            tokio::time::timeout(bounded, fs.create(dir_attr.ino, "inner.txt", false))
+                .await
+                .expect("child create must not stall in the settle loop")
+                .unwrap();
+        fs.release(ifh);
+        let looked = tokio::time::timeout(bounded, fs.lookup(dir_attr.ino, "inner.txt"))
+            .await
+            .expect("child lookup must not stall")
+            .unwrap();
+        assert_eq!(looked.kind, NodeKind::File);
+        fs.forget(looked.ino, 1);
+        fs.forget(inner.ino, 1);
+        let names = tokio::time::timeout(bounded, dir_names(&fs, dir_attr.ino))
+            .await
+            .expect("readdir must not stall");
+        assert_eq!(
+            names,
+            vec!["inner.txt".to_string()],
+            "no lower leak-through"
+        );
+        let root_names = dir_names(&fs, ROOT_INO).await;
+        assert_eq!(
+            root_names.iter().filter(|n| n.as_str() == "swap").count(),
+            1,
+            "swap appears exactly once in the parent listing"
+        );
+
+        // The pre-seal heal writes the missing whiteout (once).
+        let healed = fs.heal_replaced_files(["swap"].into_iter()).await;
+        assert_eq!(healed, vec!["swap".to_string()]);
+        let again = fs.heal_replaced_files(["swap"].into_iter()).await;
+        assert!(again.is_empty(), "already healed: the whiteout is in place");
+        let attr = fs.getattr(dir_attr.ino).await.unwrap();
+        assert_eq!(
+            attr.kind,
+            NodeKind::Dir,
+            "the marker never hides the upper dir"
+        );
+
+        // Reverse shape: upper FILE where the lower gains a directory.
+        let (rev, rfh) = fs.create(ROOT_INO, "rev", false).await.unwrap();
+        fs.release(rfh);
+        sdk.push_files(
+            PROJECT,
+            &repo,
+            "t",
+            TOKEN,
+            vec![push_file("rev/child.txt", b"below\n", 0o100644)],
+            PushOptions {
+                message: "remote dir at the file name".into(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let mut delivered = false;
+        for _ in 0..100 {
+            if core.poll_ref().await.unwrap().is_some() {
+                delivered = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(delivered, "the remote dir's refresh never arrived");
+        let attr = fs.getattr(rev.ino).await.unwrap();
+        assert_eq!(attr.kind, NodeKind::File, "upper file keeps shadowing");
+        let child = tokio::time::timeout(bounded, fs.lookup(rev.ino, "child.txt"))
+            .await
+            .expect("shadowed child lookup must not stall");
+        assert!(
+            matches!(child, Err(MountError::NotFound(_))),
+            "the lower directory's children stay hidden under the upper file"
+        );
+        fs.forget(rev.ino, 1);
+        fs.forget(dir_attr.ino, 1);
     }
 }

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -1533,7 +1533,29 @@ impl OverlayFs {
         }
         let dest = self.upper_path(&path);
         std::fs::create_dir_all(&dest).map_err(io_err)?;
-        self.clear_whiteout(&path);
+        // A whiteout here can be load-bearing: `rm file; mkdir file` replaces a lower FILE
+        // with a directory, and clearing the marker would resurface the file underneath the
+        // new dir — child lookups then resolve against the file and fail, and the merged
+        // view flip-flops. Every read path is upper-first ("a whiteout without upper
+        // presence is a hard miss"), so the kept marker never hides the new directory; it
+        // only keeps hiding what the delete deleted, and the seal reads the pair as exactly
+        // the right change set (delete the file, add the dir's children). Clear it only
+        // when the lower holds nothing or a directory (the recreate case, where the child
+        // markers own the hiding).
+        let lower_non_dir = match parent_node.core_ino() {
+            Some(core_parent) => match self.core.lookup(core_parent, name).await {
+                Ok(attr) => {
+                    let non_dir = attr.kind != gsvc_mount::NodeKind::Dir;
+                    self.core.forget(attr.ino, 1);
+                    non_dir
+                }
+                Err(_) => false,
+            },
+            None => false,
+        };
+        if !lower_non_dir {
+            self.clear_whiteout(&path);
+        }
         self.record(&path, DirtyKind::Upsert);
         let meta = dest.symlink_metadata().map_err(io_err)?;
         let (ino, _, _) = self.inodes.lock().expect("inode lock").intern(path, None);

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -2170,17 +2170,19 @@ impl OverlayFs {
         }
     }
 
-    /// Self-heal dir-over-file states before a seal: for every dirty upsert whose UPPER is
-    /// a directory while the LOWER holds a non-directory at the same path, write the
-    /// missing whiteout. `rm file; mkdir file` writes it naturally, but a mkdir that raced
-    /// another session's file LANDING never saw the file (merged_exists answered before
-    /// delivery) — the marker converts that state into the coherent replaced-file shape.
+    /// Self-heal dir-over-file states before a seal: for every dirty upsert path (and its
+    /// ancestors) whose UPPER is a directory while the LOWER holds a non-directory, write
+    /// the missing whiteout AND record the path as a dirty upsert. The record is what makes
+    /// the boundary durable: it rides every subsequent delta until a seal SUCCEEDS (a
+    /// failed push prunes nothing), and the seal's directory-upsert arm then publishes the
+    /// whiteout-delete plus the children — so retries re-derive nothing and probe nothing.
+    /// Ancestors still scan (in-memory, cheap) because the mkdir's own record can be
+    /// consumed by an earlier empty seal BEFORE the racing file lands, leaving only child
+    /// upserts to name the boundary.
     ///
-    /// Returns EVERY replacement boundary in scope — freshly healed AND already-marked
-    /// (`newly_healed` distinguishes them for the log): the caller forces all of them into
-    /// the seal's delete set, because a retry after a failed push finds the whiteout
-    /// already on disk, and returning only fresh heals would drop the boundary delete from
-    /// the retry's change set (the branch would keep the replaced file forever).
+    /// Returns the paths healed THIS pass (for the daemon log and the current seal's
+    /// forced delete — the fresh record's generation is past the in-flight delta's
+    /// watermark, so this one seal injects it by hand).
     ///
     /// Errors abort the seal (retryable): a transient index error or a failed marker write
     /// swallowed here would let the seal publish the children WITHOUT the delete half.
@@ -2188,10 +2190,7 @@ impl OverlayFs {
     pub(crate) async fn heal_replaced_files<'a>(
         &self,
         upserts: impl Iterator<Item = &'a str>,
-    ) -> Result<HealedBoundaries, MountError> {
-        // Each upsert's ANCESTOR directories are candidates too: after the race, the mkdir's
-        // own dirty record can be pruned by an earlier (empty) seal, leaving only child
-        // upserts in this delta while the dir still shadows the lower file.
+    ) -> Result<Vec<String>, MountError> {
         let mut candidates: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
         for path in upserts {
             let mut prefix = String::with_capacity(path.len());
@@ -2203,19 +2202,16 @@ impl OverlayFs {
                 candidates.insert(prefix.clone());
             }
         }
-        let mut out = HealedBoundaries::default();
+        let mut healed = Vec::new();
         for path in candidates {
             let is_upper_dir = self
                 .upper_path(&path)
                 .symlink_metadata()
                 .is_ok_and(|m| m.is_dir() && !m.file_type().is_symlink());
-            if !is_upper_dir {
-                continue;
-            }
-            if self.whited_out(&path) {
-                // Already marked (a previous seal healed it, or `rm file; mkdir file` wrote
-                // it): still a boundary this seal must delete.
-                out.boundaries.push(path);
+            if !is_upper_dir || self.whited_out(&path) {
+                // Already marked = already recorded (the heal that wrote the marker also
+                // wrote the dirty record, which only a successful seal prunes): nothing to
+                // probe, nothing to re-derive.
                 continue;
             }
             match self.walk_lower(&path).await {
@@ -2250,8 +2246,10 @@ impl OverlayFs {
                                 )));
                             }
                         }
-                        out.newly_healed.push(path.clone());
-                        out.boundaries.push(path);
+                        // Durable half: the boundary rides every future delta as a dirty
+                        // dir upsert, whose seal arm publishes the delete AND the children.
+                        self.record(&path, DirtyKind::Upsert);
+                        healed.push(path);
                     }
                 }
                 Err(MountError::NotFound(_)) => {}
@@ -2262,7 +2260,7 @@ impl OverlayFs {
                 }
             }
         }
-        Ok(out)
+        Ok(healed)
     }
 
     /// Record the published blob oid for each sealed path (from the push report). Empty oids
@@ -2768,16 +2766,6 @@ pub struct OverlayInval {
     pub parent_ino: Option<u64>,
     pub name: String,
     pub staled: bool,
-}
-
-/// Replacement boundaries found by [`OverlayFs::heal_replaced_files`]: every upper-directory
-/// path whose lower non-directory is (now) whiteouted. `boundaries` is what the seal must
-/// delete — including markers written by EARLIER seals whose push failed; `newly_healed` is
-/// the subset written this pass (for the log).
-#[derive(Debug, Default)]
-pub(crate) struct HealedBoundaries {
-    pub(crate) boundaries: Vec<String>,
-    pub(crate) newly_healed: Vec<String>,
 }
 
 /// What one [`OverlayFs::trim_retained`] pass did. `trimmed` includes candidates that were
@@ -3902,28 +3890,32 @@ mod tests {
             "swap appears exactly once in the parent listing"
         );
 
-        // The pre-seal heal writes the missing whiteout once — and a RETRY (a seal whose
-        // push failed after healing) still reports the boundary, or the retry's change set
-        // would resend only the children while the branch keeps the replaced file.
+        // The pre-seal heal writes the missing whiteout once AND records the boundary as a
+        // dirty dir upsert — the durable half: a retry (a seal whose push failed after
+        // healing) re-derives nothing because the record rides every subsequent delta, and
+        // the seal's dir-upsert arm publishes the whiteout-delete plus the children.
+        let gen_before = fs.dirty_since(0).watermark;
         let healed = fs.heal_replaced_files(["swap"].into_iter()).await.unwrap();
-        assert_eq!(healed.newly_healed, vec!["swap".to_string()]);
-        assert_eq!(healed.boundaries, vec!["swap".to_string()]);
+        assert_eq!(healed, vec!["swap".to_string()]);
+        let delta = fs.dirty_since(gen_before);
+        assert!(
+            delta.upserts.iter().any(|(p, _)| p == "swap"),
+            "the healed boundary is recorded in the dirty index: {:?}",
+            delta.upserts
+        );
         let retry = fs.heal_replaced_files(["swap"].into_iter()).await.unwrap();
         assert!(
-            retry.newly_healed.is_empty(),
-            "the whiteout is already in place"
+            retry.is_empty(),
+            "already marked and recorded: retries probe nothing"
         );
-        assert_eq!(
-            retry.boundaries,
-            vec!["swap".to_string()],
-            "an existing healed boundary must be forced into every retry's delete set"
-        );
-        // Ancestor derivation: a child-only delta still finds the boundary.
+        // Ancestor derivation still discovers a boundary whose own record was consumed
+        // before the racing file landed (child-only delta): clear the record's effect by
+        // asking with only the child — the marker short-circuits, no re-heal needed.
         let via_child = fs
             .heal_replaced_files(["swap/inner.txt"].into_iter())
             .await
             .unwrap();
-        assert_eq!(via_child.boundaries, vec!["swap".to_string()]);
+        assert!(via_child.is_empty(), "marker present: nothing to re-heal");
         let attr = fs.getattr(dir_attr.ino).await.unwrap();
         assert_eq!(
             attr.kind,

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -1586,7 +1586,13 @@ impl OverlayFs {
                     self.core.forget(attr.ino, 1);
                     non_dir
                 }
-                Err(_) => false,
+                // Only a definite "nothing below" clears the marker: a transient probe
+                // failure (stale binding mid-refresh, index lag) must KEEP a possibly
+                // load-bearing whiteout — keeping is safe in every case (it hides only
+                // deleted-or-replaced lower state), clearing can resurface a replaced
+                // file underneath the new directory.
+                Err(MountError::NotFound(_)) => false,
+                Err(_) => true,
             },
             None => false,
         };
@@ -1690,9 +1696,11 @@ impl OverlayFs {
             let mut redirects = self.redirects.lock().expect("redirect lock");
             record_committed_rename(&mut redirects, src, dst, true_src);
             self.persist_redirects(&redirects)?;
+            // Under the redirects lock, so it serializes with the sealer's clock close —
+            // see close_dirty_base_if_clean.
+            self.stamp_mutation();
         }
         self.redirect_gen.fetch_add(1, Ordering::SeqCst);
-        self.stamp_mutation();
         // Stale deletion markers at the destination belong to whatever the replace displaced.
         let dst_wh = self.wh_path(dst);
         if dst_wh
@@ -2146,7 +2154,13 @@ impl OverlayFs {
         let dirty = self.dirty.lock().expect("dirty lock");
         if dirty.is_empty() {
             *self.dirty_base.lock().expect("dirty base lock") = None;
-            if !self.has_redirects() {
+            // The emptiness check and the zeroing hold the REDIRECTS lock together:
+            // rename_committed_dir stamps the clocks inside the same critical section, so
+            // a rename either lands before this check (kept running) or stamps after the
+            // zero (re-armed) — never a pending redirect with a zeroed clock, which the
+            // event-driven autosave would sleep past forever.
+            let redirects = self.redirects.lock().expect("redirect lock");
+            if redirects.is_empty() {
                 // Batch fully sealed: the clocks re-arm on the next write. Pending
                 // redirects keep them running — they are unsealed work the dirty map
                 // never sees.
@@ -2214,6 +2228,28 @@ impl OverlayFs {
                                 "healing dir-over-file at {path}: whiteout write failed: {e}"
                             ))
                         })?;
+                        // TOCTOU re-verify: the follow poller can adopt a commit where the
+                        // BRANCH itself made this path a directory between the probe and
+                        // the marker write — that whiteout would suppress the merged dir's
+                        // lower listing. Undo and skip; a genuine dir-over-file re-heals
+                        // on the next seal.
+                        match self.walk_lower(&path).await {
+                            Ok(attr2) => {
+                                let now_dir = attr2.kind == NodeKind::Dir;
+                                self.core.forget(attr2.ino, 1);
+                                if now_dir {
+                                    self.clear_whiteout(&path);
+                                    continue;
+                                }
+                            }
+                            Err(MountError::NotFound(_)) => {}
+                            Err(e) => {
+                                self.clear_whiteout(&path);
+                                return Err(MountError::Protocol(format!(
+                                    "healing dir-over-file at {path}: re-verify failed: {e}"
+                                )));
+                            }
+                        }
                         out.newly_healed.push(path.clone());
                         out.boundaries.push(path);
                     }
@@ -2316,16 +2352,33 @@ impl OverlayFs {
             return RefreshOutputs::default();
         }
         // A divergent candidate that carries a whiteout is a sealed DELETE the branch moved
-        // past — usually a remote (re-)add over it. The whiteout was masking lower content
-        // the branch now carries; keeping it would hide the other session's file
-        // indefinitely (the delivering application commit differs from the snapshot commit,
-        // so the seal-echo hygiene never matched). Derived from the final candidate set so
-        // pending retries re-probe too; retiring an actually-inert whiteout (branch also
-        // deleted) is the trim's original no-op.
+        // past — a remote (re-)add over it. The whiteout was masking lower content the
+        // branch now carries; keeping it would hide the other session's file indefinitely.
+        // Tombstoning requires EVIDENCE the branch carries the path (a delta row with an
+        // oid): on the divergence-unknown fallback the sealed delete may simply not have
+        // APPLIED yet (reconcile lag, a start-hint mount behind the branch), and removing
+        // the marker would resurface the very files the user deleted. A whiteout under an
+        // upper DIRECTORY is a live file→directory replacement boundary and is never
+        // retired here — the seal owns it.
         let candidates: Vec<String> = candidates.into_iter().collect();
+        let branch_carries: std::collections::HashSet<&str> = match &delta.changed {
+            Some(rows) => rows
+                .iter()
+                .filter(|row| row.oid.is_some())
+                .map(|row| row.path.as_str())
+                .collect(),
+            None => Default::default(),
+        };
         let tombstones: Vec<String> = candidates
             .iter()
-            .filter(|p| self.whited_out(p))
+            .filter(|p| {
+                branch_carries.contains(p.as_str())
+                    && self.whited_out(p)
+                    && !self
+                        .upper_path(p)
+                        .symlink_metadata()
+                        .is_ok_and(|m| m.is_dir() && !m.file_type().is_symlink())
+            })
             .cloned()
             .collect();
         match self.try_trim_retained(&candidates, &tombstones) {
@@ -2359,11 +2412,9 @@ impl OverlayFs {
                     .map(String::as_str)
                     .collect();
                 let mut expectations: Vec<KernelExpectation> = Vec::new();
-                let mut covered: std::collections::HashSet<&str> = std::collections::HashSet::new();
                 if let Some(rows) = &delta.changed {
                     for row in rows {
                         if trimmed.contains(row.path.as_str()) {
-                            covered.insert(row.path.as_str());
                             expectations.push(KernelExpectation {
                                 path: row.path.clone(),
                                 present: row.oid.is_some(),
@@ -2372,15 +2423,13 @@ impl OverlayFs {
                         }
                     }
                 }
-                for path in &outcome.trimmed {
-                    if !covered.contains(path.as_str()) {
-                        expectations.push(KernelExpectation {
-                            path: path.clone(),
-                            present: true,
-                            size: None,
-                        });
-                    }
-                }
+                // Trimmed paths WITHOUT a covering delta row (boundary-expanded children,
+                // divergence-unknown drops) get no expectation: their branch-side presence
+                // is unknown, and a wrong `present: true` makes the probe loop hammer a
+                // genuinely absent path until its deadline — churning the overlay through
+                // probe_negative_dentry's create/unlink pairs on the writable mount. The
+                // Linux notify invals above cover them; macOS converges on the next
+                // covered refresh or kernel TTL.
                 RefreshOutputs {
                     invals,
                     expectations,

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -2160,13 +2160,21 @@ impl OverlayFs {
     /// a directory while the LOWER holds a non-directory at the same path, write the
     /// missing whiteout. `rm file; mkdir file` writes it naturally, but a mkdir that raced
     /// another session's file LANDING never saw the file (merged_exists answered before
-    /// delivery) — the marker converts that state into the coherent replaced-file shape,
-    /// and the seal's directory-upsert arm then publishes the delete half of the
-    /// replacement. Returns the healed paths (for the daemon log).
+    /// delivery) — the marker converts that state into the coherent replaced-file shape.
+    ///
+    /// Returns EVERY replacement boundary in scope — freshly healed AND already-marked
+    /// (`newly_healed` distinguishes them for the log): the caller forces all of them into
+    /// the seal's delete set, because a retry after a failed push finds the whiteout
+    /// already on disk, and returning only fresh heals would drop the boundary delete from
+    /// the retry's change set (the branch would keep the replaced file forever).
+    ///
+    /// Errors abort the seal (retryable): a transient index error or a failed marker write
+    /// swallowed here would let the seal publish the children WITHOUT the delete half.
+    /// Only a genuinely absent lower is "nothing to heal".
     pub(crate) async fn heal_replaced_files<'a>(
         &self,
         upserts: impl Iterator<Item = &'a str>,
-    ) -> Vec<String> {
+    ) -> Result<HealedBoundaries, MountError> {
         // Each upsert's ANCESTOR directories are candidates too: after the race, the mkdir's
         // own dirty record can be pruned by an earlier (empty) seal, leaving only child
         // upserts in this delta while the dir still shadows the lower file.
@@ -2181,27 +2189,44 @@ impl OverlayFs {
                 candidates.insert(prefix.clone());
             }
         }
-        let mut healed = Vec::new();
+        let mut out = HealedBoundaries::default();
         for path in candidates {
             let is_upper_dir = self
                 .upper_path(&path)
                 .symlink_metadata()
                 .is_ok_and(|m| m.is_dir() && !m.file_type().is_symlink());
-            if !is_upper_dir || self.whited_out(&path) {
+            if !is_upper_dir {
+                continue;
+            }
+            if self.whited_out(&path) {
+                // Already marked (a previous seal healed it, or `rm file; mkdir file` wrote
+                // it): still a boundary this seal must delete.
+                out.boundaries.push(path);
                 continue;
             }
             match self.walk_lower(&path).await {
                 Ok(attr) => {
                     let non_dir = attr.kind != NodeKind::Dir;
                     self.core.forget(attr.ino, 1);
-                    if non_dir && super::write_whiteout(&self.wh, &path).is_ok() {
-                        healed.push(path);
+                    if non_dir {
+                        super::write_whiteout(&self.wh, &path).map_err(|e| {
+                            MountError::Protocol(format!(
+                                "healing dir-over-file at {path}: whiteout write failed: {e}"
+                            ))
+                        })?;
+                        out.newly_healed.push(path.clone());
+                        out.boundaries.push(path);
                     }
                 }
-                Err(_) => {}
+                Err(MountError::NotFound(_)) => {}
+                Err(e) => {
+                    return Err(MountError::Protocol(format!(
+                        "healing dir-over-file at {path}: lower probe failed: {e}"
+                    )));
+                }
             }
         }
-        healed
+        Ok(out)
     }
 
     /// Record the published blob oid for each sealed path (from the push report). Empty oids
@@ -2694,6 +2719,16 @@ pub struct OverlayInval {
     pub parent_ino: Option<u64>,
     pub name: String,
     pub staled: bool,
+}
+
+/// Replacement boundaries found by [`OverlayFs::heal_replaced_files`]: every upper-directory
+/// path whose lower non-directory is (now) whiteouted. `boundaries` is what the seal must
+/// delete — including markers written by EARLIER seals whose push failed; `newly_healed` is
+/// the subset written this pass (for the log).
+#[derive(Debug, Default)]
+pub(crate) struct HealedBoundaries {
+    pub(crate) boundaries: Vec<String>,
+    pub(crate) newly_healed: Vec<String>,
 }
 
 /// What one [`OverlayFs::trim_retained`] pass did. `trimmed` includes candidates that were
@@ -3818,11 +3853,28 @@ mod tests {
             "swap appears exactly once in the parent listing"
         );
 
-        // The pre-seal heal writes the missing whiteout (once).
-        let healed = fs.heal_replaced_files(["swap"].into_iter()).await;
-        assert_eq!(healed, vec!["swap".to_string()]);
-        let again = fs.heal_replaced_files(["swap"].into_iter()).await;
-        assert!(again.is_empty(), "already healed: the whiteout is in place");
+        // The pre-seal heal writes the missing whiteout once — and a RETRY (a seal whose
+        // push failed after healing) still reports the boundary, or the retry's change set
+        // would resend only the children while the branch keeps the replaced file.
+        let healed = fs.heal_replaced_files(["swap"].into_iter()).await.unwrap();
+        assert_eq!(healed.newly_healed, vec!["swap".to_string()]);
+        assert_eq!(healed.boundaries, vec!["swap".to_string()]);
+        let retry = fs.heal_replaced_files(["swap"].into_iter()).await.unwrap();
+        assert!(
+            retry.newly_healed.is_empty(),
+            "the whiteout is already in place"
+        );
+        assert_eq!(
+            retry.boundaries,
+            vec!["swap".to_string()],
+            "an existing healed boundary must be forced into every retry's delete set"
+        );
+        // Ancestor derivation: a child-only delta still finds the boundary.
+        let via_child = fs
+            .heal_replaced_files(["swap/inner.txt"].into_iter())
+            .await
+            .unwrap();
+        assert_eq!(via_child.boundaries, vec!["swap".to_string()]);
         let attr = fs.getattr(dir_attr.ino).await.unwrap();
         assert_eq!(
             attr.kind,

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -1447,7 +1447,10 @@ async fn bind(
         )));
     }
 
-    let session = FsSession::open(ctx, file_system).await?;
+    // Project-wide session: the repo listing is project-scoped, and a repo-scoped mint
+    // (which FsSession would use for a named file system) deliberately lacks that scope —
+    // binding with one 403s before the workspace is ever created.
+    let session = FsSession::open(ctx, None).await?;
     let (user, token) = session.creds();
     let file_systems = session
         .client
@@ -2232,11 +2235,10 @@ pub async fn unbind(path: Option<PathBuf>) -> Result<()> {
         println!("Unbound {root}.");
     } else {
         println!(
-            "Unbound {root}. Workspace {} and its snapshots survive on the server (delete \
-             with: tl fs rm {}).",
-            short_id(&workspace),
-            short_id(&workspace),
+            "Stopped tracking {root}. Its saves survive on the filesystem — push again to \
+             re-bind."
         );
+        let _ = workspace;
     }
     Ok(())
 }

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -437,7 +437,7 @@ pub(crate) fn load_binding(state_dir: &Path) -> Result<Binding> {
 /// concurrent writers (e.g. two `tl fs init`s racing on the registry, or the push progress
 /// hook rewriting the journal) could interleave create/write/rename on the same temp inode
 /// and publish a torn file through the "atomic" path.
-fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
     use std::io::Write as _;
     let parent = path
         .parent()
@@ -505,7 +505,7 @@ struct BindingLock {
 /// it; `block: true` waits. The one flock implementation — the per-binding snapshot lock and
 /// the registry mutation lock both go through here.
 #[cfg(unix)]
-fn flock_exclusive(path: &Path, block: bool) -> Result<Option<std::fs::File>> {
+pub(crate) fn flock_exclusive(path: &Path, block: bool) -> Result<Option<std::fs::File>> {
     use std::os::unix::io::AsRawFd as _;
     let file = std::fs::OpenOptions::new()
         .create(true)
@@ -527,7 +527,7 @@ fn flock_exclusive(path: &Path, block: bool) -> Result<Option<std::fs::File>> {
 }
 
 #[cfg(not(unix))]
-fn flock_exclusive(_path: &Path, _block: bool) -> Result<Option<std::fs::File>> {
+pub(crate) fn flock_exclusive(_path: &Path, _block: bool) -> Result<Option<std::fs::File>> {
     Err(CliError::usage(
         "plain-directory bindings are supported on unix only in v1",
     ))

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -1407,7 +1407,7 @@ pub async fn push(
         }
         None => {
             let (root, state_dir, _, _) =
-                bind(ctx, Some(dir.to_path_buf()), Some(file_system), true).await?;
+                bind(ctx, Some(dir.to_path_buf()), file_system, true).await?;
             (root, state_dir)
         }
     };
@@ -1420,7 +1420,7 @@ pub async fn push(
 async fn bind(
     ctx: &CliContext,
     path: Option<PathBuf>,
-    file_system: Option<&str>,
+    file_system: &str,
     publish: bool,
 ) -> Result<(String, PathBuf, String, String)> {
     if cfg!(not(unix)) {
@@ -1447,56 +1447,14 @@ async fn bind(
         )));
     }
 
-    // Project-wide session: the repo listing is project-scoped, and a repo-scoped mint
-    // (which FsSession would use for a named file system) deliberately lacks that scope —
-    // binding with one 403s before the workspace is ever created.
-    let session = FsSession::open(ctx, None).await?;
+    // The session may run on a repo-scoped credential (a sandbox pushing into its one
+    // filesystem): the whole bind path is point-addressed — no listings — and the SERVER
+    // applies filesystem semantics (publish target, kind check) from the repo's
+    // authoritative kind via `surface`. Filesystems are born with a genesis, so no seeding.
+    let repo = file_system.to_string();
+    let session = FsSession::open(ctx, Some(&repo)).await?;
     let (user, token) = session.creds();
-    let file_systems = session
-        .client
-        .list_repos_with_credential(&session.project_id, None, user, token)
-        .await?
-        .into_inner();
-    let repo = match file_system {
-        Some(name) => {
-            if !file_systems.repos.iter().any(|r| r.name == name) {
-                return Err(CliError::usage(format!(
-                    "no filesystem named {name:?}; create it first: tl fs create {name}"
-                )));
-            }
-            name.to_string()
-        }
-        // No --file-system: unambiguous only when the project has exactly one.
-        None => match file_systems.repos.as_slice() {
-            [only] => only.name.clone(),
-            [] => {
-                return Err(CliError::usage(
-                    "this project has no filesystems; create one first: tl fs create <name>",
-                ));
-            }
-            many => {
-                return Err(CliError::usage(format!(
-                    "this project has {} file systems; pick one with --file-system ({})",
-                    many.len(),
-                    many.iter()
-                        .map(|r| r.name.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                )));
-            }
-        },
-    };
-    let default_branch = file_systems
-        .repos
-        .iter()
-        .find(|r| r.name == repo)
-        .expect("validated above")
-        .default_branch
-        .clone();
-    // A fresh `tl git create` repo has an unborn default branch; seed it with an empty
-    // initial commit (empty root tree — exactly the base v1 requires) so init just works.
-    super::ensure_seeded(&session, &default_branch, &repo).await?;
-    let ws = session
+    let ws = match session
         .client
         .create_workspace(
             &session.project_id,
@@ -1504,12 +1462,20 @@ async fn bind(
             user,
             token,
             &CreateWorkspaceRequest {
-                shared_target: publish.then(|| default_branch.clone()),
+                surface: publish.then(|| "filesystem".to_string()),
                 ..Default::default()
             },
         )
-        .await?
-        .into_inner();
+        .await
+    {
+        Ok(ws) => ws.into_inner(),
+        Err(tensorlake::error::SdkError::ServerError { status, .. }) if status.as_u16() == 404 => {
+            return Err(CliError::usage(format!(
+                "no filesystem named {repo:?} (see: tl fs ls; create one: tl fs create {repo})"
+            )));
+        }
+        Err(e) => return Err(e.into()),
+    };
     // v1 verifies — not assumes — the empty base: workspace creation defaults to the repo
     // HEAD, which is only empty on a freshly seeded repo. One root-tree page of one entry is
     // the cheapest proof either way. (425: the base commit's index can still be

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -171,8 +171,13 @@ pub async fn create_repo(
 
 pub async fn list_repos(ctx: &CliContext, output_json: bool) -> Result<()> {
     let project_id = project_id(ctx)?;
+    // Repositories only: filesystems are `tl fs ls`'s surface. Pre-kind servers ignore the
+    // filter and keep returning everything.
     let response = artifact_storage_client(ctx)?
-        .list_repos(&project_id)
+        .list_repos_of_kind(
+            &project_id,
+            Some(tensorlake::artifact_storage::models::REPO_KIND_REPOSITORY),
+        )
         .await
         .map_err(map_sdk_error)?
         .into_inner();

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -627,7 +627,13 @@ pub async fn commit_conflicts(
 }
 
 pub(crate) fn artifact_storage_client(ctx: &CliContext) -> Result<ArtifactStorageClient> {
-    let token = ctx.bearer_token()?;
+    // Sandbox attach path: no platform credential in the guest. Every data-plane call
+    // authenticates per request with the git credential; the bearer only backs the token-mint
+    // path, which the TENSORLAKE_GIT_TOKEN branch never reaches — so the git token stands in.
+    let token = match ctx.bearer_token() {
+        Ok(t) => t,
+        Err(e) => std::env::var("TENSORLAKE_GIT_TOKEN").map_err(|_| e)?,
+    };
     let mut builder = ClientBuilder::new(&ctx.api_url).bearer_token(&token);
     let use_scope_headers = ctx.personal_access_token.is_some() && ctx.api_key.is_none();
     if use_scope_headers

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -258,6 +258,16 @@ enum FsCommands {
         log_level: String,
     },
 
+    /// Mint the scoped credential a sandbox needs to attach one filesystem
+    Token {
+        /// Filesystem name
+        name: String,
+
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Upload a folder into a filesystem as one save (no mount needed)
     Push {
         /// Local directory to upload
@@ -2442,6 +2452,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
         FsCommands::Create { name, json } => {
             commands::fs::create_filesystem(ctx, &name, json).await
         }
+        FsCommands::Token { name, json } => commands::fs::token(ctx, &name, json).await,
         FsCommands::Ls { file_system, json } => match file_system {
             None => commands::fs::ls_filesystems(ctx, json).await,
             Some(fs) => commands::fs::ls(ctx, Some(&fs), json).await,
@@ -3096,6 +3107,13 @@ mod tests {
                 assert_eq!(name, "scratch");
             }
             _ => panic!("expected fs create command"),
+        }
+
+        match parse_command(["tl", "fs", "token", "scratch", "--json"]) {
+            Commands::Fs(FsCommands::Token { name, json: true }) => {
+                assert_eq!(name, "scratch");
+            }
+            _ => panic!("expected fs token command"),
         }
 
         match parse_command(["tl", "fs", "push", "./data", "scratch", "-m", "bulk load"]) {

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -138,7 +138,10 @@ pub struct PushOptions {
     pub upload_batch_bytes: usize,
     pub progress: Option<PushProgress>,
     /// When set, the commit publishes as a snapshot on this workspace's ref
-    /// (`workspaces/{id}/snapshots`) instead of advancing `branch`; `branch`/`base` are ignored.
+    /// (`workspaces/{id}/snapshots`) instead of advancing `branch` (which is ignored). `base`
+    /// declares the commit the changes were computed against — the snapshot parents there, so
+    /// the shared-rw application three-ways against what the writer saw (servers that predate
+    /// the field ignore it and chain on the workspace tip).
     pub workspace_snapshot: Option<String>,
     /// Return every CDC-path file's chunk list in `PushReport::file_chunks`, so the caller can
     /// hand them back as `PushSource::StablePrefix` prefixes on the next push of the same

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -139,9 +139,10 @@ pub struct PushOptions {
     pub progress: Option<PushProgress>,
     /// When set, the commit publishes as a snapshot on this workspace's ref
     /// (`workspaces/{id}/snapshots`) instead of advancing `branch` (which is ignored). `base`
-    /// declares the commit the changes were computed against — the snapshot parents there, so
-    /// the shared-rw application three-ways against what the writer saw (servers that predate
-    /// the field ignore it and chain on the workspace tip).
+    /// declares the commit the changes were computed against; it rides the server's
+    /// reconcile queue — the snapshot still chains on the workspace tip — and the shared-rw
+    /// application three-ways against the declared base plus this push's exact change list
+    /// (servers that predate the field ignore it and merge against the chain parent).
     pub workspace_snapshot: Option<String>,
     /// Return every CDC-path file's chunk list in `PushReport::file_chunks`, so the caller can
     /// hand them back as `PushSource::StablePrefix` prefixes on the next push of the same

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -13,7 +13,7 @@ pub mod workspaces;
 
 use models::{
     CreateRepoRequest, GitCredential, ListBranchesResponse, ListOperationsResponse,
-    ListRefsResponse, ListReposResponse, MintGitTokenRequest, RepoInfo,
+    ListRefsResponse, ListReposResponse, MintGitTokenRequest, RepoInfo, RepoMetaInfo,
 };
 
 #[derive(Clone)]
@@ -324,6 +324,27 @@ impl ArtifactStorageClient {
             url.push_str(&format!("?kind={}", urlencoding::encode(kind)));
         }
         let (request, trace_id) = self.git_request_url(Method::GET, url, git_username, git_token);
+        let response = request.send().await?;
+        decode_json(response, trace_id).await
+    }
+
+    /// Authoritative point-read of one repo's meta (kind, default branch, status). 404 =>
+    /// SdkError::ServerError with status 404.
+    pub async fn repo_meta_with_credential(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+    ) -> Result<Traced<RepoMetaInfo>, SdkError> {
+        let (request, trace_id) = self.git_request(
+            Method::GET,
+            project_id,
+            repo,
+            Some("meta"),
+            git_username,
+            git_token,
+        )?;
         let response = request.send().await?;
         decode_json(response, trace_id).await
     }

--- a/crates/cloud-sdk/src/artifact_storage/models.rs
+++ b/crates/cloud-sdk/src/artifact_storage/models.rs
@@ -63,6 +63,25 @@ impl Repo {
     }
 }
 
+/// `GET /project/{p}/repos/{r}/meta` — the authoritative point-read of one repo's product
+/// identity. Never served from the listing cache (read-your-writes after create) and
+/// answerable with a repo-scoped credential.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RepoMetaInfo {
+    pub name: String,
+    pub full_name: String,
+    pub default_branch: String,
+    pub status: String,
+    #[serde(default = "default_repo_kind")]
+    pub kind: String,
+}
+
+impl RepoMetaInfo {
+    pub fn is_filesystem(&self) -> bool {
+        self.kind == REPO_KIND_FILESYSTEM
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListReposResponse {
     pub project: String,
@@ -127,6 +146,10 @@ pub struct Operation {
     pub old_pack_count: u32,
     pub object_count: u32,
     pub pack_bytes: u64,
+    /// The operation materialized merge conflicts (its commit carries a conflict record).
+    /// Elided by the server when false; absent from pre-visibility servers.
+    #[serde(default)]
+    pub conflicted: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -53,6 +53,16 @@ pub struct CreateWorkspaceRequest {
     /// on conflicts) or `"lww"` (legacy last-writer-wins overwrite).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reconcile_policy: Option<String>,
+    /// Which product surface this session belongs to: `"filesystem"` makes the SERVER apply
+    /// filesystem semantics from the repo's authoritative kind (publish-on-save defaults;
+    /// kind=repository rejected with the right command). Requires a server with repo
+    /// surface support (issue #103); older servers ignore the field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surface: Option<String>,
+    /// The session will never write (a read-only mount's anchor): the surface kind check
+    /// still applies, publish defaults are skipped.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub read_only: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
The complete `tl fs` / `tl git` client stack for issue #103, consolidated after the stacked PRs (#844, #845) merged into this branch: live-e2e fixes, one-RTT attach, collision visibility, event-driven autosave, and three rounds of review fixes — each re-validated on a real Linux sandbox (mounts against prod for the attach path; an in-guest artifact_storage#108 server for reconcile flows).

**Requires artifact_storage#108 merged + deployed** (this branch vendors `RefreshDelta.changed` from it; the full-feature CI check goes green when it lands, and the reconcile-base semantics need it server-side).

Highlights on top of the earlier stack:

- **Headless sandbox attach**: `TENSORLAKE_GIT_TOKEN` is authentication for the fs surface (project derived from the JWT `iss` claim) — mounts in ~150ms where they used to hang forever polling for browser approval.
- **Seals declare their base** (captured at the batch's first dirty write): overwriting another session's file is a clean write, concurrent writes collide visibly, resolving a collision converges instead of nesting markers.
- **Retained shadows converge**: the overlay records each seal's blob oids and evicts shadows the branch moved past (own-echo keeps the byte cache), from the delta's raw changed rows with directory-boundary expansion; sealed-delete whiteouts retire when the branch re-adds the path (both re-seeded from the persisted seal index across restarts); divergence-unknown fallbacks evict rather than serve stale bytes. Candidates come only from seal records — dirty and ignored upper content is never touched.
- **Crash-resume preserves work under scoped tokens**: resume and `--workspace` attach through the per-repo endpoint with the known repo AND reopen exactly the selected state dir (dead registrations no longer hold dirs or push resumes onto fresh suffixed ones); Linux lazily detaches dead FUSE attachments. Verified: `kill -9`, re-run the same mount with only the repo-scoped token → same state dir, unsealed write intact.
- **Genuinely event-driven autosave**: write hooks stamp mutation clocks; the idle tick is two atomic loads, no dirty-set resolution, no mtime stats.
- **Unmount gates fixed**: OS-junk allowlist applies before gitignore classification (`.Spotlight-V100` etc. no longer block unmounts); ignored dirs count as one subtree instead of a recursive walk.

Deferred (noted for follow-up): server-side history pagination/filtering — `tl fs history` still filters client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)