### PR TITLE
Make .gitignore the sole snapshot exclusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.73"
+version = "0.5.74"
 dependencies = [
  "anyhow",
  "base64",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.73"
+version = "0.5.74"
 dependencies = [
  "anyhow",
  "base64",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.73"
+version = "0.5.74"
 dependencies = [
  "napi",
  "napi-build",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.73"
+version = "0.5.74"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.73"
+version = "0.5.74"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -3011,14 +3011,13 @@ pub async fn unmount(
 // Snapshot: the overlay is the dirty set.
 // ---------------------------------------------------------------------------------------------
 
-/// Walk the overlay state dir: `(upserts, deletes)` as repo paths. Ignored names (built-ins +
-/// the mount's `.tlignore`) are workspace-local and never enumerate.
+/// Walk the overlay state dir: `(upserts, deletes)` as repo paths. Nested `.gitignore` files are
+/// the sole authority for paths that do not enumerate.
 /// Overlay upserts as `(repo path, upper file, git mode)`.
 type OverlayUpserts = Vec<(String, PathBuf, u32)>;
 
 struct SnapshotIgnore {
     mount_root: PathBuf,
-    ignored_names: Vec<String>,
     gitignores: HashMap<PathBuf, Gitignore>,
 }
 
@@ -3026,7 +3025,6 @@ impl SnapshotIgnore {
     fn new(mount_root: &Path) -> Self {
         Self {
             mount_root: mount_root.to_path_buf(),
-            ignored_names: local::ignored_names(mount_root),
             gitignores: HashMap::new(),
         }
     }
@@ -3054,18 +3052,6 @@ impl SnapshotIgnore {
 
     fn is_ignored(&mut self, rel: &str, is_dir: bool) -> Result<bool> {
         let rel_path = Path::new(rel);
-        for component in rel_path.components() {
-            let Component::Normal(name) = component else {
-                continue;
-            };
-            let name = name.to_string_lossy();
-            if self.ignored_names.iter().any(|ignored| ignored == &*name)
-                || local::is_metadata_turd(&name)
-            {
-                return Ok(true);
-            }
-        }
-
         let abs = self.mount_root.join(rel_path);
         let mut ignored = false;
         for dir in gitignore_dirs_for(rel_path) {
@@ -5032,6 +5018,66 @@ mod tests {
 
         let upsert_paths: Vec<_> = upserts.iter().map(|(path, _, _)| path.as_str()).collect();
         assert_eq!(upsert_paths, vec!["keep.txt"]);
+        assert!(deletes.is_empty());
+    }
+
+    #[test]
+    fn snapshot_enumeration_has_no_implicit_exclusions() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        let upper = state.path().join("upper");
+        std::fs::create_dir_all(state.path().join("wh")).unwrap();
+
+        let paths = [
+            ".git/HEAD",
+            "node_modules/pkg.js",
+            "target/debug/build.o",
+            "dist/app.js",
+            ".cache/entry",
+            "__pycache__/module.pyc",
+            ".DS_Store",
+            "._index",
+            ".tlignore",
+        ];
+        for path in paths {
+            let abs = upper.join(path);
+            std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            std::fs::write(abs, "snapshot me").unwrap();
+        }
+        // `.tlignore` is an ordinary tracked file now and has no exclusion semantics.
+        std::fs::write(mount.path().join(".tlignore"), "target\n").unwrap();
+
+        let (upserts, deletes) = enumerate_overlay(state.path(), mount.path()).unwrap();
+        let upsert_paths: Vec<_> = upserts.iter().map(|(path, _, _)| path.as_str()).collect();
+        assert_eq!(
+            upsert_paths,
+            vec![
+                ".DS_Store",
+                "._index",
+                ".cache/entry",
+                ".git/HEAD",
+                ".tlignore",
+                "__pycache__/module.pyc",
+                "dist/app.js",
+                "node_modules/pkg.js",
+                "target/debug/build.o",
+            ]
+        );
+        assert!(deletes.is_empty());
+    }
+
+    #[test]
+    fn snapshot_enumeration_excludes_former_builtins_when_gitignored() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        let upper = state.path().join("upper");
+        std::fs::create_dir_all(upper.join("target/debug")).unwrap();
+        std::fs::create_dir_all(state.path().join("wh")).unwrap();
+        std::fs::write(mount.path().join(".gitignore"), "target/\n").unwrap();
+        std::fs::write(upper.join("target/debug/build.o"), "ignored by git").unwrap();
+
+        let (upserts, deletes) = enumerate_overlay(state.path(), mount.path()).unwrap();
+        assert!(upserts.is_empty());
         assert!(deletes.is_empty());
     }
 

--- a/crates/cli/src/commands/fs/local.rs
+++ b/crates/cli/src/commands/fs/local.rs
@@ -1,44 +1,11 @@
-//! Local helpers for `tl fs`: ignore rules and materializing tree entries into a directory.
+//! Local helpers for materializing `tl fs` tree entries into a directory.
 //!
-//! The FUSE overlay owns all mount state; what remains here is shared by snapshot enumeration
-//! (which paths never upload) and restore (writing fetched entries into the overlay's upper
-//! layer).
+//! The FUSE overlay owns all mount state; what remains here is shared by restore paths that write
+//! fetched entries into the overlay's upper layer.
 
 use std::path::Path;
 
 use crate::error::Result;
-
-const IGNORED_DIR_NAMES: &[&str] = &[
-    ".git",
-    "node_modules",
-    "target",
-    "dist",
-    ".cache",
-    "__pycache__",
-];
-
-/// Whether a name is inherently workspace-local: macOS metadata turds the kernel writes onto
-/// filesystems without native xattr support. They serve reads from the overlay but never
-/// version.
-pub fn is_metadata_turd(name: &str) -> bool {
-    name.starts_with("._") || name == ".DS_Store"
-}
-
-/// Names ignored at any depth: the built-in set plus `.tlignore` lines read from the mount root
-/// (comments with `#`, blank lines skipped; a trailing `/` is stripped — v1 matches
-/// directory/file *names*). Ignored paths are workspace-local: never uploaded, never restored.
-pub fn ignored_names(mount_root: &Path) -> Vec<String> {
-    let mut names: Vec<String> = IGNORED_DIR_NAMES.iter().map(|s| s.to_string()).collect();
-    if let Ok(raw) = std::fs::read_to_string(mount_root.join(".tlignore")) {
-        for line in raw.lines() {
-            let line = line.trim().trim_end_matches('/');
-            if !line.is_empty() && !line.starts_with('#') {
-                names.push(line.to_string());
-            }
-        }
-    }
-    names
-}
 
 /// Write one fetched entry (file, executable, or symlink) under `root`.
 pub fn write_entry(root: &Path, path: &str, mode: u32, bytes: &[u8]) -> Result<()> {

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -1094,20 +1094,10 @@ struct ScanEntry {
     fingerprint: Fingerprint,
 }
 
-/// A strict ignore matcher: same semantics as mount snapshot enumeration (built-ins + root
-/// `.tlignore` names + nested `.gitignore`s via [`SnapshotIgnore`]), except that an
-/// unreadable `.tlignore` aborts instead of silently ignoring nothing — a vanished ignore
-/// rule would widen the tracked set and start uploading (or deleting!) paths the user
-/// declared workspace-local. `SnapshotIgnore` already aborts on unreadable `.gitignore`s.
+/// A strict ignore matcher with the same nested `.gitignore` semantics as mount snapshot
+/// enumeration. `SnapshotIgnore` aborts on unreadable `.gitignore`s so a vanished rule cannot
+/// silently widen the tracked set and start uploading or deleting paths.
 fn strict_ignore(root: &Path) -> Result<SnapshotIgnore> {
-    let tlignore = root.join(".tlignore");
-    if std::fs::symlink_metadata(&tlignore).is_ok() && std::fs::read_to_string(&tlignore).is_err() {
-        return Err(CliError::usage(format!(
-            "cannot read {}; aborting the scan (unreadable ignore rules would silently widen \
-             what gets uploaded)",
-            tlignore.display()
-        )));
-    }
     Ok(SnapshotIgnore::new(root))
 }
 
@@ -2579,26 +2569,6 @@ mod tests {
         h.update(b"../target/file");
         assert_eq!(hashed.oid, h.finalize_hex());
         assert!(hashed.stable_fingerprint.is_some());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn unreadable_tlignore_aborts() {
-        use std::os::unix::fs::PermissionsExt as _;
-        if unsafe { libc::geteuid() } == 0 {
-            return;
-        }
-        let dir = tempfile::tempdir().unwrap();
-        let tlignore = dir.path().join(".tlignore");
-        std::fs::write(&tlignore, "scratch\n").unwrap();
-        std::fs::set_permissions(&tlignore, std::fs::Permissions::from_mode(0o000)).unwrap();
-        // (`unwrap_err` needs Debug on the Ok side; SnapshotIgnore has none.)
-        let err = match strict_ignore(dir.path()) {
-            Ok(_) => panic!("unreadable .tlignore must abort"),
-            Err(e) => e.to_string(),
-        };
-        std::fs::set_permissions(&tlignore, std::fs::Permissions::from_mode(0o644)).unwrap();
-        assert!(err.contains(".tlignore"), "{err}");
     }
 
     // -- journal recovery decision table ----------------------------------------------------

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.73"
+version = "0.5.74"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.73"
+version = "0.5.74"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.73",
+  "version": "0.5.74",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Removes the unconditional snapshot exclusions for `.git`, `node_modules`, `target`, `dist`, `.cache`, `__pycache__`, macOS metadata files, and `.tlignore` entries.

Snapshot inclusion is now controlled exclusively by nested `.gitignore` rules for both mounted and plain-directory workspaces. `.tlignore` becomes an ordinary tracked file.

Regression coverage proves all former implicit exclusions are included by default and remain excludable through `.gitignore`.

Validation:
- `just test-rust`
- full private-crate CLI test build against artifact_storage #108
- 281 full-feature tests passed; 8 local-server tests ignored