### PR TITLE
Bump Tensorlake packages to 0.5.88

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.87"
+version = "0.5.88"
 dependencies = [
  "anyhow",
  "base64",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.87"
+version = "0.5.88"
 dependencies = [
  "anyhow",
  "base64",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.87"
+version = "0.5.88"
 dependencies = [
  "anyhow",
  "base64",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.87"
+version = "0.5.88"
 dependencies = [
  "napi",
  "napi-build",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.87"
+version = "0.5.88"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.87"
+version = "0.5.88"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -2,7 +2,7 @@
 # only `src/`, keeping this workspace-adapted dependency manifest.
 [package]
 name = "gsvc-fs-client"
-version = "0.5.87"
+version = "0.5.88"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.87"
+version = "0.5.88"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.87"
+version = "0.5.88"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.87",
+  "version": "0.5.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.87",
+      "version": "0.5.88",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.87",
+  "version": "0.5.88",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the Tensorlake Rust workspace and CLI packages from 0.5.87 to 0.5.88
- bump Python package metadata for `tensorlake` and `tensorlake-rust-cloud-sdk`
- bump the TypeScript package and lockfile metadata
- keep the public `gsvc-fs-client` resolution placeholder aligned with the release version
- refresh the affected Cargo lockfile package versions

## Why

This is the companion release bump for tensorlakeai/artifact_storage#159, which adds macOS FSKit wire protocol v5 and explicit volume synchronization. Official full CLI builds inject the private FS client source, so the Tensorlake release needs a new version and matching placeholder metadata to package the updated signed FSKit client bundle.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tensorlake-cli --locked`
- `cargo metadata --format-version 1 --no-deps --locked` confirms all four workspace release packages are 0.5.88
- verified the excluded `gsvc-fs-client` placeholder, Python metadata, TypeScript package, and TypeScript lockfile all report 0.5.88
- `npm --prefix typescript install --package-lock-only --ignore-scripts` produced no additional lockfile changes

Depends on tensorlakeai/artifact_storage#159.
