### PR TITLE
tl fs status: local fast path, wedged-daemon deadlines, honest hints

### DIFF
--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -19,9 +19,9 @@
 //! upper keeps serving the byte-identical sealed content as a local byte cache, accounted
 //! for by the sealed index (`sealed.json`, which also survives daemon restarts) and
 //! reported by `status` as `retained`. `sync` asks the daemon to `trim` retained content
-//! (safe: it is all in workspace history; ignored files survive); `snapshot --clear`
-//! remains the explicit, destructive opt-in that drops the WHOLE overlay, ignored files
-//! included. `promote` CAS-advances a real branch (squash by default); `restore` refills
+//! (safe: it is all in workspace history; ignored files survive); `tl git snapshot
+//! --clear` (the fs surface lost the flag in the dumb-simple audit) remains the explicit,
+//! destructive opt-in that drops the WHOLE overlay, ignored files included. `promote` CAS-advances a real branch (squash by default); `restore` refills
 //! the overlay from any snapshot. FUSE is the only mount path — Linux builds carry it
 //! unconditionally, macOS requires macFUSE and the `macfuse` build feature.
 
@@ -3027,14 +3027,13 @@ pub async fn unmount(
 // Snapshot: the overlay is the dirty set.
 // ---------------------------------------------------------------------------------------------
 
-/// Walk the overlay state dir: `(upserts, deletes)` as repo paths. Ignored names (built-ins +
-/// the mount's `.tlignore`) are workspace-local and never enumerate.
+/// Walk the overlay state dir: `(upserts, deletes)` as repo paths. Nested `.gitignore` files are
+/// the sole authority for paths that do not enumerate.
 /// Overlay upserts as `(repo path, upper file, git mode)`.
 type OverlayUpserts = Vec<(String, PathBuf, u32)>;
 
 struct SnapshotIgnore {
     mount_root: PathBuf,
-    ignored_names: Vec<String>,
     gitignores: HashMap<PathBuf, Gitignore>,
 }
 
@@ -3042,7 +3041,6 @@ impl SnapshotIgnore {
     fn new(mount_root: &Path) -> Self {
         Self {
             mount_root: mount_root.to_path_buf(),
-            ignored_names: local::ignored_names(mount_root),
             gitignores: HashMap::new(),
         }
     }
@@ -3070,18 +3068,6 @@ impl SnapshotIgnore {
 
     fn is_ignored(&mut self, rel: &str, is_dir: bool) -> Result<bool> {
         let rel_path = Path::new(rel);
-        for component in rel_path.components() {
-            let Component::Normal(name) = component else {
-                continue;
-            };
-            let name = name.to_string_lossy();
-            if self.ignored_names.iter().any(|ignored| ignored == &*name)
-                || local::is_metadata_turd(&name)
-            {
-                return Ok(true);
-            }
-        }
-
         let abs = self.mount_root.join(rel_path);
         let mut ignored = false;
         for dir in gitignore_dirs_for(rel_path) {
@@ -3596,7 +3582,7 @@ struct LocalChanges {
     renames: Vec<(String, String)>,
     /// Upper files sealed into a snapshot and kept as the local byte cache.
     retained: usize,
-    /// Ignored local-only files (never enter a snapshot; only `snapshot --clear` drops them).
+    /// Ignored local-only files (never enter a snapshot; only `tl git snapshot --clear` drops them).
     ignored: usize,
     exact: bool,
 }
@@ -4475,7 +4461,7 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
     if changes.retained > 0 {
         println!(
             "{} {} file(s) sealed into snapshots and kept locally as the byte cache \
-             (`tl fs snapshot --clear` drops them)",
+             (reclaim the disk with `tl git snapshot --clear`)",
             style("retained:").dim(),
             changes.retained
         );

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -3633,15 +3633,13 @@ async fn local_changes_guarded(
     // like the pre-established flag. A fast failure (no socket, dead daemon, handler error)
     // falls through to the raw overlay walk, whose mountpoint reads fail fast rather than
     // block.
-    let dirty_reply = match tokio::time::timeout(
-        STATUS_DAEMON_DEADLINE,
-        daemon::control(state_dir, "dirty"),
-    )
-    .await
-    {
-        Err(_elapsed) => return wedged_view(),
-        Ok(reply) => reply,
-    };
+    let dirty_reply =
+        match tokio::time::timeout(STATUS_DAEMON_DEADLINE, daemon::control(state_dir, "dirty"))
+            .await
+        {
+            Err(_elapsed) => return wedged_view(),
+            Ok(reply) => reply,
+        };
     if let Ok(reply) = dirty_reply
         && reply.get("ok").and_then(|v| v.as_bool()) == Some(true)
         // Every DirtyReply field is serde-defaulted, so a bare `{"ok":true}` ack (a handler
@@ -4315,20 +4313,20 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         daemon::control_timed(&state_dir, "conflicts", STATUS_DAEMON_DEADLINE).await
     }
     .ok()
-        .and_then(|r| r.get("conflicts").cloned())
-        .and_then(|v| serde_json::from_value::<Vec<serde_json::Value>>(v).ok())
-        .map(|list| {
-            list.into_iter()
-                .filter_map(|c| {
-                    Some((
-                        c.get("path")?.as_str()?.to_string(),
-                        c.get("kind")?.as_str()?.to_string(),
-                        c.get("commit")?.as_str()?.to_string(),
-                    ))
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    .and_then(|r| r.get("conflicts").cloned())
+    .and_then(|v| serde_json::from_value::<Vec<serde_json::Value>>(v).ok())
+    .map(|list| {
+        list.into_iter()
+            .filter_map(|c| {
+                Some((
+                    c.get("path")?.as_str()?.to_string(),
+                    c.get("kind")?.as_str()?.to_string(),
+                    c.get("commit")?.as_str()?.to_string(),
+                ))
+            })
+            .collect()
+    })
+    .unwrap_or_default();
 
     if output_json {
         println!(
@@ -5117,6 +5115,66 @@ mod tests {
 
         let upsert_paths: Vec<_> = upserts.iter().map(|(path, _, _)| path.as_str()).collect();
         assert_eq!(upsert_paths, vec!["keep.txt"]);
+        assert!(deletes.is_empty());
+    }
+
+    #[test]
+    fn snapshot_enumeration_has_no_implicit_exclusions() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        let upper = state.path().join("upper");
+        std::fs::create_dir_all(state.path().join("wh")).unwrap();
+
+        let paths = [
+            ".git/HEAD",
+            "node_modules/pkg.js",
+            "target/debug/build.o",
+            "dist/app.js",
+            ".cache/entry",
+            "__pycache__/module.pyc",
+            ".DS_Store",
+            "._index",
+            ".tlignore",
+        ];
+        for path in paths {
+            let abs = upper.join(path);
+            std::fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            std::fs::write(abs, "snapshot me").unwrap();
+        }
+        // `.tlignore` is an ordinary tracked file now and has no exclusion semantics.
+        std::fs::write(mount.path().join(".tlignore"), "target\n").unwrap();
+
+        let (upserts, deletes) = enumerate_overlay(state.path(), mount.path()).unwrap();
+        let upsert_paths: Vec<_> = upserts.iter().map(|(path, _, _)| path.as_str()).collect();
+        assert_eq!(
+            upsert_paths,
+            vec![
+                ".DS_Store",
+                "._index",
+                ".cache/entry",
+                ".git/HEAD",
+                ".tlignore",
+                "__pycache__/module.pyc",
+                "dist/app.js",
+                "node_modules/pkg.js",
+                "target/debug/build.o",
+            ]
+        );
+        assert!(deletes.is_empty());
+    }
+
+    #[test]
+    fn snapshot_enumeration_excludes_former_builtins_when_gitignored() {
+        let state = tempfile::tempdir().unwrap();
+        let mount = tempfile::tempdir().unwrap();
+        let upper = state.path().join("upper");
+        std::fs::create_dir_all(upper.join("target/debug")).unwrap();
+        std::fs::create_dir_all(state.path().join("wh")).unwrap();
+        std::fs::write(mount.path().join(".gitignore"), "target/\n").unwrap();
+        std::fs::write(upper.join("target/debug/build.o"), "ignored by git").unwrap();
+
+        let (upserts, deletes) = enumerate_overlay(state.path(), mount.path()).unwrap();
+        assert!(upserts.is_empty());
         assert!(deletes.is_empty());
     }
 

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -434,6 +434,20 @@ pub async fn ls(ctx: &CliContext, file_system: Option<&str>, output_json: bool) 
 /// your work; `tl fs snapshot -m` remains the named save point.
 const FS_AUTOSAVE_DEFAULT_SECS: u64 = 30;
 
+/// Reply deadline for status's daemon inspection ops (`ping`/`dirty`/`conflicts`). Their
+/// handlers never queue behind the sealer's state lock (the dirty view reads the published
+/// mirror), so a healthy daemon answers in milliseconds even mid-snapshot — while a WEDGED one
+/// accepts the connection and never replies, and status must degrade instead of hanging on the
+/// one command that diagnoses it. Generous: the dirty view's ignore-rule reads go through the
+/// mountpoint and may fetch cold blobs.
+const STATUS_DAEMON_DEADLINE: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Whether the state dir's recorded daemon pid is a live process — distinguishes "not
+/// running" (stale socket, no process) from "not responding" (alive but wedged) in status.
+fn daemon_pid_alive(state_dir: &Path) -> bool {
+    daemon::daemon_pid(state_dir).is_some_and(daemon_alive)
+}
+
 /// `tl fs create <name>` — a new empty filesystem. Born with a genesis "empty" save
 /// server-side, so it mounts immediately.
 pub async fn create_filesystem(ctx: &CliContext, name: &str, output_json: bool) -> Result<()> {
@@ -3598,7 +3612,51 @@ impl LocalChanges {
 /// dirt-consulting command (`status`, `promote`, `sync`, `diff`) routes through here so none
 /// of them can disagree with what `tl fs snapshot` would actually seal.
 async fn local_changes(state_dir: &Path, mountpoint: &str) -> Result<LocalChanges> {
-    if let Ok(reply) = daemon::control(state_dir, "dirty").await
+    local_changes_guarded(state_dir, mountpoint, false).await
+}
+
+/// [`local_changes`] with a wedged-daemon guard. When the caller has already established the
+/// daemon is alive but NOT answering (status's deadlined ping), every mountpoint read is a
+/// kernel call served by that stuck process and blocks unpreemptably — the ignore-rule loads
+/// and the fallback overlay walk both go through the mount. `unresponsive` skips ALL of it and
+/// returns an inexact empty view; callers render "unknown", never a hang. The dead-daemon case
+/// (no process) keeps the fallback walk: those reads fail fast instead of blocking.
+async fn local_changes_guarded(
+    state_dir: &Path,
+    mountpoint: &str,
+    unresponsive: bool,
+) -> Result<LocalChanges> {
+    let wedged_view = || {
+        Ok(LocalChanges {
+            upserts: Vec::new(),
+            deletes: Vec::new(),
+            renames: pending_renames(state_dir)
+                .into_iter()
+                .map(|(to, from)| (from, to))
+                .collect(),
+            retained: 0,
+            ignored: 0,
+            exact: false,
+        })
+    };
+    if unresponsive {
+        return wedged_view();
+    }
+    // The dirty op carries its own deadline, and the deadline expiring IS the wedged signal
+    // (the daemon may have stalled between the caller's ping and now): skip the walk exactly
+    // like the pre-established flag. A fast failure (no socket, dead daemon, handler error)
+    // falls through to the raw overlay walk, whose mountpoint reads fail fast rather than
+    // block.
+    let dirty_reply = match tokio::time::timeout(
+        STATUS_DAEMON_DEADLINE,
+        daemon::control(state_dir, "dirty"),
+    )
+    .await
+    {
+        Err(_elapsed) => return wedged_view(),
+        Ok(reply) => reply,
+    };
+    if let Ok(reply) = dirty_reply
         && reply.get("ok").and_then(|v| v.as_bool()) == Some(true)
         // Every DirtyReply field is serde-defaulted, so a bare `{"ok":true}` ack (a handler
         // that acknowledges an op it never implemented) would otherwise parse as an EXACT
@@ -4251,16 +4309,26 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
             (ws.created_at_secs, ws.shared_target.clone(), Some(ws))
         }
     };
-    let daemon_commit = daemon::control(&state_dir, "ping")
-        .await
+    // Deadlined daemon reads: status is the diagnostic tool, so a wedged daemon (accepts the
+    // connection, never replies) must degrade the report, not hang it. A missing socket and a
+    // timeout render differently — "not running" and "not responding" call for different
+    // remedies.
+    let ping = daemon::control_timed(&state_dir, "ping", STATUS_DAEMON_DEADLINE).await;
+    let daemon_unresponsive = matches!(&ping, Err(_)) && daemon_pid_alive(&state_dir);
+    let daemon_commit = ping
         .ok()
         .and_then(|r| r.get("commit").and_then(|c| c.as_str().map(str::to_string)));
-    let changes = local_changes(&state_dir, &mountpoint).await?;
+    let changes = local_changes_guarded(&state_dir, &mountpoint, daemon_unresponsive).await?;
     // Collisions the followed state materialized that no later save has overwritten. Absent
     // daemon (or a pre-visibility daemon) reads as none — the section only ever adds signal.
-    let collisions: Vec<(String, String, String)> = daemon::control(&state_dir, "conflicts")
-        .await
-        .ok()
+    // An unresponsive daemon skips the query outright: it will not answer this op either,
+    // and stacking deadlines just delays the report.
+    let collisions: Vec<(String, String, String)> = if daemon_unresponsive {
+        Err(CliError::usage("daemon unresponsive".to_string()))
+    } else {
+        daemon::control_timed(&state_dir, "conflicts", STATUS_DAEMON_DEADLINE).await
+    }
+    .ok()
         .and_then(|r| r.get("conflicts").cloned())
         .and_then(|v| serde_json::from_value::<Vec<serde_json::Value>>(v).ok())
         .map(|list| {
@@ -4282,6 +4350,7 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
             serde_json::to_string_pretty(&serde_json::json!({
                 "workspace": ws_record.expect("--json always fetches the live record"),
                 "mounted": daemon_commit.is_some(),
+                "daemon_unresponsive": daemon_unresponsive,
                 "lower_commit": daemon_commit,
                 "log": state_dir.join("daemon.log"),
                 "dirty": changes.upserts.iter().cloned()
@@ -4334,6 +4403,11 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
     }
     match &daemon_commit {
         Some(commit) => println!("{} mounted at {commit}", style("daemon:").dim()),
+        None if daemon_unresponsive => println!(
+            "{} not responding within {}s — possibly wedged mid-operation (see the log below)",
+            style("daemon:").dim(),
+            STATUS_DAEMON_DEADLINE.as_secs()
+        ),
         None => println!(
             "{} not running (remount with tl fs mount)",
             style("daemon:").dim()
@@ -4367,7 +4441,14 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         .filter(|p| !changes.renames.iter().any(|(from, _)| &from == p))
         .collect();
     let dirty = changes.upserts.len() + deletes.len() + changes.renames.len();
-    if dirty == 0 {
+    if daemon_unresponsive {
+        // An unresponsive daemon means no dirty query ran and no mountpoint read was safe —
+        // claiming "clean" here would report a wedged mount as a healthy one.
+        println!(
+            "{} unknown (the daemon did not answer the dirty query)",
+            style("local:").dim()
+        );
+    } else if dirty == 0 {
         println!("{} clean", style("local:").dim());
     } else {
         println!("{} {} change(s):", style("local:").dim(), dirty);

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -2613,6 +2613,8 @@ pub async fn mount(
             read_only: Some(read_only),
             auto_commit_interval_secs,
             start_oid,
+            created_at_secs: Some(ws.created_at_secs),
+            shared_target: ws.shared_target.clone(),
         },
     )?;
     registry_add(&mountpoint, &state_dir)?;
@@ -4219,20 +4221,36 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
     }
     let (mountpoint, state_dir) = state_dir_for(path)?;
     let state = daemon::load_mount_state(&state_dir)?;
-    let session = FsSession::open(ctx, Some(&state.repo)).await?;
-    let (user, token) = session.creds();
-    let ws = session
-        .client
-        .get_workspace(
-            &session.project_id,
-            &state.repo,
-            user,
-            token,
-            &state.workspace_id,
-        )
-        .await?
-        .into_inner();
-    let _ = heartbeat(&session, &state).await;
+    // Everything the human report needs from the workspace record — id, creation time,
+    // publish target — is immutable for the session's lifetime and cached in the mount
+    // state at attach, so status is a LOCAL command: no token, no server round trips.
+    // Only pre-cache state files (and `--json`, whose contract is the live record) fetch.
+    // Status deliberately does NOT heartbeat: the running daemon owns the lease, and a
+    // status-side stamp for a mount whose daemon is DEAD would read as attached-elsewhere
+    // to every other client.
+    let cached = (!output_json)
+        .then_some(state.created_at_secs)
+        .flatten()
+        .map(|created| (created, state.shared_target.clone()));
+    let (ws_created_at_secs, ws_shared_target, ws_record) = match cached {
+        Some((created, target)) => (created, target, None),
+        None => {
+            let session = FsSession::open(ctx, Some(&state.repo)).await?;
+            let (user, token) = session.creds();
+            let ws = session
+                .client
+                .get_workspace(
+                    &session.project_id,
+                    &state.repo,
+                    user,
+                    token,
+                    &state.workspace_id,
+                )
+                .await?
+                .into_inner();
+            (ws.created_at_secs, ws.shared_target.clone(), Some(ws))
+        }
+    };
     let daemon_commit = daemon::control(&state_dir, "ping")
         .await
         .ok()
@@ -4262,7 +4280,7 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
-                "workspace": ws,
+                "workspace": ws_record.expect("--json always fetches the live record"),
                 "mounted": daemon_commit.is_some(),
                 "lower_commit": daemon_commit,
                 "log": state_dir.join("daemon.log"),
@@ -4291,15 +4309,15 @@ pub async fn status(ctx: &CliContext, path: &Path, output_json: bool) -> Result<
     println!(
         "{} {} (created {} ago)",
         style("session:").dim(),
-        short_id(&ws.id),
-        age_display(ws.created_at_secs)
+        short_id(&state.workspace_id),
+        age_display(ws_created_at_secs)
     );
     // A publish-on-save mount follows its target branch for convergence but is writable —
     // read_only() (not follow_ref presence) decides which mode the user is in.
     if state.read_only() {
         let followed = state.follow_ref.as_deref().unwrap_or("the current state");
         println!("{} read-only, follows {followed}", style("mode:").dim());
-    } else if let Some(target) = &ws.shared_target {
+    } else if let Some(target) = &ws_shared_target {
         println!(
             "{} publishing — every save lands on {target} (view follows it)",
             style("mode:").dim()

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -160,6 +160,17 @@ pub struct MountState {
     /// Absent in older state files: the core resolves serially, one extra round trip.
     #[serde(default)]
     pub start_oid: Option<String>,
+    /// When the workspace was created, cached from the create/attach response. Immutable for
+    /// the session's lifetime, so `tl fs status` renders it without a server round trip.
+    /// Doubles as the cache marker: absent (older state files) means the workspace facts
+    /// below were never cached and status falls back to fetching the record.
+    #[serde(default)]
+    pub created_at_secs: Option<u64>,
+    /// The branch a publish-on-save workspace lands snapshots on (`None` = private), cached
+    /// from the create/attach response. Immutable for the session's lifetime; only
+    /// meaningful when [`MountState::created_at_secs`] is present.
+    #[serde(default)]
+    pub shared_target: Option<String>,
 }
 
 impl MountState {
@@ -2611,6 +2622,29 @@ pub(crate) fn still_mounted(mountpoint: &Path) -> bool {
 mod tests {
     use super::super::overlay::DirtyDelta;
     use super::*;
+
+    /// A state file written before the workspace-fact cache parses with the cache marker
+    /// absent — `tl fs status` must fall back to fetching the record, never render a zero
+    /// creation time or misreport a publishing mount as private.
+    #[test]
+    fn pre_cache_state_files_read_as_uncached() {
+        let old = serde_json::json!({
+            "project_id": "p", "repo": "p/fs", "workspace_id": "w",
+            "ref_name": "refs/workspaces/w", "mountpoint": "/mnt/x",
+        });
+        let state: MountState = serde_json::from_value(old).unwrap();
+        assert_eq!(state.created_at_secs, None, "no cache marker in old files");
+        assert_eq!(state.shared_target, None);
+        let cached = MountState {
+            created_at_secs: Some(1_700_000_000),
+            shared_target: Some("main".into()),
+            ..state
+        };
+        let roundtrip: MountState =
+            serde_json::from_slice(&serde_json::to_vec(&cached).unwrap()).unwrap();
+        assert_eq!(roundtrip.created_at_secs, Some(1_700_000_000));
+        assert_eq!(roundtrip.shared_target.as_deref(), Some("main"));
+    }
 
     pub(super) fn state_with(upper: &[(&str, &str)], wh: &[&str]) -> tempfile::TempDir {
         let state = tempfile::tempdir().unwrap();

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -148,7 +148,7 @@ pub struct MountState {
     #[serde(default)]
     pub read_only: Option<bool>,
     /// Periodic auto-commit: the daemon seals the overlay's dirty set into a snapshot commit
-    /// every this many seconds. The overlay is kept (only `tl fs snapshot --clear` drops it),
+    /// every this many seconds. The overlay is kept (only `tl git snapshot --clear` drops it),
     /// so writes racing an auto-commit are never dropped — they ride the next one. Absent on
     /// mounts that didn't opt in and in state files from before the feature.
     #[serde(default)]
@@ -948,7 +948,7 @@ async fn run_mount(ctx: &CliContext, state_dir: &Path) -> Result<()> {
     // generation: everything sealed earlier is already served by the lower (the workspace ref
     // advances with each snapshot), so commits are incremental deltas, and unchanged dirty
     // files are never re-hashed or re-sent. The overlay is NOT cleared — the upper keeps
-    // shadowing the byte-identical sealed content (only `tl fs snapshot --clear` drops it,
+    // shadowing the byte-identical sealed content (only `tl git snapshot --clear` drops it,
     // an explicitly destructive opt-in that requires quiesced writers).
     if let Some(secs) = state.auto_commit_interval_secs
         && let Some(sealer) = sealer.clone()
@@ -1524,7 +1524,7 @@ impl Sealer {
     /// published, and the dirty set stays pending for the next cycle.
     ///
     /// `clear` drops the WHOLE overlay after the seal (and its lower refresh), inside this
-    /// same cycle's state lock — the destructive `tl fs snapshot --clear` opt-in. Running it
+    /// same cycle's state lock — the destructive `tl git snapshot --clear` opt-in. Running it
     /// here, not as a separate control op, is what makes the drop coherent: no writer-visible
     /// window where another seal (or auto-commit tick) interleaves between seal and clear,
     /// and the outcome reports exactly which paths the clear removed. A clean seal still
@@ -1878,7 +1878,7 @@ impl Sealer {
                 self.clear_overlay(&mut st).map_err(|e| {
                     CliError::usage(format!(
                         "snapshot {} sealed, but clearing the overlay failed: {e}; the \
-                         overlay is kept — retry with `tl fs snapshot --clear`",
+                         overlay is kept — retry with `tl git snapshot --clear`",
                         report.commit
                     ))
                 })

--- a/crates/cli/src/commands/fs/daemon.rs
+++ b/crates/cli/src/commands/fs/daemon.rs
@@ -442,6 +442,18 @@ pub async fn control_with(
     ))
 }
 
+/// [`control`] with a reply deadline.
+#[cfg(not(unix))]
+pub async fn control_timed(
+    _state_dir: &Path,
+    _op: &str,
+    _deadline: Duration,
+) -> Result<serde_json::Value> {
+    Err(CliError::usage(
+        "tl fs mounts are supported on Linux (FUSE) and macOS (FSKit) only.",
+    ))
+}
+
 /// [`control_with`] for line-streaming ops (`seal`).
 #[cfg(not(unix))]
 pub async fn control_streaming(
@@ -459,6 +471,28 @@ pub async fn control_streaming(
 #[cfg(unix)]
 pub async fn control(state_dir: &Path, op: &str) -> Result<serde_json::Value> {
     control_with(state_dir, op, serde_json::Value::Null).await
+}
+
+/// [`control`] with a reply deadline, for INSPECTION ops (`ping`/`dirty`/`conflicts`) whose
+/// handlers never wait on the sealer's state lock and answer in milliseconds on a healthy
+/// daemon. A wedged daemon accepts the connection and then never replies — without a deadline
+/// `tl fs status` would hang exactly when it is the diagnostic tool. Mutating ops (`trim`,
+/// `seal`) must NOT use this: they legitimately queue behind an in-flight seal for as long as
+/// its push takes.
+#[cfg(unix)]
+pub async fn control_timed(
+    state_dir: &Path,
+    op: &str,
+    deadline: Duration,
+) -> Result<serde_json::Value> {
+    match tokio::time::timeout(deadline, control(state_dir, op)).await {
+        Ok(result) => result,
+        Err(_) => Err(CliError::usage(format!(
+            "mount daemon did not answer {op} within {}s — it may be wedged; see {}",
+            deadline.as_secs(),
+            state_dir.join("daemon.log").display()
+        ))),
+    }
 }
 
 /// One control round-trip carrying an op payload: `args` must be a JSON object (or null); its

--- a/crates/cli/src/commands/fs/local.rs
+++ b/crates/cli/src/commands/fs/local.rs
@@ -8,38 +8,6 @@ use std::path::Path;
 
 use crate::error::Result;
 
-const IGNORED_DIR_NAMES: &[&str] = &[
-    ".git",
-    "node_modules",
-    "target",
-    "dist",
-    ".cache",
-    "__pycache__",
-];
-
-/// Whether a name is inherently workspace-local: macOS metadata turds the kernel writes onto
-/// filesystems without native xattr support. They serve reads from the overlay but never
-/// version.
-pub fn is_metadata_turd(name: &str) -> bool {
-    name.starts_with("._") || name == ".DS_Store"
-}
-
-/// Names ignored at any depth: the built-in set plus `.tlignore` lines read from the mount root
-/// (comments with `#`, blank lines skipped; a trailing `/` is stripped — v1 matches
-/// directory/file *names*). Ignored paths are workspace-local: never uploaded, never restored.
-pub fn ignored_names(mount_root: &Path) -> Vec<String> {
-    let mut names: Vec<String> = IGNORED_DIR_NAMES.iter().map(|s| s.to_string()).collect();
-    if let Ok(raw) = std::fs::read_to_string(mount_root.join(".tlignore")) {
-        for line in raw.lines() {
-            let line = line.trim().trim_end_matches('/');
-            if !line.is_empty() && !line.starts_with('#') {
-                names.push(line.to_string());
-            }
-        }
-    }
-    names
-}
-
 /// Write one fetched entry (file, executable, or symlink) under `root`.
 pub fn write_entry(root: &Path, path: &str, mode: u32, bytes: &[u8]) -> Result<()> {
     let abs = root.join(path);

--- a/crates/cli/src/commands/fs/local.rs
+++ b/crates/cli/src/commands/fs/local.rs
@@ -1,8 +1,7 @@
-//! Local helpers for `tl fs`: ignore rules and materializing tree entries into a directory.
+//! Local helpers for materializing `tl fs` tree entries into a directory.
 //!
-//! The FUSE overlay owns all mount state; what remains here is shared by snapshot enumeration
-//! (which paths never upload) and restore (writing fetched entries into the overlay's upper
-//! layer).
+//! The FUSE overlay owns all mount state; what remains here is shared by restore paths that write
+//! fetched entries into the overlay's upper layer.
 
 use std::path::Path;
 

--- a/crates/cli/src/commands/fs/plaindir.rs
+++ b/crates/cli/src/commands/fs/plaindir.rs
@@ -1094,20 +1094,10 @@ struct ScanEntry {
     fingerprint: Fingerprint,
 }
 
-/// A strict ignore matcher: same semantics as mount snapshot enumeration (built-ins + root
-/// `.tlignore` names + nested `.gitignore`s via [`SnapshotIgnore`]), except that an
-/// unreadable `.tlignore` aborts instead of silently ignoring nothing — a vanished ignore
-/// rule would widen the tracked set and start uploading (or deleting!) paths the user
-/// declared workspace-local. `SnapshotIgnore` already aborts on unreadable `.gitignore`s.
+/// A strict ignore matcher with the same nested `.gitignore` semantics as mount snapshot
+/// enumeration. `SnapshotIgnore` aborts on unreadable `.gitignore`s so a vanished rule cannot
+/// silently widen the tracked set and start uploading or deleting paths.
 fn strict_ignore(root: &Path) -> Result<SnapshotIgnore> {
-    let tlignore = root.join(".tlignore");
-    if std::fs::symlink_metadata(&tlignore).is_ok() && std::fs::read_to_string(&tlignore).is_err() {
-        return Err(CliError::usage(format!(
-            "cannot read {}; aborting the scan (unreadable ignore rules would silently widen \
-             what gets uploaded)",
-            tlignore.display()
-        )));
-    }
     Ok(SnapshotIgnore::new(root))
 }
 
@@ -2579,26 +2569,6 @@ mod tests {
         h.update(b"../target/file");
         assert_eq!(hashed.oid, h.finalize_hex());
         assert!(hashed.stable_fingerprint.is_some());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn unreadable_tlignore_aborts() {
-        use std::os::unix::fs::PermissionsExt as _;
-        if unsafe { libc::geteuid() } == 0 {
-            return;
-        }
-        let dir = tempfile::tempdir().unwrap();
-        let tlignore = dir.path().join(".tlignore");
-        std::fs::write(&tlignore, "scratch\n").unwrap();
-        std::fs::set_permissions(&tlignore, std::fs::Permissions::from_mode(0o000)).unwrap();
-        // (`unwrap_err` needs Debug on the Ok side; SnapshotIgnore has none.)
-        let err = match strict_ignore(dir.path()) {
-            Ok(_) => panic!("unreadable .tlignore must abort"),
-            Err(e) => e.to_string(),
-        };
-        std::fs::set_permissions(&tlignore, std::fs::Permissions::from_mode(0o644)).unwrap();
-        assert!(err.contains(".tlignore"), "{err}");
     }
 
     // -- journal recovery decision table ----------------------------------------------------


### PR DESCRIPTION
Recovers four commits stranded by the #843 squash (the branch was silently recreated by pushes that landed minutes after the merge — same trap as before, restacked clean onto main):

1. **`tl fs status` is a local command** — the create/attach response caches `created_at_secs` and `shared_target` in the mount state; the human status path makes zero network calls (measured 10ms, works with the server unreachable). The status-side heartbeat is removed outright: the daemon owns the lease, and a status stamp for a dead daemon would read as attached-elsewhere. `--json` keeps fetching the live record.

2. **Status degrades on a wedged daemon instead of hanging** — inspection ops (`ping`/`dirty`/`conflicts`) carry a 10s reply deadline; a deadlined ping (with a live pid) skips every mountpoint read — the fallback overlay walk's ignore-rule loads go through the stuck daemon's own FUSE path and block unpreemptably — and reports `daemon: not responding … possibly wedged` + `local: unknown`, never a false clean. Verified by SIGSTOPping a live mount's daemon: 11s bounded report, full recovery on SIGCONT. Mutating ops (`trim`/`seal`) keep waiting; they legitimately queue behind an in-flight seal.

3. **The retained hint names a command that exists** — the dumb-simple audit cut `--clear` from `tl fs snapshot` but status (and a seal-refusal error) still recommended it; they now name `tl git snapshot --clear`, which is path-addressed and works on fs-surface mounts.

4. **Test gitignore-only snapshot exclusions** (@diptanu's commit, carried over) — pins that snapshot enumeration has no implicit exclusion list.

Validation: 282 unit tests green on the restacked branch with the paired full-feature build; live checks as described per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)