### PR TITLE
Attach in one round trip: server-owned filesystem semantics (#103 step 2)

### DIFF
--- a/crates/cli/src/auth/context.rs
+++ b/crates/cli/src/auth/context.rs
@@ -231,3 +231,18 @@ impl CliContext {
             .and_then(|r| r.project_id.clone())
     }
 }
+
+/// The project a pre-provisioned git credential is scoped to, read from the JWT `iss` claim
+/// (artifact-storage mints carry `iss: "project_..."`). `None` for opaque dev tokens and
+/// malformed payloads — callers fall back to configured scope.
+pub(crate) fn project_from_git_token() -> Option<String> {
+    use base64::Engine;
+    let token = std::env::var("TENSORLAKE_GIT_TOKEN").ok()?;
+    let payload = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let claims: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let iss = claims.get("iss")?.as_str()?;
+    iss.starts_with("project_").then(|| iss.to_string())
+}

--- a/crates/cli/src/auth/guard.rs
+++ b/crates/cli/src/auth/guard.rs
@@ -44,6 +44,24 @@ pub async fn ensure_auth(ctx: &mut CliContext) -> Result<()> {
 /// Ensure authentication and org/project are available.
 /// Triggers login and/or init flows as needed.
 pub async fn ensure_auth_and_project(ctx: &mut CliContext) -> Result<()> {
+    // Sandbox attach path (issue #103): a pre-provisioned repo-scoped git credential IS the
+    // authentication for the fs surface, and its JWT carries the project claim. Never start
+    // an interactive login/init flow here — the guest is headless, and the browser-approval
+    // poll would hang forever.
+    if std::env::var("TENSORLAKE_GIT_TOKEN").is_ok() {
+        if ctx.effective_project_id().is_none()
+            && let Some(project) = crate::auth::context::project_from_git_token()
+        {
+            ctx.project_id = Some(project);
+        }
+        if ctx.effective_project_id().is_some() {
+            return Ok(());
+        }
+        return Err(CliError::auth(
+            "TENSORLAKE_GIT_TOKEN is set but carries no project claim; \
+             re-mint it with `tl fs token <filesystem>` or configure a project",
+        ));
+    }
     if !ctx.has_authentication() {
         eprintln!("It seems like you're not logged in. Let's log you in...\n");
         let login_result = match run_login_flow(ctx, true).await {

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -465,27 +465,6 @@ pub async fn create_filesystem(ctx: &CliContext, name: &str, output_json: bool) 
     Ok(())
 }
 
-/// One kind-stamped listing, resolved to a filesystem by name. `replacement` names the
-/// `tl git` command shown when the name is actually a repository — the one line the two call
-/// sites differ in.
-fn resolve_filesystem<'a>(
-    listing: &'a tensorlake::artifact_storage::models::ListReposResponse,
-    name: &str,
-    replacement: &str,
-) -> Result<&'a tensorlake::artifact_storage::models::Repo> {
-    let Some(repo) = listing.repos.iter().find(|r| r.name == name) else {
-        return Err(CliError::usage(format!(
-            "no filesystem named {name:?} (see: tl fs ls; create one: tl fs create {name})"
-        )));
-    };
-    if !repo.is_filesystem() {
-        return Err(CliError::usage(format!(
-            "{name} is a repository, not a filesystem — use: {replacement}"
-        )));
-    }
-    Ok(repo)
-}
-
 /// `tl fs ls` — the filesystems of this project, with where each is attached on this machine.
 pub async fn ls_filesystems(ctx: &CliContext, output_json: bool) -> Result<()> {
     let session = FsSession::open(ctx, None).await?;
@@ -561,12 +540,26 @@ pub async fn ls_filesystems(ctx: &CliContext, output_json: bool) -> Result<()> {
 pub async fn rm_filesystem(ctx: &CliContext, name: &str, force: bool) -> Result<()> {
     let session = FsSession::open(ctx, None).await?;
     let (user, token) = session.creds();
-    let listing = session
+    // Authoritative point-read: read-your-writes for a just-created filesystem, and the
+    // 404/kind answers never come from a stale listing.
+    let meta = match session
         .client
-        .list_repos_with_credential(&session.project_id, None, user, token)
-        .await?
-        .into_inner();
-    resolve_filesystem(&listing, name, &format!("tl git rm {name}"))?;
+        .repo_meta_with_credential(&session.project_id, name, user, token)
+        .await
+    {
+        Ok(meta) => meta.into_inner(),
+        Err(tensorlake::error::SdkError::ServerError { status, .. }) if status.as_u16() == 404 => {
+            return Err(CliError::usage(format!(
+                "no filesystem named {name:?} (see: tl fs ls)"
+            )));
+        }
+        Err(e) => return Err(e.into()),
+    };
+    if !meta.is_filesystem() {
+        return Err(CliError::usage(format!(
+            "{name} is a repository, not a filesystem — use: tl git rm {name}"
+        )));
+    }
     if let Some((mountpoint, _)) = live_mounts().into_iter().find(|(_, s)| s.repo == name) {
         return Err(CliError::usage(format!(
             "{name} is mounted at {mountpoint}; unmount first: tl fs unmount {mountpoint}"
@@ -610,6 +603,33 @@ pub async fn rm_filesystem(ctx: &CliContext, name: &str, force: bool) -> Result<
         .delete_repo_with_credential(&session.project_id, name, user, token)
         .await?;
     println!("Deleted filesystem {name}.");
+    Ok(())
+}
+
+/// `tl fs token <name>` — mint the narrow credential a sandbox (or any remote environment)
+/// needs to attach this one filesystem. Everything on the attach path — mount, saves,
+/// history-by-follow — works under it; project-scope surfaces (ls, history, rm) do not.
+pub async fn token(ctx: &CliContext, name: &str, output_json: bool) -> Result<()> {
+    let project_id = crate::commands::git::project_id(ctx)?;
+    let client = crate::commands::git::artifact_storage_client(ctx)?;
+    let credential = client
+        .mint_token_for_repo(&project_id, Some(name))
+        .await
+        .map_err(crate::commands::git::map_sdk_error)?
+        .into_inner();
+    if output_json {
+        println!("{}", serde_json::to_string_pretty(&credential)?);
+        return Ok(());
+    }
+    println!(
+        "Scoped credential for filesystem {name} (expires {}):",
+        credential.expires_at
+    );
+    println!("  {}", credential.token);
+    println!();
+    println!("Attach from any sandbox with FUSE:");
+    println!("  export TENSORLAKE_GIT_TOKEN={}", credential.token);
+    println!("  tl fs mount {name} <path>");
     Ok(())
 }
 
@@ -708,8 +728,10 @@ pub async fn history(
 }
 
 /// `tl fs mount <name> <path>` — the filesystem-surface mount: publish-on-save, autosave on,
-/// detached local sessions auto-resume. Branch-addressed and repository mounts live on
-/// `tl git mount`.
+/// detached local sessions auto-resume. One server round trip: the create carries
+/// `surface=filesystem` and the SERVER applies the semantics (publish target, kind check)
+/// from the repo's authoritative kind — no listing, so a filesystem created milliseconds ago
+/// mounts, and a repo-scoped credential suffices (the sandbox story).
 pub async fn mount_filesystem(
     ctx: &CliContext,
     target: &str,
@@ -727,11 +749,9 @@ pub async fn mount_filesystem(
     }
     // A drive doesn't lose your work: writable filesystem mounts always autosave.
     let autosave = (!ro).then_some(FS_AUTOSAVE_DEFAULT_SECS);
-    // Auto-resume first — it needs no server round trip. A detached local session of this
-    // filesystem (mount state present, daemon dead) picks up where it left off: "run the same
-    // command again" is the crash recovery. WritePolicy::Auto keeps the single-writer
-    // downgrade: a session attached writable elsewhere resumes read-only, never as a silent
-    // second writer.
+    // Auto-resume first — no server round trip. A detached local session of this filesystem
+    // (mount state present, daemon dead) picks up where it left off: "run the same command
+    // again" is the crash recovery. WritePolicy::Auto keeps the single-writer downgrade.
     if !ro && let Some(workspace_id) = detached_local_session(target) {
         println!(
             "Resuming detached session {} of filesystem {target}.",
@@ -751,34 +771,16 @@ pub async fn mount_filesystem(
         )
         .await;
     }
-    // Fresh session: one listing answers what the create needs — does the target exist, what
-    // kind is it, and what is its default branch (the publish target, which the genesis commit
-    // guarantees exists).
-    let session = FsSession::open(ctx, None).await?;
-    let (user, token) = session.creds();
-    let listing = session
-        .client
-        .list_repos_with_credential(&session.project_id, None, user, token)
-        .await?
-        .into_inner();
-    let repo = resolve_filesystem(&listing, target, &format!("tl git mount {target} <path>"))?;
-    // A fresh session publishes every save to the filesystem's current state; read-only mounts
-    // follow it instead.
-    let (target_spec, shared_target) = if ro {
-        (format!("{target}:{}", repo.default_branch), None)
-    } else {
-        (target.to_string(), Some(repo.default_branch.clone()))
-    };
     mount(
         ctx,
-        &target_spec,
+        target,
         path,
         if ro {
             WritePolicy::Ro
         } else {
             WritePolicy::Auto
         },
-        shared_target,
+        None,
         autosave,
         true,
         foreground,
@@ -2227,6 +2229,11 @@ pub async fn mount(
     let create_req = CreateWorkspaceRequest {
         base: base.clone(),
         shared_target: shared_target.clone(),
+        // The server applies product semantics from the repo's authoritative kind: an
+        // fs-surface create gets its publish target filled server-side (and a repository is
+        // rejected with the right command). Clients never pre-read listings to decide this.
+        surface: fs_surface.then(|| "filesystem".to_string()),
+        read_only: mode == WritePolicy::Ro,
         ..Default::default()
     };
     // One create call site for both the first attempt and the post-seed retry, so the two can
@@ -2243,17 +2250,29 @@ pub async fn mount(
             Some(CreateRecovery::RepoMissing) if base.is_none() => {
                 match resolve_workspace(&session, name).await? {
                     Some((repo, ws)) => Resolved::Attached(repo, ws),
+                    None if fs_surface => {
+                        return Err(CliError::usage(format!(
+                            "no filesystem named {name:?} (see: tl fs ls; create one: tl fs \
+                             create {name})"
+                        )));
+                    }
                     None => {
                         return Err(CliError::usage(format!(
-                            "no file system or workspace matches {name:?}. See `tl fs ls`, or \
-                             create the file system first: tl git create {name}"
+                            "no repo or workspace matches {name:?}. See `tl git ls`, or \
+                             create the repo first: tl git create {name}"
                         )));
                     }
                 }
             }
+            Some(CreateRecovery::RepoMissing) if fs_surface => {
+                return Err(CliError::usage(format!(
+                    "no filesystem named {name:?} (see: tl fs ls; create one: tl fs create \
+                     {name})"
+                )));
+            }
             Some(CreateRecovery::RepoMissing) => {
                 return Err(CliError::usage(format!(
-                    "no file system named {name:?}; create it first: tl git create {name}"
+                    "no repo named {name:?}; create it first: tl git create {name}"
                 )));
             }
             // Seed an unborn default branch whether it is implied OR named (either spelling):
@@ -2263,6 +2282,7 @@ pub async fn mount(
             // write to the server (and with read-scoped credentials the seed push would fail
             // opaquely); ro keeps the clear server error. Other branch names stay strict —
             // seeding cannot conjure them.
+            Some(CreateRecovery::BaseUnresolved) if fs_surface => return Err(e.into()),
             Some(CreateRecovery::BaseUnresolved) => {
                 let file_systems = session
                     .client
@@ -2351,11 +2371,16 @@ pub async fn mount(
             let read_only = mode == WritePolicy::Ro;
             // What the view follows. Writable workspaces follow their own ref; shared-rw
             // follows the branch it publishes to, so every writer's view converges on the
-            // reconciled branch rather than staying pinned to its own snapshots. A read-only
-            // view follows the named branch (or the repo HEAD's branch) so new commits appear —
-            // except a fixed commit base, which is a pinned view that never advances.
-            let follow_ref = if let Some(target) = &shared_target {
+            // reconciled branch rather than staying pinned to its own snapshots. The publish
+            // target comes from the CREATE RESPONSE — for fs-surface sessions the server
+            // filled it from the repo's stored default branch. A read-only view follows the
+            // named branch (fs surface: HEAD itself, resolved per poll) so new commits
+            // appear — except a fixed commit base, which is a pinned view that never
+            // advances.
+            let follow_ref = if let Some(target) = &ws.shared_target {
                 Some(format!("refs/heads/{target}"))
+            } else if read_only && fs_surface {
+                Some("HEAD".to_string())
             } else if read_only {
                 match &base {
                     Some(b) if b.len() == 40 && b.bytes().all(|c| c.is_ascii_hexdigit()) => {
@@ -2483,7 +2508,7 @@ pub async fn mount(
                         repo,
                         mountpoint,
                         short_id(&ws.id),
-                        if shared_target.is_some() {
+                        if ws.shared_target.is_some() {
                             ", saves publish automatically"
                         } else if read_only {
                             ", read-only, follows the filesystem"
@@ -2498,7 +2523,7 @@ pub async fn mount(
                         ws.base_ref.as_deref().unwrap_or(&ws.base[..12]),
                         mountpoint,
                         short_id(&ws.id),
-                        if shared_target.is_some() {
+                        if ws.shared_target.is_some() {
                             ", snapshots auto-publish to the branch"
                         } else if read_only {
                             ", read-only, follows the branch"

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -713,7 +713,11 @@ pub async fn history(
         table.add_row(vec![
             Cell::new(age_display(op.at_secs)),
             Cell::new(if op.actor.is_empty() { "-" } else { &op.actor }),
-            Cell::new(&op.kind),
+            Cell::new(if op.conflicted {
+                format!("{} (collision)", op.kind)
+            } else {
+                op.kind.clone()
+            }),
             Cell::new(
                 op.refs
                     .first()
@@ -724,6 +728,12 @@ pub async fn history(
         ]);
     }
     println!("{table}");
+    if saves.iter().any(|op| op.conflicted) {
+        println!(
+            "Collision saves kept both sides; markers are in the affected files (`tl fs \
+             status` lists unresolved ones)."
+        );
+    }
     Ok(())
 }
 
@@ -4096,6 +4106,25 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         .ok()
         .and_then(|r| r.get("commit").and_then(|c| c.as_str().map(str::to_string)));
     let changes = local_changes(&state_dir, &mountpoint).await?;
+    // Collisions the followed state materialized that no later save has overwritten. Absent
+    // daemon (or a pre-visibility daemon) reads as none — the section only ever adds signal.
+    let collisions: Vec<(String, String, String)> = daemon::control(&state_dir, "conflicts")
+        .await
+        .ok()
+        .and_then(|r| r.get("conflicts").cloned())
+        .and_then(|v| serde_json::from_value::<Vec<serde_json::Value>>(v).ok())
+        .map(|list| {
+            list.into_iter()
+                .filter_map(|c| {
+                    Some((
+                        c.get("path")?.as_str()?.to_string(),
+                        c.get("kind")?.as_str()?.to_string(),
+                        c.get("commit")?.as_str()?.to_string(),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
 
     if output_json {
         println!(
@@ -4115,6 +4144,12 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
                 "pending_renames": changes.renames
                     .iter()
                     .map(|(from, to)| serde_json::json!({ "from": from, "to": to }))
+                    .collect::<Vec<_>>(),
+                "unresolved_collisions": collisions
+                    .iter()
+                    .map(|(path, kind, commit)| serde_json::json!({
+                        "path": path, "kind": kind, "commit": commit,
+                    }))
                     .collect::<Vec<_>>(),
             }))?
         );
@@ -4159,6 +4194,21 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         style("log:").dim(),
         state_dir.join("daemon.log").display()
     );
+    if !collisions.is_empty() {
+        println!(
+            "{} {} path(s) — both saves were kept; markers are in the files. Edit and save \
+             to resolve:",
+            style("unresolved collisions:").yellow(),
+            collisions.len(),
+        );
+        for (path, kind, commit) in &collisions {
+            println!(
+                "  {:<14} {path} (save {})",
+                style(kind).yellow(),
+                short_id(commit)
+            );
+        }
+    }
     // A pending rename's source whiteout is a real delete, but showing it next to the R line
     // would read as two changes; the R line carries both sides.
     let deletes: Vec<&String> = changes

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -90,7 +90,14 @@ fn absorb_refresh(
     pending: &std::sync::Mutex<PendingProbe>,
     delta: &gsvc_mount::RefreshDelta,
 ) {
-    let outputs = overlay.refresh_outputs(delta);
+    // Divergence first: retained upper copies the branch moved past stop shadowing, so the
+    // shadow filter inside refresh_outputs sees them gone and their invalidations flow.
+    let divergence = overlay.absorb_divergence(delta);
+    if !divergence.invals.is_empty() {
+        invalidate(divergence.invals);
+    }
+    let mut outputs = overlay.refresh_outputs(delta);
+    outputs.expectations.extend(divergence.expectations);
     {
         let mut p = pending.lock().expect("pending probe lock");
         if delta.appeared.is_none() {
@@ -271,7 +278,10 @@ impl SealedIndex {
 
     pub(crate) fn save(&self, state_dir: &Path) -> std::io::Result<()> {
         let tmp = state_dir.join("sealed.json.tmp");
-        std::fs::write(&tmp, serde_json::to_vec(self).expect("plain data serializes"))?;
+        std::fs::write(
+            &tmp,
+            serde_json::to_vec(self).expect("plain data serializes"),
+        )?;
         std::fs::rename(&tmp, Self::file(state_dir))
     }
 
@@ -888,17 +898,84 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     if let Some(secs) = state.auto_commit_interval_secs
         && let Some(sealer) = sealer.clone()
     {
+        // Event-driven autosave (issue #103 step 5): seal when the overlay has been dirty AND
+        // quiet for `QUIET_SECS`, or dirty for `secs` regardless — bounded time-to-published
+        // instead of "some tick after". Quiet is measured from the dirty files' real mtimes
+        // in the upper (no write hooks needed); very large dirty sets skip the stat pass and
+        // ride the max-latency bound alone. The old behavior was one blind seal every `secs`,
+        // which let a write land right after a tick and wait the whole interval.
+        const POLL: Duration = Duration::from_secs(2);
+        const QUIET_SECS: u64 = 10;
+        const MTIME_SCAN_CAP: usize = 256;
+        let upper = state_dir.join("upper");
         tokio::spawn(async move {
+            let mut dirty_since: Option<std::time::Instant> = None;
             loop {
-                tokio::time::sleep(Duration::from_secs(secs.max(1))).await;
+                tokio::time::sleep(POLL).await;
+                let view = match sealer.dirty_view().await {
+                    Ok(view) => view,
+                    Err(e) => {
+                        eprintln!("autosave: dirty view failed: {e}");
+                        continue;
+                    }
+                };
+                let dirty_paths: Vec<&String> =
+                    view.upserts.iter().chain(view.deletes.iter()).collect();
+                let renames = view.renames.len();
+                if dirty_paths.is_empty() && renames == 0 {
+                    dirty_since = None;
+                    continue;
+                }
+                let now = std::time::Instant::now();
+                let since = *dirty_since.get_or_insert(now);
+                let dirty_for = now.duration_since(since);
+                // Quiet = no dirty file touched within QUIET_SECS. Deletes/renames have no
+                // mtime to consult; they count as quiet (their "write" was the operation
+                // itself, already at least one poll old by the time we see it twice).
+                let quiet = if view.upserts.len() > MTIME_SCAN_CAP {
+                    false // too many to stat cheaply; the max-latency bound owns this seal
+                } else {
+                    let quiet_floor =
+                        std::time::SystemTime::now() - Duration::from_secs(QUIET_SECS);
+                    view.upserts.iter().all(|rel| {
+                        match upper
+                            .join(rel)
+                            .symlink_metadata()
+                            .and_then(|m| m.modified())
+                        {
+                            Ok(mtime) => mtime <= quiet_floor,
+                            Err(_) => true, // vanished/unstattable: nothing left to wait on
+                        }
+                    })
+                };
+                if !quiet && dirty_for < Duration::from_secs(secs.max(1)) {
+                    continue;
+                }
                 // eprintln, not tracing: the daemon's stderr is the state dir's daemon.log —
-                // the one place a user can see an async flush fail.
+                // the one place a user can see an async flush fail. One structured line per
+                // stage so a slow save localizes to seal vs publish (server landing times
+                // come from the ops log).
+                let reason = if quiet { "quiet" } else { "max-latency" };
+                eprintln!(
+                    "autosave: sealing reason={reason} dirty_for_s={} files={} renames={renames}",
+                    dirty_for.as_secs(),
+                    dirty_paths.len(),
+                );
+                let seal_started = std::time::Instant::now();
                 match sealer.seal_once("tl fs auto-commit", false, None).await {
                     Ok(SealOutcome::Sealed(report)) => {
-                        eprintln!("auto-commit sealed snapshot {}", report.commit);
+                        eprintln!(
+                            "autosave: sealed snapshot {} seal_ms={} push_ms={:?}",
+                            report.commit,
+                            seal_started.elapsed().as_millis(),
+                            report.push_ms,
+                        );
+                        dirty_since = None;
                     }
-                    Ok(SealOutcome::Clean { .. }) => {}
-                    Err(e) => eprintln!("auto-commit: {e}"),
+                    Ok(SealOutcome::Clean { .. }) => {
+                        dirty_since = None;
+                    }
+                    Err(e) => eprintln!("autosave: {e}"),
                 }
             }
         });
@@ -981,6 +1058,23 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 }
                             },
                         },
+                        // The still-unresolved collisions on the followed branch (issue
+                        // #103 step 4b): fed by refresh deltas inside the mount core,
+                        // cleared when a later save changes the path again.
+                        "conflicts" => {
+                            let list: Vec<serde_json::Value> = core
+                                .open_conflicts()
+                                .into_iter()
+                                .map(|(path, c)| {
+                                    serde_json::json!({
+                                        "path": path,
+                                        "commit": c.commit,
+                                        "kind": c.kind,
+                                    })
+                                })
+                                .collect();
+                            serde_json::json!({ "ok": true, "conflicts": list })
+                        }
                         // Drop retained (sealed-and-kept) overlay state — sync's pre-flight.
                         // Unlike `clear_upper`, dirty and ignored files survive.
                         "trim" => match sealer.as_ref() {
@@ -1055,9 +1149,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
                                 None => {
                                     SealedIndex::reset(&control_state_dir);
                                     overlay.clear_upper().map_err(|e| {
-                                        CliError::usage(format!(
-                                            "clearing the overlay failed: {e}"
-                                        ))
+                                        CliError::usage(format!("clearing the overlay failed: {e}"))
                                     })
                                 }
                             };
@@ -1613,6 +1705,20 @@ impl Sealer {
                 PushOptions {
                     message: message.to_string(),
                     workspace_snapshot: Some(self.workspace.clone()),
+                    // The view this delta's edits were made against: the lower at the
+                    // batch's FIRST write (not at seal time — the branch can move during
+                    // the quiet window, and claiming the later view would turn a genuine
+                    // concurrent write into a silent overwrite). The server parents the
+                    // snapshot here, so the shared-rw application three-ways against what
+                    // the writer saw: overwriting another session's file is a clean write,
+                    // concurrent writes collide visibly, and resolving a collision
+                    // converges instead of nesting markers. Servers that predate the field
+                    // ignore it (old behavior).
+                    base: Some(
+                        self.overlay
+                            .dirty_base()
+                            .unwrap_or_else(|| lower.to_string()),
+                    ),
                     collect_file_chunks: true,
                     progress,
                     ..Default::default()
@@ -1624,6 +1730,9 @@ impl Sealer {
         st.sealed_gen = watermark;
         self.overlay.prune_dirty(watermark);
         let report = report.into_inner();
+        self.overlay
+            .record_sealed_oids(report.file_blob_oids.iter().cloned());
+        self.overlay.close_dirty_base_if_clean();
         st.recent_seals
             .push((report.commit.clone(), resolved.sealed_upserts));
         // Remember what each file's content chunked to; a blunt cap bounds daemon memory (a
@@ -1792,8 +1901,7 @@ impl Sealer {
     /// state lock serializes the drop against in-flight seals — a clear can no longer land
     /// inside a push window — and `reindex_pending` arms the fail-closed guard for the
     /// out-of-band refill that follows.
-    async fn clear_upper_control(&self) -> Result<Vec<crate::commands::fs::overlay::OverlayInval>>
-    {
+    async fn clear_upper_control(&self) -> Result<Vec<crate::commands::fs::overlay::OverlayInval>> {
         let mut st = self.state.lock().await;
         let affected = self
             .overlay
@@ -2697,7 +2805,6 @@ mod stable_prefix_tests {
         assert_eq!(stable_of(&resolved), None);
         assert!(matches!(resolved.files[0].source, PushSource::Path(_)));
     }
-
 }
 
 /// The dirty view (dry-run resolution) and the sealed index: what `tl fs status` shows must
@@ -2764,7 +2871,10 @@ mod seal_tracking_tests {
             .collect();
         sealed_deletes.sort();
         assert_eq!(deletes, sealed_deletes, "dry run and seal agree on deletes");
-        assert!(!upserts.contains(&"junk.tmp".to_string()), "ignored paths never show");
+        assert!(
+            !upserts.contains(&"junk.tmp".to_string()),
+            "ignored paths never show"
+        );
     }
 
     #[test]
@@ -2840,14 +2950,21 @@ mod seal_tracking_tests {
 
     #[test]
     fn sealed_survivors_matches_by_exact_stat_identity() {
-        let state = state_with(&[("same.txt", "stable"), ("changed.txt", "old")], &["dead.txt"]);
+        let state = state_with(
+            &[("same.txt", "stable"), ("changed.txt", "old")],
+            &["dead.txt"],
+        );
         let stat_of = |p: &str| {
             SealedStat::of(&std::fs::symlink_metadata(state.path().join("upper").join(p)).unwrap())
         };
         let mut index = SealedIndex::default();
         index.upserts.insert("same.txt".into(), stat_of("same.txt"));
-        index.upserts.insert("changed.txt".into(), stat_of("changed.txt"));
-        index.upserts.insert("missing.txt".into(), stat_of("same.txt"));
+        index
+            .upserts
+            .insert("changed.txt".into(), stat_of("changed.txt"));
+        index
+            .upserts
+            .insert("missing.txt".into(), stat_of("same.txt"));
         index.deletes.insert("dead.txt".into());
         index.deletes.insert("reaped.txt".into());
 
@@ -2856,8 +2973,16 @@ mod seal_tracking_tests {
         std::fs::write(state.path().join("upper/changed.txt"), "newer-bytes").unwrap();
 
         let (upserts, deletes) = sealed_survivors(state.path(), &index);
-        assert_eq!(upserts, vec!["same.txt"], "only the untouched file survives");
-        assert_eq!(deletes, vec!["dead.txt"], "only the still-present whiteout survives");
+        assert_eq!(
+            upserts,
+            vec!["same.txt"],
+            "only the untouched file survives"
+        );
+        assert_eq!(
+            deletes,
+            vec!["dead.txt"],
+            "only the still-present whiteout survives"
+        );
     }
 
     #[test]

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -2636,8 +2636,9 @@ mod tests {
             !repositories.repos.iter().any(|r| r.name == fs_name),
             "a filesystem must not appear in the repository listing"
         );
-        // The genesis commit is what makes `tl fs create` + mount work with no client push:
-        // a baseless, publish-on-save workspace resolves its base from the default branch.
+        // The genesis commit is what makes `tl fs create` + mount work with no client push,
+        // and `surface` is what makes it ONE round trip: the SERVER fills the publish target
+        // from the repo's stored default branch — the client never reads a listing.
         let ws = sdk
             .create_workspace(
                 PROJECT,
@@ -2645,7 +2646,7 @@ mod tests {
                 "t",
                 TOKEN,
                 &CreateWorkspaceRequest {
-                    shared_target: Some(entry.default_branch.clone()),
+                    surface: Some("filesystem".to_string()),
                     ..Default::default()
                 },
             )
@@ -2654,6 +2655,42 @@ mod tests {
             .into_inner();
         assert_eq!(ws.base_ref.as_deref(), Some("refs/heads/main"));
         assert_eq!(ws.shared_target.as_deref(), Some("main"));
+
+        // The authoritative meta point-read answers immediately after create — this is the
+        // rm/validation path's read-your-writes guarantee.
+        let meta = sdk
+            .repo_meta_with_credential(PROJECT, &fs_name, "t", TOKEN)
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(meta.is_filesystem());
+        assert_eq!(meta.default_branch, "main");
+
+        // An fs-surface session on a repository fails closed with the right command.
+        let repo_name = format!("{fs_name}-repo");
+        sdk.create_repo_with_credential(PROJECT, &repo_name, None, None, "t", TOKEN)
+            .await
+            .unwrap();
+        let err = sdk
+            .create_workspace(
+                PROJECT,
+                &repo_name,
+                "t",
+                TOKEN,
+                &CreateWorkspaceRequest {
+                    surface: Some("filesystem".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err}").contains("tl git mount"),
+            "kind mismatch must name the replacement, got: {err}"
+        );
+        sdk.delete_repo_with_credential(PROJECT, &repo_name, "t", TOKEN)
+            .await
+            .unwrap();
         // Pin `tl fs history`'s save definition to the server's operation vocabulary: the
         // genesis is a committed "push" op, i.e. exactly what the history filter
         // (kind in {push, reconcile, promote, merge} AND result == "committed") must match.

--- a/crates/cli/src/commands/fs/overlay.rs
+++ b/crates/cli/src/commands/fs/overlay.rs
@@ -356,6 +356,27 @@ pub struct OverlayFs {
     dirty: Mutex<HashMap<String, DirtyEntry>>,
     /// Out-of-band mutation epoch: see [`OverlayFs::epoch`].
     epoch: AtomicU64,
+    /// Published blob oid per retained upper path, recorded after each seal from the push
+    /// report. A branch refresh compares these against the delta's new oids: equal means the
+    /// change is this mount's own save echoing back (the retained copy stays — it IS the
+    /// byte cache), different means another session moved the path and the retained copy
+    /// must stop shadowing the lower. Unknown (never recorded, or the push skipped hashing
+    /// on the stable-prefix fast path) reads as divergent — dropping costs a refetch,
+    /// keeping costs serving stale bytes. In-memory only: after a restart every retained
+    /// path re-arms as unknown and the first branch change to touch it refetches.
+    sealed_oids: Mutex<HashMap<String, String>>,
+    /// Divergent retained paths a trim could not drop yet (open handle, contended fence).
+    /// Retried on every subsequent refresh absorption.
+    divergent_pending: Mutex<std::collections::HashSet<String>>,
+    /// The lower commit the CURRENT dirty batch's edits were made against: stamped when the
+    /// dirty set goes empty→nonempty (under the dirty lock), cleared only when a seal leaves
+    /// the set empty. This — not the lower at seal time — is the merge base a seal declares:
+    /// the lower can advance during the quiet window between a write and its autosave, and a
+    /// base captured at seal time would claim the writer saw content that landed AFTER their
+    /// edit, turning a genuine concurrent write into a silent overwrite. A too-old base costs
+    /// at worst a spurious conflict (both sides kept, visibly); a too-new base loses a write
+    /// invisibly — always err old.
+    dirty_base: Mutex<Option<String>>,
     /// The trim fence. Mutating entry points hold it shared for their whole span (copy-up
     /// through dirty-index record); [`OverlayFs::trim_retained`] holds it exclusively while it
     /// drops sealed upper files. Without it, a trim could unlink an upper file between a
@@ -470,6 +491,9 @@ impl OverlayFs {
             lower_times: Mutex::new(HashMap::new()),
             write_gen: AtomicU64::new(0),
             dirty: Mutex::new(HashMap::new()),
+            sealed_oids: Mutex::new(HashMap::new()),
+            divergent_pending: Mutex::new(std::collections::HashSet::new()),
+            dirty_base: Mutex::new(None),
             epoch: AtomicU64::new(0),
             mutate: tokio::sync::RwLock::new(()),
             redirects: Mutex::new(redirects),
@@ -499,6 +523,12 @@ impl OverlayFs {
 
     fn record_at(&self, path: &str, kind: DirtyKind, offset: u64) {
         let mut dirty = self.dirty.lock().expect("dirty lock");
+        if dirty.is_empty() {
+            // First write of a new batch: remember which view these edits are against.
+            // Stamped under the dirty lock so a sealer that empties the set and clears the
+            // base can never interleave mid-transition.
+            *self.dirty_base.lock().expect("dirty base lock") = Some(self.core.current_commit());
+        }
         // The clock bump happens UNDER the map lock: a sealer that loaded watermark W is then
         // guaranteed to either see this entry (we inserted before it acquired the lock) or to
         // have loaded W < generation (we bumped after its load) — a generation can never be
@@ -633,6 +663,11 @@ impl OverlayFs {
     /// straight into the state dir and then asks for a reindex).
     pub fn rebuild_dirty_index(&self) -> Result<(), MountError> {
         self.epoch.fetch_add(1, Ordering::SeqCst);
+        self.sealed_oids.lock().expect("sealed oid lock").clear();
+        self.divergent_pending
+            .lock()
+            .expect("divergence lock")
+            .clear();
         fn walk(root: &Path, dir: &Path, out: &mut dyn FnMut(String)) -> std::io::Result<()> {
             let Ok(read) = std::fs::read_dir(dir) else {
                 return Ok(());
@@ -1985,7 +2020,120 @@ impl OverlayFs {
         // resolutions) describe a dead world too.
         self.dirty.lock().expect("dirty lock").clear();
         self.epoch.fetch_add(1, Ordering::SeqCst);
+        self.sealed_oids.lock().expect("sealed oid lock").clear();
+        self.divergent_pending
+            .lock()
+            .expect("divergence lock")
+            .clear();
         Ok(affected)
+    }
+
+    /// The lower commit the current dirty batch was started against — the merge base a seal
+    /// must declare. `None` when nothing has been written since the last clean seal (callers
+    /// fall back to the current lower).
+    pub fn dirty_base(&self) -> Option<String> {
+        self.dirty_base.lock().expect("dirty base lock").clone()
+    }
+
+    /// After a successful seal: if no write raced in during the push (the dirty set is
+    /// empty), the batch is closed — the next write stamps a fresh base. A non-empty set
+    /// keeps the old (older-than-necessary, therefore safe) base for the writes it covers.
+    pub fn close_dirty_base_if_clean(&self) {
+        let dirty = self.dirty.lock().expect("dirty lock");
+        if dirty.is_empty() {
+            *self.dirty_base.lock().expect("dirty base lock") = None;
+        }
+    }
+
+    /// Record the published blob oid for each sealed path (from the push report). Empty oids
+    /// (deletes, stable-prefix fast-path files that never hashed) are dropped — those paths
+    /// read as divergence-unknown and err toward refetching.
+    pub fn record_sealed_oids(&self, oids: impl IntoIterator<Item = (String, String)>) {
+        let mut map = self.sealed_oids.lock().expect("sealed oid lock");
+        for (path, oid) in oids {
+            if !oid.is_empty() {
+                map.insert(path, oid);
+            }
+        }
+    }
+
+    /// Drop retained upper copies the branch has moved past, so the merged view converges to
+    /// what the branch actually says instead of serving this mount's stale byte cache. For
+    /// every delta path shadowed by the upper: a dirty path is the user's in-flight edit and
+    /// keeps shadowing (the next seal owns it); a retained path whose recorded seal oid
+    /// equals the delta's new oid is this mount's own save echoing back and stays (byte
+    /// cache); anything else — different oid, unknown oid, or branch-side deletion — stops
+    /// shadowing via the trim fence (which pins open handles and skips redirects). Paths a
+    /// trim could not drop are retried on the next absorption. Returns the kernel
+    /// invalidations for everything dropped.
+    pub fn absorb_divergence(&self, delta: &gsvc_mount::RefreshDelta) -> RefreshOutputs {
+        let mut candidates: std::collections::HashSet<String> =
+            std::mem::take(&mut *self.divergent_pending.lock().expect("divergence lock"));
+        {
+            let sealed = self.sealed_oids.lock().expect("sealed oid lock");
+            // The raw diff rows, not rebound/staled: a retained upper shadow means the
+            // kernel never looked the path up through the core, so no live inode exists
+            // and the inval lists skip it — but the branch change is exactly what must
+            // evict the shadow.
+            for row in &delta.changed {
+                let path = row.path.as_str();
+                if self.upper_meta(path).is_none() || self.whited_out(path) {
+                    continue;
+                }
+                let own_echo = matches!((sealed.get(path), row.oid.as_deref()),
+                    (Some(sealed_oid), Some(new)) if sealed_oid == new);
+                if !own_echo {
+                    candidates.insert(path.to_string());
+                }
+            }
+        }
+        if candidates.is_empty() {
+            return RefreshOutputs::default();
+        }
+        let candidates: Vec<String> = candidates.into_iter().collect();
+        match self.try_trim_retained(&candidates, &[]) {
+            Some(outcome) => {
+                {
+                    let mut sealed = self.sealed_oids.lock().expect("sealed oid lock");
+                    for path in &outcome.trimmed {
+                        sealed.remove(path);
+                    }
+                }
+                if !outcome.held_open.is_empty() {
+                    self.divergent_pending
+                        .lock()
+                        .expect("divergence lock")
+                        .extend(outcome.held_open.iter().cloned());
+                }
+                // Bindings without a notify channel (FSKit) converge via probe
+                // expectations; a dropped shadow must purge cached pages and attrs, so
+                // carry the lower's new size (or absence) for every trimmed path.
+                let trimmed: std::collections::HashSet<&str> =
+                    outcome.trimmed.iter().map(String::as_str).collect();
+                let expectations = delta
+                    .changed
+                    .iter()
+                    .filter(|row| trimmed.contains(row.path.as_str()))
+                    .map(|row| KernelExpectation {
+                        path: row.path.clone(),
+                        present: row.oid.is_some(),
+                        size: row.size,
+                    })
+                    .collect();
+                RefreshOutputs {
+                    invals: outcome.invals,
+                    expectations,
+                }
+            }
+            // Fence contended (a copy-up mid-flight): retry the whole set next time.
+            None => {
+                self.divergent_pending
+                    .lock()
+                    .expect("divergence lock")
+                    .extend(candidates);
+                RefreshOutputs::default()
+            }
+        }
     }
 
     /// Drop retained upper files (and inert whiteouts) whose content a seal has published and

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -1407,7 +1407,7 @@ pub async fn push(
         }
         None => {
             let (root, state_dir, _, _) =
-                bind(ctx, Some(dir.to_path_buf()), Some(file_system), true).await?;
+                bind(ctx, Some(dir.to_path_buf()), file_system, true).await?;
             (root, state_dir)
         }
     };
@@ -1420,7 +1420,7 @@ pub async fn push(
 async fn bind(
     ctx: &CliContext,
     path: Option<PathBuf>,
-    file_system: Option<&str>,
+    file_system: &str,
     publish: bool,
 ) -> Result<(String, PathBuf, String, String)> {
     if cfg!(not(unix)) {
@@ -1447,56 +1447,14 @@ async fn bind(
         )));
     }
 
-    // Project-wide session: the repo listing is project-scoped, and a repo-scoped mint
-    // (which FsSession would use for a named file system) deliberately lacks that scope —
-    // binding with one 403s before the workspace is ever created.
-    let session = FsSession::open(ctx, None).await?;
+    // The session may run on a repo-scoped credential (a sandbox pushing into its one
+    // filesystem): the whole bind path is point-addressed — no listings — and the SERVER
+    // applies filesystem semantics (publish target, kind check) from the repo's
+    // authoritative kind via `surface`. Filesystems are born with a genesis, so no seeding.
+    let repo = file_system.to_string();
+    let session = FsSession::open(ctx, Some(&repo)).await?;
     let (user, token) = session.creds();
-    let file_systems = session
-        .client
-        .list_repos_with_credential(&session.project_id, None, user, token)
-        .await?
-        .into_inner();
-    let repo = match file_system {
-        Some(name) => {
-            if !file_systems.repos.iter().any(|r| r.name == name) {
-                return Err(CliError::usage(format!(
-                    "no filesystem named {name:?}; create it first: tl fs create {name}"
-                )));
-            }
-            name.to_string()
-        }
-        // No --file-system: unambiguous only when the project has exactly one.
-        None => match file_systems.repos.as_slice() {
-            [only] => only.name.clone(),
-            [] => {
-                return Err(CliError::usage(
-                    "this project has no filesystems; create one first: tl fs create <name>",
-                ));
-            }
-            many => {
-                return Err(CliError::usage(format!(
-                    "this project has {} file systems; pick one with --file-system ({})",
-                    many.len(),
-                    many.iter()
-                        .map(|r| r.name.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                )));
-            }
-        },
-    };
-    let default_branch = file_systems
-        .repos
-        .iter()
-        .find(|r| r.name == repo)
-        .expect("validated above")
-        .default_branch
-        .clone();
-    // A fresh `tl git create` repo has an unborn default branch; seed it with an empty
-    // initial commit (empty root tree — exactly the base v1 requires) so init just works.
-    super::ensure_seeded(&session, &default_branch, &repo).await?;
-    let ws = session
+    let ws = match session
         .client
         .create_workspace(
             &session.project_id,
@@ -1504,12 +1462,20 @@ async fn bind(
             user,
             token,
             &CreateWorkspaceRequest {
-                shared_target: publish.then(|| default_branch.clone()),
+                surface: publish.then(|| "filesystem".to_string()),
                 ..Default::default()
             },
         )
-        .await?
-        .into_inner();
+        .await
+    {
+        Ok(ws) => ws.into_inner(),
+        Err(tensorlake::error::SdkError::ServerError { status, .. }) if status.as_u16() == 404 => {
+            return Err(CliError::usage(format!(
+                "no filesystem named {repo:?} (see: tl fs ls; create one: tl fs create {repo})"
+            )));
+        }
+        Err(e) => return Err(e.into()),
+    };
     // v1 verifies — not assumes — the empty base: workspace creation defaults to the repo
     // HEAD, which is only empty on a freshly seeded repo. One root-tree page of one entry is
     // the cheapest proof either way. (425: the base commit's index can still be

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -627,7 +627,13 @@ pub async fn commit_conflicts(
 }
 
 pub(crate) fn artifact_storage_client(ctx: &CliContext) -> Result<ArtifactStorageClient> {
-    let token = ctx.bearer_token()?;
+    // Sandbox attach path: no platform credential in the guest. Every data-plane call
+    // authenticates per request with the git credential; the bearer only backs the token-mint
+    // path, which the TENSORLAKE_GIT_TOKEN branch never reaches — so the git token stands in.
+    let token = match ctx.bearer_token() {
+        Ok(t) => t,
+        Err(e) => std::env::var("TENSORLAKE_GIT_TOKEN").map_err(|_| e)?,
+    };
     let mut builder = ClientBuilder::new(&ctx.api_url).bearer_token(&token);
     let use_scope_headers = ctx.personal_access_token.is_some() && ctx.api_key.is_none();
     if use_scope_headers

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -258,6 +258,16 @@ enum FsCommands {
         log_level: String,
     },
 
+    /// Mint the scoped credential a sandbox needs to attach one filesystem
+    Token {
+        /// Filesystem name
+        name: String,
+
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Upload a folder into a filesystem as one save (no mount needed)
     Push {
         /// Local directory to upload
@@ -2442,6 +2452,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
         FsCommands::Create { name, json } => {
             commands::fs::create_filesystem(ctx, &name, json).await
         }
+        FsCommands::Token { name, json } => commands::fs::token(ctx, &name, json).await,
         FsCommands::Ls { file_system, json } => match file_system {
             None => commands::fs::ls_filesystems(ctx, json).await,
             Some(fs) => commands::fs::ls(ctx, Some(&fs), json).await,
@@ -3096,6 +3107,13 @@ mod tests {
                 assert_eq!(name, "scratch");
             }
             _ => panic!("expected fs create command"),
+        }
+
+        match parse_command(["tl", "fs", "token", "scratch", "--json"]) {
+            Commands::Fs(FsCommands::Token { name, json: true }) => {
+                assert_eq!(name, "scratch");
+            }
+            _ => panic!("expected fs token command"),
         }
 
         match parse_command(["tl", "fs", "push", "./data", "scratch", "-m", "bulk load"]) {

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -138,7 +138,10 @@ pub struct PushOptions {
     pub upload_batch_bytes: usize,
     pub progress: Option<PushProgress>,
     /// When set, the commit publishes as a snapshot on this workspace's ref
-    /// (`workspaces/{id}/snapshots`) instead of advancing `branch`; `branch`/`base` are ignored.
+    /// (`workspaces/{id}/snapshots`) instead of advancing `branch` (which is ignored). `base`
+    /// declares the commit the changes were computed against — the snapshot parents there, so
+    /// the shared-rw application three-ways against what the writer saw (servers that predate
+    /// the field ignore it and chain on the workspace tip).
     pub workspace_snapshot: Option<String>,
     /// Return every CDC-path file's chunk list in `PushReport::file_chunks`, so the caller can
     /// hand them back as `PushSource::StablePrefix` prefixes on the next push of the same

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -13,7 +13,7 @@ pub mod workspaces;
 
 use models::{
     CreateRepoRequest, GitCredential, ListBranchesResponse, ListOperationsResponse,
-    ListRefsResponse, ListReposResponse, MintGitTokenRequest, RepoInfo,
+    ListRefsResponse, ListReposResponse, MintGitTokenRequest, RepoInfo, RepoMetaInfo,
 };
 
 #[derive(Clone)]
@@ -324,6 +324,27 @@ impl ArtifactStorageClient {
             url.push_str(&format!("?kind={}", urlencoding::encode(kind)));
         }
         let (request, trace_id) = self.git_request_url(Method::GET, url, git_username, git_token);
+        let response = request.send().await?;
+        decode_json(response, trace_id).await
+    }
+
+    /// Authoritative point-read of one repo's meta (kind, default branch, status). 404 =>
+    /// SdkError::ServerError with status 404.
+    pub async fn repo_meta_with_credential(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+    ) -> Result<Traced<RepoMetaInfo>, SdkError> {
+        let (request, trace_id) = self.git_request(
+            Method::GET,
+            project_id,
+            repo,
+            Some("meta"),
+            git_username,
+            git_token,
+        )?;
         let response = request.send().await?;
         decode_json(response, trace_id).await
     }

--- a/crates/cloud-sdk/src/artifact_storage/models.rs
+++ b/crates/cloud-sdk/src/artifact_storage/models.rs
@@ -146,6 +146,10 @@ pub struct Operation {
     pub old_pack_count: u32,
     pub object_count: u32,
     pub pack_bytes: u64,
+    /// The operation materialized merge conflicts (its commit carries a conflict record).
+    /// Elided by the server when false; absent from pre-visibility servers.
+    #[serde(default)]
+    pub conflicted: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/cloud-sdk/src/artifact_storage/models.rs
+++ b/crates/cloud-sdk/src/artifact_storage/models.rs
@@ -63,6 +63,25 @@ impl Repo {
     }
 }
 
+/// `GET /project/{p}/repos/{r}/meta` — the authoritative point-read of one repo's product
+/// identity. Never served from the listing cache (read-your-writes after create) and
+/// answerable with a repo-scoped credential.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RepoMetaInfo {
+    pub name: String,
+    pub full_name: String,
+    pub default_branch: String,
+    pub status: String,
+    #[serde(default = "default_repo_kind")]
+    pub kind: String,
+}
+
+impl RepoMetaInfo {
+    pub fn is_filesystem(&self) -> bool {
+        self.kind == REPO_KIND_FILESYSTEM
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListReposResponse {
     pub project: String,

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -53,6 +53,16 @@ pub struct CreateWorkspaceRequest {
     /// on conflicts) or `"lww"` (legacy last-writer-wins overwrite).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reconcile_policy: Option<String>,
+    /// Which product surface this session belongs to: `"filesystem"` makes the SERVER apply
+    /// filesystem semantics from the repo's authoritative kind (publish-on-save defaults;
+    /// kind=repository rejected with the right command). Requires a server with repo
+    /// surface support (issue #103); older servers ignore the field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surface: Option<String>,
+    /// The session will never write (a read-only mount's anchor): the surface kind check
+    /// still applies, publish defaults are skipped.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub read_only: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
Step 2 of [artifact_storage#103](https://github.com/tensorlakeai/artifact_storage/issues/103), stacked on #843. Consumes [artifact_storage#104](https://github.com/tensorlakeai/artifact_storage/pull/104) — **do not release before #104 is deployed** (older servers silently ignore `surface`, which would drop publish-on-save).

## What changes

- **`tl fs mount` is one server round trip again.** The workspace create carries `surface: "filesystem"` (+ `read_only` for `--ro`) and the server fills the publish target from the repo's stored default branch and rejects kind mismatches with a typed error naming `tl git mount`. The pre-flight listing is gone, which kills two prod findings structurally: the ~30s create→mount staleness window (nothing cached is consulted) and the project-scope requirement (every attach-path call is repo-scoped now).
- **Read-only mounts follow `HEAD` itself** — the daemon polls `ref-status?ref=HEAD`; no branch-name resolution anywhere on the client.
- **`tl fs push`** loses its listing and its unconditional seed the same way; first push works under a repo-scoped token.
- **`tl fs rm`** resolves via the authoritative `GET /repos/{r}/meta` point-read (read-your-writes; typed 404/kind answers).
- **`tl fs token <fs>`** mints the narrow credential and prints the sandbox attach recipe — with FUSE available in every target sandbox, "attach from any provider" is literally: `export TENSORLAKE_GIT_TOKEN=…; tl fs mount <fs> <path>`.
- Engine trusts the **create response** for publish state (follow ref + summary text come from the server-filled `shared_target`).
- SDK: `CreateWorkspaceRequest.{surface, read_only}` (omitted when unset), `RepoMetaInfo` + `repo_meta_with_credential`.

## Validation (local server built from #104)

- create → **immediate** mount, same second: writable (publish-on-save, autosave) and `--ro` (HEAD follow); a save from the writable session converged into the ro view.
- Ignored e2e suites green (kind contract incl. surface-filled target + meta point-read + kind-mismatch message; overlay suite).
- 279 unit tests; plain + full-feature builds clean; placeholders untouched.

One pre-existing quirk noticed while testing (not addressed here): the detached mount daemon re-execs without inheriting `--api-url`/`--api-key` flags (env forms propagate fine) — only visible when pointing a mount at a non-config server, e.g. local testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)