### PR TITLE
Release Tensorlake CLI 0.5.87

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.85"
+version = "0.5.87"
 dependencies = [
  "anyhow",
  "base64",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.85"
+version = "0.5.87"
 dependencies = [
  "anyhow",
  "base64",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.85"
+version = "0.5.87"
 dependencies = [
  "anyhow",
  "base64",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.85"
+version = "0.5.87"
 dependencies = [
  "napi",
  "napi-build",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.85"
+version = "0.5.87"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.85"
+version = "0.5.87"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -2,7 +2,7 @@
 # only `src/`, keeping this workspace-adapted dependency manifest.
 [package]
 name = "gsvc-fs-client"
-version = "0.5.85"
+version = "0.5.87"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.85"
+version = "0.5.87"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.85"
+version = "0.5.87"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.85",
+  "version": "0.5.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.85",
+      "version": "0.5.87",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.85",
+  "version": "0.5.87",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the Tensorlake workspace, Python packages, TypeScript package, and filesystem-client placeholder to `0.5.87`
- refresh Cargo and npm lockfile package versions to match

## Why

Prepare the next Tensorlake CLI and SDK release with one consistent package version across all published artifacts.

## Validation

- `make bump_version VERSION=0.5.87`
- `npm version 0.5.87 --no-git-tag-version --allow-same-version`
- `cargo check --workspace`
- `git diff --check`
