### PR TITLE
Keep production tl fs macOS mounts coherent

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -7,6 +7,7 @@ from pathlib import Path
 DEFAULT_FILES = (
     "pyproject.toml",
     "Cargo.toml",
+    "crates/gsvc-fs-client/Cargo.toml",
     "crates/rust-cloud-sdk-py/pyproject.toml",
     "typescript/package.json",
 )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.1.0"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "base64",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "base64",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "anyhow",
  "base64",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "napi",
  "napi-build",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.81"
+version = "0.5.82"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.81"
+version = "0.5.82"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,7 @@ build_release:
 
 bump_version:
 	@test -n "$(VERSION)" || (echo "Usage: make bump_version VERSION=x.y.z" && exit 1)
-	@for f in pyproject.toml Cargo.toml crates/rust-cloud-sdk-py/pyproject.toml; do \
-		python3 -c "import re, pathlib; p = pathlib.Path('$$f'); p.write_text(re.sub(r'^version = \"[^\"]*\"', 'version = \"$(VERSION)\"', p.read_text(), count=1, flags=re.MULTILINE))"; \
-		echo "  Updated $$f"; \
-	done
-	@echo "Version bumped to $(VERSION)"
+	@python3 .github/scripts/bump_version.py "$(VERSION)"
 
 .PHONY: all build build_proto build_cloud_sdk build_rust_py_client fmt check test test_document_ai test_sandbox install-dev install-dev-release install-global build_release bump_version fs-posix-conformance
 

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -2,7 +2,7 @@
 # only `src/`, keeping this workspace-adapted dependency manifest.
 [package]
 name = "gsvc-fs-client"
-version = "0.1.0"
+version = "0.5.82"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.81"
+version = "0.5.82"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/platform/macos/tlfs/README.md
+++ b/platform/macos/tlfs/README.md
@@ -39,10 +39,10 @@ another local user cannot attach to the volume's backend.
 
 Frames are `u32-le length | u8 opcode | payload`; responses `u32-le length | i32-le
 errno | payload`. Strings/bytes are u32-length-prefixed; attrs are packed
-`u64 ino | u8 kind | u64 size | u16 perm | u8 upper`. Opcodes `HELLO(0)…STATFS(20)`
-mirror the overlay's op set. The canonical definition lives in the daemon at
-`crates/cli/src/commands/fs/vfsserver.rs`; keep both sides in lockstep — there is no
-version negotiation beyond the HELLO check yet.
+`u64 ino | u8 kind | u64 size | u16 perm | u8 upper | u64 mtime_sec | u32 mtime_nsec |
+u64 content_version`. Opcodes `HELLO(0)…STATFS(20)` mirror the overlay's op set. The
+canonical definition lives in the injected private `gsvc-fs-client/src/vfsserver.rs`; keep both
+sides in lockstep — version 3 is enforced by the HELLO check and has no downgrade negotiation.
 
 ## Build and install (development)
 
@@ -82,7 +82,8 @@ Settings toggle. Source builds have nothing embedded and fall back to downloadin
 release asset matching the CLI version; `--from <path-or-url>` overrides either path.
 `tl fs setup --check` diagnoses an install. Users rarely run setup by hand: `tl fs
 mount` pre-flights the extension and auto-runs the install when it is missing, stopping
-only for the Settings toggle (the one step Apple reserves for the user). Embedding (and failing that, the shared
+or when its stamped version differs from the CLI, stopping only for the Settings toggle (the one
+step Apple reserves for the user). Embedding (and failing that, the shared
 release tag) is the wire-protocol-skew defense: the VFS protocol has no version
 negotiation beyond HELLO.
 
@@ -141,6 +142,10 @@ does honor (all measured on macOS 26.5 lifs):
   pinned commit. It moves exactly when content can have changed, which is what the
   kernel's revalidation compares. (Never report `time(nil)`: constant-now mtimes defeat
   caching and still leave minutes-long stale windows.)
+- **Opaque content versions guard retained FSItems.** FSKit may keep one `FSItem` alive across
+  independent opens. The private v3 localhost wire therefore carries an identity derived from the
+  pinned snapshot (or upper inode/ctime); a new read open replaces any handle whose identity is
+  stale even when size and mtime happen to match.
 - **Directory verifier from the dir's mtime.** A constant `FSDirectoryVerifier` makes
   the kernel treat cached listing pages and resume cookies as forever-valid (`ls` shows
   deleted files, or a stale empty tail). Deriving it from the directory's wire mtime
@@ -157,6 +162,14 @@ does honor (all measured on macOS 26.5 lifs):
   adopt a new size but never refetch pages — a file that grew behind the kernel keeps a
   zero-filled tail forever otherwise), and breaks pinned negative entries with an
   `O_CREAT|O_EXCL` / `mkdir` probe that the overlay answers with `EEXIST`.
+
+## Extended attributes
+
+The native snapshot format does not currently promise general xattr persistence. The FSKit module
+advertises limited, mount-lifetime support only for macOS bookkeeping attributes (`provenance`,
+`quarantine`, and `lastuseddate`) so routine copies do not materialize transient `._*` AppleDouble
+files as filesystem content. Meaningful metadata such as resource forks, Finder info, tags, and
+comments remains unsupported; the module does not accept and silently discard it.
 
 Measured result: restore returns in ~0.1s with `open`/`read` and directory listings
 fully coherent, both directions, repeatedly. Residual caveat: a bare `stat(2)`/`lstat`

--- a/platform/macos/tlfs/Sources/Extension/TLFS.swift
+++ b/platform/macos/tlfs/Sources/Extension/TLFS.swift
@@ -47,7 +47,7 @@ enum VfsOp: UInt8 {
     case statfs = 20
 }
 
-let vfsProtocolVersion: UInt32 = 2
+let vfsProtocolVersion: UInt32 = 3
 
 struct WireWriter {
     var data = Data()
@@ -111,6 +111,8 @@ struct WireAttr {
     /// changed; the kernel compares it across getattrs to decide cache revalidation.
     let mtimeSec: UInt64
     let mtimeNsec: UInt32
+    /// Opaque daemon identity for this exact lower snapshot or upper inode version.
+    let contentVersion: UInt64
 
     init(_ r: inout WireReader) throws {
         ino = try r.u64()
@@ -120,6 +122,7 @@ struct WireAttr {
         upper = try r.u8() != 0
         mtimeSec = try r.u64()
         mtimeNsec = try r.u32()
+        contentVersion = try r.u64()
     }
 
     var itemType: FSItem.ItemType {
@@ -292,6 +295,10 @@ final class VfsPool {
 // MARK: - Items
 
 final class TLFSItem: FSItem {
+    struct ContentVersion: Equatable {
+        let token: UInt64
+    }
+
     let ino: UInt64
     var itemType: FSItem.ItemType
     /// Server-side lookup references owed; reclaim sends one FORGET with the total.
@@ -299,12 +306,29 @@ final class TLFSItem: FSItem {
     /// Open file handle on the daemon, when the kernel has this item open.
     var fh: UInt64?
     var fhWritable = false
+    /// The content identity last returned by lookup/getattr and the identity pinned by `fh`.
+    /// FSKit may retain an FSItem across independent open(2)s, so an old daemon handle cannot be
+    /// reused merely because the item object itself survived a followed-head advance.
+    var contentVersion: ContentVersion?
+    var fhContentVersion: ContentVersion?
+    /// Mount-lifetime values for the deliberately limited macOS bookkeeping xattrs.
+    var limitedXattrs: [String: Data] = [:]
     let stateLock = NSLock()
 
     init(ino: UInt64, type: FSItem.ItemType) {
         self.ino = ino
         self.itemType = type
         super.init()
+    }
+
+    func observe(_ attr: WireAttr) {
+        stateLock.lock()
+        let next = ContentVersion(token: attr.contentVersion)
+        if let current = contentVersion, current != next {
+            limitedXattrs.removeAll()
+        }
+        contentVersion = next
+        stateLock.unlock()
     }
 }
 
@@ -400,6 +424,16 @@ final class TLFSVolume: FSVolume {
     let pool: VfsPool
     private let itemsLock = NSLock()
     private var items: [UInt64: TLFSItem] = [:]
+    /// macOS attaches these operating-system bookkeeping attributes while copying/editing
+    /// ordinary files. Advertising their limited support keeps copyfile from materializing `._*`
+    /// AppleDouble sidecars solely for transient OS state. They intentionally live only for the
+    /// mounted session; meaningful xattrs such as resource forks, Finder metadata, and user tags
+    /// remain unsupported rather than being accepted and silently lost by a snapshot.
+    private static let limitedXattrNames = [
+        "com.apple.provenance",
+        "com.apple.quarantine",
+        "com.apple.lastuseddate#PS",
+    ]
     let root: TLFSItem
 
     init(pool: VfsPool, port: UInt16) {
@@ -427,6 +461,7 @@ final class TLFSVolume: FSVolume {
             item = TLFSItem(ino: attr.ino, type: attr.itemType)
             items[attr.ino] = item
         }
+        item.observe(attr)
         if countLookup {
             item.lookups += 1
         }
@@ -476,7 +511,7 @@ final class TLFSVolume: FSVolume {
         if want(.birthTime) { out.birthTime = ts }
         if want(.addedTime) { out.addedTime = ts }
         if want(.backupTime) { out.backupTime = timespec() }
-        if want(.supportsLimitedXAttrs) { out.supportsLimitedXAttrs = false }
+        if want(.supportsLimitedXAttrs) { out.supportsLimitedXAttrs = true }
         return out
     }
 
@@ -495,7 +530,10 @@ final class TLFSVolume: FSVolume {
     fileprivate func ensureHandle(_ item: TLFSItem, write: Bool) throws -> UInt64 {
         item.stateLock.lock()
         defer { item.stateLock.unlock() }
-        if let fh = item.fh, item.fhWritable || !write {
+        if let fh = item.fh,
+            (item.fhWritable || !write),
+            (item.fhWritable || item.fhContentVersion == item.contentVersion)
+        {
             return fh
         }
         let fh: UInt64 = try pool.withConnection { conn in
@@ -510,6 +548,7 @@ final class TLFSVolume: FSVolume {
         }
         item.fh = fh
         item.fhWritable = write
+        item.fhContentVersion = item.contentVersion
         return fh
     }
 
@@ -529,8 +568,92 @@ extension TLFSVolume: FSVolume.PathConfOperations {
     var maximumNameLength: Int { 255 }
     var restrictsOwnershipChanges: Bool { true }
     var truncatesLongNames: Bool { false }
-    var maximumXattrSize: Int { 0 }
+    var maximumXattrSize: Int { 64 * 1024 }
     var maximumFileSize: UInt64 { UInt64.max }
+}
+
+// MARK: - Limited macOS metadata xattrs
+
+extension TLFSVolume: FSVolume.XattrOperations {
+    func supportedXattrNames(for item: FSItem) -> [FSFileName] {
+        Self.limitedXattrNames.map { FSFileName(string: $0) }
+    }
+
+    func getXattr(
+        named name: FSFileName,
+        of item: FSItem,
+        replyHandler reply: @escaping (Data?, (any Error)?) -> Void
+    ) {
+        guard let item = item as? TLFSItem, let key = name.string,
+            Self.limitedXattrNames.contains(key)
+        else {
+            reply(nil, POSIXError(.ENOATTR))
+            return
+        }
+        item.stateLock.lock()
+        let value = item.limitedXattrs[key]
+        item.stateLock.unlock()
+        if let value {
+            reply(value, nil)
+        } else {
+            reply(nil, POSIXError(.ENOATTR))
+        }
+    }
+
+    func setXattr(
+        named name: FSFileName,
+        to value: Data?,
+        on item: FSItem,
+        policy: FSVolume.SetXattrPolicy,
+        replyHandler reply: @escaping ((any Error)?) -> Void
+    ) {
+        guard let item = item as? TLFSItem, let key = name.string,
+            Self.limitedXattrNames.contains(key)
+        else {
+            reply(POSIXError(.ENOTSUP))
+            return
+        }
+        if let value, value.count > maximumXattrSize {
+            reply(POSIXError(.E2BIG))
+            return
+        }
+        item.stateLock.lock()
+        let exists = item.limitedXattrs[key] != nil
+        var result: (any Error)?
+        switch policy {
+        case .mustCreate where exists:
+            result = POSIXError(.EEXIST)
+        case .mustReplace where !exists, .delete where !exists:
+            result = POSIXError(.ENOATTR)
+        case .delete:
+            item.limitedXattrs.removeValue(forKey: key)
+            result = nil
+        default:
+            if let value {
+                item.limitedXattrs[key] = value
+                result = nil
+            } else {
+                result = POSIXError(.EINVAL)
+            }
+        }
+        item.stateLock.unlock()
+        reply(result)
+    }
+
+    func listXattrs(
+        of item: FSItem,
+        replyHandler reply: @escaping ([FSFileName]?, (any Error)?) -> Void
+    ) {
+        guard let item = item as? TLFSItem else {
+            reply(nil, POSIXError(.EIO))
+            return
+        }
+        item.stateLock.lock()
+        let names = item.limitedXattrs.keys.sorted()
+            .map { FSFileName(string: $0) }
+        item.stateLock.unlock()
+        reply(names, nil)
+    }
 }
 
 // MARK: - Core operations
@@ -628,6 +751,7 @@ extension TLFSVolume: FSVolume.Operations {
         }
         do {
             let attr = try getattr(item.ino)
+            item.observe(attr)
             reply(attributes(attr, wanted: desiredAttributes), nil)
         } catch {
             reply(nil, error)
@@ -656,6 +780,7 @@ extension TLFSVolume: FSVolume.Operations {
                 var r = try conn.request(.setattr, w.data)
                 return try WireAttr(&r)
             }
+            item.observe(attr)
             reply(attributes(attr), nil)
         } catch {
             reply(nil, error)
@@ -1032,6 +1157,7 @@ extension TLFSVolume: FSVolume.OpenCloseOperations {
         let fh = item.fh
         item.fh = nil
         item.fhWritable = false
+        item.fhContentVersion = nil
         item.stateLock.unlock()
         if let fh {
             // Flush before release so close(2) durability expectations hold.

--- a/platform/macos/tlfs/Sources/Extension/TLFS.swift
+++ b/platform/macos/tlfs/Sources/Extension/TLFS.swift
@@ -306,11 +306,10 @@ final class TLFSItem: FSItem {
     /// Open file handle on the daemon, when the kernel has this item open.
     var fh: UInt64?
     var fhWritable = false
-    /// The content identity last returned by lookup/getattr and the identity pinned by `fh`.
-    /// FSKit may retain an FSItem across independent open(2)s, so an old daemon handle cannot be
-    /// reused merely because the item object itself survived a followed-head advance.
+    /// The content identity last returned by lookup/getattr. FSKit's open/close callbacks describe
+    /// aggregate vnode modes, not individual descriptors: while any read mode remains, the shared
+    /// daemon handle stays pinned to its opened view and is released only with the final mode.
     var contentVersion: ContentVersion?
-    var fhContentVersion: ContentVersion?
     /// Mount-lifetime values for the deliberately limited macOS bookkeeping xattrs.
     var limitedXattrs: [String: Data] = [:]
     let stateLock = NSLock()
@@ -425,10 +424,11 @@ final class TLFSVolume: FSVolume {
     private let itemsLock = NSLock()
     private var items: [UInt64: TLFSItem] = [:]
     /// macOS attaches these operating-system bookkeeping attributes while copying/editing
-    /// ordinary files. Advertising their limited support keeps copyfile from materializing `._*`
-    /// AppleDouble sidecars solely for transient OS state. They intentionally live only for the
-    /// mounted session; meaningful xattrs such as resource forks, Finder metadata, and user tags
-    /// remain unsupported rather than being accepted and silently lost by a snapshot.
+    /// ordinary files. Accepting them prevents failures in ordinary tools, but the volume does
+    /// not advertise the FSKit "limited xattrs" capability: copyfile interprets that flag as a
+    /// reason to materialize `._*` AppleDouble sidecars even for names accepted here. The values
+    /// intentionally live only for the mounted session; meaningful xattrs such as resource forks,
+    /// Finder metadata, and user tags remain unsupported rather than being silently lost.
     private static let limitedXattrNames = [
         "com.apple.provenance",
         "com.apple.quarantine",
@@ -511,7 +511,10 @@ final class TLFSVolume: FSVolume {
         if want(.birthTime) { out.birthTime = ts }
         if want(.addedTime) { out.addedTime = ts }
         if want(.backupTime) { out.backupTime = timespec() }
-        if want(.supportsLimitedXAttrs) { out.supportsLimitedXAttrs = true }
+        // The volume conforms to the general XattrOperations protocol. Advertising *limited*
+        // support makes copyfile maintain AppleDouble fallbacks even for names our methods accept,
+        // producing transient `._*` files alongside ordinary mkdir/copy operations.
+        if want(.supportsLimitedXAttrs) { out.supportsLimitedXAttrs = false }
         return out
     }
 
@@ -530,10 +533,7 @@ final class TLFSVolume: FSVolume {
     fileprivate func ensureHandle(_ item: TLFSItem, write: Bool) throws -> UInt64 {
         item.stateLock.lock()
         defer { item.stateLock.unlock() }
-        if let fh = item.fh,
-            (item.fhWritable || !write),
-            (item.fhWritable || item.fhContentVersion == item.contentVersion)
-        {
+        if let fh = item.fh, item.fhWritable || !write {
             return fh
         }
         let fh: UInt64 = try pool.withConnection { conn in
@@ -548,7 +548,6 @@ final class TLFSVolume: FSVolume {
         }
         item.fh = fh
         item.fhWritable = write
-        item.fhContentVersion = item.contentVersion
         return fh
     }
 
@@ -575,10 +574,6 @@ extension TLFSVolume: FSVolume.PathConfOperations {
 // MARK: - Limited macOS metadata xattrs
 
 extension TLFSVolume: FSVolume.XattrOperations {
-    func supportedXattrNames(for item: FSItem) -> [FSFileName] {
-        Self.limitedXattrNames.map { FSFileName(string: $0) }
-    }
-
     func getXattr(
         named name: FSFileName,
         of item: FSItem,
@@ -1153,11 +1148,17 @@ extension TLFSVolume: FSVolume.OpenCloseOperations {
             reply(nil)
             return
         }
+        // `modes` are the aggregate modes FSKit is keeping after this close, not the modes of
+        // the descriptor being closed. Releasing while any remain invalidates sibling open
+        // descriptors and turns their next read into EIO.
+        if !modes.isEmpty {
+            reply(nil)
+            return
+        }
         item.stateLock.lock()
         let fh = item.fh
         item.fh = nil
         item.fhWritable = false
-        item.fhContentVersion = nil
         item.stateLock.unlock()
         if let fh {
             // Flush before release so close(2) durability expectations hold.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.81"
+version = "0.5.82"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.80",
+  "version": "0.5.82",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the CLI/FSKit bundle to 0.5.82 and move the private macOS attribute wire to protocol v3 with opaque content identities
- return complete requested FSKit attributes so size/mtime changes are accepted, and stop copyfile from manufacturing transient AppleDouble `._*` sidecars
- preserve the aggregate vnode handle until the final FSKit open mode closes, preventing sibling descriptors from turning into EIO during a followed-head advance
- pair with artifact-storage PR #116, which performs proactive and post-close cache convergence from the private mount daemon

## Validation

- `ARTIFACT_STORAGE_DIR=/Users/diptanuc/Projects/artifact_storage/.codex/worktrees/fs-status-local-diagnostics just test-cli-full`
- signed `platform/macos/tlfs/build.sh --release` build with Developer ID code-sign verification
- production macOS E2E: an open descriptor read its complete old 27-byte version after head advance, the first post-close open read the new 12-byte version, and restore converged immediately on both writable and read-only mounts
- ordinary directory/file copies no longer create transient AppleDouble sidecars; explicitly created `._*` files remain ordinary snapshot content
