### PR TITLE
Keep the public macOS tl fs surface to a one-line README

### DIFF
--- a/.github/workflows/publish_cli.yaml
+++ b/.github/workflows/publish_cli.yaml
@@ -172,17 +172,9 @@ jobs:
           name: cli-${{ matrix.target_id }}
           path: dist/*
 
-  # TLFS.app: the macOS FSKit extension `tl fs mount` needs (installed on end-user machines by
-  # `tl fs setup`). The Swift source is private: it is sparse-checked-out from
-  # tensorlakeai/artifact_storage (platform/macos/tlfs) with the same GitHub App used to vendor
-  # the private crates, and only the compiled bundle ships. Built headlessly with swiftc, signed
-  # with the Developer ID identity + Developer ID provisioning profile (FSKit Module capability,
-  # no device list), notarized, and attached to the same release so app and CLI stay in
-  # wire-protocol lockstep.
-  # Secrets (see platform/macos/tlfs/README.md in artifact_storage):
-  #   TLFS_SIGNING_CERT_P12 / TLFS_SIGNING_CERT_PASSWORD  Developer ID Application cert (.p12, base64)
-  #   TLFS_PROVISION_PROFILE                              Developer ID profile (base64)
-  #   TLFS_NOTARY_KEY / TLFS_NOTARY_KEY_ID / TLFS_NOTARY_ISSUER  App Store Connect API key (.p8 base64)
+  # Builds the signed, notarized TLFS.app that `tl fs setup` installs on macOS. The source is
+  # private; job documentation and the CI secrets it needs are described alongside it in
+  # artifact_storage (platform/macos/tlfs/README.md).
   tlfs-app:
     name: Build TLFS.app (macOS file-system extension)
     # Needs Xcode 26.x / the macOS 26 SDK (the FSKit surface tlfs uses); adjust the image if the
@@ -200,8 +192,6 @@ jobs:
           owner: tensorlakeai
           repositories: artifact_storage
 
-      # The FSKit module source is private. Check out only platform/macos/tlfs; it exists on the
-      # runner for the duration of the job and only the compiled, signed TLFS.app leaves it.
       - name: Check out private TLFS sources
         uses: actions/checkout@v4
         with:

--- a/justfile
+++ b/justfile
@@ -63,11 +63,8 @@ build-cli-full *ARGS:
 # Back-compat alias for the old recipe name.
 build-cli-mount *ARGS: (build-cli-full ARGS)
 
-# Build the macOS TLFS.app (FSKit extension) from the private artifact_storage checkout. The
-# Swift source is not in this repo — only the compiled, signed bundle ships (embedded into the
-# darwin CLI by CI). Dev build by default; pass flags through, e.g.
-# `just build-tlfs-app --release --notarize`. To embed the result in a local CLI build:
-# `TLFS_APP_ZIP=$(realpath ../artifact_storage/platform/macos/tlfs/build/TLFS.app.zip) just build-cli-full`
+# Build the macOS TLFS.app from the private artifact_storage checkout (see its
+# platform/macos/tlfs/README.md). Flags pass through, e.g. `just build-tlfs-app --release`.
 build-tlfs-app *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/platform/macos/tlfs/README.md
+++ b/platform/macos/tlfs/README.md
@@ -1,29 +1,3 @@
-# tlfs — macOS FSKit module for `tl fs mount` (source is private)
+# tl fs on macOS
 
-The production FSKit file-system extension behind `tl fs mount` on macOS is not part of
-this public repository. Like the `gsvc-mount` / `gsvc-codec` / `gsvc-fs-client` mount
-core (see `crates/gsvc-mount/src/lib.rs`), its source lives in the private
-`tensorlakeai/artifact_storage` repo, under the same `platform/macos/tlfs/` path.
-
-What ships publicly is the compiled, Developer-ID-signed, notarized `TLFS.app` bundle:
-
-- On release, the `tlfs-app` job in `.github/workflows/publish_cli.yaml` sparse-checks-
-  out `platform/macos/tlfs/` from artifact_storage (same GitHub App credentials as the
-  private-crate vendoring), builds/signs/notarizes it, and attaches
-  `TLFS-<version>.app.zip` to the `cli-v<version>` GitHub release.
-- The darwin CLI build embeds that same zip (`TLFS_APP_ZIP` →
-  `crates/gsvc-fs-client/build.rs`), so `tl fs setup` on an official binary installs the
-  extension offline. Source builds fall back to downloading the release asset matching
-  the CLI version, or `tl fs setup --from <path-or-url>`.
-
-Building the app yourself requires the private source plus an Apple provisioning
-profile with the restricted FSKit Module capability. With an artifact_storage checkout
-as a sibling of this repo (or `ARTIFACT_STORAGE_DIR` pointing at one):
-
-```sh
-just build-tlfs-app                        # dev build (device-limited profile)
-just build-tlfs-app --release --notarize   # distribution build
-```
-
-The `fskit-hello` prototype (a from-scratch FSKit walkthrough) lives in
-artifact_storage as well, at `platform/macos/fskit-hello/`.
+The macOS-specific part of `tl fs` is private and is not part of this repository.


### PR DESCRIPTION
## Summary

Follow-up to #857: the public `platform/macos/tlfs/README.md` is now a single line ("The macOS-specific part of `tl fs` is private..."), and the shipping/local-build explanations are removed from the public surface:

- The `tlfs-app` job's comment block in `publish_cli.yaml` shrinks to two lines pointing at the private README for job documentation and CI secrets.
- The `build-tlfs-app` justfile comment shrinks likewise; the `TLFS_APP_ZIP` local-embed instructions move to the private README.

The removed content is preserved in artifact_storage's `platform/macos/tlfs/README.md` (companion PR), which is now the sole place shipping mechanics are documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)