### PR TITLE
CAS image builds: rename --streaming to --cas, support import + registered-template FROM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3544,7 +3544,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.74"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "base64",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.74"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "base64",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.74"
+version = "0.5.76"
 dependencies = [
  "napi",
  "napi-build",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.74"
+version = "0.5.76"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.74"
+version = "0.5.76"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -22,7 +22,7 @@ pub async fn run(
     memory_mb: Option<i64>,
     is_public: bool,
     docker_compat: bool,
-    streaming: bool,
+    cas: bool,
     output_json: bool,
 ) -> Result<()> {
     let options = SandboxImageBuildOptions {
@@ -39,7 +39,7 @@ pub async fn run(
             cpus,
             memory_mb,
             is_public,
-            streaming,
+            cas,
             user_agent: Some(format!(
                 "Tensorlake CLI (rust/{})",
                 env!("CARGO_PKG_VERSION")

--- a/crates/cli/src/commands/sbx/image/import.rs
+++ b/crates/cli/src/commands/sbx/image/import.rs
@@ -23,6 +23,7 @@ pub async fn run(
     memory_mb: Option<i64>,
     is_public: bool,
     docker_compat: bool,
+    cas: bool,
     output_json: bool,
 ) -> Result<()> {
     let options = SandboxImageImportOptions {
@@ -39,7 +40,7 @@ pub async fn run(
             cpus,
             memory_mb,
             is_public,
-            cas: false,
+            cas,
             user_agent: Some(format!(
                 "Tensorlake CLI (rust/{})",
                 env!("CARGO_PKG_VERSION")

--- a/crates/cli/src/commands/sbx/image/import.rs
+++ b/crates/cli/src/commands/sbx/image/import.rs
@@ -39,7 +39,7 @@ pub async fn run(
             cpus,
             memory_mb,
             is_public,
-            streaming: false,
+            cas: false,
             user_agent: Some(format!(
                 "Tensorlake CLI (rust/{})",
                 env!("CARGO_PKG_VERSION")

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1438,8 +1438,7 @@ enum ImageCommands {
 
         /// Build a CAS (content-addressed streaming) image (non-default). CAS
         /// images cold-boot by faulting content on demand instead of
-        /// localizing a monolithic snapshot; the FROM image must be an
-        /// unregistered OCI image (base builds only).
+        /// localizing a monolithic snapshot.
         #[arg(long, hide = true)]
         cas: bool,
 
@@ -1483,6 +1482,12 @@ enum ImageCommands {
         /// Use Docker/BuildKit max compatibility mode (import is slower and uses more memory and disk space on builder sandbox)
         #[arg(long = "docker_compat")]
         docker_compat: bool,
+
+        /// Import as a CAS (content-addressed streaming) image (non-default).
+        /// CAS images cold-boot by faulting content on demand instead of
+        /// localizing a monolithic snapshot.
+        #[arg(long, hide = true)]
+        cas: bool,
 
         /// Print the registered sandbox image JSON response to stdout
         #[arg(long = "json")]
@@ -2244,6 +2249,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             memory,
                             public,
                             docker_compat,
+                            cas,
                             json,
                         } => {
                             commands::sbx::image::import::run(
@@ -2256,6 +2262,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 memory,
                                 public,
                                 docker_compat,
+                                cas,
                                 json,
                             )
                             .await
@@ -3755,6 +3762,26 @@ mod tests {
         ]) {
             Commands::Sbx(SbxCommands::Image(ImageCommands::Import { docker_compat, .. })) => {
                 assert!(docker_compat)
+            }
+            _ => panic!("expected sbx image import command"),
+        }
+    }
+
+    #[test]
+    fn image_create_parses_cas() {
+        match parse_command(["tl", "sbx", "image", "create", "./Dockerfile", "--cas"]) {
+            Commands::Sbx(SbxCommands::Image(ImageCommands::Create { cas, .. })) => {
+                assert!(cas)
+            }
+            _ => panic!("expected sbx image create command"),
+        }
+    }
+
+    #[test]
+    fn image_import_parses_cas() {
+        match parse_command(["tl", "sbx", "image", "import", "ubuntu:24.04", "--cas"]) {
+            Commands::Sbx(SbxCommands::Image(ImageCommands::Import { cas, .. })) => {
+                assert!(cas)
             }
             _ => panic!("expected sbx image import command"),
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1436,12 +1436,12 @@ enum ImageCommands {
         #[arg(long = "docker_compat")]
         docker_compat: bool,
 
-        /// Build a content-addressed streaming image (non-default). Streaming
+        /// Build a CAS (content-addressed streaming) image (non-default). CAS
         /// images cold-boot by faulting content on demand instead of
         /// localizing a monolithic snapshot; the FROM image must be an
         /// unregistered OCI image (base builds only).
         #[arg(long, hide = true)]
-        streaming: bool,
+        cas: bool,
 
         /// Print the registered sandbox image JSON response to stdout
         #[arg(long = "json", hide = true)]
@@ -2206,7 +2206,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             memory,
                             public,
                             docker_compat,
-                            streaming,
+                            cas,
                             json,
                         } => {
                             let disk_mb = if let Some(value) = disk_mb {
@@ -2230,7 +2230,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 memory,
                                 public,
                                 docker_compat,
-                                streaming,
+                                cas,
                                 json,
                             )
                             .await

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -209,12 +209,12 @@ pub struct CommonBuildOptions {
     pub cpus: Option<f64>,
     pub memory_mb: Option<i64>,
     pub is_public: bool,
-    /// Non-default opt-in: build a content-addressed streaming (cas-streaming)
-    /// image. Streaming builds are base-only — the Dockerfile FROM must be an
-    /// unregistered OCI image — and complete through the platform's trusted
-    /// CAS ingest, so registration takes longer while the image is verified
-    /// and admitted.
-    pub streaming: bool,
+    /// Non-default opt-in: build a CAS (content-addressed streaming,
+    /// `cas-streaming` on the wire) image. CAS builds are base-only — the
+    /// Dockerfile FROM must be an unregistered OCI image — and complete
+    /// through the platform's trusted CAS ingest, so registration takes
+    /// longer while the image is verified and admitted.
+    pub cas: bool,
     pub user_agent: Option<String>,
     pub docker_compat: bool,
 }
@@ -490,7 +490,7 @@ where
         &platform_client,
         &plan,
         options.is_public,
-        options.streaming,
+        options.cas,
     )
     .await?;
     emit(SandboxImageBuildEvent::Status(format!(
@@ -500,7 +500,7 @@ where
             _ => "Base",
         },
         if prepared.rootfs_format.as_deref() == Some("cas-streaming") {
-            " (content-addressed streaming)"
+            " (CAS)"
         } else {
             ""
         }
@@ -692,8 +692,7 @@ where
 
             if complete_request.rootfs_format.as_deref() == Some("cas-streaming") {
                 emit(SandboxImageBuildEvent::Status(
-                    "Submitting the image for verification and admission into the streaming \
-                     CAS..."
+                    "Submitting the image for verification and admission into the CAS..."
                         .to_string(),
                 ));
             } else {
@@ -716,7 +715,7 @@ where
                     || completed.get("status").and_then(Value::as_str) == Some("ingesting"))
             {
                 emit(SandboxImageBuildEvent::Status(
-                    "Verifying and admitting the image into the streaming CAS (this can take \
+                    "Verifying and admitting the image into the CAS (this can take \
                      a few minutes for large images)..."
                         .to_string(),
                 ));
@@ -980,7 +979,7 @@ async fn prepare_rootfs_build(
     client: &Client,
     plan: &DockerfileBuildPlan,
     is_public: bool,
-    streaming: bool,
+    cas: bool,
 ) -> Result<(PreparedSandboxTemplateBuild, Value)> {
     // Resolve every external image reference against the platform's template
     // registry. The final-stage FROM is treated separately so its resolution
@@ -1020,11 +1019,11 @@ async fn prepare_rootfs_build(
     } else {
         "base"
     };
-    // Streaming images are content-addressed and self-contained: fail before
+    // CAS images are content-addressed and self-contained: fail before
     // any sandbox spins up if the FROM resolved to a registered template.
-    if streaming && (parent_template_payload.is_some() || !additional_payload.is_empty()) {
+    if cas && (parent_template_payload.is_some() || !additional_payload.is_empty()) {
         return Err(SandboxImageBuildError::usage(
-            "--streaming builds support only base images: the Dockerfile FROM (and any \
+            "--cas builds support only base images: the Dockerfile FROM (and any \
              COPY --from references) must be unregistered OCI images, not registered \
              Tensorlake templates",
         ));
@@ -1040,7 +1039,7 @@ async fn prepare_rootfs_build(
         "parentTemplate": parent_template_json,
         "additionalLocalImages": additional_payload,
     });
-    if streaming {
+    if cas {
         prepare_body["rootfsFormat"] = Value::String("cas-streaming".to_string());
     }
     let request = client
@@ -1130,7 +1129,7 @@ async fn wait_for_build_completed(
                     .and_then(Value::as_str)
                     .unwrap_or("admission failed");
                 return Err(SandboxImageBuildError::other(format!(
-                    "streaming image admission failed: {error}"
+                    "CAS image admission failed: {error}"
                 )));
             }
             Some("ingesting") | Some("prepared") => {}
@@ -1142,7 +1141,7 @@ async fn wait_for_build_completed(
         }
         if std::time::Instant::now() >= deadline {
             return Err(SandboxImageBuildError::other(
-                "timed out waiting for the streaming image admission",
+                "timed out waiting for the CAS image admission",
             ));
         }
         tokio::time::sleep(BUILD_STATUS_POLL_INTERVAL).await;

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -210,10 +210,9 @@ pub struct CommonBuildOptions {
     pub memory_mb: Option<i64>,
     pub is_public: bool,
     /// Non-default opt-in: build a CAS (content-addressed streaming,
-    /// `cas-streaming` on the wire) image. CAS builds are base-only — the
-    /// Dockerfile FROM must be an unregistered OCI image — and complete
-    /// through the platform's trusted CAS ingest, so registration takes
-    /// longer while the image is verified and admitted.
+    /// `cas-streaming` on the wire) image. CAS builds complete through the
+    /// platform's trusted CAS ingest, so registration takes longer while
+    /// the image is verified and admitted.
     pub cas: bool,
     pub user_agent: Option<String>,
     pub docker_compat: bool,
@@ -916,10 +915,10 @@ async fn wait_for_sandbox_status(
 /// JSON entry the prepare endpoint expects for that local-image slot, or
 /// `None` if the lookup did not resolve.
 ///
-/// References that resolve but are not usable as a build image (only
-/// `durable_archive_v1` base templates are supported by the rootfs builder
-/// today) fail with a clear message tied to the offending reference so the
-/// user gets feedback on the exact image string that's incompatible.
+/// The client performs no template-eligibility validation (node kind,
+/// snapshot format): the in-sandbox rootfs builder owns materialization of
+/// build images and validates what it can handle. Only the structural
+/// fields required to construct the prepare payload are checked.
 async fn resolve_template_payload(
     templates: &crate::sandbox_templates::SandboxTemplatesClient,
     reference: &str,
@@ -927,7 +926,16 @@ async fn resolve_template_payload(
     let Some(found) = templates.find_by_name(reference).await? else {
         return Ok(None);
     };
-    let template = found.into_inner();
+    template_build_payload(&found.into_inner(), reference).map(Some)
+}
+
+/// Map a fetched template to the prepare-endpoint local-image payload,
+/// failing only when the lookup response is missing a field the payload
+/// needs (id, name, snapshot id).
+fn template_build_payload(
+    template: &crate::sandbox_templates::models::SandboxTemplate,
+    reference: &str,
+) -> Result<Value> {
     let template_id = template.id.clone().ok_or_else(|| {
         SandboxImageBuildError::other(format!(
             "platform returned a template lookup for '{}' without an id",
@@ -947,31 +955,13 @@ async fn resolve_template_payload(
         ))
     })?;
     let is_public = template.public.unwrap_or(false);
-    if let Some(kind) = template.rootfs_node_kind.as_deref()
-        && kind != "base"
-    {
-        return Err(SandboxImageBuildError::other(format!(
-            "template '{}' cannot be used as a build image (only base templates are supported, got rootfsNodeKind='{}'). \
-             Build a base image from this template first.",
-            reference, kind
-        )));
-    }
-    if let Some(fmt) = template.snapshot_format_version.as_deref()
-        && fmt != "durable_archive_v1"
-    {
-        return Err(SandboxImageBuildError::other(format!(
-            "template '{}' uses snapshot format '{}', which the rootfs builder cannot materialize. \
-             Re-register the template with durable_archive_v1.",
-            reference, fmt
-        )));
-    }
-    Ok(Some(json!({
+    Ok(json!({
         "templateId": template_id,
         "name": name,
         "reference": reference,
         "snapshotId": snapshot_id,
         "public": is_public,
-    })))
+    }))
 }
 
 async fn prepare_rootfs_build(
@@ -1014,34 +1004,13 @@ async fn prepare_rootfs_build(
             additional_payload.push(payload);
         }
     }
-    let rootfs_node_kind = if parent_template_payload.is_some() {
-        "diff"
-    } else {
-        "base"
-    };
-    // CAS images are content-addressed and self-contained: fail before
-    // any sandbox spins up if the FROM resolved to a registered template.
-    if cas && (parent_template_payload.is_some() || !additional_payload.is_empty()) {
-        return Err(SandboxImageBuildError::usage(
-            "--cas builds support only base images: the Dockerfile FROM (and any \
-             COPY --from references) must be unregistered OCI images, not registered \
-             Tensorlake templates",
-        ));
-    }
-    let parent_template_json = parent_template_payload.unwrap_or(Value::Null);
-
-    let mut prepare_body = json!({
-        "name": plan.registered_name,
-        "dockerfile": plan.dockerfile_text,
-        "baseImage": plan.base_image,
-        "public": is_public,
-        "rootfsNodeKind": rootfs_node_kind,
-        "parentTemplate": parent_template_json,
-        "additionalLocalImages": additional_payload,
-    });
-    if cas {
-        prepare_body["rootfsFormat"] = Value::String("cas-streaming".to_string());
-    }
+    let prepare_body = prepare_request_body(
+        plan,
+        parent_template_payload,
+        additional_payload,
+        is_public,
+        cas,
+    );
     let request = client
         .request(Method::POST, &sandbox_template_builds_path(ctx))
         .json(&prepare_body)
@@ -1060,6 +1029,39 @@ async fn prepare_rootfs_build(
     let raw: Value = response.json().await?;
     let prepared = serde_json::from_value(raw.clone())?;
     Ok((prepared, raw))
+}
+
+/// Assemble the prepare-request body from the plan and the resolved
+/// local-image payloads. A FROM that resolved to a registered template
+/// becomes the lineage parent (`rootfsNodeKind: "diff"`); registered
+/// `COPY --from` references ride along as `additionalLocalImages`. CAS
+/// builds additionally request the `cas-streaming` rootfs format — the
+/// in-sandbox rootfs builder handles template parents for both formats.
+fn prepare_request_body(
+    plan: &DockerfileBuildPlan,
+    parent_template_payload: Option<Value>,
+    additional_payload: Vec<Value>,
+    is_public: bool,
+    cas: bool,
+) -> Value {
+    let rootfs_node_kind = if parent_template_payload.is_some() {
+        "diff"
+    } else {
+        "base"
+    };
+    let mut prepare_body = json!({
+        "name": plan.registered_name,
+        "dockerfile": plan.dockerfile_text,
+        "baseImage": plan.base_image,
+        "public": is_public,
+        "rootfsNodeKind": rootfs_node_kind,
+        "parentTemplate": parent_template_payload.unwrap_or(Value::Null),
+        "additionalLocalImages": additional_payload,
+    });
+    if cas {
+        prepare_body["rootfsFormat"] = Value::String("cas-streaming".to_string());
+    }
+    prepare_body
 }
 
 async fn complete_rootfs_build(
@@ -1656,29 +1658,9 @@ fn complete_request_from_metadata(
     signed_snapshot_uri: Option<&str>,
     rootfs_disk_bytes: u64,
 ) -> Result<CompleteSandboxTemplateBuildRequest> {
-    // cas-streaming builds: the builder staged a pre-chunked image; the
-    // registered identity comes from the platform's trusted verify-and-admit,
-    // so the completion only reports the staged artifacts and declared sizes.
-    if metadata_string(metadata, "rootfs_format", "rootfsFormat").as_deref()
-        == Some("cas-streaming")
-    {
-        return Ok(CompleteSandboxTemplateBuildRequest {
-            snapshot_id: metadata_string(metadata, "snapshot_id", "snapshotId")
-                .unwrap_or_else(|| prepared.snapshot_id.clone()),
-            snapshot_uri: completion_snapshot_uri(prepared, metadata, signed_snapshot_uri)?,
-            snapshot_format_version: "content_addressed_streaming_v1".to_string(),
-            snapshot_size_bytes: required_metadata_u64(
-                metadata,
-                "image_size_bytes",
-                "imageSizeBytes",
-            )?,
-            rootfs_disk_bytes,
-            rootfs_node_kind: "base".to_string(),
-            parent_manifest_uri: None,
-            rootfs_format: Some("cas-streaming".to_string()),
-        });
-    }
-
+    // Lineage is shared by both completion shapes: builder metadata wins,
+    // falling back to the prepare response for the node kind and the diff
+    // parent manifest.
     let rootfs_node_kind = metadata_string(metadata, "rootfs_node_kind", "rootfsNodeKind")
         .unwrap_or_else(|| prepared.rootfs_node_kind.clone());
     let parent_manifest_uri = metadata_string(metadata, "parent_manifest_uri", "parentManifestUri")
@@ -1697,6 +1679,30 @@ fn complete_request_from_metadata(
         return Err(SandboxImageBuildError::other(
             "rootfs diff build completed without parent_manifest_uri",
         ));
+    }
+
+    // cas-streaming builds: the builder staged a pre-chunked image; the
+    // registered identity comes from the platform's trusted verify-and-admit,
+    // so the completion only reports the staged artifacts, declared sizes,
+    // and the lineage resolved above.
+    if metadata_string(metadata, "rootfs_format", "rootfsFormat").as_deref()
+        == Some("cas-streaming")
+    {
+        return Ok(CompleteSandboxTemplateBuildRequest {
+            snapshot_id: metadata_string(metadata, "snapshot_id", "snapshotId")
+                .unwrap_or_else(|| prepared.snapshot_id.clone()),
+            snapshot_uri: completion_snapshot_uri(prepared, metadata, signed_snapshot_uri)?,
+            snapshot_format_version: "content_addressed_streaming_v1".to_string(),
+            snapshot_size_bytes: required_metadata_u64(
+                metadata,
+                "image_size_bytes",
+                "imageSizeBytes",
+            )?,
+            rootfs_disk_bytes,
+            rootfs_node_kind,
+            parent_manifest_uri,
+            rootfs_format: Some("cas-streaming".to_string()),
+        });
     }
 
     Ok(CompleteSandboxTemplateBuildRequest {
@@ -2949,10 +2955,10 @@ mod tests {
         complete_request_from_metadata, contains_disk_space_evidence, contains_oom_killer_evidence,
         create_context_archive, default_registered_name, load_dockerfile_plan,
         load_dockerfile_text_plan, logical_dockerfile_lines, normalize_posix,
-        parse_df_line_usage_percent, parse_df_max_usage_percent, process_terminal_status,
-        rootfs_builder_env, rootfs_builder_executable, rootfs_disk_bytes, rootfs_disk_bytes_to_mb,
-        sandbox_proxy_base_with_explicit, splice_signed_upload, streaming_process_payload,
-        upload_percent,
+        parse_df_line_usage_percent, parse_df_max_usage_percent, prepare_request_body,
+        process_terminal_status, rootfs_builder_env, rootfs_builder_executable, rootfs_disk_bytes,
+        rootfs_disk_bytes_to_mb, sandbox_proxy_base_with_explicit, splice_signed_upload,
+        streaming_process_payload, template_build_payload, upload_percent,
     };
     use crate::sandboxes::models::ProcessInfo;
     use serde_json::{Value, json};
@@ -3614,6 +3620,190 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
         assert_eq!(request.rootfs_node_kind, "base");
         assert_eq!(request.rootfs_format.as_deref(), Some("cas-streaming"));
         assert!(request.parent_manifest_uri.is_none());
+    }
+
+    fn prepared_cas_diff() -> PreparedSandboxTemplateBuild {
+        PreparedSandboxTemplateBuild {
+            build_id: "build-1".to_string(),
+            snapshot_id: "snapshot-1".to_string(),
+            snapshot_uri: Some(
+                "s3://bucket/projects/p/sandbox-template-builds/b/snapshot-1.pack".to_string(),
+            ),
+            rootfs_node_kind: "diff".to_string(),
+            rootfs_format: Some("cas-streaming".to_string()),
+            builder: PreparedRootfsBuilder {
+                image: "tensorlake/rootfs-builder".to_string(),
+                command: "tl-rootfs-build".to_string(),
+                cpus: 2.0,
+                memory_mb: 4096,
+                disk_mb: 30720,
+            },
+            parent: Some(PreparedRootfsParent {
+                parent_manifest_uri: "s3://bucket/parents/prepared.manifest".to_string(),
+                rootfs_disk_bytes: None,
+            }),
+            snapshot_rel_path: None,
+        }
+    }
+
+    #[test]
+    fn complete_request_for_cas_diff_takes_lineage_from_metadata() {
+        let prepared = prepared_cas_diff();
+        let metadata = json!({
+            "rootfsFormat": "cas-streaming",
+            "snapshotId": "snapshot-1",
+            "imageSizeBytes": 600_000_000u64,
+            "rootfsNodeKind": "diff",
+            "parentManifestUri": "s3://bucket/parents/metadata.manifest",
+        });
+        let request =
+            complete_request_from_metadata(&prepared, &metadata, None, 10 * 1024 * 1024 * 1024)
+                .unwrap();
+        assert_eq!(request.rootfs_node_kind, "diff");
+        assert_eq!(
+            request.parent_manifest_uri.as_deref(),
+            Some("s3://bucket/parents/metadata.manifest")
+        );
+        assert_eq!(request.rootfs_format.as_deref(), Some("cas-streaming"));
+        assert_eq!(
+            request.snapshot_format_version,
+            "content_addressed_streaming_v1"
+        );
+    }
+
+    #[test]
+    fn complete_request_for_cas_diff_falls_back_to_prepared_lineage() {
+        let prepared = prepared_cas_diff();
+        // The builder metadata omits lineage entirely: the prepare response's
+        // node kind and parent manifest must carry the completion.
+        let metadata = json!({
+            "rootfsFormat": "cas-streaming",
+            "snapshotId": "snapshot-1",
+            "imageSizeBytes": 600_000_000u64,
+        });
+        let request =
+            complete_request_from_metadata(&prepared, &metadata, None, 10 * 1024 * 1024 * 1024)
+                .unwrap();
+        assert_eq!(request.rootfs_node_kind, "diff");
+        assert_eq!(
+            request.parent_manifest_uri.as_deref(),
+            Some("s3://bucket/parents/prepared.manifest")
+        );
+        assert_eq!(request.rootfs_format.as_deref(), Some("cas-streaming"));
+    }
+
+    #[test]
+    fn complete_request_for_cas_diff_without_parent_manifest_fails() {
+        let mut prepared = prepared_cas_diff();
+        prepared.parent = None;
+        let metadata = json!({
+            "rootfsFormat": "cas-streaming",
+            "snapshotId": "snapshot-1",
+            "imageSizeBytes": 600_000_000u64,
+        });
+        let error =
+            complete_request_from_metadata(&prepared, &metadata, None, 10 * 1024 * 1024 * 1024)
+                .unwrap_err();
+        assert!(error.to_string().contains("without parent_manifest_uri"));
+    }
+
+    #[test]
+    fn prepare_request_body_allows_cas_with_registered_parent_and_additional_images() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dockerfile_path = temp_dir.path().join("Dockerfile");
+        std::fs::write(
+            &dockerfile_path,
+            "FROM tensorlake/ubuntu-minimal\n\
+             COPY --from=tensorlake/utility:1.0 /bin/foo /usr/local/bin/foo\n",
+        )
+        .unwrap();
+        let plan = load_dockerfile_plan(&dockerfile_path, None).unwrap();
+
+        let parent = json!({
+            "templateId": "tmpl-1",
+            "name": "ubuntu-minimal",
+            "reference": "tensorlake/ubuntu-minimal",
+            "snapshotId": "snap-1",
+            "public": true,
+        });
+        let additional = json!({
+            "templateId": "tmpl-2",
+            "name": "utility",
+            "reference": "tensorlake/utility:1.0",
+            "snapshotId": "snap-2",
+            "public": false,
+        });
+        // A cas build with a registered FROM and a registered COPY --from is
+        // constructed without a rejection: the in-sandbox builder owns
+        // template materialization.
+        let body = prepare_request_body(
+            &plan,
+            Some(parent.clone()),
+            vec![additional.clone()],
+            false,
+            true,
+        );
+
+        assert_eq!(body["rootfsFormat"], "cas-streaming");
+        assert_eq!(body["rootfsNodeKind"], "diff");
+        assert_eq!(body["parentTemplate"], parent);
+        assert_eq!(body["additionalLocalImages"], json!([additional]));
+    }
+
+    #[test]
+    fn prepare_request_body_omits_rootfs_format_by_default() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let dockerfile_path = temp_dir.path().join("Dockerfile");
+        std::fs::write(&dockerfile_path, "FROM ubuntu:24.04\n").unwrap();
+        let plan = load_dockerfile_plan(&dockerfile_path, None).unwrap();
+
+        let body = prepare_request_body(&plan, None, Vec::new(), false, false);
+
+        assert!(body.get("rootfsFormat").is_none());
+        assert_eq!(body["rootfsNodeKind"], "base");
+        assert_eq!(body["parentTemplate"], Value::Null);
+    }
+
+    #[test]
+    fn template_build_payload_imposes_no_eligibility_policy() {
+        // The client owns no node-kind or snapshot-format allowlist: diff
+        // templates, cas-streaming templates, and formats this client has
+        // never heard of all map to prepare payloads. Eligibility is the
+        // in-sandbox rootfs builder's call.
+        for (kind, fmt) in [
+            (Some("diff"), Some("durable_archive_v1")),
+            (Some("base"), Some("content_addressed_streaming_v1")),
+            (Some("diff"), Some("some_future_format_v9")),
+            (None, None),
+        ] {
+            let template = crate::sandbox_templates::models::SandboxTemplate {
+                id: Some("tmpl-1".to_string()),
+                name: Some("ubuntu-minimal".to_string()),
+                snapshot_id: Some("snap-1".to_string()),
+                rootfs_node_kind: kind.map(str::to_string),
+                snapshot_format_version: fmt.map(str::to_string),
+                public: Some(true),
+                ..Default::default()
+            };
+            let payload = template_build_payload(&template, "tensorlake/ubuntu-minimal").unwrap();
+            assert_eq!(payload["templateId"], "tmpl-1");
+            assert_eq!(payload["name"], "ubuntu-minimal");
+            assert_eq!(payload["reference"], "tensorlake/ubuntu-minimal");
+            assert_eq!(payload["snapshotId"], "snap-1");
+            assert_eq!(payload["public"], true);
+        }
+    }
+
+    #[test]
+    fn template_build_payload_requires_structural_fields() {
+        let template = crate::sandbox_templates::models::SandboxTemplate {
+            id: Some("tmpl-1".to_string()),
+            name: Some("ubuntu-minimal".to_string()),
+            snapshot_id: None,
+            ..Default::default()
+        };
+        let error = template_build_payload(&template, "tensorlake/ubuntu-minimal").unwrap_err();
+        assert!(error.to_string().contains("without a snapshot id"));
     }
 
     #[test]

--- a/crates/cloud-sdk/tests/sandbox_templates.rs
+++ b/crates/cloud-sdk/tests/sandbox_templates.rs
@@ -161,7 +161,7 @@ async fn test_create_then_delete_sandbox_image() {
                     cpus: Some(1.0),
                     memory_mb: Some(1024),
                     is_public: false,
-                    streaming: false,
+                    cas: false,
                     user_agent: None,
                     docker_compat: false,
                 },

--- a/crates/rust-cloud-sdk-node/src/lib.rs
+++ b/crates/rust-cloud-sdk-node/src/lib.rs
@@ -73,6 +73,9 @@ pub struct SandboxImageImportOptionsJs {
     pub use_scope_headers: Option<bool>,
     pub user_agent: Option<String>,
     pub docker_compat: Option<bool>,
+    /// Opt into the non-default CAS (content-addressed streaming) image
+    /// format.
+    pub cas: Option<bool>,
 }
 
 #[napi(object)]
@@ -176,7 +179,7 @@ pub async fn import_sandbox_image(
             cpus: options.cpus,
             memory_mb: options.memory_mb,
             is_public: options.is_public.unwrap_or(false),
-            cas: false,
+            cas: options.cas.unwrap_or(false),
             user_agent: options.user_agent,
             docker_compat: options.docker_compat.unwrap_or(false),
         },

--- a/crates/rust-cloud-sdk-node/src/lib.rs
+++ b/crates/rust-cloud-sdk-node/src/lib.rs
@@ -46,8 +46,9 @@ pub struct SandboxImageBuildOptionsJs {
     pub docker_compat: Option<bool>,
     pub dockerfile_text: Option<String>,
     pub context_dir: Option<String>,
-    /// Opt into the non-default content-addressed streaming image format.
-    pub streaming: Option<bool>,
+    /// Opt into the non-default CAS (content-addressed streaming) image
+    /// format.
+    pub cas: Option<bool>,
 }
 
 #[napi(object)]
@@ -129,7 +130,7 @@ pub async fn build_sandbox_image(
             cpus: options.cpus,
             memory_mb: options.memory_mb,
             is_public: options.is_public.unwrap_or(false),
-            streaming: options.streaming.unwrap_or(false),
+            cas: options.cas.unwrap_or(false),
             user_agent: options.user_agent,
             docker_compat: options.docker_compat.unwrap_or(false),
         },
@@ -175,7 +176,7 @@ pub async fn import_sandbox_image(
             cpus: options.cpus,
             memory_mb: options.memory_mb,
             is_public: options.is_public.unwrap_or(false),
-            streaming: false,
+            cas: false,
             user_agent: options.user_agent,
             docker_compat: options.docker_compat.unwrap_or(false),
         },

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.74"
+version = "0.5.76"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -3516,7 +3516,7 @@ fn create_image_context_file(
     docker_compat=false,
     dockerfile_text=None,
     context_dir=None,
-    streaming=false,
+    cas=false,
     emit=None,
 ))]
 fn build_sandbox_image(
@@ -3538,7 +3538,7 @@ fn build_sandbox_image(
     docker_compat: bool,
     dockerfile_text: Option<String>,
     context_dir: Option<String>,
-    streaming: bool,
+    cas: bool,
     emit: Option<Py<PyAny>>,
 ) -> PyResult<String> {
     let options = tensorlake::sandbox_images::SandboxImageBuildOptions {
@@ -3557,7 +3557,7 @@ fn build_sandbox_image(
             is_public,
             user_agent,
             docker_compat,
-            streaming,
+            cas,
         ),
         dockerfile_path: PathBuf::from(dockerfile_path),
         dockerfile_text,
@@ -3697,7 +3697,7 @@ fn common_build_options(
     is_public: bool,
     user_agent: Option<String>,
     docker_compat: bool,
-    streaming: bool,
+    cas: bool,
 ) -> tensorlake::sandbox_images::CommonBuildOptions {
     tensorlake::sandbox_images::CommonBuildOptions {
         api_url,
@@ -3712,7 +3712,7 @@ fn common_build_options(
         cpus,
         memory_mb,
         is_public,
-        streaming,
+        cas,
         user_agent,
         docker_compat,
     }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -3609,6 +3609,7 @@ fn build_sandbox_image(
     use_scope_headers=false,
     user_agent=None,
     docker_compat=false,
+    cas=false,
     emit=None,
 ))]
 fn import_sandbox_image(
@@ -3628,6 +3629,7 @@ fn import_sandbox_image(
     use_scope_headers: bool,
     user_agent: Option<String>,
     docker_compat: bool,
+    cas: bool,
     emit: Option<Py<PyAny>>,
 ) -> PyResult<String> {
     let options = tensorlake::sandbox_images::SandboxImageImportOptions {
@@ -3646,7 +3648,7 @@ fn import_sandbox_image(
             is_public,
             user_agent,
             docker_compat,
-            false,
+            cas,
         ),
         image_reference,
     };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.74"
+version = "0.5.76"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -291,7 +291,8 @@ def _run_rust_image_import(
         ctx.personal_access_token is not None and ctx.api_key is None,
         USER_AGENT,
         docker_compat,
-        _forwarder(emit),
+        cas=False,
+        emit=_forwarder(emit),
     )
     return _finish_image_registration(result_json, registered_name, emit)
 

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -246,7 +246,7 @@ def _run_rust_image_create(
         docker_compat,
         dockerfile_text,
         context_dir,
-        streaming=False,
+        cas=False,
         emit=_forwarder(emit),
     )
     return _finish_image_registration(result_json, registered_name, emit)

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -375,7 +375,8 @@ class TestImportSandboxImage(unittest.TestCase):
             False,
             sbm.USER_AGENT,
             False,
-            ANY,
+            cas=False,
+            emit=ANY,
         )
 
     def test_default_name_strips_registry_path_and_digest(self):

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -93,7 +93,7 @@ class TestBuildSandboxImageFromDockerfile(unittest.TestCase):
             False,
             None,
             None,
-            streaming=False,
+            cas=False,
             emit=ANY,
         )
 
@@ -139,7 +139,7 @@ class TestBuildSandboxImageFromDockerfileOptions(unittest.TestCase):
             False,
             None,
             None,
-            streaming=False,
+            cas=False,
             emit=ANY,
         )
 

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.70",
+  "version": "0.5.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.70",
+      "version": "0.5.76",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",
@@ -1224,6 +1224,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1530,6 +1531,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1584,6 +1586,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2304,6 +2307,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2353,6 +2357,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2790,6 +2795,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2837,6 +2843,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.74",
+  "version": "0.5.76",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Renames the user-facing surfaces of the content-addressed streaming image-build mode from `streaming` to `cas`, then closes the two remaining CAS gaps in this repo: `sbx image import` support and registered-template `FROM` references. Bumps the lockstep version to **0.5.76** (0.5.75 skipped — a `cli-v0.5.75` tag already exists).

### Commit 1 — rename `--streaming` → `--cas`

- CLI: hidden `tl sbx image create --streaming` flag is now `--cas`.
- Rust SDK: `CommonBuildOptions.streaming` → `pub cas`, plus internal params and all user-visible text (usage error, build-mode suffix `(CAS)`, progress/admission messages).
- Node napi binding: `SandboxImageBuildOptionsJs.streaming` → `cas`.
- Python pyo3 binding: `build_sandbox_image(..., streaming=)` kwarg → `cas=`; SDK call site moved in lockstep.
- Clean rename, no deprecation alias: the flag was hidden, opt-in, and never exposed through the public TS/Python SDK wrappers.

### Commit 2 — extend `--cas` to import and registered-template parents

**`tl sbx image import --cas`** — plumbed through every layer that hardcoded cas off for imports: hidden CLI flag, `SandboxImageImportOptionsJs.cas`, pyo3 `import_sandbox_image(..., cas=False)` kwarg (inserted before `emit` for consistency with the build fn — an intentional positional-ABI break of the private `_cloud_sdk` binding; the Python SDK now passes `cas=False, emit=...` as keywords).

**Registered-template `FROM` with `--cas`** — both scenarios are handled by `tl-rootfs-build.py` in the builder sandbox, so the client no longer blocks them:
- Removed the prepare-time usage error (`--cas builds support only base images`). A cas build whose FROM resolves to a registered template now prepares as `rootfsNodeKind: "diff"` + `parentTemplate` + `rootfsFormat: "cas-streaming"`, with registered `COPY --from` references in `additionalLocalImages`.
- Removed all client-side template-eligibility validation in `resolve_template_payload` (base-only check and `durable_archive_v1`-only format check). The builder owns materialization and eligibility; only structural checks (id, name, snapshot id) remain.
- Fixed `complete_request_from_metadata`: the cas branch hardcoded `rootfs_node_kind: "base"` and dropped the parent manifest, which would have produced an incorrect completion for cas diff builds. Lineage resolution (metadata first, prepare-response fallback, missing-parent validation) is hoisted ahead of the cas/default split and shared by both branches.

### Intentionally unchanged

- Wire tokens: `rootfsFormat: "cas-streaming"`, `snapshotFormatVersion: "content_addressed_streaming_v1"`, build statuses, builder metadata keys (shared with platform-api and the in-sandbox builder).
- Public TS/Python SDK wrappers: `cas` stays exposed on the CLI and native bindings only.
- CAS completion's declared sizes (`imageSizeBytes` + client disk budget) and async admission polling (202 → poll, 3 s interval, 30 min cap).

## Testing

- New unit tests: prepare-body shape for cas + registered parent + `COPY --from`; no-format-allowlist coverage (diff, cas-streaming, unknown future format); structural-field failure; cas diff completion lineage from metadata, from prepare-response fallback, and the missing-parent error; CLI parsing tests `image_create_parses_cas` / `image_import_parses_cas`.
- `cargo test -p tensorlake --lib sandbox_images`: 59 passed.
- `cargo test -p tensorlake-cli --bin tl`: 201 passed.
- `tests/image/test_sandbox_builder.py` (mocked binding): 40 passed.
- `cargo check --workspace --tests` clean; `--cas` parses on both commands while `--streaming` is rejected; rustfmt and black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)