### PR TITLE
Hydrate the mount scope before the human fs-status early return

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2589,16 +2589,18 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
     // Human status is a local diagnostic: the private engine reads cached immutable session
     // facts plus the local journal/control socket, so it must remain available when auth or the
     // platform is unavailable. `--json` deliberately keeps its live server-record contract and
-    // therefore continues through the auth guard below.
+    // therefore continues through the auth guard below. Scope hydration is local-only (it reads
+    // the mount's cached attach-time facts, never the network), so it runs before this early
+    // return — without it, status run outside a project directory has no project ID and reports
+    // the server head as unavailable even when the server is healthy (issue
+    // tensorlakeai/artifact_storage#147 item 9). Best-effort: a mount whose state cannot
+    // hydrate a scope still gets the offline diagnostics instead of an error.
     if let FsCommands::Status { json: false, .. } = &subcmd {
-        return commands::fs::status(
-            ctx,
-            mount_dir
-                .as_ref()
-                .expect("resolved for every path-addressed command"),
-            false,
-        )
-        .await;
+        let mount_dir = mount_dir
+            .as_ref()
+            .expect("resolved for every path-addressed command");
+        let _ = commands::fs::hydrate_scope_from_mount(ctx, mount_dir);
+        return commands::fs::status(ctx, mount_dir, false).await;
     }
     // Path-addressed commands carry their scope in the mount state; resolve it from there so
     // they work from any CWD instead of triggering the interactive init flow (which, run from

--- a/crates/cloud-sdk/src/artifact_storage/workspaces.rs
+++ b/crates/cloud-sdk/src/artifact_storage/workspaces.rs
@@ -394,7 +394,7 @@ pub struct GitSmartlogPage {
 }
 
 /// One ref's head and movement generation — the poll target for branch/workspace following.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RefStatus {
     pub ref_name: String,
     /// Raw ref target (hex); for annotated tags this is the tag-object oid. Absent when deleted.
@@ -408,14 +408,14 @@ pub struct RefStatus {
 }
 
 /// One directory page from the paged tree listing.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TreePage {
     pub entries: Vec<TreeEntry>,
     pub truncated: bool,
     pub next_after: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TreeEntry {
     pub name: String,
     pub oid: String,

--- a/crates/rust-cloud-sdk-node/src/repositories.rs
+++ b/crates/rust-cloud-sdk-node/src/repositories.rs
@@ -2,13 +2,38 @@
 
 use std::path::PathBuf;
 
+use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 use tensorlake::artifact_storage::ArtifactStorageClient;
-use tensorlake::artifact_storage::ingest::PushOptions;
+use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
 use tensorlake::artifact_storage::merge::MergeRequest;
+use tensorlake::artifact_storage::models::REPO_KIND_FILESYSTEM;
 use tensorlake::{ClientBuilder, error::SdkError};
 
-use crate::sandbox::{TracedJson, duration_from_seconds, into_napi_error, usage_error, with_retry};
+use crate::sandbox::{
+    TracedBytes, TracedJson, duration_from_seconds, into_napi_error, usage_error, with_retry,
+};
+
+/// One file write in a filesystem push.
+#[napi(object)]
+pub struct FilesystemFileWrite {
+    /// Path inside the filesystem (forward-slash separated).
+    pub path: String,
+    pub content: Buffer,
+}
+
+/// Whether a failed request may nonetheless have been processed server-side.
+/// True for timeouts and gateway 5xx (the request was sent; the response was
+/// lost or the gateway gave up), false for connect failures (the request was
+/// never transmitted). Gates the 409/404-on-retry forgiveness in the
+/// filesystem create/delete bindings.
+fn request_may_have_executed(err: &SdkError) -> bool {
+    match err {
+        SdkError::ServerError { status, .. } => status.is_server_error(),
+        SdkError::Http(e) => e.is_timeout(),
+        _ => false,
+    }
+}
 
 #[napi]
 pub struct NativeRepositoryClient {
@@ -406,5 +431,366 @@ impl NativeRepositoryClient {
             }
         })
         .await
+    }
+
+    /// Create a filesystem (an artifact-storage repo of kind "filesystem").
+    ///
+    /// Returns JSON `{"trace_id", "default_branch"}` — the effective default
+    /// branch differs from "main" only when a lost-response retry adopted a
+    /// pre-existing filesystem.
+    #[napi]
+    pub async fn create_filesystem(&self, name: String) -> napi::Result<String> {
+        let project_id = self.project_id()?.to_string();
+        let maybe_executed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let maybe_executed = maybe_executed.clone();
+            async move {
+                // Minted before the forgiveness-tracked call: a mint failure
+                // says nothing about whether a create reached the server, so
+                // it must never arm the 409 forgiveness below.
+                let credential = client.git_credential_for_project(&project_id).await?;
+                match client
+                    .create_repo_with_credential(
+                        &project_id,
+                        &name,
+                        Some("main"),
+                        Some(REPO_KIND_FILESYSTEM),
+                        &credential.git_username,
+                        &credential.token,
+                    )
+                    .await
+                {
+                    Ok(traced) => Ok(serde_json::to_string(&serde_json::json!({
+                        "trace_id": traced.trace_id,
+                        "default_branch": "main",
+                    }))?),
+                    // Forgive the conflict only when an earlier attempt may
+                    // have reached the server (timeout / gateway 5xx after
+                    // send): the 409 then means that attempt created it.
+                    // After connect failures the request was never
+                    // transmitted, so a 409 can only mean the repo
+                    // pre-existed — surface it.
+                    Err(SdkError::ServerError { status, .. })
+                        if maybe_executed.load(std::sync::atomic::Ordering::SeqCst)
+                            && status.as_u16() == 409 =>
+                    {
+                        // Even then, only accept the conflict as ours if the
+                        // existing repo really is a filesystem; a same-named
+                        // plain repository must stay an error, or later
+                        // writes would land in the wrong repo.
+                        let meta = client
+                            .repo_meta_with_credential(
+                                &project_id,
+                                &name,
+                                &credential.git_username,
+                                &credential.token,
+                            )
+                            .await?;
+                        if meta.is_filesystem() {
+                            // Report the adopted filesystem's real default
+                            // branch so the SDK handle never assumes "main".
+                            Ok(serde_json::to_string(&serde_json::json!({
+                                "trace_id": "",
+                                "default_branch": meta.default_branch,
+                            }))?)
+                        } else {
+                            Err(SdkError::ClientError(format!(
+                                "a non-filesystem repo named {name} already exists"
+                            )))
+                        }
+                    }
+                    Err(e) => {
+                        if request_may_have_executed(&e) {
+                            maybe_executed.store(true, std::sync::atomic::Ordering::SeqCst);
+                        }
+                        Err(e)
+                    }
+                }
+            }
+        })
+        .await
+    }
+
+    /// List every filesystem in the project (all pages, cache-fenced).
+    #[napi]
+    pub async fn list_filesystems(&self) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            async move {
+                let traced = client
+                    .list_repos_of_kind(&project_id, Some(REPO_KIND_FILESYSTEM))
+                    .await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    /// Point-read one filesystem's identity (name, status, kind, default branch).
+    #[napi]
+    pub async fn filesystem_meta(&self, name: String) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let name = name.clone();
+            async move {
+                // A project-scoped credential: repo-scoped mints can fail for a
+                // repo that does not exist, which would mask the 404 callers
+                // need to distinguish "no such filesystem".
+                let credential = client.git_credential_for_project(&project_id).await?;
+                let traced = client
+                    .repo_meta_with_credential(
+                        &project_id,
+                        &name,
+                        &credential.git_username,
+                        &credential.token,
+                    )
+                    .await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    /// Delete a filesystem. Returns the trace id.
+    #[napi]
+    pub async fn delete_filesystem(&self, name: String) -> napi::Result<String> {
+        let project_id = self.project_id()?.to_string();
+        let maybe_executed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let maybe_executed = maybe_executed.clone();
+            async move {
+                // Minted before the forgiveness-tracked call: a mint failure
+                // says nothing about whether a delete reached the server, so
+                // it must never arm the 404 forgiveness below.
+                let credential = client.git_credential_for_project(&project_id).await?;
+                match client
+                    .delete_repo_with_credential(
+                        &project_id,
+                        &name,
+                        &credential.git_username,
+                        &credential.token,
+                    )
+                    .await
+                {
+                    Ok(traced) => Ok(traced.trace_id),
+                    // Forgive the 404 only when an earlier attempt may have
+                    // reached the server (timeout / gateway 5xx after send):
+                    // the repo is then gone because that attempt deleted it.
+                    // After connect failures the request was never
+                    // transmitted, so the 404 means the filesystem never
+                    // existed — surface FilesystemNotFoundError.
+                    Err(SdkError::ServerError { status, .. })
+                        if maybe_executed.load(std::sync::atomic::Ordering::SeqCst)
+                            && status.as_u16() == 404 =>
+                    {
+                        Ok(String::new())
+                    }
+                    Err(e) => {
+                        if request_may_have_executed(&e) {
+                            maybe_executed.store(true, std::sync::atomic::Ordering::SeqCst);
+                        }
+                        Err(e)
+                    }
+                }
+            }
+        })
+        .await
+    }
+
+    /// One ref's head + movement generation for a filesystem branch.
+    #[napi]
+    pub async fn filesystem_ref_status(
+        &self,
+        name: String,
+        refspec: String,
+    ) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let refspec = refspec.clone();
+            async move {
+                let credential = client.git_credential_for_repo(&project_id, &name).await?;
+                let traced = client
+                    .ref_status(
+                        &project_id,
+                        &name,
+                        &credential.git_username,
+                        &credential.token,
+                        &refspec,
+                    )
+                    .await?;
+                let trace_id = traced.trace_id.clone();
+                let json = serde_json::to_string(&*traced)?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    /// Raw file bytes at `version` (branch, ref, or commit).
+    #[napi]
+    pub async fn read_filesystem_file(
+        &self,
+        name: String,
+        path: String,
+        version: String,
+    ) -> napi::Result<TracedBytes> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let path = path.clone();
+            let version = version.clone();
+            async move {
+                let credential = client.git_credential_for_repo(&project_id, &name).await?;
+                let traced = client
+                    .get_file_bytes(
+                        &project_id,
+                        &name,
+                        &credential.git_username,
+                        &credential.token,
+                        &version,
+                        &path,
+                    )
+                    .await?;
+                let trace_id = traced.trace_id.clone();
+                let data = Buffer::from(traced.into_inner());
+                Ok(TracedBytes { trace_id, data })
+            }
+        })
+        .await
+    }
+
+    /// One directory's full listing at `version` (all pages), as
+    /// `{"entries": [...]}`.
+    #[napi]
+    pub async fn list_filesystem_tree(
+        &self,
+        name: String,
+        dir_path: String,
+        version: String,
+    ) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        with_retry(self.client.clone(), 5, move |client| {
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let dir_path = dir_path.clone();
+            let version = version.clone();
+            async move {
+                let credential = client.git_credential_for_repo(&project_id, &name).await?;
+                let mut entries = Vec::new();
+                let mut after: Option<String> = None;
+                let mut seen = std::collections::HashSet::new();
+                let mut trace_id;
+                loop {
+                    let traced = client
+                        .list_tree_page(
+                            &project_id,
+                            &name,
+                            &credential.git_username,
+                            &credential.token,
+                            &version,
+                            &dir_path,
+                            after.as_deref(),
+                            1000,
+                        )
+                        .await?;
+                    trace_id = traced.trace_id.clone();
+                    let page = traced.into_inner();
+                    entries.extend(page.entries);
+                    if !page.truncated {
+                        break;
+                    }
+                    // A truncated page must carry a fresh cursor; anything else
+                    // would silently drop entries or loop forever.
+                    match page.next_after {
+                        Some(next) if !next.is_empty() && seen.insert(next.clone()) => {
+                            after = Some(next);
+                        }
+                        _ => {
+                            return Err(SdkError::ClientError(
+                                "directory listing truncated without a fresh pagination cursor"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+                let json = serde_json::to_string(&serde_json::json!({ "entries": entries }))?;
+                Ok(TracedJson { trace_id, json })
+            }
+        })
+        .await
+    }
+
+    /// Write `files` and delete `deletes` in one atomic commit on `branch`.
+    ///
+    /// `idempotency_key` must be stable for one logical write: it is what
+    /// makes a retried submit reattach to the same durable commit job.
+    #[napi]
+    pub async fn push_filesystem_files(
+        &self,
+        name: String,
+        files: Vec<FilesystemFileWrite>,
+        deletes: Vec<String>,
+        message: String,
+        branch: String,
+        idempotency_key: Option<String>,
+    ) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        // Single-shot on purpose: `push_files` already retries every step
+        // internally (idempotent chunk uploads, commit reattachment through
+        // the caller's stable idempotency key), and an outer whole-push retry
+        // would force a full deep clone of the payload per attempt.
+        let client = self.client.clone();
+        let result: Result<TracedJson, SdkError> = async move {
+            let credential = client.git_credential_for_repo(&project_id, &name).await?;
+            let push_files: Vec<PushFile> = files
+                .into_iter()
+                .map(|file| PushFile {
+                    repo_path: file.path,
+                    source: PushSource::Bytes(file.content.to_vec()),
+                    mode: None,
+                    delete: false,
+                })
+                .chain(deletes.into_iter().map(|repo_path| PushFile {
+                    repo_path,
+                    source: PushSource::Bytes(Vec::new()),
+                    mode: None,
+                    delete: true,
+                }))
+                .collect();
+            let opts = PushOptions {
+                branch,
+                message,
+                idempotency_key,
+                ..Default::default()
+            };
+            let traced = client
+                .push_files(
+                    &project_id,
+                    &name,
+                    &credential.git_username,
+                    &credential.token,
+                    push_files,
+                    opts,
+                )
+                .await?;
+            let trace_id = traced.trace_id.clone();
+            let json = serde_json::to_string(&*traced)?;
+            Ok(TracedJson { trace_id, json })
+        }
+        .await;
+        result.map_err(into_napi_error)
     }
 }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -21,8 +21,9 @@ use reqwest::multipart::{Form, Part};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tensorlake::artifact_storage::ArtifactStorageClient;
-use tensorlake::artifact_storage::ingest::PushOptions;
+use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
 use tensorlake::artifact_storage::merge::MergeRequest;
+use tensorlake::artifact_storage::models::REPO_KIND_FILESYSTEM;
 use tensorlake::document_ai::DocumentAiClient;
 use tensorlake::file_systems::FileSystemsClient;
 use tensorlake::file_systems::models::CreateFileSystemRequest;
@@ -53,6 +54,19 @@ const DEFAULT_HTTP_REQUEST_TIMEOUT_SEC: f64 = 300.0;
 // pyclass spawning its own.
 fn shared_runtime() -> &'static Runtime {
     pyo3_async_runtimes::tokio::get_runtime()
+}
+
+/// Whether a failed request may nonetheless have been processed server-side.
+/// True for timeouts and gateway 5xx (the request was sent; the response was
+/// lost or the gateway gave up), false for connect failures (the request was
+/// never transmitted). Gates the 409/404-on-retry forgiveness in the
+/// filesystem create/delete bindings.
+fn request_may_have_executed(err: &SdkError) -> bool {
+    match err {
+        SdkError::ServerError { status, .. } => status.is_server_error(),
+        SdkError::Http(e) => e.is_timeout(),
+        _ => false,
+    }
 }
 
 #[pyclass]
@@ -574,6 +588,378 @@ impl CloudApiClient {
                 serde_json::to_string(&*traced).map_err(SdkError::from)
             }
         })
+    }
+
+    /// Create a filesystem (an artifact-storage repo of kind "filesystem").
+    ///
+    /// Returns JSON `{"trace_id", "default_branch"}` — the effective default
+    /// branch differs from "main" only when a lost-response retry adopted a
+    /// pre-existing filesystem.
+    fn create_filesystem(&self, project_id: String, name: String) -> PyResult<String> {
+        let maybe_executed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let maybe_executed = maybe_executed.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                // Minted before the forgiveness-tracked call: a mint failure
+                // says nothing about whether a create reached the server, so
+                // it must never arm the 409 forgiveness below.
+                let credential = client.git_credential_for_project(&project_id).await?;
+                match client
+                    .create_repo_with_credential(
+                        &project_id,
+                        &name,
+                        Some("main"),
+                        Some(REPO_KIND_FILESYSTEM),
+                        &credential.git_username,
+                        &credential.token,
+                    )
+                    .await
+                {
+                    Ok(traced) => serde_json::to_string(&serde_json::json!({
+                        "trace_id": traced.trace_id,
+                        "default_branch": "main",
+                    }))
+                    .map_err(SdkError::from),
+                    // Forgive the conflict only when an earlier attempt may
+                    // have reached the server (timeout / gateway 5xx after
+                    // send): the 409 then means that attempt created it.
+                    // After connect failures the request was never
+                    // transmitted, so a 409 can only mean the repo
+                    // pre-existed — surface it.
+                    Err(SdkError::ServerError { status, .. })
+                        if maybe_executed.load(std::sync::atomic::Ordering::SeqCst)
+                            && status.as_u16() == 409 =>
+                    {
+                        // Even then, only accept the conflict as ours if the
+                        // existing repo really is a filesystem; a same-named
+                        // plain repository must stay an error, or later
+                        // writes would land in the wrong repo.
+                        let meta = client
+                            .repo_meta_with_credential(
+                                &project_id,
+                                &name,
+                                &credential.git_username,
+                                &credential.token,
+                            )
+                            .await?;
+                        if meta.is_filesystem() {
+                            // Report the adopted filesystem's real default
+                            // branch so the SDK handle never assumes "main".
+                            serde_json::to_string(&serde_json::json!({
+                                "trace_id": "",
+                                "default_branch": meta.default_branch,
+                            }))
+                            .map_err(SdkError::from)
+                        } else {
+                            Err(SdkError::ClientError(format!(
+                                "a non-filesystem repo named {name} already exists"
+                            )))
+                        }
+                    }
+                    Err(e) => {
+                        if request_may_have_executed(&e) {
+                            maybe_executed.store(true, std::sync::atomic::Ordering::SeqCst);
+                        }
+                        Err(e)
+                    }
+                }
+            }
+        })
+    }
+
+    /// List every filesystem in the project (all pages, cache-fenced).
+    fn list_filesystems(&self, project_id: String) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client
+                    .list_repos_of_kind(&project_id, Some(REPO_KIND_FILESYSTEM))
+                    .await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    /// Point-read one filesystem's identity (name, status, kind, default branch).
+    fn filesystem_meta(&self, project_id: String, name: String) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                // A project-scoped credential: repo-scoped mints can fail for a
+                // repo that does not exist, which would mask the 404 callers
+                // need to distinguish "no such filesystem".
+                let credential = client.git_credential_for_project(&project_id).await?;
+                let traced = client
+                    .repo_meta_with_credential(
+                        &project_id,
+                        &name,
+                        &credential.git_username,
+                        &credential.token,
+                    )
+                    .await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn delete_filesystem(&self, project_id: String, name: String) -> PyResult<String> {
+        let maybe_executed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let maybe_executed = maybe_executed.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                // Minted before the forgiveness-tracked call: a mint failure
+                // says nothing about whether a delete reached the server, so
+                // it must never arm the 404 forgiveness below.
+                let credential = client.git_credential_for_project(&project_id).await?;
+                match client
+                    .delete_repo_with_credential(
+                        &project_id,
+                        &name,
+                        &credential.git_username,
+                        &credential.token,
+                    )
+                    .await
+                {
+                    Ok(traced) => Ok(traced.trace_id),
+                    // Forgive the 404 only when an earlier attempt may have
+                    // reached the server (timeout / gateway 5xx after send):
+                    // the repo is then gone because that attempt deleted it.
+                    // After connect failures the request was never
+                    // transmitted, so the 404 means the filesystem never
+                    // existed — surface FilesystemNotFoundError.
+                    Err(SdkError::ServerError { status, .. })
+                        if maybe_executed.load(std::sync::atomic::Ordering::SeqCst)
+                            && status.as_u16() == 404 =>
+                    {
+                        Ok(String::new())
+                    }
+                    Err(e) => {
+                        if request_may_have_executed(&e) {
+                            maybe_executed.store(true, std::sync::atomic::Ordering::SeqCst);
+                        }
+                        Err(e)
+                    }
+                }
+            }
+        })
+    }
+
+    /// One ref's head + movement generation for a filesystem branch.
+    fn filesystem_ref_status(
+        &self,
+        project_id: String,
+        name: String,
+        refspec: String,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let refspec = refspec.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let credential = client.git_credential_for_repo(&project_id, &name).await?;
+                let traced = client
+                    .ref_status(
+                        &project_id,
+                        &name,
+                        &credential.git_username,
+                        &credential.token,
+                        &refspec,
+                    )
+                    .await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    /// Raw file bytes at `version` (branch, ref, or commit).
+    fn read_filesystem_file(
+        &self,
+        project_id: String,
+        name: String,
+        path: String,
+        version: String,
+    ) -> PyResult<Vec<u8>> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let path = path.clone();
+            let version = version.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let credential = client.git_credential_for_repo(&project_id, &name).await?;
+                let traced = client
+                    .get_file_bytes(
+                        &project_id,
+                        &name,
+                        &credential.git_username,
+                        &credential.token,
+                        &version,
+                        &path,
+                    )
+                    .await?;
+                Ok(traced.into_inner())
+            }
+        })
+    }
+
+    /// One directory's full listing at `version` (all pages), as
+    /// `{"entries": [...]}`.
+    fn list_filesystem_tree(
+        &self,
+        project_id: String,
+        name: String,
+        dir_path: String,
+        version: String,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let dir_path = dir_path.clone();
+            let version = version.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let credential = client.git_credential_for_repo(&project_id, &name).await?;
+                let mut entries = Vec::new();
+                let mut after: Option<String> = None;
+                let mut seen = std::collections::HashSet::new();
+                loop {
+                    let page = client
+                        .list_tree_page(
+                            &project_id,
+                            &name,
+                            &credential.git_username,
+                            &credential.token,
+                            &version,
+                            &dir_path,
+                            after.as_deref(),
+                            1000,
+                        )
+                        .await?
+                        .into_inner();
+                    entries.extend(page.entries);
+                    if !page.truncated {
+                        break;
+                    }
+                    // A truncated page must carry a fresh cursor; anything else
+                    // would silently drop entries or loop forever.
+                    match page.next_after {
+                        Some(next) if !next.is_empty() && seen.insert(next.clone()) => {
+                            after = Some(next);
+                        }
+                        _ => {
+                            return Err(SdkError::ClientError(
+                                "directory listing truncated without a fresh pagination cursor"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+                serde_json::to_string(&serde_json::json!({ "entries": entries }))
+                    .map_err(SdkError::from)
+            }
+        })
+    }
+
+    /// Write `files` and delete `deletes` in one atomic commit on `branch`.
+    ///
+    /// `idempotency_key` must be stable for one logical write: it is what
+    /// makes a retried submit reattach to the same durable commit job.
+    #[pyo3(signature = (project_id, name, files, deletes, message, branch, idempotency_key=None))]
+    fn push_filesystem_files(
+        &self,
+        project_id: String,
+        name: String,
+        files: Vec<(String, Vec<u8>)>,
+        deletes: Vec<String>,
+        message: String,
+        branch: String,
+        idempotency_key: Option<String>,
+    ) -> PyResult<String> {
+        // Single-shot on purpose: `push_files` already retries every step
+        // internally (idempotent chunk uploads, commit reattachment through
+        // the caller's stable idempotency key), and an outer whole-push retry
+        // would force a full deep clone of the payload per attempt.
+        let api_client = self.client.clone();
+        let api_url = self.api_url.clone();
+        shared_runtime()
+            .block_on(async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let credential = client.git_credential_for_repo(&project_id, &name).await?;
+                let push_files: Vec<PushFile> = files
+                    .into_iter()
+                    .map(|(repo_path, data)| PushFile {
+                        repo_path,
+                        source: PushSource::Bytes(data),
+                        mode: None,
+                        delete: false,
+                    })
+                    .chain(deletes.into_iter().map(|repo_path| PushFile {
+                        repo_path,
+                        source: PushSource::Bytes(Vec::new()),
+                        mode: None,
+                        delete: true,
+                    }))
+                    .collect();
+                let opts = PushOptions {
+                    branch,
+                    message,
+                    idempotency_key,
+                    ..Default::default()
+                };
+                let traced = client
+                    .push_files(
+                        &project_id,
+                        &name,
+                        &credential.git_username,
+                        &credential.token,
+                        push_files,
+                        opts,
+                    )
+                    .await?;
+                serde_json::to_string(&*traced).map_err(SdkError::from)
+            })
+            .map_err(into_py_error)
     }
 
     #[pyo3(signature = (project_id, repo, ours, theirs, preflight=false, deep=false, materialize=false, message=None, base=None))]

--- a/src/tensorlake/filesystem/__init__.py
+++ b/src/tensorlake/filesystem/__init__.py
@@ -1,0 +1,42 @@
+"""Tensorlake filesystem SDK.
+
+Create durable, versioned filesystems; read and write files through the
+shared Rust cloud-sdk core; take snapshots; and mount filesystems to local
+paths via the ``tl`` CLI.
+"""
+
+from .client import Filesystem, FilesystemClient, Mount
+from .exceptions import (
+    CliNotFoundError,
+    FileNotFoundInFilesystemError,
+    FilesystemAPIError,
+    FilesystemError,
+    FilesystemException,
+    FilesystemNotFoundError,
+    MountError,
+)
+from .models import (
+    FileEntry,
+    FilesystemInfo,
+    FilesystemStatus,
+    MountStatus,
+    Snapshot,
+)
+
+__all__ = [
+    "FilesystemClient",
+    "Filesystem",
+    "Mount",
+    "FilesystemInfo",
+    "FilesystemStatus",
+    "FileEntry",
+    "Snapshot",
+    "MountStatus",
+    "FilesystemException",
+    "FilesystemError",
+    "FilesystemNotFoundError",
+    "FileNotFoundInFilesystemError",
+    "FilesystemAPIError",
+    "MountError",
+    "CliNotFoundError",
+]

--- a/src/tensorlake/filesystem/_cli.py
+++ b/src/tensorlake/filesystem/_cli.py
@@ -1,0 +1,145 @@
+"""Wrapper around the `tl` CLI for local mount operations.
+
+Mounting a filesystem to a local path is served by a FUSE (Linux) / FSKit
+(macOS) daemon that ships only inside the Tensorlake CLI, so the SDK drives
+mounts by invoking ``tl fs mount/unmount/snapshot/status``. Everything else
+(create, read, write, snapshot-by-write, remote status) goes over HTTP and
+does not need the CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .exceptions import CliNotFoundError, MountError
+
+_DEFAULT_INSTALL_PATH = Path.home() / ".tensorlake" / "bin" / "tl"
+
+
+def find_cli() -> str:
+    """Locate a `tl` binary that supports the `fs` command group."""
+    candidates: List[str] = []
+    env_path = os.environ.get("TENSORLAKE_CLI")
+    if env_path:
+        candidates.append(env_path)
+    which = shutil.which("tl")
+    if which:
+        candidates.append(which)
+    if _DEFAULT_INSTALL_PATH.is_file():
+        candidates.append(str(_DEFAULT_INSTALL_PATH))
+    # A candidate that exists but fails the probe means "upgrade tl"; a
+    # candidate that does not exist must not be blamed as outdated. The
+    # TypeScript SDK mirrors these exact semantics.
+    unsupported: Optional[str] = None
+    for candidate in candidates:
+        try:
+            probe = subprocess.run(
+                [candidate, "fs", "--help"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except FileNotFoundError:
+            continue
+        except (OSError, subprocess.TimeoutExpired):
+            unsupported = candidate
+            continue
+        if probe.returncode == 0:
+            return candidate
+        unsupported = candidate
+    if unsupported is not None:
+        raise CliNotFoundError(
+            f"`tl` at {unsupported} does not support `tl fs` (upgrade required)"
+        )
+    raise CliNotFoundError("`tl` was not found on PATH")
+
+
+class FsCli:
+    """Runs `tl fs ...` commands with the client's credentials in the env."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        api_url: Optional[str] = None,
+    ):
+        self._binary: Optional[str] = None
+        self._env_overrides: Dict[str, str] = {}
+        if api_key:
+            self._env_overrides["TENSORLAKE_API_KEY"] = api_key
+        if organization_id:
+            self._env_overrides["TENSORLAKE_ORGANIZATION_ID"] = organization_id
+        if project_id:
+            self._env_overrides["TENSORLAKE_PROJECT_ID"] = project_id
+        if api_url:
+            # The CLI must target the same deployment the data plane does, or
+            # a mount could resolve a same-named filesystem in the wrong
+            # environment.
+            self._env_overrides["TENSORLAKE_API_URL"] = api_url
+
+    def _run(self, args: List[str], timeout: float = 300.0) -> str:
+        if self._binary is None:
+            self._binary = find_cli()
+        env = dict(os.environ)
+        env.update(self._env_overrides)
+        try:
+            result = subprocess.run(
+                [self._binary, "fs", *args],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise MountError(f"`tl fs {args[0]}` timed out after {timeout:.0f}s") from e
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise MountError(f"`tl fs {' '.join(args)}` failed: {detail}")
+        return result.stdout
+
+    # Flags always precede a `--` end-of-options separator so caller-supplied
+    # names/paths can never be parsed as CLI flags (e.g. a path literally
+    # named "--discard" must stay a path, not become the destructive flag).
+    def mount(self, filesystem: str, local_path: str, readonly: bool) -> None:
+        args = ["mount"]
+        if readonly:
+            args.append("--ro")
+        args += ["--", filesystem, local_path]
+        self._run(args)
+
+    def unmount(self, local_path: str, discard: bool = False) -> None:
+        args = ["unmount"]
+        if discard:
+            args.append("--discard")
+        args += ["--", local_path]
+        self._run(args)
+
+    def snapshot(self, local_path: str, message: Optional[str]) -> None:
+        args = ["snapshot"]
+        if message:
+            # Attached form: a detached value ("-m", "-msg") is rejected by
+            # the CLI parser when the message starts with '-'.
+            args.append(f"--message={message}")
+        args += ["--", local_path]
+        self._run(args)
+
+    def status(self, local_path: Optional[str]) -> Dict[str, Any]:
+        args = ["status", "--json"]
+        if local_path:
+            args += ["--", local_path]
+        output = self._run(args, timeout=60.0)
+        try:
+            payload = json.loads(output)
+        except json.JSONDecodeError as e:
+            raise MountError(
+                f"`tl fs status --json` returned invalid JSON: {output[:200]!r}"
+            ) from e
+        if not isinstance(payload, dict):
+            payload = {"status": payload}
+        return payload

--- a/src/tensorlake/filesystem/_native.py
+++ b/src/tensorlake/filesystem/_native.py
@@ -1,0 +1,162 @@
+"""Bridge to the Rust cloud-sdk core for filesystem operations.
+
+All wire-protocol work (credential minting, chunked ingest with
+content-defined chunking and dedup, commit-job polling, transient retries,
+pagination) lives in the shared Rust `ArtifactStorageClient`, exposed through
+the ``tensorlake._cloud_sdk`` native module. This bridge only builds the
+native client and translates its exceptions into the filesystem exception
+hierarchy.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from tensorlake._tracing import USER_AGENT
+
+from .exceptions import (
+    FileNotFoundInFilesystemError,
+    FilesystemAPIError,
+    FilesystemError,
+    FilesystemNotFoundError,
+)
+
+
+def _native_module():
+    try:
+        from tensorlake import _cloud_sdk
+
+        return _cloud_sdk
+    except ImportError:
+        import _cloud_sdk
+
+        return _cloud_sdk
+
+
+class NativeFilesystems:
+    """Filesystem operations of one project, served by the Rust core."""
+
+    def __init__(
+        self,
+        api_url: str,
+        bearer_token: str,
+        organization_id: str,
+        project_id: str,
+    ):
+        module = _native_module()
+        self._error_type = module.CloudApiClientError
+        self._client = module.CloudApiClient(
+            api_url=api_url,
+            api_key=bearer_token,
+            organization_id=organization_id,
+            project_id=project_id,
+            user_agent=USER_AGENT,
+        )
+        self._project_id = project_id
+
+    @property
+    def project_id(self) -> str:
+        return self._project_id
+
+    def _call(self, operation: Callable[[], Any], not_found: Optional[Exception]):
+        """Run one native call, translating its exception on the way out.
+
+        ``not_found`` is raised instead of the generic API error when the
+        native call fails with a 404.
+        """
+        try:
+            return operation()
+        except self._error_type as e:
+            args = getattr(e, "args", ())
+            status = args[1] if len(args) > 1 else None
+            message = str(args[2]) if len(args) > 2 else str(e)
+            if status == 404 and not_found is not None:
+                raise not_found from e
+            if isinstance(status, int):
+                raise FilesystemAPIError(status, message) from e
+            raise FilesystemError(message) from e
+
+    def create_filesystem(self, name: str) -> str:
+        """Create the filesystem; returns its effective default branch.
+
+        The branch differs from "main" only when a lost-response retry
+        adopted a pre-existing filesystem inside the native binding.
+        """
+        raw = self._call(
+            lambda: self._client.create_filesystem(self._project_id, name),
+            not_found=None,
+        )
+        return str(json.loads(raw).get("default_branch") or "main")
+
+    def filesystem_meta(self, name: str) -> Dict[str, Any]:
+        raw = self._call(
+            lambda: self._client.filesystem_meta(self._project_id, name),
+            not_found=FilesystemNotFoundError(name),
+        )
+        return json.loads(raw)
+
+    def list_filesystems(self) -> List[Dict[str, Any]]:
+        raw = self._call(
+            lambda: self._client.list_filesystems(self._project_id),
+            not_found=None,
+        )
+        return json.loads(raw).get("repos", [])
+
+    def delete_filesystem(self, name: str) -> None:
+        self._call(
+            lambda: self._client.delete_filesystem(self._project_id, name),
+            not_found=FilesystemNotFoundError(name),
+        )
+
+    def ref_status(self, name: str, refspec: str) -> Dict[str, Any]:
+        # A 404 here means "no such ref yet" (an empty filesystem), not a
+        # missing filesystem — surface it as an API error for the caller to
+        # interpret, never as FilesystemNotFoundError.
+        raw = self._call(
+            lambda: self._client.filesystem_ref_status(self._project_id, name, refspec),
+            not_found=None,
+        )
+        return json.loads(raw)
+
+    def read_file(self, name: str, path: str, version: str) -> bytes:
+        return bytes(
+            self._call(
+                lambda: self._client.read_filesystem_file(
+                    self._project_id, name, path, version
+                ),
+                not_found=FileNotFoundInFilesystemError(name, path),
+            )
+        )
+
+    def list_tree(self, name: str, dir_path: str, version: str) -> List[Dict[str, Any]]:
+        raw = self._call(
+            lambda: self._client.list_filesystem_tree(
+                self._project_id, name, dir_path, version
+            ),
+            not_found=FileNotFoundInFilesystemError(name, dir_path or "/"),
+        )
+        return json.loads(raw).get("entries", [])
+
+    def push_files(
+        self,
+        name: str,
+        files: List[Tuple[str, bytes]],
+        deletes: List[str],
+        message: str,
+        idempotency_key: str,
+        branch: str = "main",
+    ) -> Dict[str, Any]:
+        raw = self._call(
+            lambda: self._client.push_filesystem_files(
+                self._project_id,
+                name,
+                files,
+                deletes,
+                message,
+                branch,
+                idempotency_key,
+            ),
+            not_found=FilesystemNotFoundError(name),
+        )
+        return json.loads(raw)

--- a/src/tensorlake/filesystem/client.py
+++ b/src/tensorlake/filesystem/client.py
@@ -1,0 +1,358 @@
+"""Client for Tensorlake filesystems.
+
+A filesystem is a durable, versioned file tree that lives in Tensorlake
+Cloud. Every write produces a :class:`~tensorlake.filesystem.models.Snapshot`
+(a durable version), files can be read at any version, and a filesystem can
+be mounted to a local path through the ``tl`` CLI's FUSE/FSKit daemon.
+
+Reads and writes are served by the shared Rust cloud-sdk core (the same
+engine behind the ``tl`` CLI), so uploads get content-defined chunking,
+dedup, transient retries, and idempotent commit reattachment for free.
+
+Example::
+
+    from tensorlake.filesystem import FilesystemClient
+
+    client = FilesystemClient()          # env-based auth
+    fs = client.create("my-data")
+    fs.write_file("docs/hello.txt", b"hi")
+    print(fs.read_file("docs/hello.txt"))
+    snapshot = fs.snapshot("after first write")
+
+    mount = fs.mount("/mnt/my-data")     # requires the `tl` CLI
+    ...                                   # use it as a normal directory
+    mount.unmount()
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Dict, Iterable, List, Optional, Union
+
+from tensorlake.cli._common import build_context_from_env
+
+from ._cli import FsCli
+from ._native import NativeFilesystems
+from .exceptions import FilesystemAPIError, FilesystemError, FilesystemNotFoundError
+from .models import (
+    FileEntry,
+    FilesystemInfo,
+    FilesystemStatus,
+    MountStatus,
+    Snapshot,
+)
+
+_FILESYSTEM_KIND = "filesystem"
+_FileData = Union[bytes, str]
+
+
+def _to_bytes(data: _FileData) -> bytes:
+    return data.encode("utf-8") if isinstance(data, str) else data
+
+
+def mount_status_from_raw(raw: dict, local_path: Optional[str] = None) -> MountStatus:
+    """Map one ``tl fs status --json`` payload to a :class:`MountStatus`.
+
+    ``mounted`` honors key presence (an explicit null means "not mounted"),
+    and path/filesystem fall through empty strings, not just missing keys.
+    The TypeScript SDK mirrors these exact semantics.
+    """
+    return MountStatus(
+        path=str(raw.get("path") or raw.get("mount_path") or local_path or ""),
+        filesystem=raw.get("filesystem") or raw.get("file_system") or None,
+        mounted=bool(raw.get("mounted", raw.get("active", True))),
+        raw=raw,
+    )
+
+
+class FilesystemClient:
+    """Manages the filesystems of one Tensorlake project."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ):
+        """Create a client.
+
+        Any argument left as ``None`` is resolved from the environment
+        (``TENSORLAKE_API_KEY`` / ``TENSORLAKE_PAT``, ``TENSORLAKE_API_URL``,
+        ``TENSORLAKE_ORGANIZATION_ID``, ``TENSORLAKE_PROJECT_ID``).
+        """
+        ctx = build_context_from_env()
+        token = api_key or ctx.api_key or ctx.personal_access_token
+        if not token:
+            raise FilesystemError(
+                "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
+            )
+        organization_id = organization_id or ctx.organization_id
+        project_id = project_id or ctx.project_id
+        if not organization_id or not project_id:
+            raise FilesystemError(
+                "Filesystem operations require organization and project context "
+                "(TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID)."
+            )
+        self._native = NativeFilesystems(
+            api_url=api_url or ctx.api_url,
+            bearer_token=token,
+            organization_id=organization_id,
+            project_id=project_id,
+        )
+        self._cli = FsCli(
+            api_key=api_key,
+            organization_id=organization_id,
+            project_id=project_id,
+            api_url=api_url or ctx.api_url,
+        )
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def create(self, name: str) -> "Filesystem":
+        """Create a new filesystem and return a handle to it."""
+        if not name:
+            raise FilesystemError("filesystem name must not be empty")
+        default_branch = self._native.create_filesystem(name)
+        return Filesystem(self, name, default_branch=default_branch)
+
+    def get(self, name: str) -> "Filesystem":
+        """Return a handle to an existing filesystem (verifies it exists)."""
+        meta = self._native.filesystem_meta(name)
+        if meta.get("kind", _FILESYSTEM_KIND) != _FILESYSTEM_KIND:
+            raise FilesystemNotFoundError(name)
+        return Filesystem(
+            self, name, default_branch=meta.get("default_branch") or "main"
+        )
+
+    def list(self) -> List[FilesystemInfo]:
+        """List all filesystems in the project."""
+        return [
+            FilesystemInfo.model_validate(repo)
+            for repo in self._native.list_filesystems()
+        ]
+
+    def delete(self, name: str) -> None:
+        """Permanently delete a filesystem and all its snapshots."""
+        self._native.delete_filesystem(name)
+
+    # -- local mounts ----------------------------------------------------------
+
+    def mount(self, name: str, local_path: str, readonly: bool = False) -> "Mount":
+        """Mount a filesystem to a local path (requires the ``tl`` CLI)."""
+        self._cli.mount(name, local_path, readonly)
+        return Mount(self, name, local_path, readonly)
+
+    def unmount(self, local_path: str, discard: bool = False) -> None:
+        """Unmount a locally mounted filesystem.
+
+        ``discard=True`` drops local changes that were not yet uploaded.
+        """
+        self._cli.unmount(local_path, discard=discard)
+
+    def mount_status(self, local_path: Optional[str] = None) -> MountStatus:
+        """Status of a local mount (defaults to the mount containing CWD)."""
+        return mount_status_from_raw(self._cli.status(local_path), local_path)
+
+
+class Filesystem:
+    """Handle to one filesystem; reads/writes go through the Rust core."""
+
+    def __init__(
+        self,
+        client: FilesystemClient,
+        name: str,
+        default_branch: Optional[str] = None,
+    ):
+        self._client = client
+        self._native = client._native
+        self._name = name
+        self._default_branch = default_branch
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __repr__(self) -> str:
+        return f"Filesystem(name={self._name!r})"
+
+    def _branch(self) -> str:
+        """The filesystem's default branch — the target of every write and
+        the default version of every read, so writes and ``status()`` can
+        never silently disagree on a non-"main" filesystem."""
+        if not self._default_branch:
+            meta = self._native.filesystem_meta(self._name)
+            self._default_branch = meta.get("default_branch") or "main"
+        return self._default_branch
+
+    # -- writes ---------------------------------------------------------------
+
+    def write_file(
+        self, path: str, data: _FileData, message: Optional[str] = None
+    ) -> Snapshot:
+        """Write one file. Returns the snapshot (version) the write produced."""
+        return self.write_files({path: data}, message=message)
+
+    def write_files(
+        self,
+        files: Dict[str, _FileData],
+        message: Optional[str] = None,
+        deletes: Iterable[str] = (),
+    ) -> Snapshot:
+        """Write several files (and/or delete paths) in one atomic snapshot."""
+        writes = [(path, _to_bytes(data)) for path, data in files.items()]
+        delete_paths = list(deletes)
+        if not writes and not delete_paths:
+            raise FilesystemError("nothing to write: no files or deletions given")
+        resolved_message = message or f"write {len(writes)} file(s) via SDK"
+        report = self._native.push_files(
+            self._name,
+            files=writes,
+            deletes=delete_paths,
+            message=resolved_message,
+            # One key per logical write: a retried submit reattaches to the
+            # same durable commit job instead of double-committing.
+            idempotency_key=secrets.token_hex(16),
+            branch=self._branch(),
+        )
+        return Snapshot(
+            commit=report.get("commit") or "",
+            tree=report.get("tree") or "",
+            ref_name=report.get("ref_name") or "",
+            created=bool(report.get("created", True)),
+            message=resolved_message,
+        )
+
+    def delete_file(self, path: str, message: Optional[str] = None) -> Snapshot:
+        """Delete one file. Returns the snapshot the deletion produced."""
+        return self.write_files(
+            {}, message=message or f"delete {path} via SDK", deletes=[path]
+        )
+
+    def snapshot(self, message: str = "") -> Snapshot:
+        """Return the filesystem's current version as a snapshot.
+
+        Writes already create snapshots implicitly; this pins the current
+        head without changing any content.
+        """
+        status = self.status()
+        if not status.head_commit:
+            raise FilesystemError(
+                f"filesystem {self._name} is empty: write files first"
+            )
+        return Snapshot(
+            commit=status.head_commit,
+            ref_name=f"refs/heads/{status.default_branch}",
+            created=False,
+            message=message,
+        )
+
+    # -- reads ------------------------------------------------------------------
+
+    def read_file(self, path: str, version: Optional[str] = None) -> bytes:
+        """Read a file's bytes at ``version`` (branch, ref, or snapshot
+        commit; defaults to the filesystem's default branch)."""
+        if not path.strip("/"):
+            raise FilesystemError("file path must not be empty")
+        return self._native.read_file(self._name, path, version or self._branch())
+
+    def read_text(
+        self, path: str, version: Optional[str] = None, encoding: str = "utf-8"
+    ) -> str:
+        """Read a file as text at ``version``."""
+        return self.read_file(path, version).decode(encoding)
+
+    def list_files(
+        self, dir_path: str = "", version: Optional[str] = None
+    ) -> List[FileEntry]:
+        """List one directory (non-recursive) at ``version``."""
+        prefix = dir_path.strip("/")
+        entries = []
+        for entry in self._native.list_tree(
+            self._name, dir_path, version or self._branch()
+        ):
+            model = FileEntry.model_validate(entry)
+            model.path = f"{prefix}/{model.name}" if prefix else model.name
+            entries.append(model)
+        return entries
+
+    # -- status -------------------------------------------------------------------
+
+    def status(self) -> FilesystemStatus:
+        """Remote status: identity plus the current head snapshot."""
+        meta = self._native.filesystem_meta(self._name)
+        head_commit: Optional[str] = None
+        generation: Optional[int] = None
+        default_branch = meta.get("default_branch") or "main"
+        self._default_branch = default_branch
+        try:
+            ref = self._native.ref_status(self._name, default_branch)
+            head_commit = ref.get("resolved_commit") or ref.get("oid") or None
+            generation = ref.get("generation")
+        except FilesystemAPIError as e:
+            # Only "no such ref yet" means an empty filesystem; anything else
+            # (auth, 5xx) must not masquerade as one.
+            if e.status_code != 404:
+                raise
+        return FilesystemStatus(
+            name=self._name,
+            status=meta.get("status", ""),
+            default_branch=default_branch,
+            head_commit=head_commit,
+            generation=generation,
+        )
+
+    # -- mounts ---------------------------------------------------------------------
+
+    def mount(self, local_path: str, readonly: bool = False) -> "Mount":
+        """Mount this filesystem to a local path (requires the ``tl`` CLI)."""
+        return self._client.mount(self._name, local_path, readonly)
+
+
+class Mount:
+    """A filesystem mounted to a local path via the ``tl`` CLI daemon."""
+
+    def __init__(
+        self,
+        client: FilesystemClient,
+        filesystem: str,
+        local_path: str,
+        readonly: bool,
+    ):
+        self._client = client
+        self._filesystem = filesystem
+        self._local_path = local_path
+        self._readonly = readonly
+
+    @property
+    def filesystem(self) -> str:
+        return self._filesystem
+
+    @property
+    def path(self) -> str:
+        return self._local_path
+
+    @property
+    def readonly(self) -> bool:
+        return self._readonly
+
+    def __repr__(self) -> str:
+        return f"Mount(filesystem={self._filesystem!r}, path={self._local_path!r})"
+
+    def snapshot(self, message: Optional[str] = None) -> None:
+        """Flush pending local changes into a durable snapshot."""
+        self._client._cli.snapshot(self._local_path, message)
+
+    def status(self) -> MountStatus:
+        """Local mount status as reported by the mount daemon."""
+        return self._client.mount_status(self._local_path)
+
+    def unmount(self, discard: bool = False) -> None:
+        """Unmount; ``discard=True`` drops changes not yet uploaded."""
+        self._client.unmount(self._local_path, discard=discard)
+
+    def __enter__(self) -> "Mount":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.unmount()

--- a/src/tensorlake/filesystem/exceptions.py
+++ b/src/tensorlake/filesystem/exceptions.py
@@ -1,0 +1,76 @@
+"""Exception hierarchy for filesystem operations."""
+
+
+class FilesystemException(Exception):
+    """Base exception for all filesystem-related errors."""
+
+    pass
+
+
+class FilesystemError(FilesystemException):
+    """General filesystem operation error."""
+
+    pass
+
+
+class FilesystemNotFoundError(FilesystemError):
+    """Raised when a filesystem is not found."""
+
+    def __init__(self, name: str):
+        self._name = name
+        super().__init__(f"Filesystem not found: {name}")
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+
+class FileNotFoundInFilesystemError(FilesystemError):
+    """Raised when a file path does not exist in the filesystem."""
+
+    def __init__(self, filesystem: str, path: str):
+        self._filesystem = filesystem
+        self._path = path
+        super().__init__(f"File not found in filesystem {filesystem}: {path}")
+
+    @property
+    def filesystem(self) -> str:
+        return self._filesystem
+
+    @property
+    def path(self) -> str:
+        return self._path
+
+
+class FilesystemAPIError(FilesystemError):
+    """Raised when the remote filesystem API returns an error."""
+
+    def __init__(self, status_code: int, message: str):
+        self._status_code = status_code
+        self._message = message
+        super().__init__(f"API error (status {status_code}): {message}")
+
+    @property
+    def status_code(self) -> int:
+        return self._status_code
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+
+class MountError(FilesystemError):
+    """Raised when a local mount/unmount operation fails."""
+
+    pass
+
+
+class CliNotFoundError(MountError):
+    """Raised when the `tl` CLI required for mount operations is unavailable."""
+
+    def __init__(self, detail: str):
+        super().__init__(
+            "Mount operations require the Tensorlake CLI (`tl`) with `tl fs` "
+            f"support: {detail}. Install or upgrade it with: "
+            "curl -fsSL https://tensorlake.ai/install.sh | sh"
+        )

--- a/src/tensorlake/filesystem/models.py
+++ b/src/tensorlake/filesystem/models.py
@@ -1,0 +1,98 @@
+"""Pydantic models for filesystem operations."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Git tree entry mode for a directory (0o40000 rendered by the server as an int).
+_GIT_MODE_DIR = 0o40000
+_GIT_MODE_SYMLINK = 0o120000
+
+
+class FilesystemInfo(BaseModel):
+    """One filesystem as returned by listing/point-read endpoints."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    full_name: str = ""
+    default_branch: str = "main"
+    status: str = ""
+    kind: str = "filesystem"
+
+
+class FilesystemStatus(BaseModel):
+    """Remote status of a filesystem: identity plus current head."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    status: str = ""
+    default_branch: str = "main"
+    #: Commit hash the default branch currently points at (None for an empty
+    #: filesystem that has never been written to).
+    head_commit: Optional[str] = None
+    #: Server-side movement counter for the default branch; bumps whenever the
+    #: head advances. None on servers that do not report it.
+    generation: Optional[int] = None
+
+
+class FileEntry(BaseModel):
+    """One directory entry from a filesystem listing."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    #: Git blob/tree object id.
+    oid: str = ""
+    #: Raw git mode (0o100644 file, 0o100755 executable, 0o120000 symlink,
+    #: 0o40000 directory).
+    mode: int = 0o100644
+    #: Blob size in bytes when cheaply known server-side.
+    size: Optional[int] = None
+    #: Path of the entry relative to the filesystem root.
+    path: str = ""
+
+    @property
+    def is_dir(self) -> bool:
+        return self.mode == _GIT_MODE_DIR
+
+    @property
+    def is_symlink(self) -> bool:
+        return self.mode == _GIT_MODE_SYMLINK
+
+
+class Snapshot(BaseModel):
+    """A durable version of the filesystem (a commit)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    #: Commit hash — pass as ``version=`` to read the filesystem at this point.
+    commit: str
+    tree: str = ""
+    ref_name: str = ""
+    parent: Optional[str] = None
+    #: False when the write was a no-op (content identical to the parent).
+    created: bool = True
+    message: str = ""
+
+
+class MountStatus(BaseModel):
+    """Status of a local mount as reported by ``tl fs status --json``.
+
+    The mount daemon's JSON is versioned independently of this SDK, so only
+    stable fields are typed; the full payload is preserved in :attr:`raw`.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    #: Local mount path.
+    path: str = ""
+    #: Filesystem name this mount serves, when reported.
+    filesystem: Optional[str] = None
+    #: Whether the daemon reports the mount as healthy/active.
+    mounted: bool = False
+    #: Complete parsed JSON payload from the CLI.
+    raw: Dict[str, Any] = Field(default_factory=dict)

--- a/tests/filesystem/test_filesystem_unit.py
+++ b/tests/filesystem/test_filesystem_unit.py
@@ -1,0 +1,383 @@
+"""Network-free unit tests for the filesystem SDK.
+
+The wire protocol (chunking, ingest, commit jobs, retries) lives in the Rust
+cloud-sdk core and is tested there. These tests pin the Python wrapper: how
+native results map to models, how native errors translate into the
+filesystem exception hierarchy, and the idempotency-key discipline on
+writes. The native client under `FilesystemClient._native._client` is
+replaced with a scripted stub.
+"""
+
+import json
+import unittest
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    from tensorlake._cloud_sdk import CloudApiClientError
+except ImportError:
+    from _cloud_sdk import CloudApiClientError
+from tensorlake.filesystem import (
+    FileEntry,
+    FileNotFoundInFilesystemError,
+    FilesystemAPIError,
+    FilesystemClient,
+    FilesystemError,
+    FilesystemInfo,
+    FilesystemNotFoundError,
+    Snapshot,
+)
+from tensorlake.filesystem.client import mount_status_from_raw
+
+_PROJECT = "proj_test"
+_COMMIT = "c" * 40
+
+
+def _client_with_stub(stub: "_StubNative") -> FilesystemClient:
+    client = FilesystemClient(
+        api_key="test-key",
+        api_url="https://api.tensorlake.ai",
+        organization_id="org_test",
+        project_id=_PROJECT,
+    )
+    client._native._client = stub
+    return client
+
+
+class _StubNative:
+    """Scripted stand-in for the Rust CloudApiClient filesystem surface.
+
+    ``errors`` maps a method name to a (category, status, message) tuple to
+    raise as CloudApiClientError instead of answering.
+    """
+
+    def __init__(
+        self,
+        meta: Optional[Dict[str, Any]] = None,
+        repos: Optional[List[Dict[str, Any]]] = None,
+        ref: Optional[Dict[str, Any]] = None,
+        entries: Optional[List[Dict[str, Any]]] = None,
+        file_bytes: bytes = b"",
+        push_report: Optional[Dict[str, Any]] = None,
+        errors: Optional[Dict[str, Tuple[str, Optional[int], str]]] = None,
+    ):
+        self.meta = meta or {
+            "name": "my-fs",
+            "full_name": f"{_PROJECT}/my-fs",
+            "default_branch": "main",
+            "status": "active",
+            "kind": "filesystem",
+        }
+        self.repos = repos or []
+        self.ref = ref or {
+            "ref_name": "refs/heads/main",
+            "oid": _COMMIT,
+            "resolved_commit": _COMMIT,
+            "generation": 3,
+        }
+        self.entries = entries or []
+        self.file_bytes = file_bytes
+        self.push_report = push_report or {
+            "commit": _COMMIT,
+            "tree": "t" * 40,
+            "ref_name": "refs/heads/main",
+            "created": True,
+            "files": 1,
+            "bytes_total": 1,
+            "chunks_total": 1,
+            "chunks_uploaded": 1,
+            "bytes_uploaded": 1,
+            "file_blob_oids": [],
+        }
+        self.errors = errors or {}
+        self.calls: List[Tuple[str, tuple]] = []
+
+    def _maybe_fail(self, method: str) -> None:
+        if method in self.errors:
+            raise CloudApiClientError(*self.errors[method])
+
+    #: Branch reported by create — non-"main" simulates the binding adopting
+    #: a pre-existing filesystem on a lost-response retry.
+    create_branch = "main"
+
+    def create_filesystem(self, project_id, name):
+        self.calls.append(("create_filesystem", (project_id, name)))
+        self._maybe_fail("create_filesystem")
+        return json.dumps({"trace_id": "trace-1", "default_branch": self.create_branch})
+
+    def filesystem_meta(self, project_id, name):
+        self.calls.append(("filesystem_meta", (project_id, name)))
+        self._maybe_fail("filesystem_meta")
+        return json.dumps(self.meta)
+
+    def list_filesystems(self, project_id):
+        self.calls.append(("list_filesystems", (project_id,)))
+        self._maybe_fail("list_filesystems")
+        return json.dumps(
+            {"project": project_id, "repos": self.repos, "next_after": None}
+        )
+
+    def delete_filesystem(self, project_id, name):
+        self.calls.append(("delete_filesystem", (project_id, name)))
+        self._maybe_fail("delete_filesystem")
+        return "trace-2"
+
+    def filesystem_ref_status(self, project_id, name, refspec):
+        self.calls.append(("filesystem_ref_status", (project_id, name, refspec)))
+        self._maybe_fail("filesystem_ref_status")
+        return json.dumps(self.ref)
+
+    def read_filesystem_file(self, project_id, name, path, version):
+        self.calls.append(("read_filesystem_file", (project_id, name, path, version)))
+        self._maybe_fail("read_filesystem_file")
+        return self.file_bytes
+
+    def list_filesystem_tree(self, project_id, name, dir_path, version):
+        self.calls.append(
+            ("list_filesystem_tree", (project_id, name, dir_path, version))
+        )
+        self._maybe_fail("list_filesystem_tree")
+        return json.dumps({"entries": self.entries})
+
+    def push_filesystem_files(
+        self, project_id, name, files, deletes, message, branch, idempotency_key
+    ):
+        self.calls.append(
+            (
+                "push_filesystem_files",
+                (project_id, name, files, deletes, message, branch, idempotency_key),
+            )
+        )
+        self._maybe_fail("push_filesystem_files")
+        return json.dumps(self.push_report)
+
+
+class TestModels(unittest.TestCase):
+    def test_models_parse_wire_shapes(self):
+        info = FilesystemInfo.model_validate(
+            {
+                "name": "skills",
+                "full_name": f"{_PROJECT}/skills",
+                "default_branch": "main",
+                "status": "active",
+                "kind": "filesystem",
+                "unknown_field": 1,
+            }
+        )
+        self.assertEqual(info.name, "skills")
+        entry = FileEntry.model_validate({"name": "d", "oid": "x", "mode": 0o40000})
+        self.assertTrue(entry.is_dir)
+        entry = FileEntry.model_validate({"name": "f", "oid": "y", "mode": 0o100644})
+        self.assertFalse(entry.is_dir)
+
+
+class TestFilesystemClient(unittest.TestCase):
+    def test_lifecycle_calls_native_with_project_scope(self):
+        stub = _StubNative(
+            repos=[
+                {
+                    "name": "a",
+                    "full_name": f"{_PROJECT}/a",
+                    "default_branch": "main",
+                    "status": "active",
+                    "kind": "filesystem",
+                }
+            ]
+        )
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        self.assertEqual(fs.name, "my-fs")
+        infos = client.list()
+        self.assertEqual([i.name for i in infos], ["a"])
+        client.delete("my-fs")
+        self.assertEqual(
+            [c[0] for c in stub.calls],
+            ["create_filesystem", "list_filesystems", "delete_filesystem"],
+        )
+        for _, args in stub.calls:
+            self.assertEqual(args[0], _PROJECT)
+
+    def test_get_missing_filesystem_raises_not_found(self):
+        stub = _StubNative(
+            errors={"filesystem_meta": ("remote_api", 404, "no such repo")}
+        )
+        client = _client_with_stub(stub)
+        with self.assertRaises(FilesystemNotFoundError):
+            client.get("nope")
+
+    def test_get_non_filesystem_kind_raises_not_found(self):
+        stub = _StubNative()
+        stub.meta["kind"] = "repository"
+        client = _client_with_stub(stub)
+        with self.assertRaises(FilesystemNotFoundError):
+            client.get("code-repo")
+
+    def test_write_files_maps_push_report_and_sets_idempotency_key(self):
+        stub = _StubNative()
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        snapshot = fs.write_files(
+            {"a.txt": "hello", "b.bin": b"\x00\x01"}, deletes=["old.txt"]
+        )
+        self.assertIsInstance(snapshot, Snapshot)
+        self.assertEqual(snapshot.commit, _COMMIT)
+        self.assertTrue(snapshot.created)
+
+        method, args = stub.calls[-1]
+        self.assertEqual(method, "push_filesystem_files")
+        _, name, files, deletes, _message, branch, idempotency_key = args
+        self.assertEqual(name, "my-fs")
+        # Strings are encoded to bytes; bytes pass through.
+        self.assertEqual(dict(files), {"a.txt": b"hello", "b.bin": b"\x00\x01"})
+        self.assertEqual(deletes, ["old.txt"])
+        self.assertEqual(branch, "main")
+        # A fresh stable key per logical write (the Rust core reuses it across
+        # its retries so a lost response cannot double-commit).
+        self.assertRegex(idempotency_key, r"^[0-9a-f]{32}$")
+
+    def test_empty_write_rejected(self):
+        client = _client_with_stub(_StubNative())
+        fs = client.create("my-fs")
+        with self.assertRaises(FilesystemError):
+            fs.write_files({})
+
+    def test_read_file_and_missing_file(self):
+        stub = _StubNative(file_bytes=b"content")
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        self.assertEqual(fs.read_file("docs/a.txt"), b"content")
+        self.assertEqual(stub.calls[-1][1], (_PROJECT, "my-fs", "docs/a.txt", "main"))
+
+        stub.errors["read_filesystem_file"] = ("remote_api", 404, "not found")
+        with self.assertRaises(FileNotFoundInFilesystemError):
+            fs.read_file("docs/missing.txt")
+        with self.assertRaises(FilesystemError):
+            fs.read_file("//")
+
+    def test_list_files_builds_paths(self):
+        stub = _StubNative(
+            entries=[
+                {"name": "sub", "oid": "x", "mode": 0o40000},
+                {"name": "a.txt", "oid": "y", "mode": 0o100644, "size": 3},
+            ]
+        )
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        entries = fs.list_files("docs")
+        self.assertEqual([e.path for e in entries], ["docs/sub", "docs/a.txt"])
+        self.assertTrue(entries[0].is_dir)
+        self.assertEqual(entries[1].size, 3)
+
+    def test_status_maps_head_and_generation(self):
+        client = _client_with_stub(_StubNative())
+        fs = client.create("my-fs")
+        status = fs.status()
+        self.assertEqual(status.head_commit, _COMMIT)
+        self.assertEqual(status.generation, 3)
+        self.assertEqual(status.default_branch, "main")
+
+    def test_status_of_empty_filesystem(self):
+        stub = _StubNative(
+            ref={
+                "ref_name": "refs/heads/main",
+                "oid": None,
+                "resolved_commit": None,
+                "generation": 0,
+            }
+        )
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        self.assertIsNone(fs.status().head_commit)
+        with self.assertRaises(FilesystemError):
+            fs.snapshot("nothing yet")
+
+    def test_status_swallows_only_ref_404(self):
+        stub = _StubNative(
+            errors={"filesystem_ref_status": ("remote_api", 404, "no ref")}
+        )
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        self.assertIsNone(fs.status().head_commit)
+
+        stub.errors["filesystem_ref_status"] = ("remote_api", 503, "unavailable")
+        with self.assertRaises(FilesystemAPIError) as caught:
+            fs.status()
+        self.assertEqual(caught.exception.status_code, 503)
+
+    def test_snapshot_pins_current_head(self):
+        client = _client_with_stub(_StubNative())
+        fs = client.create("my-fs")
+        snapshot = fs.snapshot("pin")
+        self.assertEqual(snapshot.commit, _COMMIT)
+        self.assertFalse(snapshot.created)
+
+    def test_create_seeds_branch_reported_by_binding(self):
+        stub = _StubNative()
+        stub.create_branch = "trunk"
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        fs.write_file("a.txt", b"x")
+        # (project, name, files, deletes, message, branch, idempotency_key)
+        self.assertEqual(stub.calls[-1][1][5], "trunk")
+
+    def test_non_main_default_branch_followed_by_writes_and_reads(self):
+        stub = _StubNative()
+        stub.meta["default_branch"] = "trunk"
+        client = _client_with_stub(stub)
+        fs = client.get("my-fs")
+        fs.write_file("a.txt", b"x")
+        # (project, name, files, deletes, message, branch, idempotency_key)
+        self.assertEqual(stub.calls[-1][1][5], "trunk")
+        fs.read_file("a.txt")
+        # (project, name, path, version)
+        self.assertEqual(stub.calls[-1][1][3], "trunk")
+        fs.list_files()
+        self.assertEqual(stub.calls[-1][1][3], "trunk")
+        # An explicit version always wins over the default branch.
+        fs.read_file("a.txt", version="c" * 40)
+        self.assertEqual(stub.calls[-1][1][3], "c" * 40)
+
+    def test_empty_message_gets_default(self):
+        stub = _StubNative()
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        # Explicit "" gets the default too — parity with the TypeScript SDK.
+        snapshot = fs.write_file("a.txt", b"x", message="")
+        message = stub.calls[-1][1][4]
+        self.assertEqual(message, "write 1 file(s) via SDK")
+        self.assertEqual(snapshot.message, "write 1 file(s) via SDK")
+
+    def test_mount_status_from_raw_semantics(self):
+        status = mount_status_from_raw(
+            {
+                "path": "",
+                "mount_path": "/mnt/x",
+                "mounted": None,
+                "active": True,
+                "filesystem": "",
+            },
+            local_path="/ignored",
+        )
+        # Empty path falls through to mount_path; a present-but-null
+        # "mounted" means not mounted; empty filesystem becomes None.
+        self.assertEqual(status.path, "/mnt/x")
+        self.assertFalse(status.mounted)
+        self.assertIsNone(status.filesystem)
+
+        defaulted = mount_status_from_raw({}, local_path="/mnt/y")
+        self.assertEqual(defaulted.path, "/mnt/y")
+        self.assertTrue(defaulted.mounted)
+
+    def test_error_translation_without_status(self):
+        stub = _StubNative(
+            errors={"push_filesystem_files": ("internal", None, "commit job failed")}
+        )
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        with self.assertRaises(FilesystemError) as caught:
+            fs.write_file("a.txt", b"x")
+        self.assertNotIsInstance(caught.exception, FilesystemAPIError)
+        self.assertIn("commit job failed", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -12,18 +12,22 @@ enable_applications_test_suite=false
 enable_cli_test_suite=false
 enable_utils_test_suite=false
 enable_document_ai_test_suite=false
+enable_filesystem_test_suite=false
 if [[ "$1" == "--function-executor" ]]; then
   enable_fe_test_suite=true
 elif [ "$1" == "--applications" ]; then
   enable_applications_test_suite=true
 elif [ "$1" == "--document-ai" ]; then
   enable_document_ai_test_suite=true
+elif [ "$1" == "--filesystem" ]; then
+  enable_filesystem_test_suite=true
 else
   # All by default
   enable_fe_test_suite=true
   enable_applications_test_suite=true
   enable_cli_test_suite=true
   enable_utils_test_suite=true
+  enable_filesystem_test_suite=true
 fi
 
 tests_exit_code=0
@@ -65,6 +69,7 @@ applications_test_files=$(find ./applications -name 'test_*.py')
 cli_test_files=$(find ./cli -name 'test_*.py')
 utils_test_files=$(find ./utils -name 'test_*.py')
 document_ai_test_files=$(find ./document_ai -name 'test_*.py')
+filesystem_test_files=$(find ./filesystem -name 'test_*.py')
 
 if [ "$enable_fe_test_suite" = true ]; then
   run_test_suite "$function_executor_test_files" "Function Executor"
@@ -80,6 +85,10 @@ fi
 
 if [ "$enable_document_ai_test_suite" = true ]; then
   run_test_suite "$document_ai_test_files" "Document AI"
+fi
+
+if [ "$enable_filesystem_test_suite" = true ]; then
+  run_test_suite "$filesystem_test_files" "Filesystem"
 fi
 
 

--- a/typescript/src/filesystem-models.ts
+++ b/typescript/src/filesystem-models.ts
@@ -4,6 +4,18 @@
 const GIT_MODE_DIR = 0o40000;
 const GIT_MODE_SYMLINK = 0o120000;
 
+/**
+ * Strip leading/trailing '/' in linear time (the regex equivalent
+ * `/^\/+|\/+$/g` backtracks polynomially on adversarial many-slash input).
+ */
+export function trimSlashes(path: string): string {
+  let start = 0;
+  let end = path.length;
+  while (start < end && path.charCodeAt(start) === 0x2f) start += 1;
+  while (end > start && path.charCodeAt(end - 1) === 0x2f) end -= 1;
+  return path.slice(start, end);
+}
+
 /** One filesystem as returned by listing/point-read endpoints. */
 export interface FilesystemInfo {
   name: string;
@@ -47,7 +59,7 @@ export function fileEntryFromWire(
   dirPath: string,
 ): FileEntry {
   const mode = entry.mode ?? 0o100644;
-  const prefix = dirPath.replace(/^\/+|\/+$/g, "");
+  const prefix = trimSlashes(dirPath);
   return {
     name: entry.name,
     path: prefix ? `${prefix}/${entry.name}` : entry.name,

--- a/typescript/src/filesystem-models.ts
+++ b/typescript/src/filesystem-models.ts
@@ -1,0 +1,167 @@
+/** Models and errors for the filesystem SDK. */
+
+/** Git tree mode for a directory entry. */
+const GIT_MODE_DIR = 0o40000;
+const GIT_MODE_SYMLINK = 0o120000;
+
+/** One filesystem as returned by listing/point-read endpoints. */
+export interface FilesystemInfo {
+  name: string;
+  fullName: string;
+  defaultBranch: string;
+  status: string;
+  kind: string;
+}
+
+/** Remote status of a filesystem: identity plus current head. */
+export interface FilesystemStatus {
+  name: string;
+  status: string;
+  defaultBranch: string;
+  /**
+   * Commit hash the default branch currently points at; null for an empty
+   * filesystem that has never been written to.
+   */
+  headCommit: string | null;
+  /** Server-side movement counter for the default branch, when reported. */
+  generation: number | null;
+}
+
+/** One directory entry from a filesystem listing. */
+export interface FileEntry {
+  name: string;
+  /** Path of the entry relative to the filesystem root. */
+  path: string;
+  /** Git blob/tree object id. */
+  oid: string;
+  /** Raw git mode (0o100644 file, 0o100755 executable, 0o120000 symlink, 0o40000 dir). */
+  mode: number;
+  /** Blob size in bytes when cheaply known server-side. */
+  size: number | null;
+  isDir: boolean;
+  isSymlink: boolean;
+}
+
+export function fileEntryFromWire(
+  entry: { name: string; oid?: string; mode?: number; size?: number | null },
+  dirPath: string,
+): FileEntry {
+  const mode = entry.mode ?? 0o100644;
+  const prefix = dirPath.replace(/^\/+|\/+$/g, "");
+  return {
+    name: entry.name,
+    path: prefix ? `${prefix}/${entry.name}` : entry.name,
+    oid: entry.oid ?? "",
+    mode,
+    size: entry.size ?? null,
+    isDir: mode === GIT_MODE_DIR,
+    isSymlink: mode === GIT_MODE_SYMLINK,
+  };
+}
+
+/** A durable version of the filesystem (a commit). */
+export interface Snapshot {
+  /** Commit hash — pass as `version` to read the filesystem at this point. */
+  commit: string;
+  tree: string;
+  refName: string;
+  parent: string | null;
+  /** False when the write was a no-op (content identical to the parent). */
+  created: boolean;
+  message: string;
+}
+
+/**
+ * Status of a local mount as reported by `tl fs status --json`.
+ *
+ * The mount daemon's JSON is versioned independently of this SDK, so only
+ * stable fields are typed; the full payload is preserved in `raw`.
+ */
+export interface MountStatus {
+  /** Local mount path. */
+  path: string;
+  /** Filesystem name this mount serves, when reported. */
+  filesystem: string | null;
+  /** Whether the daemon reports the mount as healthy/active. */
+  mounted: boolean;
+  /** Complete parsed JSON payload from the CLI. */
+  raw: Record<string, unknown>;
+}
+
+/**
+ * Map one `tl fs status --json` payload to a MountStatus.
+ *
+ * Semantics deliberately mirror the Python SDK: `mounted` honors key
+ * presence (an explicit null means "not mounted"), and path/filesystem
+ * fall through empty strings, not just null/undefined.
+ */
+export function mountStatusFromRaw(
+  raw: Record<string, unknown>,
+  localPath?: string,
+): MountStatus {
+  const mounted =
+    "mounted" in raw
+      ? Boolean(raw.mounted)
+      : "active" in raw
+        ? Boolean(raw.active)
+        : true;
+  const path = String(raw.path || raw.mount_path || localPath || "");
+  const filesystem = (raw.filesystem || raw.file_system || null) as
+    | string
+    | null;
+  return { path, filesystem, mounted, raw };
+}
+
+export class FilesystemError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FilesystemError";
+  }
+}
+
+export class FilesystemNotFoundError extends FilesystemError {
+  readonly filesystemName: string;
+  constructor(name: string) {
+    super(`Filesystem not found: ${name}`);
+    this.name = "FilesystemNotFoundError";
+    this.filesystemName = name;
+  }
+}
+
+export class FileNotFoundInFilesystemError extends FilesystemError {
+  readonly filesystem: string;
+  readonly path: string;
+  constructor(filesystem: string, path: string) {
+    super(`File not found in filesystem ${filesystem}: ${path}`);
+    this.name = "FileNotFoundInFilesystemError";
+    this.filesystem = filesystem;
+    this.path = path;
+  }
+}
+
+export class FilesystemAPIError extends FilesystemError {
+  readonly statusCode: number;
+  constructor(statusCode: number, message: string) {
+    super(`API error (status ${statusCode}): ${message}`);
+    this.name = "FilesystemAPIError";
+    this.statusCode = statusCode;
+  }
+}
+
+export class MountError extends FilesystemError {
+  constructor(message: string) {
+    super(message);
+    this.name = "MountError";
+  }
+}
+
+export class CliNotFoundError extends MountError {
+  constructor(detail: string) {
+    super(
+      "Mount operations require the Tensorlake CLI (`tl`) with `tl fs` " +
+        `support: ${detail}. Install or upgrade it with: ` +
+        "curl -fsSL https://tensorlake.ai/install.sh | sh",
+    );
+    this.name = "CliNotFoundError";
+  }
+}

--- a/typescript/src/filesystem.ts
+++ b/typescript/src/filesystem.ts
@@ -38,6 +38,7 @@ import {
   MountError,
   fileEntryFromWire,
   mountStatusFromRaw,
+  trimSlashes,
   type FileEntry,
   type FilesystemInfo,
   type FilesystemStatus,
@@ -518,7 +519,7 @@ export class Filesystem {
    * defaults to the filesystem's default branch).
    */
   async readFile(path: string, version?: string): Promise<Uint8Array> {
-    if (path.replace(/^\/+|\/+$/g, "") === "") {
+    if (trimSlashes(path) === "") {
       throw new FilesystemError("file path must not be empty");
     }
     const resolvedVersion = version || (await this.branch());

--- a/typescript/src/filesystem.ts
+++ b/typescript/src/filesystem.ts
@@ -1,0 +1,639 @@
+/**
+ * Client for Tensorlake filesystems.
+ *
+ * A filesystem is a durable, versioned file tree that lives in Tensorlake
+ * Cloud. Every write produces a {@link Snapshot} (a durable version), files
+ * can be read at any version, and a filesystem can be mounted to a local
+ * path through the `tl` CLI's FUSE/FSKit daemon.
+ *
+ * Reads and writes are served by the shared Rust cloud-sdk core (the same
+ * engine behind the `tl` CLI), so uploads get content-defined chunking,
+ * dedup, transient retries, and idempotent commit reattachment for free.
+ *
+ * @example
+ * const client = new FilesystemClient();   // env-based auth
+ * const fs = await client.create("my-data");
+ * await fs.writeFile("docs/hello.txt", "hi");
+ * console.log(await fs.readText("docs/hello.txt"));
+ * const snapshot = await fs.snapshot("after first write");
+ *
+ * const mount = await fs.mount("/mnt/my-data"); // requires the `tl` CLI
+ * // ... use it as a normal directory
+ * await mount.unmount();
+ */
+
+import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { accessSync, constants } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import * as defaults from "./defaults.js";
+import {
+  CliNotFoundError,
+  FileNotFoundInFilesystemError,
+  FilesystemAPIError,
+  FilesystemError,
+  FilesystemNotFoundError,
+  MountError,
+  fileEntryFromWire,
+  mountStatusFromRaw,
+  type FileEntry,
+  type FilesystemInfo,
+  type FilesystemStatus,
+  type MountStatus,
+  type Snapshot,
+} from "./filesystem-models.js";
+import {
+  loadNativeSandboxBinding,
+  type NativeRepositoryClient,
+} from "./native-sandbox.js";
+import { buildContextFromEnv } from "./sandbox-image.js";
+
+const execFileAsync = promisify(execFile);
+
+const FILESYSTEM_REPO_KIND = "filesystem";
+
+export interface FilesystemClientOptions {
+  apiKey?: string;
+  apiUrl?: string;
+  organizationId?: string;
+  projectId?: string;
+  /** @internal Test seam: bypass the native binding loader. */
+  nativeClient?: NativeRepositoryClient;
+}
+
+/**
+ * Translate a structured native error (`{category, status, message}` JSON in
+ * the error message) into the filesystem error hierarchy. `notFound`, when
+ * given, replaces the generic API error for 404s.
+ */
+function translateNativeError(error: unknown, notFound?: FilesystemError): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  let payload: { category?: unknown; status?: unknown; message?: unknown };
+  try {
+    payload = JSON.parse(message);
+  } catch {
+    return error instanceof Error ? error : new FilesystemError(message);
+  }
+  if (!payload || typeof payload.category !== "string") {
+    return error instanceof Error ? error : new FilesystemError(message);
+  }
+  const detail =
+    typeof payload.message === "string" ? payload.message : message;
+  // Connection-level failures carry a fabricated gateway status in the napi
+  // layer; surface them as plain FilesystemError (matching Python, where
+  // they carry no status) instead of a fake server FilesystemAPIError.
+  if (payload.category === "connection") {
+    return new FilesystemError(detail);
+  }
+  if (payload.status === 404 && notFound !== undefined) {
+    return notFound;
+  }
+  if (typeof payload.status === "number") {
+    return new FilesystemAPIError(payload.status, detail);
+  }
+  return new FilesystemError(detail);
+}
+
+async function callNative<T>(
+  fn: () => Promise<T>,
+  notFound?: FilesystemError,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    throw translateNativeError(error, notFound);
+  }
+}
+
+/**
+ * Runs `tl fs ...` commands for local mount operations.
+ *
+ * Mounting a filesystem to a local path is served by a FUSE (Linux) / FSKit
+ * (macOS) daemon that ships only inside the Tensorlake CLI, so the SDK drives
+ * mounts by invoking `tl fs mount/unmount/snapshot/status`. Everything else
+ * goes through the Rust core and does not need the CLI.
+ */
+class FsCli {
+  private binary: string | null = null;
+  private readonly envOverrides: Record<string, string>;
+
+  constructor(envOverrides: Record<string, string>) {
+    this.envOverrides = envOverrides;
+  }
+
+  private async findCli(): Promise<string> {
+    const candidates: string[] = [];
+    if (process.env.TENSORLAKE_CLI) {
+      candidates.push(process.env.TENSORLAKE_CLI);
+    }
+    candidates.push("tl");
+    const installed = join(homedir(), ".tensorlake", "bin", "tl");
+    try {
+      // Existence, not executability: a present-but-broken install should be
+      // probed and blamed as "upgrade required" (parity with Python), not
+      // reported as missing.
+      accessSync(installed, constants.F_OK);
+      candidates.push(installed);
+    } catch {
+      // not installed at the default path
+    }
+    // A candidate that exists but fails the probe means "upgrade tl"; a
+    // candidate that does not exist must not be blamed as outdated. The
+    // Python SDK mirrors these exact semantics.
+    let unsupported: string | null = null;
+    for (const candidate of candidates) {
+      try {
+        await execFileAsync(candidate, ["fs", "--help"], { timeout: 15_000 });
+        return candidate;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          unsupported = candidate;
+        }
+      }
+    }
+    throw new CliNotFoundError(
+      unsupported
+        ? `\`tl\` at ${unsupported} does not support \`tl fs\` (upgrade required)`
+        : "`tl` was not found on PATH",
+    );
+  }
+
+  private async run(args: string[], timeoutMs = 300_000): Promise<string> {
+    if (this.binary === null) {
+      this.binary = await this.findCli();
+    }
+    try {
+      const { stdout } = await execFileAsync(this.binary, ["fs", ...args], {
+        timeout: timeoutMs,
+        env: { ...process.env, ...this.envOverrides },
+        maxBuffer: 16 * 1024 * 1024,
+      });
+      return stdout;
+    } catch (error) {
+      const failure = error as { stderr?: string; stdout?: string; killed?: boolean };
+      if (failure.killed) {
+        throw new MountError(`\`tl fs ${args[0]}\` timed out after ${timeoutMs}ms`);
+      }
+      const detail = (failure.stderr || failure.stdout || String(error)).trim();
+      throw new MountError(`\`tl fs ${args.join(" ")}\` failed: ${detail}`);
+    }
+  }
+
+  // Flags always precede a `--` end-of-options separator so caller-supplied
+  // names/paths can never be parsed as CLI flags (e.g. a path literally
+  // named "--discard" must stay a path, not become the destructive flag).
+  async mount(filesystem: string, localPath: string, readonly: boolean): Promise<void> {
+    const args = ["mount"];
+    if (readonly) args.push("--ro");
+    args.push("--", filesystem, localPath);
+    await this.run(args);
+  }
+
+  async unmount(localPath: string, discard: boolean): Promise<void> {
+    const args = ["unmount"];
+    if (discard) args.push("--discard");
+    args.push("--", localPath);
+    await this.run(args);
+  }
+
+  async snapshot(localPath: string, message?: string): Promise<void> {
+    const args = ["snapshot"];
+    // Attached form: a detached value ("-m", "-msg") is rejected by the CLI
+    // parser when the message starts with '-'.
+    if (message) args.push(`--message=${message}`);
+    args.push("--", localPath);
+    await this.run(args);
+  }
+
+  async status(localPath?: string): Promise<Record<string, unknown>> {
+    const args = ["status", "--json"];
+    if (localPath) args.push("--", localPath);
+    const output = await this.run(args, 60_000);
+    try {
+      const payload = JSON.parse(output);
+      return typeof payload === "object" && payload !== null
+        ? (payload as Record<string, unknown>)
+        : { status: payload };
+    } catch {
+      throw new MountError(
+        `\`tl fs status --json\` returned invalid JSON: ${output.slice(0, 200)}`,
+      );
+    }
+  }
+}
+
+/** Manages the filesystems of one Tensorlake project. */
+export class FilesystemClient {
+  private readonly native: NativeRepositoryClient;
+  private readonly cli: FsCli;
+
+  /**
+   * Any option left unset is resolved from the environment
+   * (`TENSORLAKE_API_KEY` / `TENSORLAKE_PAT`, `TENSORLAKE_API_URL`,
+   * `TENSORLAKE_ORGANIZATION_ID`, `TENSORLAKE_PROJECT_ID`).
+   */
+  constructor(options: FilesystemClientOptions = {}) {
+    const context = buildContextFromEnv();
+    const token =
+      options.apiKey ?? context.apiKey ?? context.personalAccessToken;
+    if (!token) {
+      throw new FilesystemError(
+        "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.",
+      );
+    }
+    const organizationId = options.organizationId ?? context.organizationId;
+    const projectId = options.projectId ?? context.projectId;
+    if (!organizationId || !projectId) {
+      throw new FilesystemError(
+        "Filesystem operations require organization and project context " +
+          "(TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID).",
+      );
+    }
+    if (options.nativeClient) {
+      this.native = options.nativeClient;
+    } else {
+      const binding = loadNativeSandboxBinding();
+      if (typeof binding.NativeRepositoryClient !== "function") {
+        throw new FilesystemError(
+          "native binding does not export the repository client; rebuild with 'npm run build:native'",
+        );
+      }
+      this.native = new binding.NativeRepositoryClient(
+        options.apiUrl ?? context.apiUrl,
+        token,
+        organizationId,
+        projectId,
+        `tensorlake-typescript-sdk/${defaults.SDK_VERSION}`,
+        null,
+      );
+    }
+    const envOverrides: Record<string, string> = {
+      TENSORLAKE_ORGANIZATION_ID: organizationId,
+      TENSORLAKE_PROJECT_ID: projectId,
+      // The CLI must target the same deployment the data plane does, or a
+      // mount could resolve a same-named filesystem in the wrong environment.
+      TENSORLAKE_API_URL: options.apiUrl ?? context.apiUrl,
+    };
+    if (options.apiKey) {
+      envOverrides.TENSORLAKE_API_KEY = options.apiKey;
+    }
+    this.cli = new FsCli(envOverrides);
+  }
+
+  // -- lifecycle --------------------------------------------------------------
+
+  /** Create a new filesystem and return a handle to it. */
+  async create(name: string): Promise<Filesystem> {
+    if (typeof name !== "string") {
+      throw new TypeError("name must be a string");
+    }
+    if (name.length === 0) {
+      throw new FilesystemError("filesystem name must not be empty");
+    }
+    const raw = await callNative(() => this.native.createFilesystem(name));
+    // The binding reports the effective default branch; it differs from
+    // "main" only when a lost-response retry adopted a pre-existing
+    // filesystem.
+    const created = JSON.parse(raw) as { default_branch?: string };
+    return new Filesystem(
+      this,
+      this.native,
+      this.cli,
+      name,
+      created.default_branch || "main",
+    );
+  }
+
+  /** Return a handle to an existing filesystem (verifies it exists). */
+  async get(name: string): Promise<Filesystem> {
+    const traced = await callNative(
+      () => this.native.filesystemMeta(name),
+      new FilesystemNotFoundError(name),
+    );
+    const meta = JSON.parse(traced.json) as {
+      kind?: string;
+      default_branch?: string;
+    };
+    if ((meta.kind ?? FILESYSTEM_REPO_KIND) !== FILESYSTEM_REPO_KIND) {
+      throw new FilesystemNotFoundError(name);
+    }
+    return new Filesystem(
+      this,
+      this.native,
+      this.cli,
+      name,
+      meta.default_branch || "main",
+    );
+  }
+
+  /** List all filesystems in the project. */
+  async list(): Promise<FilesystemInfo[]> {
+    const traced = await callNative(() => this.native.listFilesystems());
+    const page = JSON.parse(traced.json) as {
+      repos?: Array<Record<string, unknown>>;
+    };
+    return (page.repos ?? []).map((repo) => ({
+      name: String(repo.name ?? ""),
+      fullName: String(repo.full_name ?? ""),
+      defaultBranch: String(repo.default_branch ?? "main"),
+      status: String(repo.status ?? ""),
+      kind: String(repo.kind ?? FILESYSTEM_REPO_KIND),
+    }));
+  }
+
+  /** Permanently delete a filesystem and all its snapshots. */
+  async delete(name: string): Promise<void> {
+    await callNative(
+      () => this.native.deleteFilesystem(name),
+      new FilesystemNotFoundError(name),
+    );
+  }
+
+  // -- local mounts -------------------------------------------------------------
+
+  /** Mount a filesystem to a local path (requires the `tl` CLI). */
+  async mount(
+    name: string,
+    localPath: string,
+    readonly = false,
+  ): Promise<FilesystemMount> {
+    await this.cli.mount(name, localPath, readonly);
+    return new FilesystemMount(this, this.cli, name, localPath, readonly);
+  }
+
+  /**
+   * Unmount a locally mounted filesystem.
+   *
+   * `discard: true` drops local changes that were not yet uploaded.
+   */
+  async unmount(localPath: string, discard = false): Promise<void> {
+    await this.cli.unmount(localPath, discard);
+  }
+
+  /** Status of a local mount (defaults to the mount containing CWD). */
+  async mountStatus(localPath?: string): Promise<MountStatus> {
+    return mountStatusFromRaw(await this.cli.status(localPath), localPath);
+  }
+}
+
+type FileData = Uint8Array | string;
+
+function toBuffer(data: FileData): Buffer {
+  return typeof data === "string" ? Buffer.from(data, "utf-8") : Buffer.from(data);
+}
+
+/** Handle to one filesystem; reads/writes go through the Rust core. */
+export class Filesystem {
+  private readonly client: FilesystemClient;
+  private readonly native: NativeRepositoryClient;
+  private readonly cli: FsCli;
+  readonly name: string;
+  private defaultBranch: string | null;
+
+  /** @internal — obtain instances via `FilesystemClient.create()` / `.get()`. */
+  constructor(
+    client: FilesystemClient,
+    native: NativeRepositoryClient,
+    cli: FsCli,
+    name: string,
+    defaultBranch: string | null = null,
+  ) {
+    this.client = client;
+    this.native = native;
+    this.cli = cli;
+    this.name = name;
+    this.defaultBranch = defaultBranch;
+  }
+
+  /**
+   * The filesystem's default branch — the target of every write and the
+   * default version of every read, so writes and `status()` can never
+   * silently disagree on a non-"main" filesystem.
+   */
+  private async branch(): Promise<string> {
+    if (!this.defaultBranch) {
+      const traced = await callNative(
+        () => this.native.filesystemMeta(this.name),
+        new FilesystemNotFoundError(this.name),
+      );
+      const meta = JSON.parse(traced.json) as { default_branch?: string };
+      this.defaultBranch = meta.default_branch || "main";
+    }
+    return this.defaultBranch;
+  }
+
+  // -- writes -------------------------------------------------------------------
+
+  /** Write one file. Returns the snapshot (version) the write produced. */
+  async writeFile(
+    path: string,
+    data: FileData,
+    message?: string,
+  ): Promise<Snapshot> {
+    return await this.writeFiles(new Map([[path, data]]), message);
+  }
+
+  /** Write several files (and/or delete paths) in one atomic snapshot. */
+  async writeFiles(
+    files: Map<string, FileData> | Record<string, FileData>,
+    message?: string,
+    deletes: string[] = [],
+  ): Promise<Snapshot> {
+    const entries =
+      files instanceof Map ? [...files.entries()] : Object.entries(files);
+    if (entries.length === 0 && deletes.length === 0) {
+      throw new FilesystemError("nothing to write: no files or deletions given");
+    }
+    const writes = entries.map(([path, data]) => ({
+      path,
+      content: toBuffer(data),
+    }));
+    // Truthiness, not nullish: an explicit "" gets the default too (parity
+    // with the Python SDK).
+    const resolvedMessage = message || `write ${writes.length} file(s) via SDK`;
+    const branch = await this.branch();
+    const traced = await callNative(
+      () =>
+        this.native.pushFilesystemFiles(
+          this.name,
+          writes,
+          deletes,
+          resolvedMessage,
+          branch,
+          // One key per logical write: a retried submit reattaches to the
+          // same durable commit job instead of double-committing.
+          randomBytes(16).toString("hex"),
+        ),
+      new FilesystemNotFoundError(this.name),
+    );
+    const report = JSON.parse(traced.json) as Record<string, unknown>;
+    return {
+      commit: String(report.commit ?? ""),
+      tree: String(report.tree ?? ""),
+      refName: String(report.ref_name ?? ""),
+      parent: null,
+      created: report.created === undefined ? true : Boolean(report.created),
+      message: resolvedMessage,
+    };
+  }
+
+  /** Delete one file. Returns the snapshot the deletion produced. */
+  async deleteFile(path: string, message?: string): Promise<Snapshot> {
+    return await this.writeFiles(
+      new Map(),
+      message || `delete ${path} via SDK`,
+      [path],
+    );
+  }
+
+  /**
+   * Return the filesystem's current version as a snapshot.
+   *
+   * Writes already create snapshots implicitly; this pins the current head
+   * without changing any content.
+   */
+  async snapshot(message = ""): Promise<Snapshot> {
+    const status = await this.status();
+    if (!status.headCommit) {
+      throw new FilesystemError(
+        `filesystem ${this.name} is empty: write files first`,
+      );
+    }
+    return {
+      commit: status.headCommit,
+      tree: "",
+      refName: `refs/heads/${status.defaultBranch}`,
+      parent: null,
+      created: false,
+      message,
+    };
+  }
+
+  // -- reads --------------------------------------------------------------------
+
+  /**
+   * Read a file's bytes at `version` (branch, ref, or snapshot commit;
+   * defaults to the filesystem's default branch).
+   */
+  async readFile(path: string, version?: string): Promise<Uint8Array> {
+    if (path.replace(/^\/+|\/+$/g, "") === "") {
+      throw new FilesystemError("file path must not be empty");
+    }
+    const resolvedVersion = version || (await this.branch());
+    const traced = await callNative(
+      () => this.native.readFilesystemFile(this.name, path, resolvedVersion),
+      new FileNotFoundInFilesystemError(this.name, path),
+    );
+    return new Uint8Array(traced.data);
+  }
+
+  /** Read a file as UTF-8 text at `version`. Throws on non-UTF-8 content. */
+  async readText(path: string, version?: string): Promise<string> {
+    // fatal: parity with Python's strict bytes.decode("utf-8") — corrupt
+    // data must raise, never silently decode to replacement characters.
+    // ignoreBOM keeps a leading U+FEFF, exactly as Python does.
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+      await this.readFile(path, version),
+    );
+  }
+
+  /** List one directory (non-recursive) at `version`. */
+  async listFiles(dirPath = "", version?: string): Promise<FileEntry[]> {
+    const resolvedVersion = version || (await this.branch());
+    const traced = await callNative(
+      () => this.native.listFilesystemTree(this.name, dirPath, resolvedVersion),
+      new FileNotFoundInFilesystemError(this.name, dirPath || "/"),
+    );
+    const page = JSON.parse(traced.json) as {
+      entries?: Array<{ name: string; oid?: string; mode?: number; size?: number | null }>;
+    };
+    return (page.entries ?? []).map((entry) => fileEntryFromWire(entry, dirPath));
+  }
+
+  // -- status -------------------------------------------------------------------
+
+  /** Remote status: identity plus the current head snapshot. */
+  async status(): Promise<FilesystemStatus> {
+    const metaTraced = await callNative(
+      () => this.native.filesystemMeta(this.name),
+      new FilesystemNotFoundError(this.name),
+    );
+    const meta = JSON.parse(metaTraced.json) as Record<string, unknown>;
+    const defaultBranch = String(meta.default_branch || "main");
+    this.defaultBranch = defaultBranch;
+    let headCommit: string | null = null;
+    let generation: number | null = null;
+    try {
+      // A 404 here means "no such ref yet" (an empty filesystem), so it is
+      // deliberately NOT mapped to FilesystemNotFoundError.
+      const refTraced = await callNative(() =>
+        this.native.filesystemRefStatus(this.name, defaultBranch),
+      );
+      const ref = JSON.parse(refTraced.json) as Record<string, unknown>;
+      headCommit =
+        (ref.resolved_commit as string) || (ref.oid as string) || null;
+      generation = typeof ref.generation === "number" ? ref.generation : null;
+    } catch (error) {
+      // Only "no such ref yet" means an empty filesystem; anything else
+      // (auth, 5xx) must not masquerade as one.
+      if (!(error instanceof FilesystemAPIError) || error.statusCode !== 404) {
+        throw error;
+      }
+    }
+    return {
+      name: this.name,
+      status: String(meta.status ?? ""),
+      defaultBranch,
+      headCommit,
+      generation,
+    };
+  }
+
+  // -- mounts -------------------------------------------------------------------
+
+  /** Mount this filesystem to a local path (requires the `tl` CLI). */
+  async mount(localPath: string, readonly = false): Promise<FilesystemMount> {
+    return await this.client.mount(this.name, localPath, readonly);
+  }
+}
+
+/** A filesystem mounted to a local path via the `tl` CLI daemon. */
+export class FilesystemMount {
+  private readonly client: FilesystemClient;
+  private readonly cli: FsCli;
+  readonly filesystem: string;
+  readonly path: string;
+  readonly readonly: boolean;
+
+  /** @internal — obtain instances via `FilesystemClient.mount()`. */
+  constructor(
+    client: FilesystemClient,
+    cli: FsCli,
+    filesystem: string,
+    path: string,
+    readonly: boolean,
+  ) {
+    this.client = client;
+    this.cli = cli;
+    this.filesystem = filesystem;
+    this.path = path;
+    this.readonly = readonly;
+  }
+
+  /** Flush pending local changes into a durable snapshot. */
+  async snapshot(message?: string): Promise<void> {
+    await this.cli.snapshot(this.path, message);
+  }
+
+  /** Local mount status as reported by the mount daemon. */
+  async status(): Promise<MountStatus> {
+    return await this.client.mountStatus(this.path);
+  }
+
+  /** Unmount; `discard: true` drops changes not yet uploaded. */
+  async unmount(discard = false): Promise<void> {
+    await this.client.unmount(this.path, discard);
+  }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -19,6 +19,27 @@ export {
   listFileSystems,
   deleteFileSystem,
 } from "./file-system.js";
+export {
+  FilesystemClient,
+  Filesystem,
+  FilesystemMount,
+} from "./filesystem.js";
+export type { FilesystemClientOptions } from "./filesystem.js";
+export {
+  FilesystemError,
+  FilesystemNotFoundError,
+  FileNotFoundInFilesystemError,
+  FilesystemAPIError,
+  MountError,
+  CliNotFoundError,
+} from "./filesystem-models.js";
+export type {
+  FilesystemInfo,
+  FilesystemStatus,
+  FileEntry,
+  Snapshot,
+  MountStatus,
+} from "./filesystem-models.js";
 export { Image, dockerfileContent, ImageBuildOperationType } from "./image.js";
 export { sandboxUrlFromIngressEndpoint } from "./url.js";
 

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -164,6 +164,29 @@ export interface NativeRepositoryClient {
     base?: string | null,
   ): Promise<TracedJson>;
   commitConflicts(repo: string, commit: string): Promise<TracedJson>;
+  createFilesystem(name: string): Promise<string>;
+  listFilesystems(): Promise<TracedJson>;
+  filesystemMeta(name: string): Promise<TracedJson>;
+  deleteFilesystem(name: string): Promise<string>;
+  filesystemRefStatus(name: string, refspec: string): Promise<TracedJson>;
+  readFilesystemFile(
+    name: string,
+    path: string,
+    version: string,
+  ): Promise<TracedBytes>;
+  listFilesystemTree(
+    name: string,
+    dirPath: string,
+    version: string,
+  ): Promise<TracedJson>;
+  pushFilesystemFiles(
+    name: string,
+    files: Array<{ path: string; content: Buffer }>,
+    deletes: string[],
+    message: string,
+    branch: string,
+    idempotencyKey?: string | null,
+  ): Promise<TracedJson>;
 }
 
 interface NativeSandboxClientCtor {

--- a/typescript/tests/filesystem.test.ts
+++ b/typescript/tests/filesystem.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Network-free unit tests for the filesystem SDK.
+ *
+ * The wire protocol (chunking, ingest, commit jobs, retries) lives in the
+ * Rust cloud-sdk core and is tested there. These tests pin the TypeScript
+ * wrapper: how native results map to models, how native errors translate
+ * into the filesystem error hierarchy, and the idempotency-key discipline on
+ * writes. The native client is injected through the `nativeClient` test seam.
+ */
+
+import { describe, expect, it } from "vitest";
+import { FilesystemClient } from "../src/filesystem.js";
+import {
+  FileNotFoundInFilesystemError,
+  FilesystemAPIError,
+  FilesystemError,
+  FilesystemNotFoundError,
+  fileEntryFromWire,
+  mountStatusFromRaw,
+} from "../src/filesystem-models.js";
+import type {
+  NativeRepositoryClient,
+  TracedBytes,
+  TracedJson,
+} from "../src/native-sandbox.js";
+
+const PROJECT = "proj_test";
+const COMMIT = "c".repeat(40);
+
+type NativeErrorSpec = { category: string; status: number | null; message: string };
+
+function nativeError(spec: NativeErrorSpec): Error {
+  return new Error(JSON.stringify(spec));
+}
+
+function traced(json: unknown): TracedJson {
+  return { traceId: "trace-1", json: JSON.stringify(json) };
+}
+
+interface StubOptions {
+  meta?: Record<string, unknown>;
+  repos?: Array<Record<string, unknown>>;
+  ref?: Record<string, unknown>;
+  entries?: Array<Record<string, unknown>>;
+  fileBytes?: Buffer;
+  pushReport?: Record<string, unknown>;
+  errors?: Record<string, NativeErrorSpec>;
+  createBranch?: string;
+}
+
+/** Scripted stand-in for the napi NativeRepositoryClient filesystem surface. */
+class StubNative {
+  readonly calls: Array<{ method: string; args: unknown[] }> = [];
+  private readonly options: StubOptions;
+
+  constructor(options: StubOptions = {}) {
+    this.options = options;
+  }
+
+  private record(method: string, args: unknown[]): void {
+    this.calls.push({ method, args });
+    const failure = this.options.errors?.[method];
+    if (failure) throw nativeError(failure);
+  }
+
+  async createFilesystem(name: string): Promise<string> {
+    this.record("createFilesystem", [name]);
+    return JSON.stringify({
+      trace_id: "trace-1",
+      // Non-"main" simulates the binding adopting a pre-existing filesystem
+      // on a lost-response retry.
+      default_branch: this.options.createBranch ?? "main",
+    });
+  }
+
+  async listFilesystems(): Promise<TracedJson> {
+    this.record("listFilesystems", []);
+    return traced({
+      project: PROJECT,
+      repos: this.options.repos ?? [],
+      next_after: null,
+    });
+  }
+
+  async filesystemMeta(name: string): Promise<TracedJson> {
+    this.record("filesystemMeta", [name]);
+    return traced(
+      this.options.meta ?? {
+        name: "my-fs",
+        full_name: `${PROJECT}/my-fs`,
+        default_branch: "main",
+        status: "active",
+        kind: "filesystem",
+      },
+    );
+  }
+
+  async deleteFilesystem(name: string): Promise<string> {
+    this.record("deleteFilesystem", [name]);
+    return "trace-2";
+  }
+
+  async filesystemRefStatus(name: string, refspec: string): Promise<TracedJson> {
+    this.record("filesystemRefStatus", [name, refspec]);
+    return traced(
+      this.options.ref ?? {
+        ref_name: "refs/heads/main",
+        oid: COMMIT,
+        resolved_commit: COMMIT,
+        generation: 3,
+      },
+    );
+  }
+
+  async readFilesystemFile(
+    name: string,
+    path: string,
+    version: string,
+  ): Promise<TracedBytes> {
+    this.record("readFilesystemFile", [name, path, version]);
+    return { traceId: "trace-1", data: this.options.fileBytes ?? Buffer.alloc(0) };
+  }
+
+  async listFilesystemTree(
+    name: string,
+    dirPath: string,
+    version: string,
+  ): Promise<TracedJson> {
+    this.record("listFilesystemTree", [name, dirPath, version]);
+    return traced({ entries: this.options.entries ?? [] });
+  }
+
+  async pushFilesystemFiles(
+    name: string,
+    files: Array<{ path: string; content: Buffer }>,
+    deletes: string[],
+    message: string,
+    branch: string,
+    idempotencyKey?: string | null,
+  ): Promise<TracedJson> {
+    this.record("pushFilesystemFiles", [
+      name,
+      files,
+      deletes,
+      message,
+      branch,
+      idempotencyKey,
+    ]);
+    return traced(
+      this.options.pushReport ?? {
+        commit: COMMIT,
+        tree: "t".repeat(40),
+        ref_name: "refs/heads/main",
+        created: true,
+      },
+    );
+  }
+}
+
+function clientWith(stub: StubNative): FilesystemClient {
+  return new FilesystemClient({
+    apiKey: "test-key",
+    apiUrl: "https://api.tensorlake.ai",
+    organizationId: "org_test",
+    projectId: PROJECT,
+    nativeClient: stub as unknown as NativeRepositoryClient,
+  });
+}
+
+describe("filesystem models", () => {
+  it("maps tree entries to FileEntry", () => {
+    const dir = fileEntryFromWire({ name: "d", oid: "x", mode: 0o40000 }, "docs");
+    expect(dir.isDir).toBe(true);
+    expect(dir.path).toBe("docs/d");
+    const file = fileEntryFromWire({ name: "f", mode: 0o100644, size: 3 }, "");
+    expect(file.isDir).toBe(false);
+    expect(file.path).toBe("f");
+  });
+
+  it("maps mount status with Python-parity semantics", () => {
+    const status = mountStatusFromRaw(
+      {
+        path: "",
+        mount_path: "/mnt/x",
+        mounted: null,
+        active: true,
+        filesystem: "",
+      },
+      "/ignored",
+    );
+    // Empty path falls through to mount_path; a present-but-null "mounted"
+    // means not mounted; empty filesystem becomes null.
+    expect(status.path).toBe("/mnt/x");
+    expect(status.mounted).toBe(false);
+    expect(status.filesystem).toBeNull();
+
+    const defaulted = mountStatusFromRaw({}, "/mnt/y");
+    expect(defaulted.path).toBe("/mnt/y");
+    expect(defaulted.mounted).toBe(true);
+  });
+});
+
+describe("FilesystemClient", () => {
+  it("runs the lifecycle against the native core", async () => {
+    const stub = new StubNative({
+      repos: [
+        {
+          name: "a",
+          full_name: `${PROJECT}/a`,
+          default_branch: "main",
+          status: "active",
+          kind: "filesystem",
+        },
+      ],
+    });
+    const client = clientWith(stub);
+    const fs = await client.create("my-fs");
+    expect(fs.name).toBe("my-fs");
+    const infos = await client.list();
+    expect(infos.map((i) => i.name)).toEqual(["a"]);
+    expect(infos[0].fullName).toBe(`${PROJECT}/a`);
+    await client.delete("my-fs");
+    expect(stub.calls.map((c) => c.method)).toEqual([
+      "createFilesystem",
+      "listFilesystems",
+      "deleteFilesystem",
+    ]);
+  });
+
+  it("maps a 404 meta to FilesystemNotFoundError", async () => {
+    const stub = new StubNative({
+      errors: {
+        filesystemMeta: { category: "remote_api", status: 404, message: "no repo" },
+      },
+    });
+    await expect(clientWith(stub).get("nope")).rejects.toThrow(
+      FilesystemNotFoundError,
+    );
+  });
+
+  it("rejects a non-filesystem repo kind", async () => {
+    const stub = new StubNative({
+      meta: { name: "code", default_branch: "main", kind: "repository" },
+    });
+    await expect(clientWith(stub).get("code")).rejects.toThrow(
+      FilesystemNotFoundError,
+    );
+  });
+
+  it("maps push reports to snapshots and sets a stable idempotency key", async () => {
+    const stub = new StubNative();
+    const client = clientWith(stub);
+    const fs = await client.create("my-fs");
+    const snapshot = await fs.writeFiles(
+      new Map<string, Uint8Array | string>([
+        ["a.txt", "hello"],
+        ["b.bin", new Uint8Array([0, 1])],
+      ]),
+      undefined,
+      ["old.txt"],
+    );
+    expect(snapshot.commit).toBe(COMMIT);
+    expect(snapshot.created).toBe(true);
+
+    const push = stub.calls.at(-1)!;
+    expect(push.method).toBe("pushFilesystemFiles");
+    const [name, files, deletes, , branch, idempotencyKey] = push.args as [
+      string,
+      Array<{ path: string; content: Buffer }>,
+      string[],
+      string,
+      string,
+      string,
+    ];
+    expect(name).toBe("my-fs");
+    expect(files.map((f) => f.path)).toEqual(["a.txt", "b.bin"]);
+    expect(files[0].content.toString()).toBe("hello");
+    expect([...files[1].content]).toEqual([0, 1]);
+    expect(deletes).toEqual(["old.txt"]);
+    expect(branch).toBe("main");
+    // A fresh stable key per logical write (the Rust core reuses it across
+    // its retries so a lost response cannot double-commit).
+    expect(idempotencyKey).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("rejects an empty write", async () => {
+    const client = clientWith(new StubNative());
+    const fs = await client.create("my-fs");
+    await expect(fs.writeFiles(new Map())).rejects.toThrow(FilesystemError);
+  });
+
+  it("reads files and maps missing files", async () => {
+    const stub = new StubNative({ fileBytes: Buffer.from("content") });
+    const client = clientWith(stub);
+    const fs = await client.create("my-fs");
+    expect(Buffer.from(await fs.readFile("docs/a.txt")).toString()).toBe(
+      "content",
+    );
+    expect(stub.calls.at(-1)!.args).toEqual(["my-fs", "docs/a.txt", "main"]);
+
+    const failing = new StubNative({
+      errors: {
+        readFilesystemFile: {
+          category: "remote_api",
+          status: 404,
+          message: "not found",
+        },
+      },
+    });
+    const failingFs = await clientWith(failing).create("my-fs");
+    await expect(failingFs.readFile("missing.txt")).rejects.toThrow(
+      FileNotFoundInFilesystemError,
+    );
+    await expect(failingFs.readFile("//")).rejects.toThrow(FilesystemError);
+  });
+
+  it("lists files with paths and modes", async () => {
+    const stub = new StubNative({
+      entries: [
+        { name: "sub", oid: "x", mode: 0o40000 },
+        { name: "a.txt", oid: "y", mode: 0o100644, size: 3 },
+      ],
+    });
+    const client = clientWith(stub);
+    const fs = await client.create("my-fs");
+    const entries = await fs.listFiles("docs");
+    expect(entries.map((e) => e.path)).toEqual(["docs/sub", "docs/a.txt"]);
+    expect(entries[0].isDir).toBe(true);
+    expect(entries[1].size).toBe(3);
+  });
+
+  it("maps status, including an empty filesystem", async () => {
+    const client = clientWith(new StubNative());
+    const fs = await client.create("my-fs");
+    const status = await fs.status();
+    expect(status.headCommit).toBe(COMMIT);
+    expect(status.generation).toBe(3);
+
+    const empty = new StubNative({
+      ref: { ref_name: "refs/heads/main", oid: null, resolved_commit: null, generation: 0 },
+    });
+    const emptyFs = await clientWith(empty).create("my-fs");
+    expect((await emptyFs.status()).headCommit).toBeNull();
+    await expect(emptyFs.snapshot("nothing yet")).rejects.toThrow(
+      FilesystemError,
+    );
+  });
+
+  it("swallows only 404 from ref-status", async () => {
+    const notFound = new StubNative({
+      errors: {
+        filesystemRefStatus: { category: "remote_api", status: 404, message: "no ref" },
+      },
+    });
+    const fs = await clientWith(notFound).create("my-fs");
+    expect((await fs.status()).headCommit).toBeNull();
+
+    const unavailable = new StubNative({
+      errors: {
+        filesystemRefStatus: {
+          category: "remote_api",
+          status: 503,
+          message: "unavailable",
+        },
+      },
+    });
+    const failingFs = await clientWith(unavailable).create("my-fs");
+    await expect(failingFs.status()).rejects.toThrow(FilesystemAPIError);
+  });
+
+  it("pins the current head as a snapshot", async () => {
+    const fs = await clientWith(new StubNative()).create("my-fs");
+    const snapshot = await fs.snapshot("pin");
+    expect(snapshot.commit).toBe(COMMIT);
+    expect(snapshot.created).toBe(false);
+  });
+
+  it("seeds the branch reported by the create binding", async () => {
+    const stub = new StubNative({ createBranch: "trunk" });
+    const fs = await clientWith(stub).create("my-fs");
+    await fs.writeFile("a.txt", "x");
+    // (name, files, deletes, message, branch, idempotencyKey)
+    expect(stub.calls.at(-1)!.args[4]).toBe("trunk");
+  });
+
+  it("follows a non-main default branch for writes and reads", async () => {
+    const stub = new StubNative({
+      meta: {
+        name: "my-fs",
+        default_branch: "trunk",
+        status: "active",
+        kind: "filesystem",
+      },
+    });
+    const client = clientWith(stub);
+    const fs = await client.get("my-fs");
+    await fs.writeFile("a.txt", "x");
+    // (name, files, deletes, message, branch, idempotencyKey)
+    expect(stub.calls.at(-1)!.args[4]).toBe("trunk");
+    await fs.readFile("a.txt");
+    // (name, path, version)
+    expect(stub.calls.at(-1)!.args[2]).toBe("trunk");
+    await fs.listFiles();
+    expect(stub.calls.at(-1)!.args[2]).toBe("trunk");
+    // An explicit version always wins over the default branch.
+    await fs.readFile("a.txt", "c".repeat(40));
+    expect(stub.calls.at(-1)!.args[2]).toBe("c".repeat(40));
+  });
+
+  it("readText raises on non-UTF-8 content instead of mangling it", async () => {
+    const stub = new StubNative({ fileBytes: Buffer.from([0xff, 0xfe]) });
+    const fs = await clientWith(stub).create("my-fs");
+    await expect(fs.readText("a.bin")).rejects.toThrow();
+  });
+
+  it("rejects empty and non-string names with the right error types", async () => {
+    const client = clientWith(new StubNative());
+    await expect(client.create("")).rejects.toThrow(FilesystemError);
+    await expect(client.create("")).rejects.toThrow(/must not be empty/);
+    await expect(
+      client.create(123 as unknown as string),
+    ).rejects.toThrow(TypeError);
+  });
+
+  it("substitutes the default message for an explicit empty string", async () => {
+    const stub = new StubNative();
+    const fs = await clientWith(stub).create("my-fs");
+    const snapshot = await fs.writeFile("a.txt", "x", "");
+    const message = stub.calls.at(-1)!.args[3];
+    expect(message).toBe("write 1 file(s) via SDK");
+    expect(snapshot.message).toBe("write 1 file(s) via SDK");
+  });
+
+  it("maps connection-category errors to FilesystemError, not APIError", async () => {
+    const stub = new StubNative({
+      errors: {
+        readFilesystemFile: {
+          category: "connection",
+          // The napi layer fabricates a gateway status for connect failures;
+          // it must not surface as a server FilesystemAPIError.
+          status: 503,
+          message: "connect ECONNREFUSED",
+        },
+      },
+    });
+    const fs = await clientWith(stub).create("my-fs");
+    const failure = await fs.readFile("a.txt").catch((e) => e);
+    expect(failure).toBeInstanceOf(FilesystemError);
+    expect(failure).not.toBeInstanceOf(FilesystemAPIError);
+  });
+
+  it("translates statusless native errors to FilesystemError", async () => {
+    const stub = new StubNative({
+      errors: {
+        pushFilesystemFiles: {
+          category: "internal",
+          status: null,
+          message: "commit job failed (conflict): boom",
+        },
+      },
+    });
+    const fs = await clientWith(stub).create("my-fs");
+    const failure = await fs.writeFile("a.txt", "x").catch((e) => e);
+    expect(failure).toBeInstanceOf(FilesystemError);
+    expect(failure).not.toBeInstanceOf(FilesystemAPIError);
+    expect(String(failure.message)).toContain("commit job failed");
+  });
+});

--- a/typescript/tests/filesystem.test.ts
+++ b/typescript/tests/filesystem.test.ts
@@ -17,6 +17,7 @@ import {
   FilesystemNotFoundError,
   fileEntryFromWire,
   mountStatusFromRaw,
+  trimSlashes,
 } from "../src/filesystem-models.js";
 import type {
   NativeRepositoryClient,
@@ -175,6 +176,14 @@ describe("filesystem models", () => {
     const file = fileEntryFromWire({ name: "f", mode: 0o100644, size: 3 }, "");
     expect(file.isDir).toBe(false);
     expect(file.path).toBe("f");
+  });
+
+  it("trims slashes in linear time with Python strip('/') semantics", () => {
+    expect(trimSlashes("/a/b/")).toBe("a/b");
+    expect(trimSlashes("///a//b///")).toBe("a//b");
+    expect(trimSlashes("////")).toBe("");
+    expect(trimSlashes("")).toBe("");
+    expect(trimSlashes("a")).toBe("a");
   });
 
   it("maps mount status with Python-parity semantics", () => {


### PR DESCRIPTION
Fixes the remaining half of the original slow-mount report (tensorlakeai/artifact_storage#147 item 9): human `tl fs status` run outside a project directory showed `last autosave: unknown (missing project ID; run tl init)` (historically the blanket "server unavailable") because the command returned before `hydrate_scope_from_mount` ran.

The hydration is local-only (cached attach-time mount facts, never the network) and is called best-effort, so the offline-diagnostic contract of human status is preserved: with an unreachable server or invalid credentials the local report still prints.

Verified against a live mount: from `/`, status now reports the real last-autosave and permanent-snapshot count; with a bogus `TENSORLAKE_API_KEY` the full local report still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)