### PR TITLE
Release the FSKit v4 client bundle

### DIFF
--- a/.github/actions/vendor-private-crates/README.md
+++ b/.github/actions/vendor-private-crates/README.md
@@ -10,9 +10,11 @@ for the duration of the job.
 
 1. Mints a short-lived token from a GitHub App scoped to `tensorlakeai/artifact_storage`.
 2. Sparse-checks-out the three private crate source trees into `.mount-core/`.
-3. Copies the real sources over the placeholders, keeping the placeholders' workspace-adapted
+3. Resolves that checkout to an exact commit; the optional FSKit companion checkout is pinned to
+   the same revision instead of resolving a moving branch a second time.
+4. Copies the real sources over the placeholders, keeping the placeholders' workspace-adapted
    manifests.
-4. When `include-macos-fskit: "true"`, separately stages the private FSKit `Sources` and
+5. When `include-macos-fskit: "true"`, separately stages the private FSKit `Sources` and
    `Resources` needed by the macOS Rust source-contract tests. Linux and Windows callers leave the
    input disabled and do not fetch or compile Swift sources. The FSKit `build.sh` remains confined
    to the dedicated TLFS.app release job.
@@ -20,6 +22,9 @@ for the duration of the job.
 The calling job must run `actions/checkout` for this repo first, then call this action before the
 build step, and add `--features git-clone` (plus `mount` on mount-capable targets; or
 `mount,git-clone` for official standalone CLI builds) to that build.
+Release workflows pass the `source-ref` input as one previously resolved 40-character
+`artifact_storage` commit SHA. Ordinary test workflows may omit it and resolve `main` once per
+action invocation; core and FSKit companion sources still use the same resolved commit.
 
 ## One-time setup
 

--- a/.github/actions/vendor-private-crates/action.yml
+++ b/.github/actions/vendor-private-crates/action.yml
@@ -24,6 +24,17 @@ inputs:
       Leave disabled on Linux and Windows so those builds have no Swift source dependency.
     required: false
     default: "false"
+  source-ref:
+    description: >
+      artifact_storage Git ref to vendor. Release workflows must pass one resolved commit SHA so
+      every job consumes the same private source revision.
+    required: false
+    default: main
+
+outputs:
+  source-sha:
+    description: Exact artifact_storage commit vendored by this invocation.
+    value: ${{ steps.resolved-source.outputs.sha }}
 
 runs:
   using: composite
@@ -41,6 +52,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: tensorlakeai/artifact_storage
+        ref: ${{ inputs.source-ref }}
         token: ${{ steps.app-token.outputs.token }}
         path: .mount-core
         sparse-checkout: |
@@ -50,11 +62,25 @@ runs:
         sparse-checkout-cone-mode: false
         persist-credentials: false
 
+    - name: Resolve private source revision
+      id: resolved-source
+      shell: bash
+      run: |
+        set -euo pipefail
+        sha=$(git -C .mount-core rev-parse HEAD)
+        if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::error::artifact_storage checkout did not resolve to a full commit SHA"
+          exit 1
+        fi
+        echo "sha=$sha" >> "$GITHUB_OUTPUT"
+        echo "Vendoring artifact_storage@$sha"
+
     - name: Check out private macOS FSKit companions
       if: ${{ inputs.include-macos-fskit == 'true' }}
       uses: actions/checkout@v4
       with:
         repository: tensorlakeai/artifact_storage
+        ref: ${{ steps.resolved-source.outputs.sha }}
         token: ${{ steps.app-token.outputs.token }}
         path: .mount-fskit
         sparse-checkout: |

--- a/.github/workflows/publish_cli.yaml
+++ b/.github/workflows/publish_cli.yaml
@@ -12,12 +12,50 @@ permissions:
   contents: write
 
 jobs:
+  artifact-storage-source:
+    name: Pin private artifact_storage source
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Mint artifact_storage access token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ARTIFACT_STORAGE_APP_ID }}
+          private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
+          owner: tensorlakeai
+          repositories: artifact_storage
+
+      - name: Check out private source revision
+        uses: actions/checkout@v4
+        with:
+          repository: tensorlakeai/artifact_storage
+          token: ${{ steps.app-token.outputs.token }}
+          path: .artifact-storage-source
+          sparse-checkout: AGENTS.md
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Export exact private source revision
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha=$(git -C .artifact-storage-source rev-parse HEAD)
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::artifact_storage did not resolve to a full commit SHA"
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Pinned artifact_storage@$sha for every release job"
+
   build:
     name: Build (${{ matrix.target_id }})
     # The darwin build embeds the notarized TLFS.app.zip from tlfs-app into the binary, so
     # `tl fs setup` installs offline. tlfs-app is continue-on-error: when it produced nothing,
     # the darwin binary falls back to downloading the release asset at setup time.
-    needs: tlfs-app
+    needs: [artifact-storage-source, tlfs-app]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -87,6 +125,7 @@ jobs:
           app-id: ${{ secrets.ARTIFACT_STORAGE_APP_ID }}
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: ${{ matrix.target_id == 'darwin-aarch64' && 'true' || 'false' }}
+          source-ref: ${{ needs.artifact-storage-source.outputs.sha }}
 
       - name: Fetch notarized TLFS.app (embedded into `tl fs setup`)
         if: matrix.target_id == 'darwin-aarch64'
@@ -181,6 +220,7 @@ jobs:
     # Needs Xcode 26.x / the macOS 26 SDK (the FSKit surface tlfs uses); adjust the image if the
     # hosted runner catalog changes.
     runs-on: macos-26
+    needs: artifact-storage-source
     steps:
       - uses: actions/checkout@v4
 
@@ -197,6 +237,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: tensorlakeai/artifact_storage
+          ref: ${{ needs.artifact-storage-source.outputs.sha }}
           token: ${{ steps.app-token.outputs.token }}
           path: .tlfs-src
           sparse-checkout: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.84"
+version = "0.5.85"
 dependencies = [
  "anyhow",
  "base64",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.84"
+version = "0.5.85"
 dependencies = [
  "anyhow",
  "base64",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.84"
+version = "0.5.85"
 dependencies = [
  "anyhow",
  "base64",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.84"
+version = "0.5.85"
 dependencies = [
  "napi",
  "napi-build",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.84"
+version = "0.5.85"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.84"
+version = "0.5.85"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -2,7 +2,7 @@
 # only `src/`, keeping this workspace-adapted dependency manifest.
 [package]
 name = "gsvc-fs-client"
-version = "0.5.84"
+version = "0.5.85"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.84"
+version = "0.5.85"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/justfile
+++ b/justfile
@@ -110,6 +110,16 @@ build-tlfs-app *ARGS:
         echo "or point ARTIFACT_STORAGE_DIR at an existing checkout." >&2
         exit 1
     fi
+    workspace_version="$(sed -n 's/^version = "\([^"]*\)"$/\1/p' Cargo.toml | head -n 1)"
+    if [ -z "$workspace_version" ]; then
+        echo "error: could not read [workspace.package] version from Cargo.toml" >&2
+        exit 1
+    fi
+    if [ -n "${TLFS_VERSION:-}" ] && [ "$TLFS_VERSION" != "$workspace_version" ]; then
+        echo "error: TLFS_VERSION $TLFS_VERSION does not match workspace version $workspace_version" >&2
+        exit 1
+    fi
+    export TLFS_VERSION="$workspace_version"
     exec "$build_sh" {{ARGS}}
 
 # Run the CLI test suite with the same ephemeral private-crate swap as the official full build.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.84"
+version = "0.5.85"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.84",
+  "version": "0.5.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.84",
+      "version": "0.5.85",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.84",
+  "version": "0.5.85",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the CLI, Rust SDK, Python SDK, TypeScript SDK, and private fs-client package to 0.5.85
- make the macOS app build derive its package version from the workspace and reject an explicit mismatched TLFS_VERSION
- pass the exact version into the private artifact-storage bundle build so the host app, nested appex, CLI expectation, and wire-v4 stamp agree
- resolve artifact_storage once per release and pass that exact 40-character commit to every binary and TLFS.app job, preventing mixed private revisions during a release

Depends on tensorlakeai/artifact_storage#138 and should merge after it. Official builds will inject the private sources from the exact artifact-storage revision selected when the release workflow starts.

## Validation

- all GitHub checks green, including Rust full-feature tests, macOS private FSKit source contract, sandbox integration, Windows smoke, TypeScript SDK tests, and CodeQL
- full private-client vendoring and CLI test suite via artifact_storage `make test-fs-client`
- 356 gsvc-fs-client tests at the final artifact-storage head
- 162 Rust SDK tests
- 223 CLI tests
- 13 doctests
- exact 0.5.85 TLFS.app build and signing verification
