### PR TITLE
Adopt the shared WAL workflow for filesystem and Git mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,7 +1360,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.82"
+version = "0.5.83"
 dependencies = [
  "anyhow",
  "base64",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.82"
+version = "0.5.83"
 dependencies = [
  "anyhow",
  "base64",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.82"
+version = "0.5.83"
 dependencies = [
  "anyhow",
  "base64",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.82"
+version = "0.5.83"
 dependencies = [
  "napi",
  "napi-build",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.82"
+version = "0.5.83"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.82"
+version = "0.5.83"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -131,15 +131,6 @@ pub async fn history(
     map(gsvc_fs_client::history(&private_context(ctx), target, limit, json).await)
 }
 
-pub async fn name_snapshot(
-    ctx: &CliContext,
-    filesystem: &str,
-    version: &str,
-    name: &str,
-) -> Result<()> {
-    map(gsvc_fs_client::name_snapshot(&private_context(ctx), filesystem, version, name).await)
-}
-
 pub async fn delete_snapshot(ctx: &CliContext, filesystem: &str, version: &str) -> Result<()> {
     map(gsvc_fs_client::delete_snapshot(&private_context(ctx), filesystem, version).await)
 }

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -191,9 +191,8 @@ pub async fn list_repos(ctx: &CliContext, output_json: bool) -> Result<()> {
 }
 
 /// Stable public shape for `tl git workspaces`. The repo-scoped workspace endpoint is usable by
-/// ordinary repository credentials, unlike the operator fleet endpoint. Older servers only return
-/// the workspace identity fields, so the WAL/activity/attachment facts remain explicit `null`
-/// instead of being guessed from the snapshot tip.
+/// ordinary repository credentials, unlike the operator fleet endpoint. Optional fields remain
+/// explicit `null` against older servers instead of being guessed from the snapshot tip.
 #[derive(serde::Serialize)]
 struct GitWorkspaceListItem {
     id: String,
@@ -214,13 +213,11 @@ impl From<WorkspaceInfo> for GitWorkspaceListItem {
             base: workspace.base,
             base_ref: workspace.base_ref,
             head: workspace.head,
-            // These are intentionally unknown against the current repo-scoped list wire. A
-            // future server can enrich WorkspaceInfo without changing this command's JSON schema.
-            snapshot_count: None,
-            last_activity_ms: None,
-            wal_state: None,
-            attachment_state: None,
-            mounted_on: None,
+            snapshot_count: Some(workspace.snapshot_count),
+            last_activity_ms: workspace.last_activity_ms,
+            wal_state: Some(workspace.wal_state),
+            attachment_state: Some(workspace.attachment_state),
+            mounted_on: workspace.mounted_on,
         }
     }
 }
@@ -1040,7 +1037,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn workspace_list_json_keeps_unknown_wal_and_attachment_facts_explicit() {
+    fn workspace_list_json_renders_server_wal_and_attachment_facts() {
         let workspace: WorkspaceInfo = serde_json::from_value(serde_json::json!({
             "id": "ws-1",
             "ref_name": "refs/workspaces/ws-1",
@@ -1052,17 +1049,23 @@ mod tests {
             "lease_secs": 0,
             "lease_due_ms": null,
             "pinned": true,
-            "shared_target": null
+            "shared_target": null,
+            "snapshot_count": 2,
+            "last_activity_ms": 99,
+            "wal_state": "dirty",
+            "attachment_state": "attached",
+            "mounted_on": "sandbox-1",
+            "wal_generation": 7
         }))
         .unwrap();
         let row = GitWorkspaceListItem::from(workspace);
         let json = serde_json::to_value(row).unwrap();
         assert_eq!(json["id"], "ws-1");
-        assert!(json["snapshot_count"].is_null());
-        assert!(json["last_activity_ms"].is_null());
-        assert!(json["wal_state"].is_null());
-        assert!(json["attachment_state"].is_null());
-        assert!(json["mounted_on"].is_null());
+        assert_eq!(json["snapshot_count"], 2);
+        assert_eq!(json["last_activity_ms"], 99);
+        assert_eq!(json["wal_state"], "dirty");
+        assert_eq!(json["attachment_state"], "attached");
+        assert_eq!(json["mounted_on"], "sandbox-1");
     }
 
     #[test]

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -17,6 +17,7 @@ use tensorlake::artifact_storage::merge::MergeRequest;
 use tensorlake::artifact_storage::models::{
     ListBranchesResponse, ListOperationsResponse, ListRefsResponse, ListReposResponse,
 };
+use tensorlake::artifact_storage::workspaces::WorkspaceInfo;
 use tensorlake::{ClientBuilder, Sdk};
 
 use crate::auth::context::CliContext;
@@ -186,6 +187,111 @@ pub async fn list_repos(ctx: &CliContext, output_json: bool) -> Result<()> {
         return Ok(());
     }
     print_repos_table(&response);
+    Ok(())
+}
+
+/// Stable public shape for `tl git workspaces`. The repo-scoped workspace endpoint is usable by
+/// ordinary repository credentials, unlike the operator fleet endpoint. Older servers only return
+/// the workspace identity fields, so the WAL/activity/attachment facts remain explicit `null`
+/// instead of being guessed from the snapshot tip.
+#[derive(serde::Serialize)]
+struct GitWorkspaceListItem {
+    id: String,
+    base: String,
+    base_ref: Option<String>,
+    head: String,
+    snapshot_count: Option<u64>,
+    last_activity_ms: Option<u64>,
+    wal_state: Option<String>,
+    attachment_state: Option<String>,
+    mounted_on: Option<String>,
+}
+
+impl From<WorkspaceInfo> for GitWorkspaceListItem {
+    fn from(workspace: WorkspaceInfo) -> Self {
+        Self {
+            id: workspace.id,
+            base: workspace.base,
+            base_ref: workspace.base_ref,
+            head: workspace.head,
+            // These are intentionally unknown against the current repo-scoped list wire. A
+            // future server can enrich WorkspaceInfo without changing this command's JSON schema.
+            snapshot_count: None,
+            last_activity_ms: None,
+            wal_state: None,
+            attachment_state: None,
+            mounted_on: None,
+        }
+    }
+}
+
+pub async fn list_workspaces(ctx: &CliContext, repo: &str, output_json: bool) -> Result<()> {
+    let project_id = project_id(ctx)?;
+    let client = artifact_storage_client(ctx)?;
+    let credential = client
+        .git_credential_for_repo(&project_id, repo)
+        .await
+        .map_err(map_sdk_error)?;
+    let mut workspaces: Vec<GitWorkspaceListItem> = client
+        .list_workspaces(
+            &project_id,
+            repo,
+            &credential.git_username,
+            &credential.token,
+        )
+        .await
+        .map_err(map_sdk_error)?
+        .into_inner()
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    workspaces.sort_by(|a, b| a.id.cmp(&b.id));
+
+    if output_json {
+        return print_json(&workspaces);
+    }
+    if workspaces.is_empty() {
+        println!("no workspaces found for {repo}");
+        return Ok(());
+    }
+
+    let short = |oid: &str| oid[..oid.len().min(12)].to_string();
+    let mut table = new_table(&[
+        "Workspace",
+        "Base",
+        "Head",
+        "Snapshots",
+        "WAL",
+        "Attachment",
+        "Last activity",
+    ]);
+    for workspace in &workspaces {
+        table.add_row(vec![
+            Cell::new(&workspace.id),
+            Cell::new(short(&workspace.base)),
+            Cell::new(short(&workspace.head)),
+            Cell::new(
+                workspace
+                    .snapshot_count
+                    .map_or_else(|| "unknown".to_string(), |count| count.to_string()),
+            ),
+            Cell::new(workspace.wal_state.as_deref().unwrap_or("unknown")),
+            Cell::new(
+                workspace
+                    .mounted_on
+                    .as_deref()
+                    .or(workspace.attachment_state.as_deref())
+                    .unwrap_or("unknown"),
+            ),
+            Cell::new(
+                workspace
+                    .last_activity_ms
+                    .map_or_else(|| "unknown".to_string(), |time| time.to_string()),
+            ),
+        ]);
+    }
+    println!("{table}");
+    println!("{} workspaces", workspaces.len());
     Ok(())
 }
 
@@ -932,6 +1038,32 @@ pub async fn commit_status(ctx: &CliContext, repo: &str, job_id: &str) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn workspace_list_json_keeps_unknown_wal_and_attachment_facts_explicit() {
+        let workspace: WorkspaceInfo = serde_json::from_value(serde_json::json!({
+            "id": "ws-1",
+            "ref_name": "refs/workspaces/ws-1",
+            "principal": "agent-1",
+            "base": "a".repeat(40),
+            "base_ref": "refs/heads/main",
+            "head": "b".repeat(40),
+            "created_at_secs": 10,
+            "lease_secs": 0,
+            "lease_due_ms": null,
+            "pinned": true,
+            "shared_target": null
+        }))
+        .unwrap();
+        let row = GitWorkspaceListItem::from(workspace);
+        let json = serde_json::to_value(row).unwrap();
+        assert_eq!(json["id"], "ws-1");
+        assert!(json["snapshot_count"].is_null());
+        assert!(json["last_activity_ms"].is_null());
+        assert!(json["wal_state"].is_null());
+        assert!(json["attachment_state"].is_null());
+        assert!(json["mounted_on"].is_null());
+    }
 
     #[test]
     fn git_worktree_root_rejects_non_git_dir() {

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -89,5 +89,10 @@ pub(crate) fn push_event_message(ev: &PushEvent) -> String {
             }
         }
         PushEvent::Committed { ref_name, .. } => format!("committed to {ref_name}"),
+        PushEvent::Checkpointed {
+            workspace_id,
+            generation,
+            ..
+        } => format!("autosaved workspace {workspace_id} generation {generation}"),
     }
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -89,10 +89,5 @@ pub(crate) fn push_event_message(ev: &PushEvent) -> String {
             }
         }
         PushEvent::Committed { ref_name, .. } => format!("committed to {ref_name}"),
-        PushEvent::Checkpointed {
-            workspace_id,
-            generation,
-            ..
-        } => format!("autosaved workspace {workspace_id} generation {generation}"),
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -627,7 +627,7 @@ enum GitCommands {
         path: PathBuf,
 
         /// A stateless read-only view (branches and tags follow; full commits stay pinned)
-        #[arg(long, conflicts_with = "publish")]
+        #[arg(long, conflicts_with_all = ["publish", "workspace"])]
         ro: bool,
 
         /// Every explicit snapshot also promotes onto the mounted branch. Autosaves never
@@ -3568,6 +3568,20 @@ mod tests {
             }
             _ => panic!("expected git mount command"),
         }
+        assert!(
+            Cli::try_parse_from([
+                "tl",
+                "git",
+                "mount",
+                "demo",
+                "./w",
+                "--ro",
+                "--workspace",
+                "0123456789abcdef0123456789abcdef01234567",
+            ])
+            .is_err(),
+            "read-only workspace resume would silently omit the unmaterialized WAL"
+        );
         match parse_command(["tl", "git", "promote", "main", "--merge"]) {
             Commands::Git(GitCommands::Promote {
                 path: None,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -294,12 +294,13 @@ enum FsCommands {
         #[arg(short = 'n', long, default_value_t = 20)]
         limit: usize,
 
-        /// Output JSON
+        /// Output JSON with separate `snapshots` and `autosaves` arrays
         #[arg(long)]
         json: bool,
     },
 
-    /// Delete a permanent snapshot; unreferenced content is reclaimed asynchronously
+    /// Remove a permanent retention point. Referenced content remains available; unreferenced
+    /// bytes are reclaimed asynchronously
     #[command(name = "delete-snapshot")]
     DeleteSnapshot {
         /// Filesystem name
@@ -3383,6 +3384,7 @@ mod tests {
         let history_help = String::from_utf8(history_help).unwrap();
         assert!(history_help.contains("permanent snapshots are always included"));
         assert!(history_help.contains("recent ephemeral autosave WAL"));
+        assert!(history_help.contains("separate `snapshots` and `autosaves` arrays"));
 
         let mut command = Cli::command();
         let push = command
@@ -3410,6 +3412,19 @@ mod tests {
             }
             _ => panic!("expected fs delete-snapshot command"),
         }
+        let mut command = Cli::command();
+        let delete_snapshot = command
+            .find_subcommand_mut("fs")
+            .unwrap()
+            .find_subcommand_mut("delete-snapshot")
+            .unwrap();
+        let mut delete_snapshot_help = Vec::new();
+        delete_snapshot
+            .write_long_help(&mut delete_snapshot_help)
+            .unwrap();
+        let delete_snapshot_help = String::from_utf8(delete_snapshot_help).unwrap();
+        assert!(delete_snapshot_help.contains("Remove a permanent retention point"));
+        assert!(delete_snapshot_help.contains("Referenced content remains available"));
 
         match parse_command(["tl", "fs", "ls"]) {
             Commands::Fs(FsCommands::Ls {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -616,8 +616,8 @@ enum GitCommands {
         /// Operation requested by git: get, store, or erase
         operation: String,
     },
-    /// Mount a repo as a lazy working tree. Writes autosave durably into a private workspace,
-    /// but no branch changes until `tl git promote`
+    /// Mount a repo as a lazy working tree. Writes autosave durably into a private workspace.
+    /// Branches change only through `tl git promote`, or each snapshot when `--publish` is set
     Mount {
         /// `<repo>[:<ref-or-full-commit>][//<subtree>]` — selects the base view and optionally
         /// exposes one directory as the mount root; the workspace is created on first write

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -180,7 +180,7 @@ enum Commands {
     #[command(subcommand)]
     Secrets(SecretsCommands),
 
-    /// Manage versioned filesystems
+    /// Manage shared drives with continuous autosave and permanent snapshots
     #[command(subcommand, name = "fs")]
     Fs(FsCommands),
 
@@ -229,11 +229,11 @@ enum FsCommands {
         json: bool,
     },
 
-    /// Mount a filesystem: reads stream lazily, saves publish to the filesystem.
-    /// Name a retained save as `filesystem:save-id` for a fixed read-only time-travel view.
+    /// Mount a filesystem: reads stream lazily and autosaves publish to the shared drive.
+    /// Use `filesystem:snapshot-id` for a fixed read-only time-travel view.
     /// Remounting a filesystem this machine has a detached session for resumes that session
     Mount {
-        /// Filesystem name, optionally followed by `:<save-id>` (see `tl fs history`)
+        /// Filesystem name, optionally followed by `:<snapshot-id>` (see `tl fs history`)
         target: String,
 
         /// Mountpoint directory (created; must be empty)
@@ -270,7 +270,8 @@ enum FsCommands {
     },
 
     /// Upload a folder into a filesystem and track it for later incremental saves (no mount
-    /// needed). Interrupted attempts resume from durable local state
+    /// needed). Without -m the upload is an automatic save; -m creates a permanent snapshot.
+    /// Interrupted attempts resume from durable local state
     Push {
         /// Local directory to upload
         dir: PathBuf,
@@ -278,18 +279,18 @@ enum FsCommands {
         /// Filesystem name
         name: String,
 
-        /// Save message
+        /// Create a permanent, billed snapshot with this message
         #[arg(short, long)]
         message: Option<String>,
     },
 
-    /// Show recent automatic history plus every named retained save
+    /// Show permanent snapshots, followed by the recent ephemeral autosave WAL
     History {
         /// Filesystem name, or a mounted directory (default: the mount containing the
         /// current directory)
         target: Option<String>,
 
-        /// Show at most N recent timeline entries (named retained saves are always included)
+        /// Show at most N recent autosaves (permanent snapshots are always included)
         #[arg(short = 'n', long, default_value_t = 20)]
         limit: usize,
 
@@ -298,25 +299,13 @@ enum FsCommands {
         json: bool,
     },
 
-    /// Name a recent automatic save and keep it until explicitly deleted
-    Name {
-        /// Filesystem name
-        name: String,
-
-        /// Save ID or unambiguous hexadecimal prefix
-        version: String,
-
-        /// Durable name for this save
-        snapshot_name: String,
-    },
-
-    /// Remove a durable name; the save then follows automatic retention
+    /// Delete a permanent snapshot; unreferenced content is reclaimed asynchronously
     #[command(name = "delete-snapshot")]
     DeleteSnapshot {
         /// Filesystem name
         name: String,
 
-        /// Save ID or unambiguous hexadecimal prefix
+        /// Snapshot ID or unambiguous hexadecimal prefix
         version: String,
     },
 
@@ -353,13 +342,13 @@ enum FsCommands {
         log_level: String,
     },
 
-    /// Save the current state of the filesystem (a clean tree is a quiet no-op)
+    /// Create a permanent, billed snapshot of the drive (a clean tree is a quiet no-op)
     Snapshot {
         /// A mounted or pushed directory (default: the attachment containing the current
         /// directory)
         path: Option<PathBuf>,
 
-        /// Save message
+        /// Snapshot message
         #[arg(short, long)]
         message: Option<String>,
 
@@ -369,7 +358,7 @@ enum FsCommands {
         clear: bool,
     },
 
-    /// Show mount, autosave, and local-change status
+    /// Show local changes, last autosave, and permanent snapshot count
     Status {
         /// A mounted or tracked directory (default: the attachment containing the current
         /// directory)
@@ -380,7 +369,7 @@ enum FsCommands {
         json: bool,
     },
 
-    /// Inspect the crash-safe local snapshot journal of a native mount or tracked directory
+    /// Inspect the crash-safe local autosave journal of a native mount or tracked directory
     Doctor {
         /// A mounted or tracked directory (default: the attachment containing the current
         /// directory)
@@ -396,19 +385,23 @@ enum FsCommands {
         #[arg(long)]
         repair_journal: bool,
 
-        /// Required repair baseline when the existing journal cannot prove one. Pass a native
-        /// save ID, or `empty` only for a filesystem that has never had a save.
-        #[arg(long, value_name = "SAVE_ID|empty", requires = "repair_journal")]
+        /// Required repair baseline when the existing journal cannot prove one. Pass a snapshot
+        /// or recent autosave ID, or `empty` only for a filesystem that has never been saved.
+        #[arg(
+            long,
+            value_name = "SNAPSHOT_OR_AUTOSAVE_ID|empty",
+            requires = "repair_journal"
+        )]
         base: Option<String>,
     },
 
-    /// Restore a writable filesystem mount to an earlier save
+    /// Restore a writable filesystem mount to a snapshot or recent autosave
     #[command(allow_missing_positional = true)]
     Restore {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
 
-        /// Save ID or unambiguous hexadecimal prefix
+        /// Snapshot or recent autosave ID, or an unambiguous hexadecimal prefix
         version: String,
 
         /// Drop the local overlay to apply the restore. Destructive: unsaved changes AND
@@ -423,7 +416,7 @@ enum FsCommands {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
 
-        /// Also delete the server-side session (its unpublished saves become unreachable)
+        /// Also delete the detached server-side session and its unretained autosave history
         #[arg(long, hide = true)]
         delete: bool,
 
@@ -622,11 +615,11 @@ enum GitCommands {
         /// Operation requested by git: get, store, or erase
         operation: String,
     },
-    /// Mount a repo branch as a working tree (FUSE), without cloning: reads stream lazily,
-    /// writes stay local until `tl git snapshot`
+    /// Mount a repo as a lazy working tree. Writes autosave durably into a private workspace,
+    /// but no branch changes until `tl git promote`
     Mount {
-        /// `<repo>[:<ref-or-full-commit>][//<subtree>]` — forks a private workspace off the
-        /// selected source and optionally exposes one directory as the mount root
+        /// `<repo>[:<ref-or-full-commit>][//<subtree>]` — selects the base view and optionally
+        /// exposes one directory as the mount root; the workspace is created on first write
         target: String,
 
         /// Mountpoint directory (created; must be empty)
@@ -636,12 +629,12 @@ enum GitCommands {
         #[arg(long, conflicts_with = "publish")]
         ro: bool,
 
-        /// Every snapshot lands on the mounted branch automatically (server-ordered, merged,
-        /// one attributed commit per snapshot). Requires `<repo>:<branch>`
+        /// Every explicit snapshot also promotes onto the mounted branch. Autosaves never
+        /// publish. Requires `<repo>:<branch>`
         #[arg(long)]
         publish: bool,
 
-        /// Reattach an existing workspace instead of forking a new one
+        /// Resume an existing workspace, including its unsnapshotted autosave WAL
         #[arg(long, conflicts_with = "publish")]
         workspace: Option<String>,
 
@@ -658,7 +651,7 @@ enum GitCommands {
         log_level: String,
     },
 
-    /// Unmount a repo working tree; the workspace survives unless --delete
+    /// Unmount a repo working tree; its durable WAL and snapshots survive unless --delete
     Unmount {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
@@ -673,7 +666,7 @@ enum GitCommands {
         discard: bool,
     },
 
-    /// Checkpoint the mounted working tree as a commit on its private workspace line
+    /// Materialize the current autosaved state as one commit on the private workspace line
     Snapshot {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
@@ -688,7 +681,7 @@ enum GitCommands {
         clear: bool,
     },
 
-    /// Refresh the mounted view, or switch a pristine workspace to another ref or commit
+    /// Refresh or switch the base view, carrying any unsnapshotted autosave state forward
     Sync {
         /// A mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
@@ -697,7 +690,7 @@ enum GitCommands {
         target: Option<String>,
     },
 
-    /// Replay a snapshotted workspace onto another ref or commit on the server
+    /// Replay the workspace snapshots and unsnapshotted autosave tail onto another base
     #[command(allow_missing_positional = true)]
     Rebase {
         /// A mounted directory (default: the mount containing the current directory)
@@ -711,7 +704,7 @@ enum GitCommands {
         fail_on_conflict: bool,
     },
 
-    /// Land the mounted working tree's checkpoint on a branch (squash by default)
+    /// Autosave live changes, materialize a snapshot, then squash-land it on a branch
     #[command(allow_missing_positional = true)]
     Promote {
         /// A mounted directory (default: the mount containing the current directory)
@@ -724,6 +717,16 @@ enum GitCommands {
         /// publish nothing
         #[arg(long)]
         merge: bool,
+    },
+
+    /// List a repository's durable workspaces, autosave state, snapshots, and attachments
+    Workspaces {
+        /// Repository name
+        repo: String,
+
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Show workspace and local-change status for a mounted working tree
@@ -2536,7 +2539,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             if path.is_none() {
                 commands::fs::reject_mount_like_positional(
                     version,
-                    "save ID",
+                    "snapshot or autosave ID",
                     "tl fs restore [PATH] <VERSION>",
                 )?;
             }
@@ -2623,11 +2626,6 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             limit,
             json,
         } => commands::fs::history(ctx, target.as_deref(), limit, json).await,
-        FsCommands::Name {
-            name,
-            version,
-            snapshot_name,
-        } => commands::fs::name_snapshot(ctx, &name, &version, &snapshot_name).await,
         FsCommands::DeleteSnapshot { name, version } => {
             commands::fs::delete_snapshot(ctx, &name, &version).await
         }
@@ -2675,8 +2673,9 @@ async fn run_fs_command(_ctx: &mut CliContext, _subcmd: FsCommands) -> error::Re
     ))
 }
 
-/// The `tl git` mount family: the same battle-tested engine as `tl fs`, with git vocabulary
-/// and git defaults (explicit checkpointing, no autosave, no publish unless asked).
+/// The `tl git` mount family: the same journal and autosave engine as `tl fs`, with Git
+/// publication policy (autosave checkpoints are durable but only snapshots create commits,
+/// and only promote advances a branch).
 #[cfg(feature = "mount")]
 async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> error::Result<()> {
     // Path-addressed commands carry their scope in the mount state; resolve it before auth so
@@ -2860,6 +2859,9 @@ async fn run_git_command(ctx: &CliContext, subcmd: GitCommands) -> error::Result
             json,
         } => commands::git::create_repo(ctx, &repo, Some(&default_branch), json).await,
         GitCommands::Ls { json } => commands::git::list_repos(ctx, json).await,
+        GitCommands::Workspaces { repo, json } => {
+            commands::git::list_workspaces(ctx, &repo, json).await
+        }
         GitCommands::Rm { repo } => commands::git::delete_repo(ctx, &repo).await,
         GitCommands::Fork { repo, base_repo } => {
             commands::git::fork_repo(ctx, &repo, &base_repo).await
@@ -3379,20 +3381,27 @@ mod tests {
         let mut history_help = Vec::new();
         history.write_long_help(&mut history_help).unwrap();
         let history_help = String::from_utf8(history_help).unwrap();
-        assert!(history_help.contains("named retained saves are always included"));
+        assert!(history_help.contains("permanent snapshots are always included"));
+        assert!(history_help.contains("recent ephemeral autosave WAL"));
 
-        match parse_command(["tl", "fs", "name", "scratch", "abc123", "before-upgrade"]) {
-            Commands::Fs(FsCommands::Name {
-                name,
-                version,
-                snapshot_name,
-            }) => {
-                assert_eq!(name, "scratch");
-                assert_eq!(version, "abc123");
-                assert_eq!(snapshot_name, "before-upgrade");
-            }
-            _ => panic!("expected fs name command"),
-        }
+        let mut command = Cli::command();
+        let push = command
+            .find_subcommand_mut("fs")
+            .unwrap()
+            .find_subcommand_mut("push")
+            .unwrap();
+        let mut push_help = Vec::new();
+        push.write_long_help(&mut push_help).unwrap();
+        let push_help = String::from_utf8(push_help).unwrap();
+        assert!(push_help.contains("Without -m the upload is an automatic save"));
+        assert!(push_help.contains("permanent, billed snapshot"));
+
+        // Snapshot creation and deletion are the whole permanent-retention surface. There is
+        // no second command that promotes an autosave into a snapshot.
+        assert!(
+            Cli::try_parse_from(["tl", "fs", "name", "scratch", "abc123", "before-upgrade"])
+                .is_err()
+        );
 
         match parse_command(["tl", "fs", "delete-snapshot", "scratch", "abc123"]) {
             Commands::Fs(FsCommands::DeleteSnapshot { name, version }) => {
@@ -3555,6 +3564,17 @@ mod tests {
             }
             _ => panic!("expected git promote command"),
         }
+        let mut command = Cli::command();
+        let promote = command
+            .find_subcommand_mut("git")
+            .unwrap()
+            .find_subcommand_mut("promote")
+            .unwrap();
+        let mut promote_help = Vec::new();
+        promote.write_long_help(&mut promote_help).unwrap();
+        let promote_help = String::from_utf8(promote_help).unwrap();
+        assert!(promote_help.contains("Autosave live changes"));
+        assert!(promote_help.contains("squash-land"));
         match parse_command(["tl", "git", "sync"]) {
             Commands::Git(GitCommands::Sync {
                 path: None,
@@ -3590,6 +3610,13 @@ mod tests {
                 assert!(json);
             }
             _ => panic!("expected git log command"),
+        }
+        match parse_command(["tl", "git", "workspaces", "demo", "--json"]) {
+            Commands::Git(GitCommands::Workspaces { repo, json }) => {
+                assert_eq!(repo, "demo");
+                assert!(json);
+            }
+            _ => panic!("expected git workspaces command"),
         }
         match parse_command(["tl", "git", "smartlog", "demo", "--project", "--json"]) {
             Commands::Git(GitCommands::Smartlog {

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -232,6 +232,15 @@ fn canonical_repo_path(path: &str, what: &str) -> Result<(), SdkError> {
     Ok(())
 }
 
+fn encoded_repo_path(path: &str, what: &str) -> Result<String, SdkError> {
+    canonical_repo_path(path, what)?;
+    Ok(path
+        .split('/')
+        .map(super::encode_path_segment)
+        .collect::<Vec<_>>()
+        .join("/"))
+}
+
 fn is_hex_oid(value: &str) -> bool {
     value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
@@ -363,6 +372,35 @@ impl MaterializeWorkspaceCheckpointRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspaceCheckpointPublishStatus {
+    NotConfigured,
+    Published,
+    Conflict,
+    Failed,
+    /// Forward-compatible, but deliberately not successful: a new server outcome must not be
+    /// mistaken for a branch publication by an older client.
+    #[serde(other)]
+    Unknown,
+}
+
+impl WorkspaceCheckpointPublishStatus {
+    pub fn is_success(&self) -> bool {
+        matches!(self, Self::NotConfigured | Self::Published)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::NotConfigured => "not_configured",
+            Self::Published => "published",
+            Self::Conflict => "conflict",
+            Self::Failed => "failed",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MaterializeWorkspaceCheckpointResponse {
     pub generation: u64,
     pub commit: String,
@@ -372,7 +410,7 @@ pub struct MaterializeWorkspaceCheckpointResponse {
     pub created: bool,
     /// Outcome of the separate publish-on-snapshot transition: `not_configured`, `published`,
     /// `conflict`, or `failed`. Materialization itself succeeded whenever this response exists.
-    pub publish_status: String,
+    pub publish_status: WorkspaceCheckpointPublishStatus,
     /// Target-branch commit written by configured publication, including idempotent replays.
     pub published_commit: Option<String>,
     /// Actionable configured-publication failure. The snapshot commit named by `commit` remains
@@ -2089,9 +2127,9 @@ impl ArtifactStorageClient {
         checkpoint_id: &str,
         tree: &str,
     ) -> Result<Traced<Vec<u8>>, SdkError> {
-        canonical_repo_path(file_path, "checkpoint file path")?;
+        let encoded_file_path = encoded_repo_path(file_path, "checkpoint file path")?;
         let suffix = format!(
-            "workspaces/{}/checkpoint/files/{file_path}",
+            "workspaces/{}/checkpoint/files/{encoded_file_path}",
             super::encode_path_segment(workspace_id)
         );
         let query = [
@@ -2117,6 +2155,86 @@ impl ArtifactStorageClient {
                 });
             }
             Ok((response.bytes().await?.to_vec(), trace_id))
+        })
+        .await?;
+        Ok(Traced::new(trace_id, bytes))
+    }
+
+    /// Read a bounded byte range from an exact, principal-bound workspace checkpoint revision.
+    /// The server must answer with `206 Partial Content`; accepting a full-body `200` here would
+    /// silently defeat the resume path's memory bound when talking to an incompatible server.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn workspace_checkpoint_file_range(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        workspace_id: &str,
+        file_path: &str,
+        generation: u64,
+        checkpoint_id: &str,
+        tree: &str,
+        start: u64,
+        end_inclusive: u64,
+    ) -> Result<Traced<Vec<u8>>, SdkError> {
+        let encoded_file_path = encoded_repo_path(file_path, "checkpoint file path")?;
+        if start > end_inclusive {
+            return Err(SdkError::ClientError(
+                "checkpoint file range start exceeds end".to_string(),
+            ));
+        }
+        let suffix = format!(
+            "workspaces/{}/checkpoint/files/{encoded_file_path}",
+            super::encode_path_segment(workspace_id)
+        );
+        let query = [
+            ("generation", generation.to_string()),
+            ("checkpoint_id", checkpoint_id.to_string()),
+            ("tree", tree.to_string()),
+        ];
+        let expected_len = end_inclusive - start + 1;
+        let range_header = format!("bytes={start}-{end_inclusive}");
+        let (bytes, trace_id) = with_transient_retries(|| async {
+            let (request, trace_id) = self.git_request(
+                Method::GET,
+                project_id,
+                repo,
+                Some(&suffix),
+                git_username,
+                git_token,
+            )?;
+            let response = request
+                .query(&query)
+                .header(reqwest::header::RANGE, &range_header)
+                .send()
+                .await?;
+            let status = response.status();
+            if status != reqwest::StatusCode::PARTIAL_CONTENT {
+                return Err(SdkError::ServerError {
+                    status,
+                    message: response.text().await.unwrap_or_default(),
+                });
+            }
+            let expected_content_range = format!("bytes {start}-{end_inclusive}/");
+            let content_range_matches = response
+                .headers()
+                .get(reqwest::header::CONTENT_RANGE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with(&expected_content_range));
+            if !content_range_matches {
+                return Err(SdkError::ClientError(format!(
+                    "checkpoint file range response did not bind bytes {start}-{end_inclusive}"
+                )));
+            }
+            let bytes = response.bytes().await?.to_vec();
+            if bytes.len() as u64 != expected_len {
+                return Err(SdkError::ClientError(format!(
+                    "checkpoint file range returned {} bytes, expected {expected_len}",
+                    bytes.len()
+                )));
+            }
+            Ok((bytes, trace_id))
         })
         .await?;
         Ok(Traced::new(trace_id, bytes))
@@ -2454,6 +2572,41 @@ async fn expect_ok(resp: reqwest::Response) -> Result<(), SdkError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn checkpoint_file_paths_encode_components_without_hiding_separators() {
+        assert_eq!(
+            encoded_repo_path("src/what ?#%.rs", "test path").unwrap(),
+            "src/what%20%3F%23%25.rs"
+        );
+        assert_eq!(
+            encoded_repo_path("日本語/é.rs", "test path").unwrap(),
+            "%E6%97%A5%E6%9C%AC%E8%AA%9E/%C3%A9.rs"
+        );
+        assert!(encoded_repo_path("../secret", "test path").is_err());
+    }
+
+    #[test]
+    fn unknown_publish_outcomes_fail_closed() {
+        let response: MaterializeWorkspaceCheckpointResponse =
+            serde_json::from_value(serde_json::json!({
+                "generation": 1,
+                "commit": "a".repeat(40),
+                "tree": "b".repeat(40),
+                "ref_name": "refs/workspaces/w",
+                "parent": null,
+                "created": true,
+                "publish_status": "new_server_outcome",
+                "published_commit": null,
+                "publish_error": null,
+            }))
+            .unwrap();
+        assert_eq!(
+            response.publish_status,
+            WorkspaceCheckpointPublishStatus::Unknown
+        );
+        assert!(!response.publish_status.is_success());
+    }
 
     fn cf(chunks: Vec<([u8; 32], u32)>, delete: bool, known_oid: bool) -> ChunkedFile {
         let cdc = !delete && !known_oid && !chunks.is_empty();
@@ -2882,7 +3035,10 @@ mod tests {
             .expect("materialize POST must retry a 503")
             .into_inner();
         assert_eq!(materialized.commit, materialized_commit);
-        assert_eq!(materialized.publish_status, "published");
+        assert_eq!(
+            materialized.publish_status,
+            WorkspaceCheckpointPublishStatus::Published
+        );
         assert_eq!(
             materialized.published_commit.as_deref(),
             Some("9999999999999999999999999999999999999999")

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -31,8 +31,8 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::Traced;
 use crate::error::SdkError;
+use crate::Traced;
 
 use super::ArtifactStorageClient;
 
@@ -212,6 +212,10 @@ pub struct WorkspaceCheckpointOptions {
     /// Branch promoted by each explicit snapshot (`tl git mount --publish`). Autosave only
     /// persists this policy; a checkpoint never advances the branch itself.
     pub publish_target: Option<String>,
+    /// Writable mount fencing token and its fleet-visible location. Generation one sends both so
+    /// workspace allocation and ownership are one atomic server transaction.
+    pub mount_id: Option<String>,
+    pub mounted_on: Option<String>,
 }
 
 fn canonical_repo_path(path: &str, what: &str) -> Result<(), SdkError> {
@@ -357,6 +361,8 @@ pub struct MaterializeWorkspaceCheckpointRequest {
     pub author: Option<super::merge::Signature>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub committer: Option<super::merge::Signature>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mount_id: Option<String>,
 }
 
 impl MaterializeWorkspaceCheckpointRequest {
@@ -367,6 +373,7 @@ impl MaterializeWorkspaceCheckpointRequest {
             message: message.into(),
             author: None,
             committer: None,
+            mount_id: None,
         }
     }
 }
@@ -601,6 +608,10 @@ struct WorkspaceCheckpointWire<'a> {
     base_ref: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     publish_target: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mount_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mounted_on: Option<&'a str>,
     session_id: &'a str,
     files: &'a [CommitFileWire],
 }
@@ -1756,6 +1767,8 @@ impl ArtifactStorageClient {
                 base,
                 base_ref: checkpoint.base_ref.as_deref(),
                 publish_target: checkpoint.publish_target.as_deref(),
+                mount_id: checkpoint.mount_id.as_deref(),
+                mounted_on: checkpoint.mounted_on.as_deref(),
                 session_id: &session.session_id,
                 files: &commit_files,
             };
@@ -2701,6 +2714,8 @@ mod tests {
             base: &base,
             base_ref: Some("refs/heads/main"),
             publish_target: Some("main"),
+            mount_id: Some("mount-1"),
+            mounted_on: Some("sandbox:/code"),
             session_id: "session-1",
             files: &files,
         };
@@ -2711,6 +2726,8 @@ mod tests {
         assert_eq!(value["base"], "1".repeat(40));
         assert_eq!(value["base_ref"], "refs/heads/main");
         assert_eq!(value["publish_target"], "main");
+        assert_eq!(value["mount_id"], "mount-1");
+        assert_eq!(value["mounted_on"], "sandbox:/code");
         assert_eq!(value["session_id"], "session-1");
         assert_eq!(value["files"][0]["path"], "src/lib.rs");
         assert_eq!(value["files"][0]["chunks"][0]["size"], 17);
@@ -3000,6 +3017,8 @@ mod tests {
                     checkpoint_id: "checkpoint-7".to_string(),
                     base_ref: Some("refs/heads/main".to_string()),
                     publish_target: Some("main".to_string()),
+                    mount_id: Some("mount-1".to_string()),
+                    mounted_on: Some("sandbox:/code".to_string()),
                 },
             )
             .await
@@ -3101,6 +3120,8 @@ mod tests {
         assert_eq!(checkpoint_body["base"], base_oid);
         assert_eq!(checkpoint_body["base_ref"], "refs/heads/main");
         assert_eq!(checkpoint_body["publish_target"], "main");
+        assert_eq!(checkpoint_body["mount_id"], "mount-1");
+        assert_eq!(checkpoint_body["mounted_on"], "sandbox:/code");
         assert_eq!(checkpoint_body["session_id"], "session-1");
         assert_eq!(checkpoint_body["files"][0]["path"], "src/main.rs");
         assert_eq!(checkpoint_body["files"][0]["oid"], "f".repeat(40));

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -31,8 +31,8 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::error::SdkError;
 use crate::Traced;
+use crate::error::SdkError;
 
 use super::ArtifactStorageClient;
 
@@ -363,6 +363,10 @@ pub struct MaterializeWorkspaceCheckpointRequest {
     pub committer: Option<super::merge::Signature>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mount_id: Option<String>,
+    /// Whether materialization should also run the workspace's configured publish policy.
+    /// Full-history promotion suppresses this one squash publication, then lands the exact
+    /// materialized chain through the explicit promote transaction.
+    pub publish_configured: bool,
 }
 
 impl MaterializeWorkspaceCheckpointRequest {
@@ -374,6 +378,7 @@ impl MaterializeWorkspaceCheckpointRequest {
             author: None,
             committer: None,
             mount_id: None,
+            publish_configured: true,
         }
     }
 }
@@ -3184,6 +3189,7 @@ mod tests {
         assert_eq!(materialize_body["format_ver"], 1);
         assert_eq!(materialize_body["generation"], 7);
         assert_eq!(materialize_body["message"], "intentional snapshot");
+        assert_eq!(materialize_body["publish_configured"], true);
         assert_eq!(materialize_body["author"]["name"], "Agent");
         assert!(materialize_body.get("committer").is_none());
     }

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -122,6 +122,13 @@ pub enum PushEvent {
     },
     /// The commit published.
     Committed { commit: String, ref_name: String },
+    /// Uploaded content was sealed into a durable workspace WAL checkpoint. No commit or
+    /// branch update was created.
+    Checkpointed {
+        workspace_id: String,
+        generation: u64,
+        tree: String,
+    },
 }
 
 pub type PushProgress = Arc<dyn Fn(PushEvent) + Send + Sync>;
@@ -144,6 +151,10 @@ pub struct PushOptions {
     /// application three-ways against the declared base plus this push's exact change list
     /// (servers that predate the field ignore it and merge against the chain parent).
     pub workspace_snapshot: Option<String>,
+    /// Seal the prepared file list as a durable workspace WAL checkpoint instead of creating a
+    /// commit. This shares the complete hashing/chunk/upload pipeline with ordinary pushes; only
+    /// the final metadata submit differs. Mutually exclusive with [`Self::workspace_snapshot`].
+    pub workspace_checkpoint: Option<WorkspaceCheckpointOptions>,
     /// Return every CDC-path file's chunk list in `PushReport::file_chunks`, so the caller can
     /// hand them back as `PushSource::StablePrefix` prefixes on the next push of the same
     /// content. Off by default: the lists cost memory proportional to the push.
@@ -188,12 +199,28 @@ impl Default for PushOptions {
             upload_batch_bytes: 48 * 1024 * 1024,
             progress: None,
             workspace_snapshot: None,
+            workspace_checkpoint: None,
             collect_file_chunks: false,
             idempotency_key: None,
             on_prepared: None,
             path_prefix: None,
         }
     }
+}
+
+/// Identity and ordering fields for one crash-resumable Git workspace WAL checkpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceCheckpointOptions {
+    /// Client-generated 40-hex workspace id. The server allocates the workspace lazily and
+    /// atomically with generation one.
+    pub workspace_id: String,
+    /// Strictly increasing generation within the workspace WAL.
+    pub generation: u64,
+    /// Stable idempotency identity journaled before upload.
+    pub checkpoint_id: String,
+    /// Canonical ref from which the lazy workspace base was resolved, for display and promote
+    /// defaults. The immutable base commit itself is [`PushOptions::base`].
+    pub base_ref: Option<String>,
 }
 
 fn canonical_repo_path(path: &str, what: &str) -> Result<(), SdkError> {
@@ -212,6 +239,10 @@ fn canonical_repo_path(path: &str, what: &str) -> Result<(), SdkError> {
         )));
     }
     Ok(())
+}
+
+fn is_hex_oid(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn apply_path_prefix(files: &mut [PushFile], prefix: Option<&str>) -> Result<(), SdkError> {
@@ -251,6 +282,90 @@ pub struct PushReport {
     /// `PushSource::StablePrefix`. Never serialized: caller-local plumbing, not wire data.
     #[serde(skip_serializing)]
     pub file_chunks: Vec<(String, Vec<([u8; 32], u32)>)>,
+    /// Present when the push target was [`PushOptions::workspace_checkpoint`]. `commit` is the
+    /// current materialized snapshot tip in that case (normally the base commit), while `tree`
+    /// is the newly checkpointed uncommitted tree.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<WorkspaceCheckpointResponse>,
+}
+
+/// Durable server acknowledgement for a Git workspace WAL checkpoint.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceCheckpointResponse {
+    pub format_ver: u16,
+    pub workspace_id: String,
+    pub ref_name: String,
+    pub generation: u64,
+    pub checkpoint_id: String,
+    pub base: String,
+    pub snapshot_tip: String,
+    pub tree: String,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+    pub materialized_generation: Option<u64>,
+    /// Derived from the PUT status: true when this checkpoint lazily allocated the workspace.
+    #[serde(default)]
+    pub workspace_created: bool,
+}
+
+/// Upload and durable-checkpoint outcome. The byte/chunk fields have the same meaning as
+/// [`PushReport`]; `checkpoint` is the server-authoritative WAL head.
+#[non_exhaustive]
+#[derive(Clone, Debug, Serialize)]
+pub struct WorkspaceCheckpointPushReport {
+    pub checkpoint: WorkspaceCheckpointResponse,
+    pub files: usize,
+    pub bytes_total: u64,
+    pub chunks_total: usize,
+    pub chunks_uploaded: usize,
+    pub bytes_uploaded: u64,
+    pub file_blob_oids: Vec<(String, String)>,
+    #[serde(skip_serializing)]
+    pub file_chunks: Vec<(String, Vec<([u8; 32], u32)>)>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceCheckpointChange {
+    pub path: String,
+    pub change: String,
+    pub mode: Option<u32>,
+    pub size: Option<u64>,
+    pub oid: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceCheckpointChangesPage {
+    pub generation: u64,
+    pub entries: Vec<WorkspaceCheckpointChange>,
+    pub truncated: bool,
+    pub next_after: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkspaceCheckpointSignature {
+    pub name: String,
+    pub email: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct MaterializeWorkspaceCheckpointRequest {
+    pub format_ver: u16,
+    pub generation: u64,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<WorkspaceCheckpointSignature>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub committer: Option<WorkspaceCheckpointSignature>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaterializeWorkspaceCheckpointResponse {
+    pub generation: u64,
+    pub commit: String,
+    pub tree: String,
+    pub ref_name: String,
+    pub parent: Option<String>,
+    pub created: bool,
 }
 
 #[derive(Deserialize)]
@@ -424,6 +539,18 @@ struct CommitWire {
     base: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expect_oid: Option<String>,
+}
+
+#[derive(Serialize)]
+struct WorkspaceCheckpointWire<'a> {
+    format_ver: u16,
+    generation: u64,
+    checkpoint_id: &'a str,
+    base: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    base_ref: Option<&'a str>,
+    session_id: &'a str,
+    files: &'a [CommitFileWire],
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -850,6 +977,34 @@ impl ArtifactStorageClient {
         opts: PushOptions,
     ) -> Result<Traced<PushReport>, SdkError> {
         apply_path_prefix(&mut files, opts.path_prefix.as_deref())?;
+        if opts.workspace_snapshot.is_some() && opts.workspace_checkpoint.is_some() {
+            return Err(SdkError::ClientError(
+                "workspace_snapshot and workspace_checkpoint are mutually exclusive".into(),
+            ));
+        }
+        if let Some(checkpoint) = opts.workspace_checkpoint.as_ref() {
+            if !is_hex_oid(&checkpoint.workspace_id) {
+                return Err(SdkError::ClientError(format!(
+                    "workspace checkpoint id must be a 40-hex id, got {:?}",
+                    checkpoint.workspace_id
+                )));
+            }
+            if checkpoint.generation == 0 {
+                return Err(SdkError::ClientError(
+                    "workspace checkpoint generation must be greater than zero".into(),
+                ));
+            }
+            if checkpoint.checkpoint_id.is_empty() {
+                return Err(SdkError::ClientError(
+                    "workspace checkpoint idempotency id must not be empty".into(),
+                ));
+            }
+            if !opts.base.as_deref().is_some_and(is_hex_oid) {
+                return Err(SdkError::ClientError(
+                    "workspace checkpoint requires a 40-hex base commit".into(),
+                ));
+            }
+        }
         let emit = |ev: PushEvent| {
             if let Some(p) = &opts.progress {
                 p(ev)
@@ -1522,6 +1677,82 @@ impl ArtifactStorageClient {
                 }
             })
             .collect();
+        if let Some(checkpoint) = opts.workspace_checkpoint.as_ref() {
+            let base = opts
+                .base
+                .as_deref()
+                .expect("checkpoint base validated above");
+            let body = WorkspaceCheckpointWire {
+                format_ver: 1,
+                generation: checkpoint.generation,
+                checkpoint_id: &checkpoint.checkpoint_id,
+                base,
+                base_ref: checkpoint.base_ref.as_deref(),
+                session_id: &session.session_id,
+                files: &commit_files,
+            };
+            let suffix = format!(
+                "workspaces/{}/checkpoint",
+                super::encode_path_segment(&checkpoint.workspace_id)
+            );
+            let (response, trace_id) = with_transient_retries(|| async {
+                let (request, trace_id) = self.git_request(
+                    Method::PUT,
+                    project_id,
+                    repo,
+                    Some(&suffix),
+                    git_username,
+                    git_token,
+                )?;
+                let response = request
+                    .header("idempotency-key", &checkpoint.checkpoint_id)
+                    .timeout(std::time::Duration::from_secs(60))
+                    .json(&body)
+                    .send()
+                    .await?;
+                Ok((response, trace_id))
+            })
+            .await?;
+            let workspace_created = response.status() == reqwest::StatusCode::CREATED;
+            let mut checkpoint_response: WorkspaceCheckpointResponse =
+                expect_json(response).await?;
+            checkpoint_response.workspace_created = workspace_created;
+            emit(PushEvent::Checkpointed {
+                workspace_id: checkpoint_response.workspace_id.clone(),
+                generation: checkpoint_response.generation,
+                tree: checkpoint_response.tree.clone(),
+            });
+            return Ok(Traced::new(
+                trace_id,
+                PushReport {
+                    // Keep the legacy report fields meaningful for internal shared plumbing:
+                    // the materialized tip is the last commit, while `tree` is the WAL head.
+                    commit: checkpoint_response.snapshot_tip.clone(),
+                    tree: checkpoint_response.tree.clone(),
+                    ref_name: checkpoint_response.ref_name.clone(),
+                    created: workspace_created,
+                    files: chunked.len(),
+                    bytes_total: total_bytes,
+                    chunks_total: distinct.len(),
+                    chunks_uploaded: uploaded_chunks,
+                    bytes_uploaded: uploaded_bytes,
+                    file_chunks: if opts.collect_file_chunks {
+                        chunked
+                            .iter()
+                            .filter(|file| !file.delete && !file.known_oid && file.cdc)
+                            .map(|file| (file.repo_path.clone(), file.chunks.clone()))
+                            .collect()
+                    } else {
+                        Vec::new()
+                    },
+                    file_blob_oids: chunked
+                        .into_iter()
+                        .map(|file| (file.repo_path, file.blob_oid))
+                        .collect(),
+                    checkpoint: Some(checkpoint_response),
+                },
+            ));
+        }
         // One match keeps the submit route and the branch field coupled to the same
         // discriminant: a workspace snapshot commits on the workspace ref (no wire branch),
         // an ordinary push commits on a branch.
@@ -1700,8 +1931,138 @@ impl ArtifactStorageClient {
                     .into_iter()
                     .map(|f| (f.repo_path, f.blob_oid))
                     .collect(),
+                checkpoint: None,
             },
         ))
+    }
+
+    /// Push a prepared change list through the ordinary resumable ingest pipeline, but seal the
+    /// result as a Git workspace WAL checkpoint rather than creating a commit. This is the Git
+    /// mount autosave path; callers materialize an explicit commit separately.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn push_workspace_checkpoint(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        files: Vec<PushFile>,
+        mut opts: PushOptions,
+        target: WorkspaceCheckpointOptions,
+    ) -> Result<Traced<WorkspaceCheckpointPushReport>, SdkError> {
+        if opts.workspace_snapshot.is_some() || opts.workspace_checkpoint.is_some() {
+            return Err(SdkError::ClientError(
+                "workspace checkpoint push cannot also target a snapshot or checkpoint".into(),
+            ));
+        }
+        opts.workspace_checkpoint = Some(target);
+        let report = self
+            .push_files(project_id, repo, git_username, git_token, files, opts)
+            .await?;
+        let trace_id = report.trace_id.clone();
+        let report = report.into_inner();
+        let checkpoint = report.checkpoint.ok_or_else(|| {
+            SdkError::ClientError("checkpoint push returned a commit response".into())
+        })?;
+        Ok(Traced::new(
+            trace_id,
+            WorkspaceCheckpointPushReport {
+                checkpoint,
+                files: report.files,
+                bytes_total: report.bytes_total,
+                chunks_total: report.chunks_total,
+                chunks_uploaded: report.chunks_uploaded,
+                bytes_uploaded: report.bytes_uploaded,
+                file_blob_oids: report.file_blob_oids,
+                file_chunks: report.file_chunks,
+            },
+        ))
+    }
+
+    /// Read the current durable WAL head for one workspace.
+    pub async fn workspace_checkpoint(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        workspace_id: &str,
+    ) -> Result<Traced<WorkspaceCheckpointResponse>, SdkError> {
+        let suffix = format!(
+            "workspaces/{}/checkpoint",
+            super::encode_path_segment(workspace_id)
+        );
+        let (request, trace_id) = self.git_request(
+            Method::GET,
+            project_id,
+            repo,
+            Some(&suffix),
+            git_username,
+            git_token,
+        )?;
+        let response = expect_json(request.send().await?).await?;
+        Ok(Traced::new(trace_id, response))
+    }
+
+    /// Page the path changes represented by the current WAL head. Rebase/sync use this to carry
+    /// uncommitted autosave state to a new base without creating an intermediate commit.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn workspace_checkpoint_changes(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        workspace_id: &str,
+        after: Option<&str>,
+        limit: usize,
+    ) -> Result<Traced<WorkspaceCheckpointChangesPage>, SdkError> {
+        let suffix = format!(
+            "workspaces/{}/checkpoint/changes",
+            super::encode_path_segment(workspace_id)
+        );
+        let (request, trace_id) = self.git_request(
+            Method::GET,
+            project_id,
+            repo,
+            Some(&suffix),
+            git_username,
+            git_token,
+        )?;
+        let mut query = vec![("limit", limit.clamp(1, 1_000).to_string())];
+        if let Some(after) = after {
+            query.push(("after", after.to_string()));
+        }
+        let response = expect_json(request.query(&query).send().await?).await?;
+        Ok(Traced::new(trace_id, response))
+    }
+
+    /// Materialize one WAL generation as exactly one commit on the workspace ref. Replaying the
+    /// same generation is idempotent and returns `created=false`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn materialize_workspace_checkpoint(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        workspace_id: &str,
+        request: &MaterializeWorkspaceCheckpointRequest,
+    ) -> Result<Traced<MaterializeWorkspaceCheckpointResponse>, SdkError> {
+        let suffix = format!(
+            "workspaces/{}/checkpoint/materialize",
+            super::encode_path_segment(workspace_id)
+        );
+        let (http_request, trace_id) = self.git_request(
+            Method::POST,
+            project_id,
+            repo,
+            Some(&suffix),
+            git_username,
+            git_token,
+        )?;
+        let response = expect_json(http_request.json(request).send().await?).await?;
+        Ok(Traced::new(trace_id, response))
     }
 
     async fn negotiate_missing(
@@ -2068,6 +2429,44 @@ mod tests {
             delete: true,
         }];
         assert!(apply_path_prefix(&mut files, Some("services/auth")).is_err());
+    }
+
+    #[test]
+    fn workspace_checkpoint_wire_reuses_commit_file_declarations_without_commit_fields() {
+        let files = vec![CommitFileWire {
+            path: "src/lib.rs".to_string(),
+            chunks: vec![CommitChunkWire {
+                hash: "ab".repeat(32),
+                size: 17,
+            }],
+            content: None,
+            file_token: None,
+            oid: None,
+            delete: false,
+            mode: Some("100644".to_string()),
+        }];
+        let base = "1".repeat(40);
+        let wire = WorkspaceCheckpointWire {
+            format_ver: 1,
+            generation: 7,
+            checkpoint_id: "checkpoint-7",
+            base: &base,
+            base_ref: Some("refs/heads/main"),
+            session_id: "session-1",
+            files: &files,
+        };
+        let value = serde_json::to_value(wire).unwrap();
+        assert_eq!(value["format_ver"], 1);
+        assert_eq!(value["generation"], 7);
+        assert_eq!(value["checkpoint_id"], "checkpoint-7");
+        assert_eq!(value["base"], "1".repeat(40));
+        assert_eq!(value["base_ref"], "refs/heads/main");
+        assert_eq!(value["session_id"], "session-1");
+        assert_eq!(value["files"][0]["path"], "src/lib.rs");
+        assert_eq!(value["files"][0]["chunks"][0]["size"], 17);
+        assert!(value.get("branch").is_none());
+        assert!(value.get("message").is_none());
+        assert!(value.get("expect_oid").is_none());
     }
 
     /// Transient failures (5xx/429/transport) retry with backoff and then succeed; 4xx

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -2499,6 +2499,357 @@ mod tests {
         assert!(value.get("expect_oid").is_none());
     }
 
+    /// Pin the complete public WAL protocol, not just its private serialization structs. Both
+    /// mutations are idempotent, so a transient response must replay the identical request;
+    /// reads must retain their exact route and pagination query.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn workspace_checkpoint_endpoints_retry_and_preserve_wire() {
+        use std::collections::HashMap;
+        use std::sync::{Arc, Mutex};
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        #[derive(Clone, Debug)]
+        struct RecordedRequest {
+            method: String,
+            target: String,
+            body: Vec<u8>,
+        }
+
+        let workspace_id = "a".repeat(40);
+        let base_oid = "b".repeat(40);
+        let snapshot_tip = "c".repeat(40);
+        let checkpoint_tree = "d".repeat(40);
+        let materialized_commit = "e".repeat(40);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let seen: Arc<Mutex<Vec<RecordedRequest>>> = Arc::default();
+        let attempts: Arc<Mutex<HashMap<String, usize>>> = Arc::default();
+        let seen_server = seen.clone();
+        let attempts_server = attempts.clone();
+        let checkpoint_path = format!("/project/p/repos/r/workspaces/{workspace_id}/checkpoint");
+        let changes_path = format!("{checkpoint_path}/changes");
+        let materialize_path = format!("{checkpoint_path}/materialize");
+        let checkpoint_path_server = checkpoint_path.clone();
+        let changes_path_server = changes_path.clone();
+        let materialize_path_server = materialize_path.clone();
+        let server = tokio::spawn({
+            let workspace_id = workspace_id.clone();
+            let base_oid = base_oid.clone();
+            let snapshot_tip = snapshot_tip.clone();
+            let checkpoint_tree = checkpoint_tree.clone();
+            let materialized_commit = materialized_commit.clone();
+            async move {
+                loop {
+                    let Ok((mut socket, _)) = listener.accept().await else {
+                        return;
+                    };
+                    let seen = seen_server.clone();
+                    let attempts = attempts_server.clone();
+                    let workspace_id = workspace_id.clone();
+                    let base_oid = base_oid.clone();
+                    let snapshot_tip = snapshot_tip.clone();
+                    let checkpoint_tree = checkpoint_tree.clone();
+                    let materialized_commit = materialized_commit.clone();
+                    let checkpoint_path = checkpoint_path_server.clone();
+                    let changes_path = changes_path_server.clone();
+                    let materialize_path = materialize_path_server.clone();
+                    tokio::spawn(async move {
+                        let mut buffered = Vec::new();
+                        loop {
+                            let head_end = loop {
+                                if let Some(pos) =
+                                    buffered.windows(4).position(|window| window == b"\r\n\r\n")
+                                {
+                                    break pos + 4;
+                                }
+                                let mut chunk = [0_u8; 4096];
+                                match socket.read(&mut chunk).await {
+                                    Ok(0) | Err(_) => return,
+                                    Ok(read) => buffered.extend_from_slice(&chunk[..read]),
+                                }
+                            };
+                            let head = String::from_utf8_lossy(&buffered[..head_end]).to_string();
+                            let request_line = head.lines().next().unwrap_or_default();
+                            let mut request_parts = request_line.split_whitespace();
+                            let method = request_parts.next().unwrap_or_default().to_string();
+                            let target = request_parts.next().unwrap_or_default().to_string();
+                            let content_length = head
+                                .lines()
+                                .find_map(|line| {
+                                    line.to_ascii_lowercase()
+                                        .strip_prefix("content-length:")
+                                        .and_then(|value| value.trim().parse::<usize>().ok())
+                                })
+                                .unwrap_or(0);
+                            while buffered.len() < head_end + content_length {
+                                let mut chunk = [0_u8; 4096];
+                                match socket.read(&mut chunk).await {
+                                    Ok(0) | Err(_) => return,
+                                    Ok(read) => buffered.extend_from_slice(&chunk[..read]),
+                                }
+                            }
+                            let body = buffered[head_end..head_end + content_length].to_vec();
+                            buffered.drain(..head_end + content_length);
+                            seen.lock().unwrap().push(RecordedRequest {
+                                method: method.clone(),
+                                target: target.clone(),
+                                body,
+                            });
+
+                            let path = target.split('?').next().unwrap_or_default();
+                            let route = format!("{method} {path}");
+                            let attempt = {
+                                let mut attempts = attempts.lock().unwrap();
+                                let count = attempts.entry(route).or_default();
+                                *count += 1;
+                                *count
+                            };
+                            let (status, response_body) = if path.ends_with("/ingest/sessions") {
+                                (
+                                    "200 OK",
+                                    serde_json::json!({
+                                        "session_id": "session-1",
+                                        "cdc_min_bytes": 1024,
+                                        "cdc_avg_bytes": 4096,
+                                        "cdc_max_bytes": 16384,
+                                        "max_hashes_per_query": 512,
+                                        "max_chunk_bytes": 1_048_576,
+                                        "features": ["oid_files"]
+                                    })
+                                    .to_string(),
+                                )
+                            } else if method == "PUT" && path == checkpoint_path {
+                                if attempt == 1 {
+                                    (
+                                        "503 Service Unavailable",
+                                        serde_json::json!({"message": "retry checkpoint"})
+                                            .to_string(),
+                                    )
+                                } else {
+                                    (
+                                        "201 Created",
+                                        serde_json::json!({
+                                            "format_ver": 1,
+                                            "workspace_id": workspace_id,
+                                            "ref_name": format!("refs/workspaces/{workspace_id}"),
+                                            "generation": 7,
+                                            "checkpoint_id": "checkpoint-7",
+                                            "base": base_oid,
+                                            "snapshot_tip": snapshot_tip,
+                                            "tree": checkpoint_tree,
+                                            "created_at_ms": 10,
+                                            "updated_at_ms": 11,
+                                            "materialized_generation": null
+                                        })
+                                        .to_string(),
+                                    )
+                                }
+                            } else if method == "GET" && path == checkpoint_path {
+                                (
+                                    "200 OK",
+                                    serde_json::json!({
+                                        "format_ver": 1,
+                                        "workspace_id": workspace_id,
+                                        "ref_name": format!("refs/workspaces/{workspace_id}"),
+                                        "generation": 7,
+                                        "checkpoint_id": "checkpoint-7",
+                                        "base": base_oid,
+                                        "snapshot_tip": snapshot_tip,
+                                        "tree": checkpoint_tree,
+                                        "created_at_ms": 10,
+                                        "updated_at_ms": 11,
+                                        "materialized_generation": null
+                                    })
+                                    .to_string(),
+                                )
+                            } else if method == "GET" && path == changes_path {
+                                (
+                                    "200 OK",
+                                    serde_json::json!({
+                                        "generation": 7,
+                                        "entries": [{
+                                            "path": "src/main.rs",
+                                            "change": "modified",
+                                            "mode": 0o100644,
+                                            "size": 12,
+                                            "oid": "f".repeat(40)
+                                        }],
+                                        "truncated": false,
+                                        "next_after": null
+                                    })
+                                    .to_string(),
+                                )
+                            } else if method == "POST" && path == materialize_path {
+                                if attempt == 1 {
+                                    (
+                                        "503 Service Unavailable",
+                                        serde_json::json!({"message": "retry materialize"})
+                                            .to_string(),
+                                    )
+                                } else {
+                                    (
+                                        "201 Created",
+                                        serde_json::json!({
+                                            "generation": 7,
+                                            "commit": materialized_commit,
+                                            "tree": checkpoint_tree,
+                                            "ref_name": format!("refs/workspaces/{workspace_id}"),
+                                            "parent": snapshot_tip,
+                                            "created": true
+                                        })
+                                        .to_string(),
+                                    )
+                                }
+                            } else {
+                                (
+                                    "404 Not Found",
+                                    serde_json::json!({
+                                        "message": format!("unhandled test route {method} {target}")
+                                    })
+                                    .to_string(),
+                                )
+                            };
+                            let response = format!(
+                                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{response_body}",
+                                response_body.len()
+                            );
+                            if socket.write_all(response.as_bytes()).await.is_err() {
+                                return;
+                            }
+                        }
+                    });
+                }
+            }
+        });
+
+        let base_url = format!("http://{addr}");
+        let client = crate::ClientBuilder::new(&base_url)
+            .bearer_token("dummy")
+            .build()
+            .unwrap();
+        let sdk = ArtifactStorageClient::new(client, &base_url).unwrap();
+        let checkpoint = sdk
+            .push_workspace_checkpoint(
+                "p",
+                "r",
+                "u",
+                "tok",
+                vec![PushFile {
+                    repo_path: "src/main.rs".to_string(),
+                    source: PushSource::KnownOid("f".repeat(40)),
+                    mode: Some(0o100644),
+                    delete: false,
+                }],
+                PushOptions {
+                    base: Some(base_oid.clone()),
+                    ..Default::default()
+                },
+                WorkspaceCheckpointOptions {
+                    workspace_id: workspace_id.clone(),
+                    generation: 7,
+                    checkpoint_id: "checkpoint-7".to_string(),
+                    base_ref: Some("refs/heads/main".to_string()),
+                    publish_target: Some("main".to_string()),
+                },
+            )
+            .await
+            .expect("checkpoint PUT must retry a 503")
+            .into_inner();
+        assert_eq!(checkpoint.checkpoint.tree, checkpoint_tree);
+
+        let read = sdk
+            .workspace_checkpoint("p", "r", "u", "tok", &workspace_id)
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(read.generation, 7);
+
+        let changes = sdk
+            .workspace_checkpoint_changes(
+                "p",
+                "r",
+                "u",
+                "tok",
+                &workspace_id,
+                Some("src/lib.rs"),
+                23,
+            )
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(changes.entries[0].path, "src/main.rs");
+
+        let mut materialize = MaterializeWorkspaceCheckpointRequest::new(7, "intentional snapshot");
+        materialize.author = Some(super::super::merge::Signature {
+            name: "Agent".to_string(),
+            email: "agent@example.com".to_string(),
+        });
+        let materialized = sdk
+            .materialize_workspace_checkpoint("p", "r", "u", "tok", &workspace_id, &materialize)
+            .await
+            .expect("materialize POST must retry a 503")
+            .into_inner();
+        assert_eq!(materialized.commit, materialized_commit);
+        server.abort();
+
+        let seen = seen.lock().unwrap().clone();
+        let checkpoint_puts: Vec<_> = seen
+            .iter()
+            .filter(|request| request.method == "PUT" && request.target == checkpoint_path)
+            .collect();
+        assert_eq!(checkpoint_puts.len(), 2, "503 checkpoint PUT must retry");
+        assert_eq!(checkpoint_puts[0].body, checkpoint_puts[1].body);
+        let checkpoint_body: serde_json::Value =
+            serde_json::from_slice(&checkpoint_puts[0].body).unwrap();
+        assert_eq!(checkpoint_body["format_ver"], 1);
+        assert_eq!(checkpoint_body["generation"], 7);
+        assert_eq!(checkpoint_body["checkpoint_id"], "checkpoint-7");
+        assert_eq!(checkpoint_body["base"], base_oid);
+        assert_eq!(checkpoint_body["base_ref"], "refs/heads/main");
+        assert_eq!(checkpoint_body["publish_target"], "main");
+        assert_eq!(checkpoint_body["session_id"], "session-1");
+        assert_eq!(checkpoint_body["files"][0]["path"], "src/main.rs");
+        assert_eq!(checkpoint_body["files"][0]["oid"], "f".repeat(40));
+        assert_eq!(checkpoint_body["files"][0]["mode"], "100644");
+        assert!(checkpoint_body.get("branch").is_none());
+        assert!(checkpoint_body.get("message").is_none());
+
+        assert_eq!(
+            seen.iter()
+                .filter(|request| request.method == "GET" && request.target == checkpoint_path)
+                .count(),
+            1
+        );
+        let changes_request = seen
+            .iter()
+            .find(|request| request.method == "GET" && request.target.starts_with(&changes_path))
+            .expect("changes GET");
+        let changes_url =
+            reqwest::Url::parse(&format!("http://test{}", changes_request.target)).unwrap();
+        let query: HashMap<_, _> = changes_url.query_pairs().into_owned().collect();
+        assert_eq!(query.get("limit").map(String::as_str), Some("23"));
+        assert_eq!(query.get("after").map(String::as_str), Some("src/lib.rs"));
+
+        let materialize_posts: Vec<_> = seen
+            .iter()
+            .filter(|request| request.method == "POST" && request.target == materialize_path)
+            .collect();
+        assert_eq!(
+            materialize_posts.len(),
+            2,
+            "503 materialize POST must retry"
+        );
+        assert_eq!(materialize_posts[0].body, materialize_posts[1].body);
+        let materialize_body: serde_json::Value =
+            serde_json::from_slice(&materialize_posts[0].body).unwrap();
+        assert_eq!(materialize_body["format_ver"], 1);
+        assert_eq!(materialize_body["generation"], 7);
+        assert_eq!(materialize_body["message"], "intentional snapshot");
+        assert_eq!(materialize_body["author"]["name"], "Agent");
+        assert!(materialize_body.get("committer").is_none());
+    }
+
     /// Transient failures (5xx/429/transport) retry with backoff and then succeed; 4xx
     /// rejections are deterministic and never retried.
     #[tokio::test(start_paused = true)]

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -2211,6 +2211,11 @@ impl ArtifactStorageClient {
                 .await?;
             let status = response.status();
             if status != reqwest::StatusCode::PARTIAL_CONTENT {
+                if status.is_success() {
+                    return Err(SdkError::ClientError(format!(
+                        "checkpoint file range endpoint returned {status} instead of 206 Partial Content"
+                    )));
+                }
                 return Err(SdkError::ServerError {
                     status,
                     message: response.text().await.unwrap_or_default(),
@@ -2728,6 +2733,7 @@ mod tests {
             method: String,
             target: String,
             body: Vec<u8>,
+            range: Option<String>,
         }
 
         let workspace_id = "a".repeat(40);
@@ -2800,6 +2806,11 @@ mod tests {
                                         .and_then(|value| value.trim().parse::<usize>().ok())
                                 })
                                 .unwrap_or(0);
+                            let range = head.lines().find_map(|line| {
+                                let (name, value) = line.split_once(':')?;
+                                name.eq_ignore_ascii_case("range")
+                                    .then(|| value.trim().to_string())
+                            });
                             while buffered.len() < head_end + content_length {
                                 let mut chunk = [0_u8; 4096];
                                 match socket.read(&mut chunk).await {
@@ -2813,6 +2824,7 @@ mod tests {
                                 method: method.clone(),
                                 target: target.clone(),
                                 body,
+                                range: range.clone(),
                             });
 
                             let path = target.split('?').next().unwrap_or_default();
@@ -2823,7 +2835,12 @@ mod tests {
                                 *count += 1;
                                 *count
                             };
-                            let (status, response_body) = if path.ends_with("/ingest/sessions") {
+                            let (status, response_body) = if method == "GET"
+                                && path == checkpoint_file_path
+                                && range.as_deref() == Some("bytes=0-4")
+                            {
+                                ("206 Partial Content", "check".to_string())
+                            } else if path.ends_with("/ingest/sessions") {
                                 (
                                     "200 OK",
                                     serde_json::json!({
@@ -2937,8 +2954,13 @@ mod tests {
                                     .to_string(),
                                 )
                             };
+                            let range_headers = if status == "206 Partial Content" {
+                                "content-range: bytes 0-4/15\r\naccept-ranges: bytes\r\n"
+                            } else {
+                                ""
+                            };
                             let response = format!(
-                                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{response_body}",
+                                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\n{range_headers}content-length: {}\r\n\r\n{response_body}",
                                 response_body.len()
                             );
                             if socket.write_all(response.as_bytes()).await.is_err() {
@@ -3023,6 +3045,24 @@ mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(checkpoint_bytes, b"checkpoint-body");
+        let checkpoint_range = sdk
+            .workspace_checkpoint_file_range(
+                "p",
+                "r",
+                "u",
+                "tok",
+                &workspace_id,
+                "src/main.rs",
+                7,
+                "checkpoint-7",
+                &checkpoint_tree,
+                0,
+                4,
+            )
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(checkpoint_range, b"check");
 
         let mut materialize = MaterializeWorkspaceCheckpointRequest::new(7, "intentional snapshot");
         materialize.author = Some(super::super::merge::Signature {
@@ -3102,6 +3142,11 @@ mod tests {
             file_query.get("tree").map(String::as_str),
             Some(checkpoint_tree.as_str())
         );
+        assert!(seen.iter().any(|request| {
+            request.method == "GET"
+                && request.target.starts_with(&checkpoint_file_path)
+                && request.range.as_deref() == Some("bytes=0-4")
+        }));
 
         let materialize_posts: Vec<_> = seen
             .iter()

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -366,6 +366,14 @@ pub struct MaterializeWorkspaceCheckpointResponse {
     pub ref_name: String,
     pub parent: Option<String>,
     pub created: bool,
+    /// Outcome of the separate publish-on-snapshot transition: `not_configured`, `published`,
+    /// `conflict`, or `failed`. Materialization itself succeeded whenever this response exists.
+    pub publish_status: String,
+    /// Target-branch commit written by configured publication, including idempotent replays.
+    pub published_commit: Option<String>,
+    /// Actionable configured-publication failure. The snapshot commit named by `commit` remains
+    /// durable and callers must still retire their local WAL generation.
+    pub publish_error: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -2062,7 +2070,8 @@ impl ArtifactStorageClient {
     }
 
     /// Materialize one WAL generation as exactly one commit on the workspace ref. Replaying the
-    /// same generation is idempotent and returns `created=false`.
+    /// same generation is idempotent and returns the original durable receipt byte-for-byte;
+    /// `created` describes that operation, not the current HTTP attempt.
     #[allow(clippy::too_many_arguments)]
     pub async fn materialize_workspace_checkpoint(
         &self,
@@ -2696,7 +2705,10 @@ mod tests {
                                             "tree": checkpoint_tree,
                                             "ref_name": format!("refs/workspaces/{workspace_id}"),
                                             "parent": snapshot_tip,
-                                            "created": true
+                                            "created": true,
+                                            "publish_status": "published",
+                                            "published_commit": "9".repeat(40),
+                                            "publish_error": null
                                         })
                                         .to_string(),
                                     )
@@ -2791,6 +2803,12 @@ mod tests {
             .expect("materialize POST must retry a 503")
             .into_inner();
         assert_eq!(materialized.commit, materialized_commit);
+        assert_eq!(materialized.publish_status, "published");
+        assert_eq!(
+            materialized.published_commit.as_deref(),
+            Some("9999999999999999999999999999999999999999")
+        );
+        assert_eq!(materialized.publish_error, None);
         server.abort();
 
         let seen = seen.lock().unwrap().clone();

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -330,6 +330,10 @@ pub struct WorkspaceCheckpointChange {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkspaceCheckpointChangesPage {
     pub generation: u64,
+    pub checkpoint_id: String,
+    pub snapshot_tip: String,
+    pub tree: String,
+    pub materialized_generation: Option<u64>,
     pub entries: Vec<WorkspaceCheckpointChange>,
     pub truncated: bool,
     pub next_after: Option<String>,
@@ -2069,6 +2073,55 @@ impl ArtifactStorageClient {
         Ok(Traced::new(trace_id, response))
     }
 
+    /// Read one file from an exact, principal-bound workspace checkpoint revision. The revision
+    /// fields prevent a generation advancing between change pagination and byte fetch from
+    /// silently serving a different same-path body.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn workspace_checkpoint_file_bytes(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        workspace_id: &str,
+        file_path: &str,
+        generation: u64,
+        checkpoint_id: &str,
+        tree: &str,
+    ) -> Result<Traced<Vec<u8>>, SdkError> {
+        canonical_repo_path(file_path, "checkpoint file path")?;
+        let suffix = format!(
+            "workspaces/{}/checkpoint/files/{file_path}",
+            super::encode_path_segment(workspace_id)
+        );
+        let query = [
+            ("generation", generation.to_string()),
+            ("checkpoint_id", checkpoint_id.to_string()),
+            ("tree", tree.to_string()),
+        ];
+        let (bytes, trace_id) = with_transient_retries(|| async {
+            let (request, trace_id) = self.git_request(
+                Method::GET,
+                project_id,
+                repo,
+                Some(&suffix),
+                git_username,
+                git_token,
+            )?;
+            let response = request.query(&query).send().await?;
+            let status = response.status();
+            if !status.is_success() {
+                return Err(SdkError::ServerError {
+                    status,
+                    message: response.text().await.unwrap_or_default(),
+                });
+            }
+            Ok((response.bytes().await?.to_vec(), trace_id))
+        })
+        .await?;
+        Ok(Traced::new(trace_id, bytes))
+    }
+
     /// Materialize one WAL generation as exactly one commit on the workspace ref. Replaying the
     /// same generation is idempotent and returns the original durable receipt byte-for-byte;
     /// `created` describes that operation, not the current HTTP attempt.
@@ -2538,9 +2591,11 @@ mod tests {
         let attempts_server = attempts.clone();
         let checkpoint_path = format!("/project/p/repos/r/workspaces/{workspace_id}/checkpoint");
         let changes_path = format!("{checkpoint_path}/changes");
+        let checkpoint_file_path = format!("{checkpoint_path}/files/src/main.rs");
         let materialize_path = format!("{checkpoint_path}/materialize");
         let checkpoint_path_server = checkpoint_path.clone();
         let changes_path_server = changes_path.clone();
+        let checkpoint_file_path_server = checkpoint_file_path.clone();
         let materialize_path_server = materialize_path.clone();
         let server = tokio::spawn({
             let workspace_id = workspace_id.clone();
@@ -2562,6 +2617,7 @@ mod tests {
                     let materialized_commit = materialized_commit.clone();
                     let checkpoint_path = checkpoint_path_server.clone();
                     let changes_path = changes_path_server.clone();
+                    let checkpoint_file_path = checkpoint_file_path_server.clone();
                     let materialize_path = materialize_path_server.clone();
                     tokio::spawn(async move {
                         let mut buffered = Vec::new();
@@ -2677,6 +2733,10 @@ mod tests {
                                     "200 OK",
                                     serde_json::json!({
                                         "generation": 7,
+                                        "checkpoint_id": "checkpoint-7",
+                                        "snapshot_tip": snapshot_tip,
+                                        "tree": checkpoint_tree,
+                                        "materialized_generation": null,
                                         "entries": [{
                                             "path": "src/main.rs",
                                             "change": "modified",
@@ -2689,6 +2749,8 @@ mod tests {
                                     })
                                     .to_string(),
                                 )
+                            } else if method == "GET" && path == checkpoint_file_path {
+                                ("200 OK", "checkpoint-body".to_string())
                             } else if method == "POST" && path == materialize_path {
                                 if attempt == 1 {
                                     (
@@ -2791,6 +2853,23 @@ mod tests {
             .unwrap()
             .into_inner();
         assert_eq!(changes.entries[0].path, "src/main.rs");
+        assert_eq!(changes.checkpoint_id, "checkpoint-7");
+        let checkpoint_bytes = sdk
+            .workspace_checkpoint_file_bytes(
+                "p",
+                "r",
+                "u",
+                "tok",
+                &workspace_id,
+                "src/main.rs",
+                7,
+                "checkpoint-7",
+                &checkpoint_tree,
+            )
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(checkpoint_bytes, b"checkpoint-body");
 
         let mut materialize = MaterializeWorkspaceCheckpointRequest::new(7, "intentional snapshot");
         materialize.author = Some(super::super::merge::Signature {
@@ -2848,6 +2927,25 @@ mod tests {
         let query: HashMap<_, _> = changes_url.query_pairs().into_owned().collect();
         assert_eq!(query.get("limit").map(String::as_str), Some("23"));
         assert_eq!(query.get("after").map(String::as_str), Some("src/lib.rs"));
+
+        let checkpoint_file_request = seen
+            .iter()
+            .find(|request| {
+                request.method == "GET" && request.target.starts_with(&checkpoint_file_path)
+            })
+            .expect("revision-bound checkpoint file GET");
+        let checkpoint_file_url =
+            reqwest::Url::parse(&format!("http://test{}", checkpoint_file_request.target)).unwrap();
+        let file_query: HashMap<_, _> = checkpoint_file_url.query_pairs().into_owned().collect();
+        assert_eq!(file_query.get("generation").map(String::as_str), Some("7"));
+        assert_eq!(
+            file_query.get("checkpoint_id").map(String::as_str),
+            Some("checkpoint-7")
+        );
+        assert_eq!(
+            file_query.get("tree").map(String::as_str),
+            Some(checkpoint_tree.as_str())
+        );
 
         let materialize_posts: Vec<_> = seen
             .iter()

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -122,13 +122,6 @@ pub enum PushEvent {
     },
     /// The commit published.
     Committed { commit: String, ref_name: String },
-    /// Uploaded content was sealed into a durable workspace WAL checkpoint. No commit or
-    /// branch update was created.
-    Checkpointed {
-        workspace_id: String,
-        generation: u64,
-        tree: String,
-    },
 }
 
 pub type PushProgress = Arc<dyn Fn(PushEvent) + Send + Sync>;
@@ -151,10 +144,6 @@ pub struct PushOptions {
     /// application three-ways against the declared base plus this push's exact change list
     /// (servers that predate the field ignore it and merge against the chain parent).
     pub workspace_snapshot: Option<String>,
-    /// Seal the prepared file list as a durable workspace WAL checkpoint instead of creating a
-    /// commit. This shares the complete hashing/chunk/upload pipeline with ordinary pushes; only
-    /// the final metadata submit differs. Mutually exclusive with [`Self::workspace_snapshot`].
-    pub workspace_checkpoint: Option<WorkspaceCheckpointOptions>,
     /// Return every CDC-path file's chunk list in `PushReport::file_chunks`, so the caller can
     /// hand them back as `PushSource::StablePrefix` prefixes on the next push of the same
     /// content. Off by default: the lists cost memory proportional to the push.
@@ -199,7 +188,6 @@ impl Default for PushOptions {
             upload_batch_bytes: 48 * 1024 * 1024,
             progress: None,
             workspace_snapshot: None,
-            workspace_checkpoint: None,
             collect_file_chunks: false,
             idempotency_key: None,
             on_prepared: None,
@@ -221,6 +209,9 @@ pub struct WorkspaceCheckpointOptions {
     /// Canonical ref from which the lazy workspace base was resolved, for display and promote
     /// defaults. The immutable base commit itself is [`PushOptions::base`].
     pub base_ref: Option<String>,
+    /// Branch promoted by each explicit snapshot (`tl git mount --publish`). Autosave only
+    /// persists this policy; a checkpoint never advances the branch itself.
+    pub publish_target: Option<String>,
 }
 
 fn canonical_repo_path(path: &str, what: &str) -> Result<(), SdkError> {
@@ -243,6 +234,13 @@ fn canonical_repo_path(path: &str, what: &str) -> Result<(), SdkError> {
 
 fn is_hex_oid(value: &str) -> bool {
     value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_lower_hex_oid(value: &str) -> bool {
+    value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 fn apply_path_prefix(files: &mut [PushFile], prefix: Option<&str>) -> Result<(), SdkError> {
@@ -282,11 +280,10 @@ pub struct PushReport {
     /// `PushSource::StablePrefix`. Never serialized: caller-local plumbing, not wire data.
     #[serde(skip_serializing)]
     pub file_chunks: Vec<(String, Vec<([u8; 32], u32)>)>,
-    /// Present when the push target was [`PushOptions::workspace_checkpoint`]. `commit` is the
-    /// current materialized snapshot tip in that case (normally the base commit), while `tree`
-    /// is the newly checkpointed uncommitted tree.
+    /// Internal shared-pipeline result consumed by [`ArtifactStorageClient::push_workspace_checkpoint`].
+    /// Ordinary `push_files`/`push_worktree` calls always return `None`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub checkpoint: Option<WorkspaceCheckpointResponse>,
+    checkpoint: Option<WorkspaceCheckpointResponse>,
 }
 
 /// Durable server acknowledgement for a Git workspace WAL checkpoint.
@@ -303,9 +300,6 @@ pub struct WorkspaceCheckpointResponse {
     pub created_at_ms: u64,
     pub updated_at_ms: u64,
     pub materialized_generation: Option<u64>,
-    /// Derived from the PUT status: true when this checkpoint lazily allocated the workspace.
-    #[serde(default)]
-    pub workspace_created: bool,
 }
 
 /// Upload and durable-checkpoint outcome. The byte/chunk fields have the same meaning as
@@ -328,9 +322,9 @@ pub struct WorkspaceCheckpointPushReport {
 pub struct WorkspaceCheckpointChange {
     pub path: String,
     pub change: String,
-    pub mode: Option<u32>,
+    pub mode: u32,
     pub size: Option<u64>,
-    pub oid: Option<String>,
+    pub oid: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -341,21 +335,27 @@ pub struct WorkspaceCheckpointChangesPage {
     pub next_after: Option<String>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WorkspaceCheckpointSignature {
-    pub name: String,
-    pub email: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MaterializeWorkspaceCheckpointRequest {
     pub format_ver: u16,
     pub generation: u64,
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub author: Option<WorkspaceCheckpointSignature>,
+    pub author: Option<super::merge::Signature>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub committer: Option<WorkspaceCheckpointSignature>,
+    pub committer: Option<super::merge::Signature>,
+}
+
+impl MaterializeWorkspaceCheckpointRequest {
+    pub fn new(generation: u64, message: impl Into<String>) -> Self {
+        Self {
+            format_ver: 1,
+            generation,
+            message: message.into(),
+            author: None,
+            committer: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -549,6 +549,8 @@ struct WorkspaceCheckpointWire<'a> {
     base: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     base_ref: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    publish_target: Option<&'a str>,
     session_id: &'a str,
     files: &'a [CommitFileWire],
 }
@@ -973,19 +975,34 @@ impl ArtifactStorageClient {
         repo: &str,
         git_username: &str,
         git_token: &str,
-        mut files: Vec<PushFile>,
+        files: Vec<PushFile>,
         opts: PushOptions,
     ) -> Result<Traced<PushReport>, SdkError> {
+        self.push_files_inner(project_id, repo, git_username, git_token, files, opts, None)
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn push_files_inner(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        mut files: Vec<PushFile>,
+        opts: PushOptions,
+        workspace_checkpoint: Option<WorkspaceCheckpointOptions>,
+    ) -> Result<Traced<PushReport>, SdkError> {
         apply_path_prefix(&mut files, opts.path_prefix.as_deref())?;
-        if opts.workspace_snapshot.is_some() && opts.workspace_checkpoint.is_some() {
+        if opts.workspace_snapshot.is_some() && workspace_checkpoint.is_some() {
             return Err(SdkError::ClientError(
                 "workspace_snapshot and workspace_checkpoint are mutually exclusive".into(),
             ));
         }
-        if let Some(checkpoint) = opts.workspace_checkpoint.as_ref() {
-            if !is_hex_oid(&checkpoint.workspace_id) {
+        if let Some(checkpoint) = workspace_checkpoint.as_ref() {
+            if !is_lower_hex_oid(&checkpoint.workspace_id) {
                 return Err(SdkError::ClientError(format!(
-                    "workspace checkpoint id must be a 40-hex id, got {:?}",
+                    "workspace checkpoint id must be a 40-character lowercase hex id, got {:?}",
                     checkpoint.workspace_id
                 )));
             }
@@ -994,9 +1011,9 @@ impl ArtifactStorageClient {
                     "workspace checkpoint generation must be greater than zero".into(),
                 ));
             }
-            if checkpoint.checkpoint_id.is_empty() {
+            if checkpoint.checkpoint_id.is_empty() || checkpoint.checkpoint_id.len() > 128 {
                 return Err(SdkError::ClientError(
-                    "workspace checkpoint idempotency id must not be empty".into(),
+                    "workspace checkpoint idempotency id must contain 1..128 bytes".into(),
                 ));
             }
             if !opts.base.as_deref().is_some_and(is_hex_oid) {
@@ -1677,7 +1694,7 @@ impl ArtifactStorageClient {
                 }
             })
             .collect();
-        if let Some(checkpoint) = opts.workspace_checkpoint.as_ref() {
+        if let Some(checkpoint) = workspace_checkpoint.as_ref() {
             let base = opts
                 .base
                 .as_deref()
@@ -1688,6 +1705,7 @@ impl ArtifactStorageClient {
                 checkpoint_id: &checkpoint.checkpoint_id,
                 base,
                 base_ref: checkpoint.base_ref.as_deref(),
+                publish_target: checkpoint.publish_target.as_deref(),
                 session_id: &session.session_id,
                 files: &commit_files,
             };
@@ -1695,7 +1713,7 @@ impl ArtifactStorageClient {
                 "workspaces/{}/checkpoint",
                 super::encode_path_segment(&checkpoint.workspace_id)
             );
-            let (response, trace_id) = with_transient_retries(|| async {
+            let (checkpoint_response, trace_id) = with_transient_retries(|| async {
                 let (request, trace_id) = self.git_request(
                     Method::PUT,
                     project_id,
@@ -1705,23 +1723,14 @@ impl ArtifactStorageClient {
                     git_token,
                 )?;
                 let response = request
-                    .header("idempotency-key", &checkpoint.checkpoint_id)
                     .timeout(std::time::Duration::from_secs(60))
                     .json(&body)
                     .send()
                     .await?;
-                Ok((response, trace_id))
+                let checkpoint: WorkspaceCheckpointResponse = expect_json(response).await?;
+                Ok((checkpoint, trace_id))
             })
             .await?;
-            let workspace_created = response.status() == reqwest::StatusCode::CREATED;
-            let mut checkpoint_response: WorkspaceCheckpointResponse =
-                expect_json(response).await?;
-            checkpoint_response.workspace_created = workspace_created;
-            emit(PushEvent::Checkpointed {
-                workspace_id: checkpoint_response.workspace_id.clone(),
-                generation: checkpoint_response.generation,
-                tree: checkpoint_response.tree.clone(),
-            });
             return Ok(Traced::new(
                 trace_id,
                 PushReport {
@@ -1730,7 +1739,7 @@ impl ArtifactStorageClient {
                     commit: checkpoint_response.snapshot_tip.clone(),
                     tree: checkpoint_response.tree.clone(),
                     ref_name: checkpoint_response.ref_name.clone(),
-                    created: workspace_created,
+                    created: false,
                     files: chunked.len(),
                     bytes_total: total_bytes,
                     chunks_total: distinct.len(),
@@ -1947,17 +1956,24 @@ impl ArtifactStorageClient {
         git_username: &str,
         git_token: &str,
         files: Vec<PushFile>,
-        mut opts: PushOptions,
+        opts: PushOptions,
         target: WorkspaceCheckpointOptions,
     ) -> Result<Traced<WorkspaceCheckpointPushReport>, SdkError> {
-        if opts.workspace_snapshot.is_some() || opts.workspace_checkpoint.is_some() {
+        if opts.workspace_snapshot.is_some() {
             return Err(SdkError::ClientError(
-                "workspace checkpoint push cannot also target a snapshot or checkpoint".into(),
+                "workspace checkpoint push cannot also target a snapshot commit".into(),
             ));
         }
-        opts.workspace_checkpoint = Some(target);
         let report = self
-            .push_files(project_id, repo, git_username, git_token, files, opts)
+            .push_files_inner(
+                project_id,
+                repo,
+                git_username,
+                git_token,
+                files,
+                opts,
+                Some(target),
+            )
             .await?;
         let trace_id = report.trace_id.clone();
         let report = report.into_inner();
@@ -1992,15 +2008,19 @@ impl ArtifactStorageClient {
             "workspaces/{}/checkpoint",
             super::encode_path_segment(workspace_id)
         );
-        let (request, trace_id) = self.git_request(
-            Method::GET,
-            project_id,
-            repo,
-            Some(&suffix),
-            git_username,
-            git_token,
-        )?;
-        let response = expect_json(request.send().await?).await?;
+        let (response, trace_id) = with_transient_retries(|| async {
+            let (request, trace_id) = self.git_request(
+                Method::GET,
+                project_id,
+                repo,
+                Some(&suffix),
+                git_username,
+                git_token,
+            )?;
+            let response = expect_json(request.send().await?).await?;
+            Ok((response, trace_id))
+        })
+        .await?;
         Ok(Traced::new(trace_id, response))
     }
 
@@ -2021,19 +2041,23 @@ impl ArtifactStorageClient {
             "workspaces/{}/checkpoint/changes",
             super::encode_path_segment(workspace_id)
         );
-        let (request, trace_id) = self.git_request(
-            Method::GET,
-            project_id,
-            repo,
-            Some(&suffix),
-            git_username,
-            git_token,
-        )?;
         let mut query = vec![("limit", limit.clamp(1, 1_000).to_string())];
         if let Some(after) = after {
             query.push(("after", after.to_string()));
         }
-        let response = expect_json(request.query(&query).send().await?).await?;
+        let (response, trace_id) = with_transient_retries(|| async {
+            let (request, trace_id) = self.git_request(
+                Method::GET,
+                project_id,
+                repo,
+                Some(&suffix),
+                git_username,
+                git_token,
+            )?;
+            let response = expect_json(request.query(&query).send().await?).await?;
+            Ok((response, trace_id))
+        })
+        .await?;
         Ok(Traced::new(trace_id, response))
     }
 
@@ -2053,15 +2077,19 @@ impl ArtifactStorageClient {
             "workspaces/{}/checkpoint/materialize",
             super::encode_path_segment(workspace_id)
         );
-        let (http_request, trace_id) = self.git_request(
-            Method::POST,
-            project_id,
-            repo,
-            Some(&suffix),
-            git_username,
-            git_token,
-        )?;
-        let response = expect_json(http_request.json(request).send().await?).await?;
+        let (response, trace_id) = with_transient_retries(|| async {
+            let (http_request, trace_id) = self.git_request(
+                Method::POST,
+                project_id,
+                repo,
+                Some(&suffix),
+                git_username,
+                git_token,
+            )?;
+            let response = expect_json(http_request.json(request).send().await?).await?;
+            Ok((response, trace_id))
+        })
+        .await?;
         Ok(Traced::new(trace_id, response))
     }
 
@@ -2452,6 +2480,7 @@ mod tests {
             checkpoint_id: "checkpoint-7",
             base: &base,
             base_ref: Some("refs/heads/main"),
+            publish_target: Some("main"),
             session_id: "session-1",
             files: &files,
         };
@@ -2461,6 +2490,7 @@ mod tests {
         assert_eq!(value["checkpoint_id"], "checkpoint-7");
         assert_eq!(value["base"], "1".repeat(40));
         assert_eq!(value["base_ref"], "refs/heads/main");
+        assert_eq!(value["publish_target"], "main");
         assert_eq!(value["session_id"], "session-1");
         assert_eq!(value["files"][0]["path"], "src/lib.rs");
         assert_eq!(value["files"][0]["chunks"][0]["size"], 17);

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -15,6 +15,33 @@ use super::ingest::{expect_json, with_transient_retries};
 use super::merge::{MergeConflict, MergeReport, MergeStats, Signature, expect_json_or_conflict};
 use super::{ArtifactStorageClient, advance_pagination_cursor, decode_empty};
 
+fn encoded_git_path(path: &str, allow_empty: bool) -> Result<String, SdkError> {
+    if path.is_empty() {
+        return if allow_empty {
+            Ok(String::new())
+        } else {
+            Err(SdkError::ClientError("Git path must not be empty".into()))
+        };
+    }
+    if path.starts_with('/')
+        || path.split('/').any(|component| {
+            component.is_empty()
+                || component == "."
+                || component == ".."
+                || component.contains('\0')
+        })
+    {
+        return Err(SdkError::ClientError(format!(
+            "Git path is not canonical: {path:?}"
+        )));
+    }
+    Ok(path
+        .split('/')
+        .map(super::encode_path_segment)
+        .collect::<Vec<_>>()
+        .join("/"))
+}
+
 /// One workspace joined across its identity record, ref, and lease rows.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct WorkspaceInfo {
@@ -1059,10 +1086,14 @@ impl ArtifactStorageClient {
         limit: usize,
     ) -> Result<Traced<TreePage>, SdkError> {
         let enc = |s: &str| url::form_urlencoded::byte_serialize(s.as_bytes()).collect::<String>();
+        let encoded_dir_path = encoded_git_path(dir_path, true)?;
         let mut suffix = if dir_path.is_empty() {
             format!("tree?version={}&limit={limit}", enc(version))
         } else {
-            format!("tree/{}?version={}&limit={limit}", dir_path, enc(version))
+            format!(
+                "tree/{encoded_dir_path}?version={}&limit={limit}",
+                enc(version)
+            )
         };
         if let Some(after) = after {
             suffix.push_str(&format!("&after={}", enc(after)));
@@ -1089,8 +1120,9 @@ impl ArtifactStorageClient {
         version: &str,
         file_path: &str,
     ) -> Result<Traced<Vec<u8>>, SdkError> {
+        let encoded_file_path = encoded_git_path(file_path, false)?;
         let suffix = format!(
-            "files/{file_path}?version={}",
+            "files/{encoded_file_path}?version={}",
             url::form_urlencoded::byte_serialize(version.as_bytes()).collect::<String>()
         );
         let (req, trace_id) = self.git_request(
@@ -1118,6 +1150,17 @@ impl ArtifactStorageClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn git_paths_are_component_encoded_and_canonical() {
+        assert_eq!(
+            encoded_git_path("src/what ?#%.rs", false).unwrap(),
+            "src/what%20%3F%23%25.rs"
+        );
+        assert_eq!(encoded_git_path("", true).unwrap(), "");
+        assert!(encoded_git_path("../secret", false).is_err());
+        assert!(encoded_git_path("a//b", false).is_err());
+    }
 
     #[test]
     fn mount_heartbeat_distinguishes_attach_keepalive_and_clean_unmount() {

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::Traced;
 use crate::error::SdkError;
 
-use super::ingest::expect_json;
+use super::ingest::{expect_json, with_transient_retries};
 use super::merge::{MergeConflict, MergeReport, MergeStats, Signature, expect_json_or_conflict};
 use super::{ArtifactStorageClient, advance_pagination_cursor, decode_empty};
 
@@ -759,15 +759,19 @@ impl ArtifactStorageClient {
         git_token: &str,
         workspace_id: &str,
     ) -> Result<Traced<WorkspaceHeartbeat>, SdkError> {
-        let (req, trace_id) = self.git_request(
-            Method::POST,
-            project_id,
-            repo,
-            Some(&format!("workspaces/{workspace_id}/heartbeat")),
-            git_username,
-            git_token,
-        )?;
-        let hb = expect_json(req.send().await?).await?;
+        let suffix = format!("workspaces/{workspace_id}/heartbeat");
+        let (hb, trace_id) = with_transient_retries(|| async {
+            let (req, trace_id) = self.git_request(
+                Method::POST,
+                project_id,
+                repo,
+                Some(&suffix),
+                git_username,
+                git_token,
+            )?;
+            Ok((expect_json(req.send().await?).await?, trace_id))
+        })
+        .await?;
         Ok(Traced::new(trace_id, hb))
     }
 
@@ -781,15 +785,22 @@ impl ArtifactStorageClient {
         workspace_id: &str,
         request: &WorkspaceMountHeartbeatRequest,
     ) -> Result<Traced<WorkspaceHeartbeat>, SdkError> {
-        let (req, trace_id) = self.git_request(
-            Method::POST,
-            project_id,
-            repo,
-            Some(&format!("workspaces/{workspace_id}/heartbeat")),
-            git_username,
-            git_token,
-        )?;
-        let hb = expect_json(req.json(request).send().await?).await?;
+        let suffix = format!("workspaces/{workspace_id}/heartbeat");
+        let (hb, trace_id) = with_transient_retries(|| async {
+            let (req, trace_id) = self.git_request(
+                Method::POST,
+                project_id,
+                repo,
+                Some(&suffix),
+                git_username,
+                git_token,
+            )?;
+            Ok((
+                expect_json(req.json(request).send().await?).await?,
+                trace_id,
+            ))
+        })
+        .await?;
         Ok(Traced::new(trace_id, hb))
     }
 

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -8,12 +8,12 @@
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
-use crate::Traced;
 use crate::error::SdkError;
+use crate::Traced;
 
 use super::ingest::{expect_json, with_transient_retries};
-use super::merge::{MergeConflict, MergeReport, MergeStats, Signature, expect_json_or_conflict};
-use super::{ArtifactStorageClient, advance_pagination_cursor, decode_empty};
+use super::merge::{expect_json_or_conflict, MergeConflict, MergeReport, MergeStats, Signature};
+use super::{advance_pagination_cursor, decode_empty, ArtifactStorageClient};
 
 fn encoded_git_path(path: &str, allow_empty: bool) -> Result<String, SdkError> {
     if path.is_empty() {
@@ -165,6 +165,10 @@ pub struct PromoteWorkspaceRequest {
     pub message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<Signature>,
+    /// Writable mount owner. Omitted callers remain compatible while the workspace is unclaimed;
+    /// once a daemon claims it the server rejects no-id mutations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mount_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -219,6 +223,8 @@ pub struct SyncWorkspaceRequest {
     pub message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<Signature>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mount_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -1185,6 +1191,28 @@ mod tests {
             detached,
             serde_json::json!({"mount_id": "mount-1", "unmount": true})
         );
+    }
+
+    #[test]
+    fn workspace_mutations_serialize_optional_mount_fence() {
+        let promote = serde_json::to_value(PromoteWorkspaceRequest {
+            branch: "main".to_string(),
+            mount_id: Some("mount-1".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(promote["mount_id"], "mount-1");
+
+        let sync = serde_json::to_value(SyncWorkspaceRequest {
+            target: Some("main".to_string()),
+            mount_id: Some("mount-1".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(sync["mount_id"], "mount-1");
+
+        let legacy = serde_json::to_value(SyncWorkspaceRequest::default()).unwrap();
+        assert!(legacy.get("mount_id").is_none());
     }
 
     /// Promote responses from servers that predate merge mode decode with the new fields

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -102,6 +102,18 @@ pub struct WorkspaceHeartbeat {
     pub pinned: bool,
 }
 
+/// Writable-mount presence update. This is deliberately separate from the bodyless lease
+/// heartbeat so callers must opt into changing fleet-visible attachment state.
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct WorkspaceMountHeartbeatRequest {
+    /// Human-readable mount location shown by workspace listing/status.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mounted_on: Option<String>,
+    /// Clear the active attachment on a clean unmount while re-arming detached retention.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub unmount: bool,
+}
+
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct PromoteWorkspaceRequest {
     /// Target branch (short name; `refs/heads/` implied).
@@ -759,6 +771,28 @@ impl ArtifactStorageClient {
         Ok(Traced::new(trace_id, hb))
     }
 
+    /// Re-arm a writable workspace lease and atomically update its fleet-visible mount presence.
+    pub async fn workspace_mount_heartbeat(
+        &self,
+        project_id: &str,
+        repo: &str,
+        git_username: &str,
+        git_token: &str,
+        workspace_id: &str,
+        request: &WorkspaceMountHeartbeatRequest,
+    ) -> Result<Traced<WorkspaceHeartbeat>, SdkError> {
+        let (req, trace_id) = self.git_request(
+            Method::POST,
+            project_id,
+            repo,
+            Some(&format!("workspaces/{workspace_id}/heartbeat")),
+            git_username,
+            git_token,
+        )?;
+        let hb = expect_json(req.json(request).send().await?).await?;
+        Ok(Traced::new(trace_id, hb))
+    }
+
     /// CAS-advance a real branch to the workspace's snapshot (squash by default). Merge mode
     /// (`mode: "merge"`) lands a two-parent merge commit when the target moved; its conflicts
     /// are returned as `PromoteOutcome::Conflicted`, not an error. A plain `409` (concurrent
@@ -1069,6 +1103,23 @@ impl ArtifactStorageClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mount_heartbeat_distinguishes_attach_keepalive_and_clean_unmount() {
+        let attached = serde_json::to_value(WorkspaceMountHeartbeatRequest {
+            mounted_on: Some("sandbox:/code".to_string()),
+            unmount: false,
+        })
+        .unwrap();
+        assert_eq!(attached, serde_json::json!({"mounted_on": "sandbox:/code"}));
+
+        let detached = serde_json::to_value(WorkspaceMountHeartbeatRequest {
+            mounted_on: None,
+            unmount: true,
+        })
+        .unwrap();
+        assert_eq!(detached, serde_json::json!({"unmount": true}));
+    }
 
     /// Promote responses from servers that predate merge mode decode with the new fields
     /// defaulting to false.

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -106,6 +106,10 @@ pub struct WorkspaceHeartbeat {
 /// heartbeat so callers must opt into changing fleet-visible attachment state.
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct WorkspaceMountHeartbeatRequest {
+    /// Stable random owner of this writable attachment. Attach, heartbeat, and unmount carry the
+    /// same id so a stale process cannot replace or clear another sandbox's live claim.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mount_id: Option<String>,
     /// Human-readable mount location shown by workspace listing/status.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mounted_on: Option<String>,
@@ -1118,18 +1122,26 @@ mod tests {
     #[test]
     fn mount_heartbeat_distinguishes_attach_keepalive_and_clean_unmount() {
         let attached = serde_json::to_value(WorkspaceMountHeartbeatRequest {
+            mount_id: Some("mount-1".to_string()),
             mounted_on: Some("sandbox:/code".to_string()),
             unmount: false,
         })
         .unwrap();
-        assert_eq!(attached, serde_json::json!({"mounted_on": "sandbox:/code"}));
+        assert_eq!(
+            attached,
+            serde_json::json!({"mount_id": "mount-1", "mounted_on": "sandbox:/code"})
+        );
 
         let detached = serde_json::to_value(WorkspaceMountHeartbeatRequest {
+            mount_id: Some("mount-1".to_string()),
             mounted_on: None,
             unmount: true,
         })
         .unwrap();
-        assert_eq!(detached, serde_json::json!({"unmount": true}));
+        assert_eq!(
+            detached,
+            serde_json::json!({"mount_id": "mount-1", "unmount": true})
+        );
     }
 
     /// Promote responses from servers that predate merge mode decode with the new fields

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -1,11 +1,9 @@
 //! Workspace client: private durable refs (`refs/workspaces/<id>`) on artifact storage.
 //!
-//! A workspace is the unit of ongoing work (artifact_storage issue #24): created from a base
-//! commit, advanced by snapshots (ordinary commits on the workspace ref, uploaded as CDC chunks
-//! through the resumable-ingest pipeline), and published by promoting a snapshot onto a real
-//! branch (squash by default). Workspaces are durable scratch pads — they survive crashes,
-//! timeouts, and unmounts, and die only by explicit deletion. All calls authenticate with a
-//! minted git credential, like the repo/commit APIs.
+//! A workspace is the unit of ongoing work: it is allocated lazily by the first write, advances a
+//! crash-safe autosave WAL without creating commits, materializes explicit snapshots as commits,
+//! and publishes only through promote (squash by default). All calls authenticate with a minted
+//! git credential, like the repo/commit APIs.
 
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
@@ -39,6 +37,31 @@ pub struct WorkspaceInfo {
     /// name), in server-assigned order.
     #[serde(default)]
     pub shared_target: Option<String>,
+    /// Number of explicit snapshot commits on this workspace line. Autosave checkpoints are not
+    /// commits and are deliberately excluded.
+    #[serde(default)]
+    pub snapshot_count: u64,
+    /// Newest mount heartbeat, WAL append, snapshot, or promote time.
+    #[serde(default)]
+    pub last_activity_ms: Option<u64>,
+    /// `none`, `dirty`, or `materialized`.
+    #[serde(default = "default_workspace_wal_state")]
+    pub wal_state: String,
+    /// `attached` or `detached`; `unknown` when returned by an older server.
+    #[serde(default = "default_workspace_attachment_state")]
+    pub attachment_state: String,
+    #[serde(default)]
+    pub mounted_on: Option<String>,
+    #[serde(default)]
+    pub wal_generation: Option<u64>,
+}
+
+fn default_workspace_wal_state() -> String {
+    "none".to_string()
+}
+
+fn default_workspace_attachment_state() -> String {
+    "unknown".to_string()
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1056,6 +1079,34 @@ mod tests {
         assert!(resp.squashed);
         assert!(!resp.merged);
         assert!(!resp.fast_forwarded);
+    }
+
+    #[test]
+    fn workspace_info_decodes_wal_and_activity_state_with_old_server_defaults() {
+        let base = r#"{
+            "id":"aa", "ref_name":"refs/workspaces/aa", "principal":"user:u1",
+            "base":"1111111111111111111111111111111111111111",
+            "base_ref":"refs/heads/main",
+            "head":"1111111111111111111111111111111111111111",
+            "created_at_secs":1, "lease_secs":0, "lease_due_ms":null, "pinned":true
+        }"#;
+        let old: WorkspaceInfo = serde_json::from_str(base).unwrap();
+        assert_eq!(old.snapshot_count, 0);
+        assert_eq!(old.wal_state, "none");
+        assert_eq!(old.attachment_state, "unknown");
+        assert_eq!(old.wal_generation, None);
+
+        let current = base.replace(
+            "\"pinned\":true",
+            "\"pinned\":true,\"snapshot_count\":2,\"last_activity_ms\":99,\"wal_state\":\"dirty\",\"attachment_state\":\"attached\",\"mounted_on\":\"sandbox-1\",\"wal_generation\":7",
+        );
+        let current: WorkspaceInfo = serde_json::from_str(&current).unwrap();
+        assert_eq!(current.snapshot_count, 2);
+        assert_eq!(current.last_activity_ms, Some(99));
+        assert_eq!(current.wal_state, "dirty");
+        assert_eq!(current.attachment_state, "attached");
+        assert_eq!(current.mounted_on.as_deref(), Some("sandbox-1"));
+        assert_eq!(current.wal_generation, Some(7));
     }
 
     /// The fleet page decodes gsvc-server's exact wire shape (`fleet_item_json` /

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -2,7 +2,7 @@
 # only `src/`, keeping this workspace-adapted dependency manifest.
 [package]
 name = "gsvc-fs-client"
-version = "0.5.82"
+version = "0.5.83"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.82"
+version = "0.5.83"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/docs/git-mount.md
+++ b/docs/git-mount.md
@@ -40,6 +40,11 @@ workspace, including its unsnapshotted WAL, from any machine with:
 tl git mount monorepo /code --workspace WORKSPACE_ID
 ```
 
+A writable workspace has one live mount owner at a time. The mount claims it with a random local
+id, renews that claim while the daemon is healthy, and releases it on clean unmount. A second
+sandbox cannot attach the same workspace writable until the first releases it or its short claim
+lease expires; a delayed unmount from the old sandbox cannot clear the replacement claim.
+
 `--ro` creates no workspace, ref, or GC root. It records only an expiring, principal-bound presence
 row so the control plane can show live mounts; a clean unmount removes the row immediately and a
 crashed sandbox disappears at expiry.
@@ -75,7 +80,8 @@ A `--publish` workspace continuously serves its fixed target branch. Its explici
 reconciled onto that branch server-side, so `sync` refreshes the target but cannot retarget it and
 `rebase` is intentionally rejected: rebasing only the private workspace ref would make the result
 invisible in the live branch view. Create a normal workspace when explicit rebase/retarget control
-is required.
+is required. `--publish` is accepted only when the resolved source is a branch; tags and pinned
+commits are rejected before the mount starts.
 
 Before replacing a snapshotted chain, rebase retains its prior tip under a recovery ref. `log`,
 `smartlog`, and `status` expose these retained chains. They remain recoverable and GC-rooted until

--- a/docs/git-mount.md
+++ b/docs/git-mount.md
@@ -56,7 +56,7 @@ tl git status [/code]
 tl git snapshot [/code] --message "checkpoint"
 tl git sync [/code] [BRANCH|TAG|FULL_COMMIT]
 tl git rebase [/code] BRANCH|TAG|FULL_COMMIT
-tl git promote [/code] BRANCH [--merge | --full-history]
+tl git promote [/code] BRANCH [--merge]
 tl git log [/code|REPOSITORY]
 tl git smartlog [/code|REPOSITORY] [--project]
 ```
@@ -95,9 +95,7 @@ retained refs.
 
 `promote` autosaves outstanding edits, materializes the current state as a workspace snapshot, and
 deliberately lands it onto a real branch. The default is a squash landing; `--merge` creates a true
-merge when the branch moved and publishes nothing if conflicts remain. `--full-history` lands the
-workspace snapshot chain itself. On a `--publish` mount it suppresses that snapshot's automatic
-squash publication first, so the branch advances exactly once in the requested mode.
+merge when the branch moved and publishes nothing if conflicts remain.
 
 ## How this differs from `tl fs`
 

--- a/docs/git-mount.md
+++ b/docs/git-mount.md
@@ -98,4 +98,11 @@ Filesystem snapshots are path-addressed rather than repository-style named commi
 mounted or tracked directory and defaults to the attachment containing the current directory. A
 filesystem gets its name at `tl fs create`; there is no `tl fs name` command or snapshot-name
 argument. `-m`/`--message` is descriptive metadata. Use `tl fs history [FILESYSTEM|PATH]` to see
-permanent snapshots and the recent autosave WAL.
+permanent snapshots first and the visibly ephemeral recent autosave WAL second. Its JSON output
+keeps these as distinct `snapshots` and `autosaves` arrays. `tl fs status [PATH]` reports local
+changes, the last autosave time, and the permanent snapshot count without walking filesystem
+history.
+
+Deleting a filesystem snapshot removes that permanent retention point; it does not immediately
+delete content that another snapshot, autosave, or live filesystem head still references.
+Unreferenced bytes are reclaimed asynchronously.

--- a/docs/git-mount.md
+++ b/docs/git-mount.md
@@ -83,6 +83,11 @@ invisible in the live branch view. Create a normal workspace when explicit rebas
 is required. `--publish` is accepted only when the resolved source is a branch; tags and pinned
 commits are rejected before the mount starts.
 
+On success, `snapshot` reports both the private snapshot and the exact published branch commit. If
+the branch moved, retry with `tl git promote PATH BRANCH --merge`; do not rebase the publish
+workspace. If that server-side merge reports content conflicts, create a normal workspace on the
+branch, reapply and resolve the listed paths there, and promote that workspace.
+
 Before replacing a snapshotted chain, rebase retains its prior tip under a recovery ref. `log`,
 `smartlog`, and `status` expose these retained chains. They remain recoverable and GC-rooted until
 the workspace is explicitly deleted; deleting the workspace atomically releases its active and

--- a/docs/git-mount.md
+++ b/docs/git-mount.md
@@ -56,7 +56,7 @@ tl git status [/code]
 tl git snapshot [/code] --message "checkpoint"
 tl git sync [/code] [BRANCH|TAG|FULL_COMMIT]
 tl git rebase [/code] BRANCH|TAG|FULL_COMMIT
-tl git promote [/code] BRANCH [--merge]
+tl git promote [/code] BRANCH [--merge | --full-history]
 tl git log [/code|REPOSITORY]
 tl git smartlog [/code|REPOSITORY] [--project]
 ```
@@ -95,7 +95,9 @@ retained refs.
 
 `promote` autosaves outstanding edits, materializes the current state as a workspace snapshot, and
 deliberately lands it onto a real branch. The default is a squash landing; `--merge` creates a true
-merge when the branch moved and publishes nothing if conflicts remain.
+merge when the branch moved and publishes nothing if conflicts remain. `--full-history` lands the
+workspace snapshot chain itself. On a `--publish` mount it suppresses that snapshot's automatic
+squash publication first, so the branch advances exactly once in the requested mode.
 
 ## How this differs from `tl fs`
 

--- a/docs/git-mount.md
+++ b/docs/git-mount.md
@@ -1,8 +1,10 @@
 # Repository mounts
 
 `tl git mount` exposes a repository lazily without cloning it. Reads fetch only the objects a
-process opens. Paths written through a writable mount stay in its local overlay until an explicit
-snapshot; the durable workspace and every snapshot live on the server.
+process opens. A writable mount journals edits locally and autosaves them as durable, non-commit
+WAL checkpoints on the server. An explicit snapshot materializes the current checkpoint as a
+commit on the private workspace line; only `promote` (or an explicit snapshot from a `--publish`
+mount) changes a branch.
 
 ## Sources and subtrees
 
@@ -30,7 +32,9 @@ repository tree, so siblings outside the subtree remain untouched.
 
 ## Writable workspaces and read-only views
 
-A plain mount is writable and creates a durable private workspace. Resume it from any machine with:
+A plain mount is writable, but mounting alone does not allocate a server workspace. The first
+autosaved checkpoint after a write creates the durable private workspace lazily. Resume that
+workspace, including its unsnapshotted WAL, from any machine with:
 
 ```bash
 tl git mount monorepo /code --workspace WORKSPACE_ID
@@ -52,12 +56,20 @@ tl git log [/code|REPOSITORY]
 tl git smartlog [/code|REPOSITORY] [--project]
 ```
 
-`sync` refreshes the current source. With a target it switches a stateless read-only view or a
-pristine workspace without rewriting history. Once a workspace has snapshots, changing its base is
-an explicit `rebase`. Rebase runs server-side; conflicts materialize as normal diff3 markers unless
-`--fail-on-conflict` is requested. A rebase can touch the full repository: conflicts inside a
-mounted subtree are shown with subtree-relative paths, while conflicts outside it are reported as
-repository paths and must be resolved by resuming the same workspace in a view that contains them.
+Writes first enter the crash-safe local journal. The mount continuously prepares and uploads them,
+then records ordered, idempotent checkpoints in the workspace WAL. These checkpoints make edits
+durable and resumable, but they are not repository commits and do not update a branch. `snapshot`
+flushes the current WAL state and materializes it as one immutable commit on the workspace's private
+line.
+
+`sync` refreshes the current source while carrying the unsnapshotted WAL forward. With a target it
+switches a stateless read-only view or a workspace with no materialized snapshots without rewriting
+history. Once a workspace has snapshots, changing its base is an explicit `rebase`. Rebase runs
+server-side and replays both materialized snapshots and the unsnapshotted WAL tail; conflicts
+materialize as normal diff3 markers unless `--fail-on-conflict` is requested. A rebase can touch the
+full repository: conflicts inside a mounted subtree are shown with subtree-relative paths, while
+conflicts outside it are reported as repository paths and must be resolved by resuming the same
+workspace in a view that contains them.
 
 A `--publish` workspace continuously serves its fixed target branch. Its explicit snapshots are
 reconciled onto that branch server-side, so `sync` refreshes the target but cannot retarget it and
@@ -70,5 +82,20 @@ Before replacing a snapshotted chain, rebase retains its prior tip under a recov
 the workspace is explicitly deleted; deleting the workspace atomically releases its active and
 retained refs.
 
-`promote` deliberately lands the workspace onto a real branch. The default is a squash landing;
-`--merge` creates a true merge when the branch moved and publishes nothing if conflicts remain.
+`promote` autosaves outstanding edits, materializes the current state as a workspace snapshot, and
+deliberately lands it onto a real branch. The default is a squash landing; `--merge` creates a true
+merge when the branch moved and publishes nothing if conflicts remain.
+
+## How this differs from `tl fs`
+
+`tl fs` is a continuously published drive, not a private commit workflow. A writable filesystem
+mount autosaves its latest state to the shared drive and retains recent saves as an ephemeral WAL.
+`tl fs snapshot [PATH] -m "message"` records a new autosaved generation as a permanent, billed
+snapshot; it is a quiet no-op when there is no new generation. `tl fs push DIR FILESYSTEM` follows
+the same rule: without `-m` it is an autosave, while `-m` creates a permanent snapshot.
+
+Filesystem snapshots are path-addressed rather than repository-style named commits. `PATH` is a
+mounted or tracked directory and defaults to the attachment containing the current directory. A
+filesystem gets its name at `tl fs create`; there is no `tl fs name` command or snapshot-name
+argument. `-m`/`--message` is descriptive metadata. Use `tl fs history [FILESYSTEM|PATH]` to see
+permanent snapshots and the recent autosave WAL.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.82"
+version = "0.5.83"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.82",
+  "version": "0.5.83",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- expose the two-surface filesystem/Git workflow backed by the shared private WAL engine
- make writable Git mounts autosave without creating commits and resume checkpoints across machines
- preserve explicit snapshot, squash-publish, and full-history promotion semantics through retries
- carry active mount ownership on every writable Git workspace mutation
- align filesystem snapshot/history commands with permanent snapshots and ephemeral WAL history
- add client API models, CLI commands, documentation, and the 0.5.83 SDK version bump

## Companion server PR

- tensorlakeai/artifact_storage#117

The server PR must deploy before or together with this client because the Git WAL materialization and mount-fencing wire fields are coordinated.

## Validation

- combined private/public client suite: private mount/WAL tests, public SDK tests, CLI tests, and doctests
- 186 private client tests passed with expected local-server-only ignores
- 160 public SDK tests passed with expected ignore
- 207 CLI tests passed with expected ignore
- Git checkpoint lifecycle, crash replay, cross-machine resume, publish-mode, and writer-fencing coverage
- Cargo.lock regenerated and verified at SDK version 0.5.83