### PR TITLE
Harden sandbox TLFS daemon lifecycle and inventory

### DIFF
--- a/.github/actions/vendor-private-crates/README.md
+++ b/.github/actions/vendor-private-crates/README.md
@@ -12,6 +12,10 @@ for the duration of the job.
 2. Sparse-checks-out the three private crate source trees into `.mount-core/`.
 3. Copies the real sources over the placeholders, keeping the placeholders' workspace-adapted
    manifests.
+4. When `include-macos-fskit: "true"`, separately stages the private FSKit `Sources` and
+   `Resources` needed by the macOS Rust source-contract tests. Linux and Windows callers leave the
+   input disabled and do not fetch or compile Swift sources. The FSKit `build.sh` remains confined
+   to the dedicated TLFS.app release job.
 
 The calling job must run `actions/checkout` for this repo first, then call this action before the
 build step, and add `--features git-clone` (plus `mount` on mount-capable targets; or
@@ -41,4 +45,7 @@ default (no-mount) lanes still run for them, so external contributors' PRs build
 - `.github/workflows/tests.yaml` — full-feature Rust workspace tests.
 - `.github/workflows/publish_cli.yaml` — release `tensorlake` binaries (Linux + macOS).
 
-Local equivalent (no App needed, uses a sibling artifact_storage checkout): `just build-cli-mount`.
+Local equivalent (no App needed, uses a sibling artifact_storage checkout): `just build-cli-full`.
+On macOS, `build-cli-full` and `test-cli-full` stage the matching private FSKit `Sources` and
+`Resources` for the command and restore the public one-line TLFS directory afterward, including on
+failure.

--- a/.github/actions/vendor-private-crates/action.yml
+++ b/.github/actions/vendor-private-crates/action.yml
@@ -18,6 +18,12 @@ inputs:
   private-key:
     description: Private key (PEM) for that GitHub App.
     required: true
+  include-macos-fskit:
+    description: >
+      Also stage the private macOS FSKit Sources and Resources needed by macOS client tests.
+      Leave disabled on Linux and Windows so those builds have no Swift source dependency.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -44,6 +50,19 @@ runs:
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
+    - name: Check out private macOS FSKit companions
+      if: ${{ inputs.include-macos-fskit == 'true' }}
+      uses: actions/checkout@v4
+      with:
+        repository: tensorlakeai/artifact_storage
+        token: ${{ steps.app-token.outputs.token }}
+        path: .mount-fskit
+        sparse-checkout: |
+          platform/macos/tlfs/Sources
+          platform/macos/tlfs/Resources
+        sparse-checkout-cone-mode: false
+        persist-credentials: false
+
     - name: Swap real sources over the placeholders
       shell: bash
       run: |
@@ -62,3 +81,19 @@ runs:
           echo "Vendored ${count} ${crate} source file(s)."
         done
         echo "The CLI can now build with --features mount,git-clone."
+
+    - name: Stage private macOS FSKit companions
+      if: ${{ inputs.include-macos-fskit == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        real=".mount-fskit/platform/macos/tlfs"
+        destination="platform/macos/tlfs"
+        if [ ! -f "$real/Sources/Extension/TLFS.swift" ] || [ ! -d "$real/Resources" ]; then
+          echo "::error::private macOS FSKit Sources/Resources are incomplete at $real"
+          exit 1
+        fi
+        mkdir -p "$destination"
+        rm -rf "$destination/Sources" "$destination/Resources"
+        cp -R "$real/Sources" "$real/Resources" "$destination/"
+        echo "Vendored the macOS FSKit source companions for this runner."

--- a/.github/workflows/publish_cli.yaml
+++ b/.github/workflows/publish_cli.yaml
@@ -86,6 +86,7 @@ jobs:
         with:
           app-id: ${{ secrets.ARTIFACT_STORAGE_APP_ID }}
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
+          include-macos-fskit: ${{ matrix.target_id == 'darwin-aarch64' && 'true' || 'false' }}
 
       - name: Fetch notarized TLFS.app (embedded into `tl fs setup`)
         if: matrix.target_id == 'darwin-aarch64'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,6 +58,41 @@ jobs:
       - name: Run Rust workspace tests with customer features
         run: cargo test --workspace --features tensorlake-cli/mount,tensorlake-cli/git-clone
 
+  macos_private_source_contract:
+    name: macOS private FSKit source contract
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: macos-14
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v1-rust-macos-private-source
+          cache-bin: false
+
+      - name: Vendor private artifact_storage crates and FSKit companions
+        uses: ./.github/actions/vendor-private-crates
+        with:
+          app-id: ${{ secrets.ARTIFACT_STORAGE_APP_ID }}
+          private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
+          include-macos-fskit: "true"
+
+      - name: Verify the CLI and FSKit source contract compile together
+        run: >-
+          CARGO_TARGET_DIR="$PWD/target"
+          cargo test --manifest-path crates/gsvc-fs-client/Cargo.toml
+          fskit_close_to_open_tracks_the_daemon_handle_content_version
+
   windows_build_smoke:
     name: Windows build smoke test
     runs-on: windows-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,15 +1156,20 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuser"
-version = "0.15.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
+checksum = "80a5eca878900c2e39e9e52fd797954b7fc39eeefc8558257114bfea6a698fcf"
 dependencies = [
+ "bitflags",
  "libc",
  "log",
  "memchr",
  "nix",
+ "num_enum",
  "page_size",
+ "parking_lot",
+ "pkg-config",
+ "ref-cast",
  "smallvec",
  "zerocopy",
 ]
@@ -1360,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.83"
+version = "0.5.84"
 dependencies = [
  "anyhow",
  "base64",
@@ -2226,6 +2231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,14 +2361,15 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2398,6 +2413,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2645,6 +2682,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -3726,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.83"
+version = "0.5.84"
 dependencies = [
  "anyhow",
  "base64",
@@ -3778,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.83"
+version = "0.5.84"
 dependencies = [
  "anyhow",
  "base64",
@@ -3827,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.83"
+version = "0.5.84"
 dependencies = [
  "napi",
  "napi-build",
@@ -3841,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.83"
+version = "0.5.84"
 dependencies = [
  "futures",
  "pyo3",
@@ -4056,7 +4102,7 @@ dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
@@ -4069,6 +4115,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4885,6 +4952,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.83"
+version = "0.5.84"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -6,7 +6,36 @@
 use std::path::{Path, PathBuf};
 
 use crate::auth::context::CliContext;
-use crate::error::Result;
+use crate::error::{CliError, Result};
+
+fn reject_background_mount_in_one_shot_exec(foreground: bool, surface: &str) -> Result<()> {
+    validate_mount_process_mode(
+        foreground,
+        std::env::var_os(crate::commands::sbx::exec::SANDBOX_EXEC_MODE_ENV).as_deref(),
+        surface,
+    )
+}
+
+fn validate_mount_process_mode(
+    foreground: bool,
+    process_mode: Option<&std::ffi::OsStr>,
+    surface: &str,
+) -> Result<()> {
+    if !foreground
+        && process_mode
+            == Some(std::ffi::OsStr::new(
+                crate::commands::sbx::exec::SANDBOX_EXEC_MODE_ONE_SHOT,
+            ))
+    {
+        return Err(CliError::usage(format!(
+            "`tl {surface} mount` cannot background its daemon from inside a one-shot `tl sbx \
+             exec` command: the sandbox runtime reaps that command's cgroup when it exits. \
+             Launch the mount directly from the controller instead (`tl sbx exec <sandbox> -- \
+             tl {surface} mount ...`); the outer CLI will keep it as a sandbox-owned process."
+        )));
+    }
+    Ok(())
+}
 
 fn private_context(ctx: &CliContext) -> gsvc_fs_client::CliContext {
     gsvc_fs_client::CliContext {
@@ -144,6 +173,7 @@ pub async fn mount_filesystem(
     trace_ops: bool,
     log_level: &str,
 ) -> Result<()> {
+    reject_background_mount_in_one_shot_exec(foreground, "fs")?;
     map(gsvc_fs_client::mount_filesystem(
         &private_context(ctx),
         target,
@@ -168,6 +198,7 @@ pub async fn mount_repo(
     trace_ops: bool,
     log_level: &str,
 ) -> Result<()> {
+    reject_background_mount_in_one_shot_exec(foreground, "git")?;
     map(gsvc_fs_client::mount_repo(
         &private_context(ctx),
         target,
@@ -180,6 +211,30 @@ pub async fn mount_repo(
         log_level,
     )
     .await)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::validate_mount_process_mode;
+
+    #[test]
+    fn background_mount_fails_closed_inside_one_shot_sandbox_exec() {
+        let error = validate_mount_process_mode(false, Some(OsStr::new("one-shot")), "fs")
+            .expect_err("background daemon would be reaped with the exec cgroup");
+
+        let message = error.to_string();
+        assert!(message.contains("cannot background its daemon"));
+        assert!(message.contains("tl sbx exec <sandbox>"));
+    }
+
+    #[test]
+    fn foreground_or_non_sandbox_mount_keeps_existing_behavior() {
+        validate_mount_process_mode(true, Some(OsStr::new("one-shot")), "fs").unwrap();
+        validate_mount_process_mode(false, None, "fs").unwrap();
+        validate_mount_process_mode(false, Some(OsStr::new("detached")), "fs").unwrap();
+    }
 }
 
 pub async fn snapshot(

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -28,10 +28,10 @@ fn validate_mount_process_mode(
             ))
     {
         return Err(CliError::usage(format!(
-            "`tl {surface} mount` cannot background its daemon from inside a one-shot `tl sbx \
-             exec` command: the sandbox runtime reaps that command's cgroup when it exits. \
-             Launch the mount directly from the controller instead (`tl sbx exec <sandbox> -- \
-             tl {surface} mount ...`); the outer CLI will keep it as a sandbox-owned process."
+            "`tl {surface} mount` cannot background its daemon from inside a sandbox process \
+             unit: the sandbox runtime reaps that unit's cgroup when its leader exits. Launch the \
+             mount directly from the controller instead (`tl sbx exec <sandbox> -- tl {surface} \
+             mount ...`); the outer CLI will keep it as a sandbox-owned process."
         )));
     }
     Ok(())

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -2,6 +2,8 @@ use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::header::ACCEPT;
 use serde_json::Value;
+use std::path::Path;
+use std::time::Duration;
 
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{parse_env_vars, resolve_sandbox_proxy_target, with_sandbox_headers};
@@ -25,6 +27,25 @@ pub struct ExecOptions<'a> {
     pub health_interval_ms: Option<u64>,
     pub health_timeout_ms: Option<u64>,
     pub health_failure_threshold: Option<u32>,
+    /// Promote a directly-invoked `tl fs mount` or `tl git mount` to a detached sandbox process.
+    /// The mount daemon must be the process-unit leader: a daemon forked by `/processes/run`
+    /// remains in that one-shot unit's cgroup and is reaped when the unit finishes.
+    pub protect_long_lived_mounts: bool,
+}
+
+/// Runtime marker inherited by descendants of the one-shot Sandbox Process API. This is not
+/// user configuration: mount commands use it to fail closed instead of forking a daemon into an
+/// exec cgroup that will be torn down as soon as the outer command exits.
+pub const SANDBOX_EXEC_MODE_ENV: &str = "TENSORLAKE_SANDBOX_PROCESS_MODE";
+pub const SANDBOX_EXEC_MODE_ONE_SHOT: &str = "one-shot";
+
+const DEFAULT_MOUNT_READY_TIMEOUT: Duration = Duration::from_secs(25);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DetachedMountCommand {
+    args: Vec<String>,
+    mountpoint: String,
+    surface: &'static str,
 }
 
 pub async fn run(
@@ -36,35 +57,70 @@ pub async fn run(
 ) -> Result<()> {
     let target = resolve_sandbox_proxy_target(ctx, sandbox_id).await?;
     let client = ctx.client()?;
-    let body = build_process_payload(command, args, options)?;
+    if !options.detach && managed_or_detached_only_fields_present(options) {
+        return Err(CliError::usage(
+            "managed process flags require --detach; use plain `tl sbx exec` for blocking output",
+        ));
+    }
 
-    if options.detach {
-        let resp = with_sandbox_headers(
-            client
-                .post(format!("{}/api/v1/processes", target.proxy_base))
-                .json(&body),
+    // `/api/v1/processes/run` owns one process group and one cgroup leaf. A normal
+    // `tl fs mount` / `tl git mount` returns after forking `tl fs daemon`; that child remains
+    // inside the one-shot unit and the sandbox runtime reaps it when the request ends. `setsid(2)`
+    // cannot escape that cgroup. Make the foreground mount daemon itself a detached Process API unit.
+    // Explicit `--foreground` retains its debugging/blocking contract, and shell-wrapped
+    // commands are not guessed at because rewriting their quoting is unsafe.
+    let detached_mount = (options.detach || options.protect_long_lived_mounts)
+        .then(|| rewrite_direct_mount(command, args))
+        .flatten();
+    let effective_args = detached_mount
+        .as_ref()
+        .map_or(args, |mount| mount.args.as_slice());
+    let body = if detached_mount.is_some() && !options.detach {
+        let mut detached_options = options;
+        detached_options.detach = true;
+        detached_options.timeout = None;
+        build_process_payload(command, effective_args, detached_options)?
+    } else {
+        build_process_payload(command, effective_args, options)?
+    };
+
+    if options.detach || detached_mount.is_some() {
+        let process = start_detached_process(&client, &target, &body).await?;
+        let pid = process_pid(&process)?;
+        if options.detach {
+            println!("{pid}");
+            return Ok(());
+        }
+
+        let mount = detached_mount.expect("detached mount checked above");
+        let ready_timeout = mount_ready_timeout(options.timeout)?;
+        if let Err(error) = wait_for_mount_ready(
+            &client,
             &target,
+            &mount.mountpoint,
+            pid,
+            options.workdir,
+            options.user,
+            ready_timeout,
         )
-        .send()
         .await
-        .map_err(CliError::Http)?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
+        {
+            let tail = process_output_tail(&client, &target, pid).await;
+            stop_process(&client, &target, pid).await;
+            let detail = tail
+                .filter(|tail| !tail.is_empty())
+                .map(|tail| format!("\nMount process output:\n  {}", tail.replace('\n', "\n  ")))
+                .unwrap_or_default();
             return Err(CliError::Other(anyhow::anyhow!(
-                "failed to start process (HTTP {}): {}",
-                status,
-                body
+                "sandbox mount process {pid} did not make {} ready: {error}.{detail}",
+                mount.mountpoint
             )));
         }
 
-        let process: Value = resp.json().await.map_err(CliError::Http)?;
-        let pid = process
-            .get("pid")
-            .and_then(|value| value.as_i64())
-            .ok_or_else(|| CliError::usage("start process response missing pid"))?;
-        println!("{pid}");
+        println!(
+            "Mounted {} {} in sandbox process {pid}; the process remains attached to the sandbox lifecycle.",
+            mount.surface, mount.mountpoint
+        );
         return Ok(());
     }
 
@@ -97,6 +153,241 @@ pub async fn run(
     Ok(())
 }
 
+async fn start_detached_process(
+    client: &reqwest::Client,
+    target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
+    body: &Value,
+) -> Result<Value> {
+    let resp = with_sandbox_headers(
+        client
+            .post(format!("{}/api/v1/processes", target.proxy_base))
+            .json(body),
+        target,
+    )
+    .send()
+    .await
+    .map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to start process (HTTP {}): {}",
+            status,
+            body
+        )));
+    }
+    resp.json().await.map_err(CliError::Http)
+}
+
+fn process_pid(process: &Value) -> Result<i64> {
+    process
+        .get("pid")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| CliError::usage("start process response missing pid"))
+}
+
+fn mount_ready_timeout(configured: Option<f64>) -> Result<Duration> {
+    match configured {
+        None => Ok(DEFAULT_MOUNT_READY_TIMEOUT),
+        Some(seconds) if seconds.is_finite() && seconds > 0.0 => {
+            Ok(Duration::from_secs_f64(seconds))
+        }
+        Some(_) => Err(CliError::usage("--timeout must be greater than zero")),
+    }
+}
+
+fn rewrite_direct_mount(command: &str, args: &[String]) -> Option<DetachedMountCommand> {
+    if Path::new(command).file_name()?.to_str()? != "tl" {
+        return None;
+    }
+    let mount_index = args
+        .windows(2)
+        .position(|pair| matches!(pair[0].as_str(), "fs" | "git") && pair[1] == "mount")?;
+    let surface = match args[mount_index].as_str() {
+        "fs" => "filesystem",
+        "git" => "repository",
+        _ => unreachable!("the mount window accepted only fs or git"),
+    };
+    let mount_args = &args[mount_index + 2..];
+    if mount_args.iter().any(|arg| arg == "--foreground") {
+        return None;
+    }
+
+    let mountpoint = parse_mountpoint(&args[mount_index], mount_args)?;
+    let mut detached_args = args.to_vec();
+    detached_args.push("--foreground".to_string());
+    Some(DetachedMountCommand {
+        args: detached_args,
+        mountpoint,
+        surface,
+    })
+}
+
+fn parse_mountpoint(surface: &str, args: &[String]) -> Option<String> {
+    let mut positional = Vec::with_capacity(2);
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        match arg.as_str() {
+            "--ro" | "--trace-ops" => index += 1,
+            "--publish" if surface == "git" => index += 1,
+            "--log-level" => {
+                if index + 1 == args.len() {
+                    return None;
+                }
+                index += 2;
+            }
+            "--workspace" if surface == "git" => {
+                if index + 1 == args.len() {
+                    return None;
+                }
+                index += 2;
+            }
+            "--" => {
+                positional.extend(args[index + 1..].iter().cloned());
+                break;
+            }
+            _ if arg.starts_with("--log-level=")
+                || (surface == "git" && arg.starts_with("--workspace=")) =>
+            {
+                index += 1;
+            }
+            // Unknown options are left to the ordinary execution path. Guessing whether they
+            // consume a value could accidentally treat that value as the mountpoint.
+            _ if arg.starts_with('-') => return None,
+            _ => {
+                positional.push(arg.clone());
+                index += 1;
+            }
+        }
+    }
+    (positional.len() == 2).then(|| positional[1].clone())
+}
+
+fn build_mount_readiness_payload(
+    mountpoint: &str,
+    pid: i64,
+    workdir: Option<&str>,
+    user: Option<&str>,
+    timeout: Duration,
+) -> Value {
+    let attempts = timeout.as_millis().div_ceil(100).max(1);
+    let script = "i=0; while [ \"$i\" -lt \"$2\" ]; do \
+                  kill -0 \"$3\" 2>/dev/null || exit 125; \
+                  mountpoint -q -- \"$1\" && exit 0; \
+                  i=$((i + 1)); sleep 0.1; \
+                  done; exit 124";
+    let mut body = serde_json::json!({
+        "command": "/bin/sh",
+        "args": [
+            "-c",
+            script,
+            "tlfs-mount-readiness",
+            mountpoint,
+            attempts.to_string(),
+            pid.to_string(),
+        ],
+        "timeout": timeout.as_secs_f64() + 2.0,
+    });
+    if let Some(workdir) = workdir {
+        body["working_dir"] = Value::String(workdir.to_string());
+    }
+    if let Some(user) = user {
+        body["user"] = Value::String(user.to_string());
+    }
+    body
+}
+
+async fn wait_for_mount_ready(
+    client: &reqwest::Client,
+    target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
+    mountpoint: &str,
+    pid: i64,
+    workdir: Option<&str>,
+    user: Option<&str>,
+    timeout: Duration,
+) -> Result<()> {
+    let body = build_mount_readiness_payload(mountpoint, pid, workdir, user, timeout);
+    let resp = with_sandbox_headers(
+        client
+            .post(format!("{}/api/v1/processes/run", target.proxy_base))
+            .header(ACCEPT, "text/event-stream")
+            .json(&body),
+        target,
+    )
+    .send()
+    .await
+    .map_err(CliError::Http)?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "readiness check failed (HTTP {status}): {body}"
+        )));
+    }
+    match stream_run_events(resp).await? {
+        0 => Ok(()),
+        125 => Err(CliError::Other(anyhow::anyhow!(
+            "the detached mount process exited during startup"
+        ))),
+        124 => Err(CliError::Other(anyhow::anyhow!(
+            "the mount was not ready within {:.1}s",
+            timeout.as_secs_f64()
+        ))),
+        code => Err(CliError::Other(anyhow::anyhow!(
+            "mount readiness check exited with code {code}"
+        ))),
+    }
+}
+
+async fn process_output_tail(
+    client: &reqwest::Client,
+    target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
+    pid: i64,
+) -> Option<String> {
+    let response = with_sandbox_headers(
+        client.get(format!(
+            "{}/api/v1/processes/{pid}/output",
+            target.proxy_base
+        )),
+        target,
+    )
+    .send()
+    .await
+    .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let body: Value = response.json().await.ok()?;
+    let lines = body.get("lines")?.as_array()?;
+    Some(
+        lines
+            .iter()
+            .filter_map(Value::as_str)
+            .rev()
+            .take(8)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
+}
+
+async fn stop_process(
+    client: &reqwest::Client,
+    target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
+    pid: i64,
+) {
+    let _ = with_sandbox_headers(
+        client.delete(format!("{}/api/v1/processes/{pid}", target.proxy_base)),
+        target,
+    )
+    .send()
+    .await;
+}
+
 fn build_process_payload(
     command: &str,
     args: &[String],
@@ -111,7 +402,16 @@ fn build_process_payload(
         return Err(CliError::usage("--timeout cannot be used with --detach"));
     }
 
-    let env_dict = parse_env_vars(options.env)?;
+    let mut env_dict = parse_env_vars(options.env)?;
+    if !options.detach {
+        let env = env_dict.get_or_insert_with(|| Value::Object(serde_json::Map::new()));
+        env.as_object_mut()
+            .expect("parse_env_vars always returns an object")
+            .insert(
+                SANDBOX_EXEC_MODE_ENV.to_string(),
+                Value::String(SANDBOX_EXEC_MODE_ONE_SHOT.to_string()),
+            );
+    }
     let mut body = serde_json::json!({ "command": command });
     if !args.is_empty() {
         body["args"] = serde_json::json!(args);
@@ -344,7 +644,13 @@ fn should_skip_event(value: &serde_json::Value) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{ExecOptions, build_process_payload, parse_run_event};
+    use std::time::Duration;
+
+    use super::{
+        ExecOptions, SANDBOX_EXEC_MODE_ENV, SANDBOX_EXEC_MODE_ONE_SHOT,
+        build_mount_readiness_payload, build_process_payload, parse_run_event,
+        rewrite_direct_mount,
+    };
 
     fn options<'a>() -> ExecOptions<'a> {
         ExecOptions {
@@ -364,6 +670,7 @@ mod tests {
             health_interval_ms: None,
             health_timeout_ms: None,
             health_failure_threshold: None,
+            protect_long_lived_mounts: true,
         }
     }
 
@@ -441,6 +748,111 @@ mod tests {
         assert_eq!(payload["health_check"]["port"], 8000);
         assert_eq!(payload["health_check"]["path"], "/health");
         assert_eq!(payload["health_check"]["interval_ms"], 5_000);
+        assert!(payload["env"].get(SANDBOX_EXEC_MODE_ENV).is_none());
+    }
+
+    #[test]
+    fn one_shot_payload_marks_descendants_and_caller_cannot_spoof_it() {
+        let mut opts = options();
+        let environment = ["TENSORLAKE_SANDBOX_PROCESS_MODE=detached".to_string()];
+        opts.env = &environment;
+
+        let payload = build_process_payload("python", &["remote.py".to_string()], opts).unwrap();
+
+        assert_eq!(
+            payload["env"][SANDBOX_EXEC_MODE_ENV],
+            SANDBOX_EXEC_MODE_ONE_SHOT
+        );
+    }
+
+    #[test]
+    fn direct_filesystem_mount_becomes_foreground_process_unit() {
+        let command = rewrite_direct_mount(
+            "/home/tl-user/bin/tl",
+            &[
+                "fs".to_string(),
+                "mount".to_string(),
+                "drive".to_string(),
+                "mnt/drive".to_string(),
+                "--ro".to_string(),
+                "--log-level=debug".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(command.surface, "filesystem");
+        assert_eq!(command.mountpoint, "mnt/drive");
+        assert_eq!(
+            command.args.last().map(String::as_str),
+            Some("--foreground")
+        );
+    }
+
+    #[test]
+    fn direct_git_mount_parses_workspace_option() {
+        let command = rewrite_direct_mount(
+            "tl",
+            &[
+                "git".to_string(),
+                "mount".to_string(),
+                "repo:main".to_string(),
+                "--workspace".to_string(),
+                "workspace-1".to_string(),
+                "/code".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(command.surface, "repository");
+        assert_eq!(command.mountpoint, "/code");
+    }
+
+    #[test]
+    fn explicit_foreground_and_shell_wrapped_mounts_are_not_rewritten() {
+        assert!(
+            rewrite_direct_mount(
+                "tl",
+                &[
+                    "fs".to_string(),
+                    "mount".to_string(),
+                    "drive".to_string(),
+                    "/mnt".to_string(),
+                    "--foreground".to_string(),
+                ],
+            )
+            .is_none()
+        );
+        assert!(
+            rewrite_direct_mount(
+                "/bin/sh",
+                &["-lc".to_string(), "tl fs mount drive /mnt".to_string()],
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn readiness_probe_tracks_process_liveness_and_mountpoint() {
+        let payload = build_mount_readiness_payload(
+            "relative mount",
+            4242,
+            Some("/work"),
+            Some("tl-user"),
+            Duration::from_millis(250),
+        );
+
+        assert_eq!(payload["working_dir"], "/work");
+        assert_eq!(payload["user"], "tl-user");
+        assert_eq!(payload["args"][3], "relative mount");
+        assert_eq!(payload["args"][4], "3");
+        assert_eq!(payload["args"][5], "4242");
+        assert!(
+            payload["args"][1]
+                .as_str()
+                .unwrap()
+                .contains("mountpoint -q")
+        );
+        assert!(payload["args"][1].as_str().unwrap().contains("kill -0"));
     }
 
     #[test]

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -202,7 +202,13 @@ fn mount_ready_timeout(configured: Option<f64>) -> Result<Duration> {
     match configured {
         None => Ok(DEFAULT_MOUNT_READY_TIMEOUT),
         Some(seconds) if seconds.is_finite() && seconds > 0.0 => {
-            Ok(Duration::from_secs_f64(seconds))
+            let timeout = Duration::try_from_secs_f64(seconds).map_err(|_| {
+                CliError::usage("--timeout is outside the supported duration range")
+            })?;
+            if timeout.is_zero() {
+                return Err(CliError::usage("--timeout must be at least one nanosecond"));
+            }
+            Ok(timeout)
         }
         Some(_) => Err(CliError::usage("--timeout must be greater than zero")),
     }
@@ -999,6 +1005,8 @@ mod tests {
         assert!(mount_ready_timeout(Some(-1.0)).is_err());
         assert!(mount_ready_timeout(Some(f64::NAN)).is_err());
         assert!(mount_ready_timeout(Some(f64::INFINITY)).is_err());
+        assert!(mount_ready_timeout(Some(f64::MAX)).is_err());
+        assert!(mount_ready_timeout(Some(f64::MIN_POSITIVE)).is_err());
         assert_eq!(
             mount_ready_timeout(Some(1.25)).unwrap(),
             Duration::from_millis(1_250)

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -33,9 +33,9 @@ pub struct ExecOptions<'a> {
     pub protect_long_lived_mounts: bool,
 }
 
-/// Runtime marker inherited by descendants of the one-shot Sandbox Process API. This is not
-/// user configuration: mount commands use it to fail closed instead of forking a daemon into an
-/// exec cgroup that will be torn down as soon as the outer command exits.
+/// Runtime marker inherited by descendants of a Sandbox Process API unit. This is not user
+/// configuration: mount commands use it to fail closed instead of forking a daemon into a process
+/// unit whose cgroup will be torn down as soon as the unit leader exits.
 pub const SANDBOX_EXEC_MODE_ENV: &str = "TENSORLAKE_SANDBOX_PROCESS_MODE";
 pub const SANDBOX_EXEC_MODE_ONE_SHOT: &str = "one-shot";
 
@@ -72,6 +72,14 @@ pub async fn run(
     let detached_mount = (options.detach || options.protect_long_lived_mounts)
         .then(|| rewrite_direct_mount(command, args))
         .flatten();
+    // Validate the readiness deadline before creating the detached process. The direct-mount
+    // rewrite removes `timeout` from the process payload, so delaying this check until the
+    // readiness phase would leak a live mount unit for an invalid value.
+    let ready_timeout = if detached_mount.is_some() && !options.detach {
+        Some(mount_ready_timeout(options.timeout)?)
+    } else {
+        None
+    };
     let effective_args = detached_mount
         .as_ref()
         .map_or(args, |mount| mount.args.as_slice());
@@ -93,7 +101,6 @@ pub async fn run(
         }
 
         let mount = detached_mount.expect("detached mount checked above");
-        let ready_timeout = mount_ready_timeout(options.timeout)?;
         if let Err(error) = wait_for_mount_ready(
             &client,
             &target,
@@ -101,19 +108,23 @@ pub async fn run(
             pid,
             options.workdir,
             options.user,
-            ready_timeout,
+            ready_timeout.expect("direct mounts validate a readiness timeout before spawning"),
         )
         .await
         {
             let tail = process_output_tail(&client, &target, pid).await;
-            stop_process(&client, &target, pid).await;
+            let cleanup = stop_process(&client, &target, pid)
+                .await
+                .err()
+                .map(|cleanup| format!("\nCleanup also failed: {cleanup}"))
+                .unwrap_or_default();
             let detail = tail
                 .filter(|tail| !tail.is_empty())
                 .map(|tail| format!("\nMount process output:\n  {}", tail.replace('\n', "\n  ")))
                 .unwrap_or_default();
             return Err(CliError::Other(anyhow::anyhow!(
-                "sandbox mount process {pid} did not make {} ready: {error}.{detail}",
-                mount.mountpoint
+                "sandbox mount process {pid} did not make {} ready: {error}.{detail}{cleanup}",
+                mount.mountpoint,
             )));
         }
 
@@ -198,12 +209,22 @@ fn mount_ready_timeout(configured: Option<f64>) -> Result<Duration> {
 }
 
 fn rewrite_direct_mount(command: &str, args: &[String]) -> Option<DetachedMountCommand> {
-    if Path::new(command).file_name()?.to_str()? != "tl" {
+    if !matches!(
+        Path::new(command).file_name()?.to_str()?,
+        "tl" | "tensorlake"
+    ) {
         return None;
     }
-    let mount_index = args
-        .windows(2)
-        .position(|pair| matches!(pair[0].as_str(), "fs" | "git") && pair[1] == "mount")?;
+    let mount_index = top_level_subcommand_index(args)?;
+    if !matches!(
+        (
+            args.get(mount_index)?.as_str(),
+            args.get(mount_index + 1)?.as_str()
+        ),
+        ("fs" | "git", "mount")
+    ) {
+        return None;
+    }
     let surface = match args[mount_index].as_str() {
         "fs" => "filesystem",
         "git" => "repository",
@@ -216,12 +237,48 @@ fn rewrite_direct_mount(command: &str, args: &[String]) -> Option<DetachedMountC
 
     let mountpoint = parse_mountpoint(&args[mount_index], mount_args)?;
     let mut detached_args = args.to_vec();
-    detached_args.push("--foreground".to_string());
+    // Insert before the mount operands (and, importantly, before a possible `--` sentinel).
+    // Appending after `--` would turn this into a third positional argument instead of a flag.
+    detached_args.insert(mount_index + 2, "--foreground".to_string());
     Some(DetachedMountCommand {
         args: detached_args,
         mountpoint,
         surface,
     })
+}
+
+/// Find the first top-level subcommand after the CLI's global options. This deliberately does not
+/// search the whole argv: operands of `tl sbx exec` (or another command) may themselves contain the
+/// words `fs mount`, and rewriting those would detach the wrong process.
+fn top_level_subcommand_index(args: &[String]) -> Option<usize> {
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--debug" => index += 1,
+            "--api-url" | "--cloud-url" | "--api-key" | "--pat" | "--namespace"
+            | "--organization" | "--project" => {
+                if index + 1 == args.len() {
+                    return None;
+                }
+                index += 2;
+            }
+            "--" => return (index + 1 < args.len()).then_some(index + 1),
+            option
+                if option.starts_with("--api-url=")
+                    || option.starts_with("--cloud-url=")
+                    || option.starts_with("--api-key=")
+                    || option.starts_with("--pat=")
+                    || option.starts_with("--namespace=")
+                    || option.starts_with("--organization=")
+                    || option.starts_with("--project=") =>
+            {
+                index += 1;
+            }
+            option if option.starts_with('-') => return None,
+            _ => return Some(index),
+        }
+    }
+    None
 }
 
 fn parse_mountpoint(surface: &str, args: &[String]) -> Option<String> {
@@ -379,13 +436,22 @@ async fn stop_process(
     client: &reqwest::Client,
     target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
     pid: i64,
-) {
-    let _ = with_sandbox_headers(
+) -> Result<()> {
+    let response = with_sandbox_headers(
         client.delete(format!("{}/api/v1/processes/{pid}", target.proxy_base)),
         target,
     )
     .send()
-    .await;
+    .await
+    .map_err(CliError::Http)?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to stop process {pid} (HTTP {status}): {body}"
+        )));
+    }
+    Ok(())
 }
 
 fn build_process_payload(
@@ -403,15 +469,17 @@ fn build_process_payload(
     }
 
     let mut env_dict = parse_env_vars(options.env)?;
-    if !options.detach {
-        let env = env_dict.get_or_insert_with(|| Value::Object(serde_json::Map::new()));
-        env.as_object_mut()
-            .expect("parse_env_vars always returns an object")
-            .insert(
-                SANDBOX_EXEC_MODE_ENV.to_string(),
-                Value::String(SANDBOX_EXEC_MODE_ONE_SHOT.to_string()),
-            );
-    }
+    // Every Process API payload owns a cgroup around its leader, including detached/managed
+    // processes. If a shell or supervisor inside that unit starts a background TLFS mount and then
+    // exits, the daemon is reaped with the unit. Mark every payload so nested mount commands fail
+    // closed unless they explicitly remain in the foreground as the unit leader.
+    let env = env_dict.get_or_insert_with(|| Value::Object(serde_json::Map::new()));
+    env.as_object_mut()
+        .expect("parse_env_vars always returns an object")
+        .insert(
+            SANDBOX_EXEC_MODE_ENV.to_string(),
+            Value::String(SANDBOX_EXEC_MODE_ONE_SHOT.to_string()),
+        );
     let mut body = serde_json::json!({ "command": command });
     if !args.is_empty() {
         body["args"] = serde_json::json!(args);
@@ -648,7 +716,7 @@ mod tests {
 
     use super::{
         ExecOptions, SANDBOX_EXEC_MODE_ENV, SANDBOX_EXEC_MODE_ONE_SHOT,
-        build_mount_readiness_payload, build_process_payload, parse_run_event,
+        build_mount_readiness_payload, build_process_payload, mount_ready_timeout, parse_run_event,
         rewrite_direct_mount,
     };
 
@@ -748,7 +816,10 @@ mod tests {
         assert_eq!(payload["health_check"]["port"], 8000);
         assert_eq!(payload["health_check"]["path"], "/health");
         assert_eq!(payload["health_check"]["interval_ms"], 5_000);
-        assert!(payload["env"].get(SANDBOX_EXEC_MODE_ENV).is_none());
+        assert_eq!(
+            payload["env"][SANDBOX_EXEC_MODE_ENV],
+            SANDBOX_EXEC_MODE_ONE_SHOT
+        );
     }
 
     #[test]
@@ -782,10 +853,7 @@ mod tests {
 
         assert_eq!(command.surface, "filesystem");
         assert_eq!(command.mountpoint, "mnt/drive");
-        assert_eq!(
-            command.args.last().map(String::as_str),
-            Some("--foreground")
-        );
+        assert_eq!(command.args[2], "--foreground");
     }
 
     #[test]
@@ -805,6 +873,66 @@ mod tests {
 
         assert_eq!(command.surface, "repository");
         assert_eq!(command.mountpoint, "/code");
+    }
+
+    #[test]
+    fn direct_mount_accepts_official_binary_and_global_options() {
+        let command = rewrite_direct_mount(
+            "/usr/local/bin/tensorlake",
+            &[
+                "--debug".to_string(),
+                "--project".to_string(),
+                "project-a".to_string(),
+                "git".to_string(),
+                "mount".to_string(),
+                "repo:main".to_string(),
+                "/code".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(command.mountpoint, "/code");
+        assert_eq!(command.args[5], "--foreground");
+    }
+
+    #[test]
+    fn nested_mount_words_do_not_rewrite_an_unrelated_command() {
+        assert!(
+            rewrite_direct_mount(
+                "tl",
+                &[
+                    "sbx".to_string(),
+                    "exec".to_string(),
+                    "sandbox".to_string(),
+                    "tl".to_string(),
+                    "fs".to_string(),
+                    "mount".to_string(),
+                    "drive".to_string(),
+                    "/mnt".to_string(),
+                ],
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn foreground_flag_stays_before_an_option_sentinel() {
+        let command = rewrite_direct_mount(
+            "tl",
+            &[
+                "fs".to_string(),
+                "mount".to_string(),
+                "--".to_string(),
+                "drive".to_string(),
+                "/mnt".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            command.args,
+            ["fs", "mount", "--foreground", "--", "drive", "/mnt"]
+        );
     }
 
     #[test]
@@ -863,6 +991,18 @@ mod tests {
         let result = build_process_payload("python", &[], opts);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn mount_readiness_timeout_fails_closed_before_spawn() {
+        assert!(mount_ready_timeout(Some(0.0)).is_err());
+        assert!(mount_ready_timeout(Some(-1.0)).is_err());
+        assert!(mount_ready_timeout(Some(f64::NAN)).is_err());
+        assert!(mount_ready_timeout(Some(f64::INFINITY)).is_err());
+        assert_eq!(
+            mount_ready_timeout(Some(1.25)).unwrap(),
+            Duration::from_millis(1_250)
+        );
     }
 
     #[test]

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -1,7 +1,8 @@
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
-use reqwest::header::ACCEPT;
+use reqwest::{StatusCode, header::ACCEPT};
 use serde_json::Value;
+use std::future::Future;
 use std::path::Path;
 use std::time::Duration;
 
@@ -39,7 +40,19 @@ pub struct ExecOptions<'a> {
 pub const SANDBOX_EXEC_MODE_ENV: &str = "TENSORLAKE_SANDBOX_PROCESS_MODE";
 pub const SANDBOX_EXEC_MODE_ONE_SHOT: &str = "one-shot";
 
-const DEFAULT_MOUNT_READY_TIMEOUT: Duration = Duration::from_secs(25);
+const MOUNT_READY_PROBE_WINDOW: Duration = Duration::from_secs(30);
+const MOUNT_READY_PROBE_TIMEOUT: Duration = Duration::from_secs(32);
+// The Process API timeout is enforced inside the sandbox. Bound the client side separately so a
+// lost final SSE event cannot pin startup forever; an elapsed window is retried while the mount
+// leader remains healthy.
+const MOUNT_READY_CLIENT_TIMEOUT: Duration = Duration::from_secs(35);
+const MOUNT_READY_POLL_INITIAL: Duration = Duration::from_millis(100);
+const MOUNT_READY_POLL_MAX: Duration = Duration::from_millis(500);
+// The mount daemon gives its kernel unmount helper up to ten seconds. The outer process owner must
+// leave enough margin for that handler and the status observation before resorting to SIGKILL.
+const MOUNT_GRACEFUL_STOP_TIMEOUT: Duration = Duration::from_secs(15);
+const MOUNT_STOP_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const MOUNT_CONTROL_REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DetachedMountCommand {
@@ -72,11 +85,12 @@ pub async fn run(
     let detached_mount = (options.detach || options.protect_long_lived_mounts)
         .then(|| rewrite_direct_mount(command, args))
         .flatten();
-    // Validate the readiness deadline before creating the detached process. The direct-mount
-    // rewrite removes `timeout` from the process payload, so delaying this check until the
-    // readiness phase would leak a live mount unit for an invalid value.
+    // Validate an explicitly configured readiness deadline before creating the detached process.
+    // With no `--timeout`, wait as long as the mount leader remains alive: cross-machine Git WAL
+    // recovery downloads and installs all dirty files before attaching the mount and can
+    // legitimately take much longer than a fixed startup deadline.
     let ready_timeout = if detached_mount.is_some() && !options.detach {
-        Some(mount_ready_timeout(options.timeout)?)
+        mount_ready_timeout(options.timeout)?
     } else {
         None
     };
@@ -101,23 +115,34 @@ pub async fn run(
         }
 
         let mount = detached_mount.expect("detached mount checked above");
-        if let Err(error) = wait_for_mount_ready(
+        let readiness = wait_for_mount_ready(
             &client,
             &target,
             &mount.mountpoint,
             pid,
             options.workdir,
             options.user,
-            ready_timeout.expect("direct mounts validate a readiness timeout before spawning"),
-        )
-        .await
-        {
-            let tail = process_output_tail(&client, &target, pid).await;
+            ready_timeout,
+        );
+        if let Err(error) = mount_readiness_or_interrupt(readiness, tokio::signal::ctrl_c()).await {
+            // Preserve the process diagnostics before cleanup: the hard-delete fallback may reap
+            // the process record and its output immediately.
+            let tail = if matches!(error, CliError::Cancelled) {
+                None
+            } else {
+                process_output_tail(&client, &target, pid).await
+            };
             let cleanup = stop_process(&client, &target, pid)
                 .await
                 .err()
                 .map(|cleanup| format!("\nCleanup also failed: {cleanup}"))
                 .unwrap_or_default();
+            if matches!(error, CliError::Cancelled) {
+                if !cleanup.is_empty() {
+                    eprintln!("Mount process {pid} cleanup failed:{cleanup}");
+                }
+                return Err(CliError::Cancelled);
+            }
             let detail = tail
                 .filter(|tail| !tail.is_empty())
                 .map(|tail| format!("\nMount process output:\n  {}", tail.replace('\n', "\n  ")))
@@ -198,9 +223,9 @@ fn process_pid(process: &Value) -> Result<i64> {
         .ok_or_else(|| CliError::usage("start process response missing pid"))
 }
 
-fn mount_ready_timeout(configured: Option<f64>) -> Result<Duration> {
+fn mount_ready_timeout(configured: Option<f64>) -> Result<Option<Duration>> {
     match configured {
-        None => Ok(DEFAULT_MOUNT_READY_TIMEOUT),
+        None => Ok(None),
         Some(seconds) if seconds.is_finite() && seconds > 0.0 => {
             let timeout = Duration::try_from_secs_f64(seconds).map_err(|_| {
                 CliError::usage("--timeout is outside the supported duration range")
@@ -208,7 +233,7 @@ fn mount_ready_timeout(configured: Option<f64>) -> Result<Duration> {
             if timeout.is_zero() {
                 return Err(CliError::usage("--timeout must be at least one nanosecond"));
             }
-            Ok(timeout)
+            Ok(Some(timeout))
         }
         Some(_) => Err(CliError::usage("--timeout must be greater than zero")),
     }
@@ -333,9 +358,11 @@ fn build_mount_readiness_payload(
     pid: i64,
     workdir: Option<&str>,
     user: Option<&str>,
-    timeout: Duration,
 ) -> Value {
-    let attempts = timeout.as_millis().div_ceil(100).max(1);
+    // Keep each server-side readiness unit bounded. The client repeats these windows for an
+    // arbitrarily long healthy restore. Cancelling the local CLI stops the mount leader, which
+    // makes this helper observe `kill -0` failure and exit on its next 100ms iteration.
+    let attempts = MOUNT_READY_PROBE_WINDOW.as_millis().div_ceil(100).max(1);
     let script = "i=0; while [ \"$i\" -lt \"$2\" ]; do \
                   kill -0 \"$3\" 2>/dev/null || exit 125; \
                   mountpoint -q -- \"$1\" && exit 0; \
@@ -351,7 +378,7 @@ fn build_mount_readiness_payload(
             attempts.to_string(),
             pid.to_string(),
         ],
-        "timeout": timeout.as_secs_f64() + 2.0,
+        "timeout": MOUNT_READY_PROBE_TIMEOUT.as_secs_f64(),
     });
     if let Some(workdir) = workdir {
         body["working_dir"] = Value::String(workdir.to_string());
@@ -362,16 +389,52 @@ fn build_mount_readiness_payload(
     body
 }
 
-async fn wait_for_mount_ready(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MountReadinessProbe {
+    Ready,
+    Waiting,
+    ProcessExited,
+}
+
+async fn probe_mount_ready(
     client: &reqwest::Client,
     target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
     mountpoint: &str,
     pid: i64,
     workdir: Option<&str>,
     user: Option<&str>,
+) -> Result<MountReadinessProbe> {
+    bounded_mount_readiness_probe(
+        probe_mount_ready_request(client, target, mountpoint, pid, workdir, user),
+        MOUNT_READY_CLIENT_TIMEOUT,
+    )
+    .await
+}
+
+async fn bounded_mount_readiness_probe<F>(
+    probe: F,
     timeout: Duration,
-) -> Result<()> {
-    let body = build_mount_readiness_payload(mountpoint, pid, workdir, user, timeout);
+) -> Result<MountReadinessProbe>
+where
+    F: Future<Output = Result<MountReadinessProbe>>,
+{
+    match tokio::time::timeout(timeout, probe).await {
+        Ok(result) => result,
+        // The in-sandbox helper is independently bounded. If its terminal SSE event is lost in
+        // transit, open a new observation window instead of killing an otherwise healthy mount.
+        Err(_) => Ok(MountReadinessProbe::Waiting),
+    }
+}
+
+async fn probe_mount_ready_request(
+    client: &reqwest::Client,
+    target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
+    mountpoint: &str,
+    pid: i64,
+    workdir: Option<&str>,
+    user: Option<&str>,
+) -> Result<MountReadinessProbe> {
+    let body = build_mount_readiness_payload(mountpoint, pid, workdir, user);
     let resp = with_sandbox_headers(
         client
             .post(format!("{}/api/v1/processes/run", target.proxy_base))
@@ -390,17 +453,81 @@ async fn wait_for_mount_ready(
         )));
     }
     match stream_run_events(resp).await? {
-        0 => Ok(()),
-        125 => Err(CliError::Other(anyhow::anyhow!(
-            "the detached mount process exited during startup"
-        ))),
-        124 => Err(CliError::Other(anyhow::anyhow!(
-            "the mount was not ready within {:.1}s",
-            timeout.as_secs_f64()
-        ))),
+        0 => Ok(MountReadinessProbe::Ready),
+        124 => Ok(MountReadinessProbe::Waiting),
+        125 => Ok(MountReadinessProbe::ProcessExited),
         code => Err(CliError::Other(anyhow::anyhow!(
             "mount readiness check exited with code {code}"
         ))),
+    }
+}
+
+async fn wait_for_mount_ready(
+    client: &reqwest::Client,
+    target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
+    mountpoint: &str,
+    pid: i64,
+    workdir: Option<&str>,
+    user: Option<&str>,
+    timeout: Option<Duration>,
+) -> Result<()> {
+    let deadline = timeout.map(|timeout| tokio::time::Instant::now() + timeout);
+    let mut poll_interval = MOUNT_READY_POLL_INITIAL;
+    loop {
+        let probe = probe_mount_ready(client, target, mountpoint, pid, workdir, user);
+        let result = match deadline {
+            Some(deadline) => tokio::time::timeout_at(deadline, probe)
+                .await
+                .map_err(|_| mount_readiness_timeout_error(timeout))?,
+            None => probe.await,
+        }?;
+        match result {
+            MountReadinessProbe::Ready => return Ok(()),
+            MountReadinessProbe::ProcessExited => {
+                return Err(CliError::Other(anyhow::anyhow!(
+                    "the detached mount process exited during startup"
+                )));
+            }
+            MountReadinessProbe::Waiting => {}
+        }
+
+        let sleep_for = match deadline {
+            Some(deadline) => {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    return Err(mount_readiness_timeout_error(timeout));
+                }
+                poll_interval.min(remaining)
+            }
+            None => poll_interval,
+        };
+        tokio::time::sleep(sleep_for).await;
+        poll_interval = (poll_interval * 2).min(MOUNT_READY_POLL_MAX);
+    }
+}
+
+fn mount_readiness_timeout_error(timeout: Option<Duration>) -> CliError {
+    CliError::Other(anyhow::anyhow!(
+        "the mount was not ready within {:.1}s",
+        timeout
+            .expect("a readiness deadline always carries its duration")
+            .as_secs_f64()
+    ))
+}
+
+async fn mount_readiness_or_interrupt<R, I>(readiness: R, interrupt: I) -> Result<()>
+where
+    R: Future<Output = Result<()>>,
+    I: Future<Output = std::io::Result<()>>,
+{
+    tokio::pin!(readiness);
+    tokio::pin!(interrupt);
+    tokio::select! {
+        result = &mut readiness => result,
+        signal = &mut interrupt => {
+            signal.map_err(CliError::Io)?;
+            Err(CliError::Cancelled)
+        }
     }
 }
 
@@ -410,10 +537,12 @@ async fn process_output_tail(
     pid: i64,
 ) -> Option<String> {
     let response = with_sandbox_headers(
-        client.get(format!(
-            "{}/api/v1/processes/{pid}/output",
-            target.proxy_base
-        )),
+        client
+            .get(format!(
+                "{}/api/v1/processes/{pid}/output",
+                target.proxy_base
+            ))
+            .timeout(MOUNT_CONTROL_REQUEST_TIMEOUT),
         target,
     )
     .send()
@@ -443,14 +572,147 @@ async fn stop_process(
     target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
     pid: i64,
 ) -> Result<()> {
+    let graceful = signal_process(client, target, pid, 15).await;
+    if graceful.is_ok() {
+        let deadline = tokio::time::Instant::now() + MOUNT_GRACEFUL_STOP_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match process_has_stopped(
+                client,
+                target,
+                pid,
+                remaining.min(MOUNT_CONTROL_REQUEST_TIMEOUT),
+            )
+            .await
+            {
+                Ok(true) => return Ok(()),
+                Ok(false) if tokio::time::Instant::now() < deadline => {
+                    tokio::time::sleep(
+                        MOUNT_STOP_POLL_INTERVAL
+                            .min(deadline.saturating_duration_since(tokio::time::Instant::now())),
+                    )
+                    .await;
+                }
+                Err(_) if tokio::time::Instant::now() < deadline => {
+                    // A transient status read must not turn an otherwise graceful unmount into an
+                    // immediate SIGKILL. Preserve the full grace window, then use the hard
+                    // backstop if the process still cannot be observed as stopped.
+                    tokio::time::sleep(
+                        MOUNT_STOP_POLL_INTERVAL
+                            .min(deadline.saturating_duration_since(tokio::time::Instant::now())),
+                    )
+                    .await;
+                }
+                Ok(false) | Err(_) => break,
+            }
+        }
+    }
+
+    // DELETE is the hard SIGKILL API for an unmanaged process. Use it only after SIGTERM had a
+    // chance to run the mount daemon's detach handler, or when signaling/observing the process
+    // failed and leaving a detached unit behind would be worse.
+    hard_stop_process(client, target, pid)
+        .await
+        .map_err(|hard| {
+            let graceful = graceful
+                .err()
+                .map(|error| format!("; graceful stop failed first: {error}"))
+                .unwrap_or_default();
+            CliError::Other(anyhow::anyhow!("{hard}{graceful}"))
+        })
+}
+
+async fn signal_process(
+    client: &reqwest::Client,
+    target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
+    pid: i64,
+    signal: i32,
+) -> Result<()> {
     let response = with_sandbox_headers(
-        client.delete(format!("{}/api/v1/processes/{pid}", target.proxy_base)),
+        client
+            .post(format!(
+                "{}/api/v1/processes/{pid}/signal",
+                target.proxy_base
+            ))
+            .timeout(MOUNT_CONTROL_REQUEST_TIMEOUT)
+            .json(&serde_json::json!({ "signal": signal })),
         target,
     )
     .send()
     .await
     .map_err(CliError::Http)?;
+    if response.status().is_success() || response.status() == StatusCode::NOT_FOUND {
+        return Ok(());
+    }
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    Err(CliError::Other(anyhow::anyhow!(
+        "failed to signal process {pid} (HTTP {status}): {body}"
+    )))
+}
+
+async fn process_has_stopped(
+    client: &reqwest::Client,
+    target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
+    pid: i64,
+    request_timeout: Duration,
+) -> Result<bool> {
+    let response = with_sandbox_headers(
+        client
+            .get(format!("{}/api/v1/processes/{pid}", target.proxy_base))
+            .timeout(request_timeout),
+        target,
+    )
+    .send()
+    .await
+    .map_err(CliError::Http)?;
+    if response.status() == StatusCode::NOT_FOUND {
+        return Ok(true);
+    }
     if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to inspect process {pid} (HTTP {status}): {body}"
+        )));
+    }
+    let process: Value = response.json().await.map_err(CliError::Http)?;
+    Ok(process_status_is_terminal(&process))
+}
+
+fn process_status_is_terminal(process: &Value) -> bool {
+    matches!(
+        process.get("status").and_then(Value::as_str),
+        Some("exited" | "signaled" | "oom_killed")
+    ) || process
+        .get("ended_at")
+        .is_some_and(|ended_at| !ended_at.is_null())
+        || process.get("exit_code").is_some_and(Value::is_number)
+        || process.get("signal").is_some_and(Value::is_number)
+        || process
+            .get("oom_killed")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+}
+
+async fn hard_stop_process(
+    client: &reqwest::Client,
+    target: &crate::commands::sbx::ResolvedSandboxProxyTarget,
+    pid: i64,
+) -> Result<()> {
+    let response = with_sandbox_headers(
+        client
+            .delete(format!("{}/api/v1/processes/{pid}", target.proxy_base))
+            .timeout(MOUNT_CONTROL_REQUEST_TIMEOUT),
+        target,
+    )
+    .send()
+    .await
+    .map_err(CliError::Http)?;
+    if !response.status().is_success() && response.status() != StatusCode::NOT_FOUND {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
         return Err(CliError::Other(anyhow::anyhow!(
@@ -720,11 +982,85 @@ fn should_skip_event(value: &serde_json::Value) -> bool {
 mod tests {
     use std::time::Duration;
 
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
     use super::{
         ExecOptions, SANDBOX_EXEC_MODE_ENV, SANDBOX_EXEC_MODE_ONE_SHOT,
-        build_mount_readiness_payload, build_process_payload, mount_ready_timeout, parse_run_event,
-        rewrite_direct_mount,
+        build_mount_readiness_payload, build_process_payload, mount_readiness_or_interrupt,
+        mount_ready_timeout, parse_run_event, process_status_is_terminal, rewrite_direct_mount,
+        stop_process,
     };
+
+    async fn serve_process_responses(
+        responses: Vec<(u16, &'static str)>,
+    ) -> (
+        crate::commands::sbx::ResolvedSandboxProxyTarget,
+        tokio::task::JoinHandle<Vec<String>>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::with_capacity(responses.len());
+            for (status, body) in responses {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = Vec::new();
+                let mut buffer = [0u8; 1024];
+                let header_end = loop {
+                    let count = stream.read(&mut buffer).await.unwrap();
+                    assert!(count > 0, "client closed before sending HTTP headers");
+                    request.extend_from_slice(&buffer[..count]);
+                    if let Some(offset) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n")
+                    {
+                        break offset + 4;
+                    }
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length:")
+                            .map(str::trim)
+                            .map(str::parse::<usize>)
+                    })
+                    .transpose()
+                    .unwrap()
+                    .unwrap_or(0);
+                while request.len() < header_end + content_length {
+                    let count = stream.read(&mut buffer).await.unwrap();
+                    assert!(count > 0, "client closed before sending HTTP body");
+                    request.extend_from_slice(&buffer[..count]);
+                }
+                requests.push(String::from_utf8_lossy(&request).into_owned());
+
+                let reason = match status {
+                    200 => "OK",
+                    204 => "No Content",
+                    500 => "Internal Server Error",
+                    _ => "Test",
+                };
+                let response = format!(
+                    "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+                stream.shutdown().await.unwrap();
+            }
+            requests
+        });
+        (
+            crate::commands::sbx::ResolvedSandboxProxyTarget {
+                sandbox_id: "sandbox-test".to_string(),
+                proxy_base: format!("http://{address}"),
+                host_override: None,
+                routing_hint: None,
+                ingress_endpoint: None,
+                sandbox_url: None,
+            },
+            server,
+        )
+    }
 
     fn options<'a>() -> ExecOptions<'a> {
         ExecOptions {
@@ -967,19 +1303,15 @@ mod tests {
 
     #[test]
     fn readiness_probe_tracks_process_liveness_and_mountpoint() {
-        let payload = build_mount_readiness_payload(
-            "relative mount",
-            4242,
-            Some("/work"),
-            Some("tl-user"),
-            Duration::from_millis(250),
-        );
+        let payload =
+            build_mount_readiness_payload("relative mount", 4242, Some("/work"), Some("tl-user"));
 
         assert_eq!(payload["working_dir"], "/work");
         assert_eq!(payload["user"], "tl-user");
         assert_eq!(payload["args"][3], "relative mount");
-        assert_eq!(payload["args"][4], "3");
+        assert_eq!(payload["args"][4], "300");
         assert_eq!(payload["args"][5], "4242");
+        assert_eq!(payload["timeout"], 32.0);
         assert!(
             payload["args"][1]
                 .as_str()
@@ -987,6 +1319,83 @@ mod tests {
                 .contains("mountpoint -q")
         );
         assert!(payload["args"][1].as_str().unwrap().contains("kill -0"));
+    }
+
+    #[tokio::test]
+    async fn readiness_interrupt_returns_cancelled() {
+        let readiness = std::future::pending::<super::Result<()>>();
+        let interrupt = std::future::ready(Ok(()));
+
+        assert!(matches!(
+            mount_readiness_or_interrupt(readiness, interrupt).await,
+            Err(super::CliError::Cancelled)
+        ));
+    }
+
+    #[tokio::test]
+    async fn completed_readiness_wins_without_interrupt() {
+        let readiness = std::future::ready(Ok(()));
+        let interrupt = std::future::pending::<std::io::Result<()>>();
+
+        mount_readiness_or_interrupt(readiness, interrupt)
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn process_terminal_statuses_are_recognized() {
+        for status in ["exited", "signaled", "oom_killed"] {
+            assert!(process_status_is_terminal(
+                &serde_json::json!({ "status": status })
+            ));
+        }
+        assert!(!process_status_is_terminal(
+            &serde_json::json!({ "status": "running" })
+        ));
+        assert!(process_status_is_terminal(
+            &serde_json::json!({ "status": "completed", "ended_at": 123 })
+        ));
+        assert!(process_status_is_terminal(
+            &serde_json::json!({ "status": "unknown", "signal": 15 })
+        ));
+        assert!(!process_status_is_terminal(&serde_json::json!({})));
+    }
+
+    #[tokio::test]
+    async fn mount_cleanup_signals_before_observing_exit() {
+        let (target, server) = serve_process_responses(vec![
+            (200, r#"{"success":true}"#),
+            (200, r#"{"pid":4242,"status":"exited"}"#),
+        ])
+        .await;
+        let client = crate::http::client_builder().build().unwrap();
+
+        stop_process(&client, &target, 4242).await.unwrap();
+        let requests = server.await.unwrap();
+
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].starts_with("POST /api/v1/processes/4242/signal "));
+        assert!(requests[0].contains(r#"{"signal":15}"#));
+        assert!(requests[1].starts_with("GET /api/v1/processes/4242 "));
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request.starts_with("DELETE "))
+        );
+    }
+
+    #[tokio::test]
+    async fn mount_cleanup_uses_hard_delete_only_after_signal_failure() {
+        let (target, server) =
+            serve_process_responses(vec![(500, "signal failed"), (204, "")]).await;
+        let client = crate::http::client_builder().build().unwrap();
+
+        stop_process(&client, &target, 4242).await.unwrap();
+        let requests = server.await.unwrap();
+
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].starts_with("POST /api/v1/processes/4242/signal "));
+        assert!(requests[1].starts_with("DELETE /api/v1/processes/4242 "));
     }
 
     #[test]
@@ -1001,6 +1410,7 @@ mod tests {
 
     #[test]
     fn mount_readiness_timeout_fails_closed_before_spawn() {
+        assert_eq!(mount_ready_timeout(None).unwrap(), None);
         assert!(mount_ready_timeout(Some(0.0)).is_err());
         assert!(mount_ready_timeout(Some(-1.0)).is_err());
         assert!(mount_ready_timeout(Some(f64::NAN)).is_err());
@@ -1009,7 +1419,7 @@ mod tests {
         assert!(mount_ready_timeout(Some(f64::MIN_POSITIVE)).is_err());
         assert_eq!(
             mount_ready_timeout(Some(1.25)).unwrap(),
-            Duration::from_millis(1_250)
+            Some(Duration::from_millis(1_250))
         );
     }
 

--- a/crates/cli/src/commands/sbx/run.rs
+++ b/crates/cli/src/commands/sbx/run.rs
@@ -116,6 +116,9 @@ pub async fn run(
             health_interval_ms: None,
             health_timeout_ms: None,
             health_failure_threshold: None,
+            // `sbx run` normally destroys the sandbox after this command. Only turn a mount
+            // into a sandbox-owned process when the caller explicitly keeps the sandbox.
+            protect_long_lived_mounts: keep,
         },
     )
     .await;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2124,6 +2124,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 health_interval_ms,
                                 health_timeout_ms,
                                 health_failure_threshold,
+                                protect_long_lived_mounts: true,
                             },
                         )
                         .await

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -15,6 +15,7 @@ pub mod workspaces;
 use models::{
     CreateRepoRequest, GitCredential, ListBranchesResponse, ListOperationsResponse,
     ListRefsResponse, ListReposResponse, MintGitTokenRequest, RepoInfo, RepoMetaInfo,
+    REPO_KIND_FILESYSTEM,
 };
 
 #[derive(Clone)]
@@ -320,20 +321,7 @@ impl ArtifactStorageClient {
         let mut after = None::<String>;
         let mut seen_after = HashSet::new();
         loop {
-            // `form_urlencoded::Serializer` contains a non-Send callback reference. Keep it in
-            // this synchronous scope so napi/tonic callers can carry the async request future
-            // across worker threads.
-            let query = {
-                let mut params = url::form_urlencoded::Serializer::new(String::new());
-                if let Some(kind) = kind {
-                    params.append_pair("kind", kind);
-                }
-                if let Some(after) = &after {
-                    params.append_pair("after", after);
-                }
-                params.append_pair("limit", "1000");
-                params.finish()
-            };
+            let query = repo_list_query(kind, after.as_deref());
             let url = format!(
                 "{}/project/{}/repos?{}",
                 self.git_base_url,
@@ -653,6 +641,27 @@ impl ArtifactStorageClient {
     }
 }
 
+fn repo_list_query(kind: Option<&str>, after: Option<&str>) -> String {
+    // `form_urlencoded::Serializer` contains a non-Send callback reference. Keep it in this
+    // synchronous helper so napi/tonic callers can carry the request future across worker threads.
+    let mut params = url::form_urlencoded::Serializer::new(String::new());
+    if let Some(kind) = kind {
+        params.append_pair("kind", kind);
+        // A filesystem create/delete is immediately followed by discovery surprisingly often,
+        // and successive requests may land on different artifact-storage pods. The normal project
+        // inventory is intentionally stale-while-revalidate; the filesystem surface instead asks
+        // for an authoritative metadata page so `tl fs ls` is read-your-writes across replicas.
+        if kind == REPO_KIND_FILESYSTEM {
+            params.append_pair("fresh", "true");
+        }
+    }
+    if let Some(after) = after {
+        params.append_pair("after", after);
+    }
+    params.append_pair("limit", "1000");
+    params.finish()
+}
+
 pub fn resolve_artifact_storage_url(api_url: &str) -> String {
     if let Ok(parsed) = url::Url::parse(api_url) {
         let host = parsed.host_str().unwrap_or("");
@@ -737,8 +746,9 @@ mod tests {
 
     use super::{
         ArtifactStorageClient, advance_pagination_cursor, encode_path_segment,
-        resolve_artifact_storage_url,
+        repo_list_query, resolve_artifact_storage_url,
     };
+    use crate::artifact_storage::models::REPO_KIND_FILESYSTEM;
     use crate::ClientBuilder;
 
     #[test]
@@ -786,5 +796,17 @@ mod tests {
         );
         assert!(advance_pagination_cursor(&mut seen, "page-2".to_string(), "test").is_err());
         assert!(advance_pagination_cursor(&mut seen, String::new(), "test").is_err());
+    }
+
+    #[test]
+    fn filesystem_inventory_requests_authoritative_pages() {
+        assert_eq!(
+            repo_list_query(Some(REPO_KIND_FILESYSTEM), Some("project/demo")),
+            "kind=filesystem&fresh=true&after=project%2Fdemo&limit=1000"
+        );
+        assert_eq!(
+            repo_list_query(Some("repository"), None),
+            "kind=repository&limit=1000"
+        );
     }
 }

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -647,9 +647,11 @@ fn repo_list_query(kind: Option<&str>, after: Option<&str>) -> String {
     let mut params = url::form_urlencoded::Serializer::new(String::new());
     if let Some(kind) = kind {
         params.append_pair("kind", kind);
-        // The first filesystem page carries a synchronous cache-generation fence. Later pages use
-        // the now-current cache, avoiding one FoundationDB check per page on large projects.
-        if kind == REPO_KIND_FILESYSTEM && after.is_none() {
+        // Every filesystem page carries a synchronous cache-generation fence. Project inventory
+        // routes have no repository affinity, so consecutive requests may land on different
+        // server pods; fencing only page one could splice a fresh first page to a stale later page
+        // and omit a just-created filesystem after the first cursor.
+        if kind == REPO_KIND_FILESYSTEM {
             params.append_pair("fresh", "true");
         }
     }
@@ -797,14 +799,14 @@ mod tests {
     }
 
     #[test]
-    fn filesystem_inventory_fences_only_the_first_page() {
+    fn filesystem_inventory_fences_every_page() {
         assert_eq!(
             repo_list_query(Some(REPO_KIND_FILESYSTEM), None),
             "kind=filesystem&fresh=true&limit=1000"
         );
         assert_eq!(
             repo_list_query(Some(REPO_KIND_FILESYSTEM), Some("project/repo")),
-            "kind=filesystem&after=project%2Frepo&limit=1000"
+            "kind=filesystem&fresh=true&after=project%2Frepo&limit=1000"
         );
         assert_eq!(
             repo_list_query(Some("repository"), None),

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -643,15 +643,13 @@ impl ArtifactStorageClient {
 
 fn repo_list_query(kind: Option<&str>, after: Option<&str>) -> String {
     // `form_urlencoded::Serializer` contains a non-Send callback reference. Keep it in this
-    // synchronous helper so napi/tonic callers can carry the request future across worker threads.
+    // synchronous helper so napi/tonic callers can carry the async request future across workers.
     let mut params = url::form_urlencoded::Serializer::new(String::new());
     if let Some(kind) = kind {
         params.append_pair("kind", kind);
-        // A filesystem create/delete is immediately followed by discovery surprisingly often,
-        // and successive requests may land on different artifact-storage pods. The normal project
-        // inventory is intentionally stale-while-revalidate; the filesystem surface instead asks
-        // for an authoritative metadata page so `tl fs ls` is read-your-writes across replicas.
-        if kind == REPO_KIND_FILESYSTEM {
+        // The first filesystem page carries a synchronous cache-generation fence. Later pages use
+        // the now-current cache, avoiding one FoundationDB check per page on large projects.
+        if kind == REPO_KIND_FILESYSTEM && after.is_none() {
             params.append_pair("fresh", "true");
         }
     }
@@ -745,11 +743,11 @@ mod tests {
     use std::collections::HashSet;
 
     use super::{
-        ArtifactStorageClient, advance_pagination_cursor, encode_path_segment,
-        repo_list_query, resolve_artifact_storage_url,
+        ArtifactStorageClient, advance_pagination_cursor, encode_path_segment, repo_list_query,
+        resolve_artifact_storage_url,
     };
-    use crate::artifact_storage::models::REPO_KIND_FILESYSTEM;
     use crate::ClientBuilder;
+    use crate::artifact_storage::models::REPO_KIND_FILESYSTEM;
 
     #[test]
     fn resolves_git_url_from_api_url() {
@@ -799,10 +797,14 @@ mod tests {
     }
 
     #[test]
-    fn filesystem_inventory_requests_authoritative_pages() {
+    fn filesystem_inventory_fences_only_the_first_page() {
         assert_eq!(
-            repo_list_query(Some(REPO_KIND_FILESYSTEM), Some("project/demo")),
-            "kind=filesystem&fresh=true&after=project%2Fdemo&limit=1000"
+            repo_list_query(Some(REPO_KIND_FILESYSTEM), None),
+            "kind=filesystem&fresh=true&limit=1000"
+        );
+        assert_eq!(
+            repo_list_query(Some(REPO_KIND_FILESYSTEM), Some("project/repo")),
+            "kind=filesystem&after=project%2Frepo&limit=1000"
         );
         assert_eq!(
             repo_list_query(Some("repository"), None),

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -14,8 +14,8 @@ pub mod workspaces;
 
 use models::{
     CreateRepoRequest, GitCredential, ListBranchesResponse, ListOperationsResponse,
-    ListRefsResponse, ListReposResponse, MintGitTokenRequest, RepoInfo, RepoMetaInfo,
-    REPO_KIND_FILESYSTEM,
+    ListRefsResponse, ListReposResponse, MintGitTokenRequest, REPO_KIND_FILESYSTEM, RepoInfo,
+    RepoMetaInfo,
 };
 
 #[derive(Clone)]

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -8,12 +8,12 @@
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
-use crate::error::SdkError;
 use crate::Traced;
+use crate::error::SdkError;
 
 use super::ingest::{expect_json, with_transient_retries};
-use super::merge::{expect_json_or_conflict, MergeConflict, MergeReport, MergeStats, Signature};
-use super::{advance_pagination_cursor, decode_empty, ArtifactStorageClient};
+use super::merge::{MergeConflict, MergeReport, MergeStats, Signature, expect_json_or_conflict};
+use super::{ArtifactStorageClient, advance_pagination_cursor, decode_empty};
 
 fn encoded_git_path(path: &str, allow_empty: bool) -> Result<String, SdkError> {
     if path.is_empty() {

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -2,7 +2,7 @@
 # only `src/`, keeping this workspace-adapted dependency manifest.
 [package]
 name = "gsvc-fs-client"
-version = "0.5.83"
+version = "0.5.84"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"
@@ -55,7 +55,7 @@ xattr = "1"
 zstd = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-fuser = { version = "0.15", default-features = false, features = ["abi-7-12"] }
+fuser = { version = "0.17", default-features = false }
 
 [lints.clippy]
 large_enum_variant = "allow"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.83"
+version = "0.5.84"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/justfile
+++ b/justfile
@@ -44,11 +44,39 @@ build-cli-full *ARGS:
             exit 1
         fi
     done
+    stage_macos_tlfs=false
+    tlfs_backup=""
+    if [ "$(uname -s)" = "Darwin" ]; then
+        private_tlfs="$artifact_storage/platform/macos/tlfs"
+        for directory in Sources Resources; do
+            if [ ! -d "$private_tlfs/$directory" ]; then
+                echo "error: $private_tlfs/$directory not found." >&2
+                echo "The macOS full build needs the private FSKit companion sources." >&2
+                exit 1
+            fi
+        done
+        stage_macos_tlfs=true
+        tlfs_backup="$(mktemp -d "${TMPDIR:-/tmp}/tensorlake-tlfs.XXXXXX")"
+        for directory in Sources Resources; do
+            if [ -e "platform/macos/tlfs/$directory" ]; then
+                cp -R "platform/macos/tlfs/$directory" "$tlfs_backup/"
+            fi
+        done
+    fi
     restore() {
         for crate in gsvc-mount gsvc-codec gsvc-fs-client; do
             git checkout -q -- "crates/$crate/src" 2>/dev/null || true
             git clean -fdq "crates/$crate/src" 2>/dev/null || true
         done
+        if [ "$stage_macos_tlfs" = true ]; then
+            rm -rf "platform/macos/tlfs/Sources" "platform/macos/tlfs/Resources"
+            for directory in Sources Resources; do
+                if [ -e "$tlfs_backup/$directory" ]; then
+                    cp -R "$tlfs_backup/$directory" "platform/macos/tlfs/"
+                fi
+            done
+            rm -rf "$tlfs_backup"
+        fi
         rm -f "crates/gsvc-fs-client/Cargo.lock"
     }
     trap restore EXIT
@@ -58,6 +86,13 @@ build-cli-full *ARGS:
         echo "swapping crates/$crate/src with $artifact_storage/crates/$crate/src"
         cp "$artifact_storage/crates/$crate/src"/*.rs "crates/$crate/src"/
     done
+    # macOS-only tests compile a source-level wire/coherence contract against the private FSKit
+    # bridge. Sources and resources are staged with the Rust crates and removed by the trap. The
+    # app build script stays private and is invoked directly by `build-tlfs-app`.
+    if [ "$stage_macos_tlfs" = true ]; then
+        rm -rf "platform/macos/tlfs/Sources" "platform/macos/tlfs/Resources"
+        cp -R "$private_tlfs/Sources" "$private_tlfs/Resources" "platform/macos/tlfs/"
+    fi
     cargo build -p tensorlake-cli --release --features mount,git-clone {{ARGS}}
 
 # Back-compat alias for the old recipe name.
@@ -90,11 +125,39 @@ test-cli-full *ARGS:
             exit 1
         fi
     done
+    stage_macos_tlfs=false
+    tlfs_backup=""
+    if [ "$(uname -s)" = "Darwin" ]; then
+        private_tlfs="$artifact_storage/platform/macos/tlfs"
+        for directory in Sources Resources; do
+            if [ ! -d "$private_tlfs/$directory" ]; then
+                echo "error: $private_tlfs/$directory not found." >&2
+                echo "The macOS full test needs the private FSKit companion sources." >&2
+                exit 1
+            fi
+        done
+        stage_macos_tlfs=true
+        tlfs_backup="$(mktemp -d "${TMPDIR:-/tmp}/tensorlake-tlfs.XXXXXX")"
+        for directory in Sources Resources; do
+            if [ -e "platform/macos/tlfs/$directory" ]; then
+                cp -R "platform/macos/tlfs/$directory" "$tlfs_backup/"
+            fi
+        done
+    fi
     restore() {
         for crate in gsvc-mount gsvc-codec gsvc-fs-client; do
             git checkout -q -- "crates/$crate/src" 2>/dev/null || true
             git clean -fdq "crates/$crate/src" 2>/dev/null || true
         done
+        if [ "$stage_macos_tlfs" = true ]; then
+            rm -rf "platform/macos/tlfs/Sources" "platform/macos/tlfs/Resources"
+            for directory in Sources Resources; do
+                if [ -e "$tlfs_backup/$directory" ]; then
+                    cp -R "$tlfs_backup/$directory" "platform/macos/tlfs/"
+                fi
+            done
+            rm -rf "$tlfs_backup"
+        fi
         rm -f "crates/gsvc-fs-client/Cargo.lock"
     }
     trap restore EXIT
@@ -102,6 +165,10 @@ test-cli-full *ARGS:
         rm -f "crates/$crate/src"/*.rs
         cp "$artifact_storage/crates/$crate/src"/*.rs "crates/$crate/src"/
     done
+    if [ "$stage_macos_tlfs" = true ]; then
+        rm -rf "platform/macos/tlfs/Sources" "platform/macos/tlfs/Resources"
+        cp -R "$private_tlfs/Sources" "$private_tlfs/Resources" "platform/macos/tlfs/"
+    fi
     CARGO_TARGET_DIR="$PWD/target" cargo clippy --manifest-path crates/gsvc-fs-client/Cargo.toml --all-targets -- -D warnings
     CARGO_TARGET_DIR="$PWD/target" cargo test --manifest-path crates/gsvc-fs-client/Cargo.toml {{ARGS}}
     cargo test --workspace --features tensorlake-cli/mount,tensorlake-cli/git-clone {{ARGS}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.83"
+version = "0.5.84"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.80",
+  "version": "0.5.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.80",
+      "version": "0.5.84",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.83",
+  "version": "0.5.84",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- keep sandbox-created mount daemons supervised after the initiating exec scope exits
- make foreground mount startup release its temporary claim cleanly to the daemon
- make filesystem inventory requests authoritative and page through the complete result set
- harden mount timeout validation and private-crate vendoring for full macOS/Linux CLI builds
- format the mirrored artifact-storage SDK changes

## Dependency

Merge tensorlakeai/artifact_storage#126 first. This PR is the public CLI/sandbox side of that TLFS correctness work.

## Validation

- built the full private-crate CLI for macOS arm64 and Linux x86_64 musl
- Linux binary was used in the 4 CPU / 16 GiB / 50 GiB SlateDB-on-TLFS proof
- git clone directly onto TLFS succeeded in 4.40s
- cold SlateDB workspace build with its 14 GiB Rust cache on TLFS succeeded in 3m52.50s
- warm rebuild succeeded in 28.61s
- snapshot/restore integrity, pinned read-only behavior, mmap persistence, daemon survival, and cleanup were verified end to end

The uniquely named test filesystem and sandbox were removed after evidence capture.
