### PR TITLE
Release Tensorlake CLI 0.5.86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.85"
+version = "0.5.86"
 dependencies = [
  "anyhow",
  "base64",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.85"
+version = "0.5.86"
 dependencies = [
  "anyhow",
  "base64",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.85"
+version = "0.5.86"
 dependencies = [
  "anyhow",
  "base64",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.85"
+version = "0.5.86"
 dependencies = [
  "napi",
  "napi-build",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.85"
+version = "0.5.86"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.85"
+version = "0.5.86"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -2,7 +2,7 @@
 # only `src/`, keeping this workspace-adapted dependency manifest.
 [package]
 name = "gsvc-fs-client"
-version = "0.5.85"
+version = "0.5.86"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.85"
+version = "0.5.86"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.85"
+version = "0.5.86"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.85",
+  "version": "0.5.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.85",
+      "version": "0.5.86",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.85",
+  "version": "0.5.86",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the lockstep Python, Rust, CLI, private filesystem-client placeholder, and TypeScript packages from 0.5.85 to 0.5.86
- regenerate `Cargo.lock` and `typescript/package-lock.json`
- prepare the CLI release that carries Git WAL prevention and startup self-healing from [artifact_storage #141](https://github.com/tensorlakeai/artifact_storage/pull/141)

## Release ordering

Merge and deploy artifact_storage #141 before dispatching the Tensorlake release workflow. The workflow resolves and pins artifact_storage `main` at dispatch time; dispatching earlier would build 0.5.86 without the new private client.

## Validation

- `cargo check --workspace --locked`
- official full-feature CLI suite against the exact artifact_storage #141 worktree via `just test-cli-full`
  - 355 gsvc-fs-client tests
  - 161 Rust SDK tests
  - 224 CLI tests
  - 13 doctests
- `npm ci --ignore-scripts`
- `npm run typecheck`
- `npm test`: 250 tests
- `git diff --check`

Local Python formatting/unit checks were unavailable because Poetry is not installed in this checkout's environment; CI remains the release gate for those checks.
