### PR TITLE
Publish Cloud Volume files directly to blob storage

### DIFF
--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -6,6 +6,8 @@ on:
   pull_request:
     paths:
       - "typescript/**"
+      - "crates/rust-cloud-sdk-node/**"
+      - "Cargo.lock"
       - ".github/workflows/typescript_sdk.yaml"
 
   push:
@@ -13,6 +15,8 @@ on:
       - "main"
     paths:
       - "typescript/**"
+      - "crates/rust-cloud-sdk-node/**"
+      - "Cargo.lock"
       - ".github/workflows/typescript_sdk.yaml"
 
 permissions:
@@ -105,6 +109,7 @@ jobs:
 
   integration-tests:
     name: Integration tests
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: prod
@@ -174,4 +179,6 @@ jobs:
         run: npm run test:integration
         env:
           TENSORLAKE_API_KEY: ${{ secrets.TENSORLAKE_API_KEY }}
+          TENSORLAKE_ORGANIZATION_ID: ${{ vars.TENSORLAKE_ORGANIZATION_ID }}
+          TENSORLAKE_PROJECT_ID: ${{ vars.TENSORLAKE_PROJECT_ID }}
           TENSORLAKE_TEST_CLEANUP_GRACE_SECS: "60"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,6 +3883,7 @@ dependencies = [
  "serde_json",
  "tensorlake",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -3899,6 +3900,7 @@ dependencies = [
  "tensorlake",
  "tokio",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -141,6 +141,52 @@ sandbox = client.connect("stable-name")
 
 ---
 
+## Cloud Volumes
+
+`FilesystemClient` manages durable, versioned file trees without mounting them. SDK writes hash
+files locally, upload missing 64 MiB parts directly to checksum-bound object-store URLs, and then
+atomically publish metadata. File payloads do not pass through the Tensorlake API service.
+
+```ts
+import { FilesystemClient } from "tensorlake";
+
+const client = new FilesystemClient({
+  apiKey: "your-api-key",
+  organizationId: "org_...",
+  projectId: "proj_...",
+});
+const fs = await client.create("agent-artifacts");
+
+// In-memory data; all changes become visible atomically.
+await fs.writeFiles({
+  "run/config.json": JSON.stringify({ model: "gpt-5" }),
+  "run/input.txt": "hello",
+});
+
+// Multi-GiB files use bounded memory and stream directly to object storage.
+await fs.writeFileFromPath("models/weights.bin", "./weights.bin");
+
+// These reuse immutable content references and transfer no payload bytes.
+await fs.copyFile("run/input.txt", "run/input-copy.txt");
+await fs.moveFile("run/config.json", "archive/config.json");
+
+// Snapshot retention and forks are metadata-only operations.
+const snapshot = await fs.snapshot("ready for evaluation");
+const fork = await client.fork("agent-artifacts-eval", fs.name, snapshot.id);
+await fork.writeFile("results/score.txt", "0.98");
+
+await fs.deleteSnapshot(snapshot.id);
+```
+
+`writeFile()` and `writeFiles()` accept bytes already in memory. Prefer `writeFileFromPath()` or
+`writeFilesFromPaths()` for large local files so neither JavaScript nor Rust retains the complete
+payload. A successful write is durable before it returns, but only the live head is retained
+automatically; `snapshot()` pins the current head permanently in one client/server round trip.
+Deleting a snapshot releases that retention root, while bytes still reachable from a live head,
+another snapshot, a fork, or a mount remain durable.
+
+---
+
 ## Orchestrate
 
 Create orchestration APIs on a distributed runtime with automatic scaling, fan-out capabilities and built-in tracking. The orchestration APIs can be invoked using HTTP requests or using the Python SDK.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ await fs.writeFileFromPath("models/weights.bin", "./weights.bin");
 await fs.copyFile("run/input.txt", "run/input-copy.txt");
 await fs.moveFile("run/config.json", "archive/config.json");
 
+// One request returns only the selected bytes plus full-file identity/size.
+const read = await fs.readFileWithMetadata("models/weights.bin", {
+  range: { offset: 0, length: 1024 * 1024 },
+});
+
 // Snapshot retention and forks are metadata-only operations.
 const snapshot = await fs.snapshot("ready for evaluation");
 const fork = await client.fork("agent-artifacts-eval", fs.name, snapshot.id);
@@ -182,6 +187,8 @@ await fs.deleteSnapshot(snapshot.id);
 `writeFilesFromPaths()` for large local files so neither JavaScript nor Rust retains the complete
 payload. A successful write is durable before it returns, but only the live head is retained
 automatically; `snapshot()` pins the current head permanently in one client/server round trip.
+`readFileWithMetadata()` returns immutable content identity and total size with the bytes; its
+optional range is executed server-side rather than downloading and slicing the complete file.
 Deleting a snapshot releases that retention root, while bytes still reachable from a live head,
 another snapshot, a fork, or a mount remain durable.
 

--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -101,7 +101,7 @@ pub async fn mint_token(ctx: &CliContext, repo: Option<&str>, output_json: bool)
                 .green()
         );
         println!("  {} {}", style("username:").dim(), credential.git_username);
-        println!("  {} {}", style("password:").dim(), "the token above");
+        println!("  {} the token above", style("password:").dim());
     }
     Ok(())
 }
@@ -351,8 +351,7 @@ fn normalize_repo_arg(repo: &str) -> String {
     url.path_segments()
         .into_iter()
         .flatten()
-        .filter(|s| !s.is_empty())
-        .next_back()
+        .rfind(|s| !s.is_empty())
         .map(|s| s.strip_suffix(".git").unwrap_or(s).to_string())
         .unwrap_or_else(|| repo.to_string())
 }
@@ -831,9 +830,10 @@ pub(crate) fn map_sdk_error(error: tensorlake::error::SdkError) -> CliError {
             "permission denied. set TENSORLAKE_API_KEY with required permissions, or run 'tl init'.",
         ),
         tensorlake::error::SdkError::ServerError { status, message } => {
-            if status == reqwest::StatusCode::CONFLICT {
-                CliError::usage(parse_remote_message(&message))
-            } else if status == reqwest::StatusCode::NOT_FOUND {
+            if matches!(
+                status,
+                reqwest::StatusCode::CONFLICT | reqwest::StatusCode::NOT_FOUND
+            ) {
                 CliError::usage(parse_remote_message(&message))
             } else {
                 CliError::from(tensorlake::error::SdkError::ServerError { status, message })
@@ -1019,7 +1019,7 @@ pub async fn commit_status(ctx: &CliContext, repo: &str, job_id: &str) -> Result
             if let Some(read_back) = job.read_back {
                 let done = read_back.done;
                 let total = read_back.total;
-                let pct = if total > 0 { done * 100 / total } else { 0 };
+                let pct = done.saturating_mul(100).checked_div(total).unwrap_or(0);
                 println!(
                     "{} {phase}: {done}/{total} chunks ({pct}%)",
                     console::style(state).yellow().bold(),

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -136,13 +136,10 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
         file_systems,
     } = args;
 
-    let gpu = match gpu_count {
-        Some(count) => Some(GpuRequest {
-            count,
-            model: gpu_model.unwrap_or("A10"),
-        }),
-        None => None,
-    };
+    let gpu = gpu_count.map(|count| GpuRequest {
+        count,
+        model: gpu_model.unwrap_or("A10"),
+    });
 
     let mut body = build_create_request_body(
         cpus,
@@ -327,6 +324,7 @@ fn post_create_proxy_base_with_explicit(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_create_request_body(
     cpus: Option<f64>,
     memory: Option<i64>,

--- a/crates/cli/src/commands/sbx/resume.rs
+++ b/crates/cli/src/commands/sbx/resume.rs
@@ -39,10 +39,8 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str, wait: bool) -> Result<()> {
 
     if is_tty {
         eprintln!("Sandbox {} is running.", sandbox_id);
-        if wait {
-            if let Ok(target) = resolve_sandbox_proxy_target(ctx, sandbox_id).await {
-                eprintln!("{}", format_post_resume_url_line(&target));
-            }
+        if wait && let Ok(target) = resolve_sandbox_proxy_target(ctx, sandbox_id).await {
+            eprintln!("{}", format_post_resume_url_line(&target));
         }
     } else {
         println!("{sandbox_id}");

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -268,6 +268,13 @@ fn apply_path_prefix(files: &mut [PushFile], prefix: Option<&str>) -> Result<(),
     Ok(())
 }
 
+/// One content chunk's SHA-256 and logical byte length.
+pub type FileChunk = ([u8; 32], u32);
+/// Ordered chunk identities for one file.
+pub type FileChunks = Vec<FileChunk>;
+/// Per-file chunk identities collected by a push.
+pub type PushFileChunks = Vec<(String, FileChunks)>;
+
 /// Outcome of a push.
 // Fields get added (file_chunks most recently); non_exhaustive keeps external full-literal
 // construction/destructuring from breaking on this published crate's lockstep releases.
@@ -292,7 +299,7 @@ pub struct PushReport {
     /// when `PushOptions::collect_file_chunks` is set. The raw material for the next push's
     /// `PushSource::StablePrefix`. Never serialized: caller-local plumbing, not wire data.
     #[serde(skip_serializing)]
-    pub file_chunks: Vec<(String, Vec<([u8; 32], u32)>)>,
+    pub file_chunks: PushFileChunks,
     /// Internal shared-pipeline result consumed by [`ArtifactStorageClient::push_workspace_checkpoint`].
     /// Ordinary `push_files`/`push_worktree` calls always return `None`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -328,7 +335,7 @@ pub struct WorkspaceCheckpointPushReport {
     pub bytes_uploaded: u64,
     pub file_blob_oids: Vec<(String, String)>,
     #[serde(skip_serializing)]
-    pub file_chunks: Vec<(String, Vec<([u8; 32], u32)>)>,
+    pub file_chunks: PushFileChunks,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -634,7 +641,7 @@ struct ChunkedFile {
     repo_path: String,
     source: PushSource,
     /// `(sha256, size)` in file order; empty for deletes and known-oid references.
-    chunks: Vec<([u8; 32], u32)>,
+    chunks: FileChunks,
     mode: Option<u32>,
     delete: bool,
     /// The file is a `PushSource::KnownOid` reference: commit by oid, move no bytes.
@@ -653,7 +660,7 @@ fn chunk_source(
     min: usize,
     avg: usize,
     max: usize,
-) -> Result<(Vec<([u8; 32], u32)>, String), SdkError> {
+) -> Result<(FileChunks, String), SdkError> {
     let len: u64 = match source {
         PushSource::Path(p) => std::fs::metadata(p).map_err(io_err)?.len(),
         PushSource::Bytes(b) => b.len() as u64,
@@ -688,11 +695,11 @@ fn chunk_source(
 /// read (see the variant's docs).
 fn chunk_stable_prefix(
     path: &Path,
-    stable_chunks: &[([u8; 32], u32)],
+    stable_chunks: &[FileChunk],
     min: usize,
     avg: usize,
     max: usize,
-) -> Result<Vec<([u8; 32], u32)>, SdkError> {
+) -> Result<FileChunks, SdkError> {
     use std::io::Seek as _;
     let stable_len: u64 = stable_chunks.iter().map(|(_, s)| *s as u64).sum();
     let mut file = std::fs::File::open(path).map_err(io_err)?;
@@ -788,7 +795,7 @@ where
 /// file's single upload frame. CDC buys nothing under the staged threshold — those chunks are
 /// never registered for dedup server-side — so small files skip the chunker (and, downstream,
 /// the `missing` negotiation) entirely.
-fn chunk_source_whole(source: &PushSource) -> Result<(Vec<([u8; 32], u32)>, String), SdkError> {
+fn chunk_source_whole(source: &PushSource) -> Result<(FileChunks, String), SdkError> {
     let owned: Vec<u8>;
     let data: &[u8] = match source {
         PushSource::Path(p) => {
@@ -803,13 +810,13 @@ fn chunk_source_whole(source: &PushSource) -> Result<(Vec<([u8; 32], u32)>, Stri
         }
     };
     let mut blob = BlobOidHasher::new(data.len() as u64);
-    blob.update(&data);
+    blob.update(data);
     // An empty file has an empty chunk list (like the CDC path) so it publishes as inline
     // `content` — a zero-length chunk frame is rejected by the server.
     let chunks = if data.is_empty() {
         Vec::new()
     } else {
-        let hash: [u8; 32] = Sha256::digest(&data).into();
+        let hash: [u8; 32] = Sha256::digest(data).into();
         vec![(hash, data.len() as u32)]
     };
     Ok((chunks, blob.finalize_hex()))

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -19,9 +19,9 @@ use models::{
     NativeDirectBlobTargetsRequest, NativeDirectBlobTargetsResponse, NativeDirectFilePathWrite,
     NativeDirectFileWrite, NativeDirectMutation, NativeDirectPathTransfer,
     NativeDirectPublishRequest, NativeDirectPublishResponse, NativeDirectUploadLeaseResponse,
-    NativeDirectUploadReceipt, NativeFilesystemSnapshot, NativeFilesystemSnapshotPage,
-    NativeFilesystemSnapshotRetentionResponse, NativeHeadResponse, REPO_KIND_FILESYSTEM, RepoInfo,
-    RepoMetaInfo,
+    NativeDirectUploadReceipt, NativeFilesystemFileRead, NativeFilesystemSnapshot,
+    NativeFilesystemSnapshotPage, NativeFilesystemSnapshotRetentionResponse, NativeHeadResponse,
+    REPO_KIND_FILESYSTEM, RepoInfo, RepoMetaInfo,
 };
 
 #[derive(Clone)]
@@ -131,7 +131,20 @@ impl ArtifactStorageClient {
         if let Some(credential) = Self::git_credential_from_env() {
             return Ok(credential);
         }
-        Ok(self.mint_token(project_id).await?.into_inner())
+        let key = (project_id.to_string(), "*".to_string());
+        if let Some(credential) = self.repo_credentials.lock().await.get(&key).cloned()
+            && git_credential_is_fresh(&credential)
+        {
+            return Ok(credential);
+        }
+        let credential = self.mint_token(project_id).await?.into_inner();
+        if git_credential_is_fresh(&credential) {
+            self.repo_credentials
+                .lock()
+                .await
+                .insert(key, credential.clone());
+        }
+        Ok(credential)
     }
 
     pub async fn create_repo(
@@ -657,6 +670,19 @@ impl ArtifactStorageClient {
         path: &str,
         version: &str,
     ) -> Result<Traced<Vec<u8>>, SdkError> {
+        self.read_native_filesystem_file_with_metadata(project_id, filesystem, path, version, None)
+            .await
+            .map(|read| read.map(|read| read.data))
+    }
+
+    pub async fn read_native_filesystem_file_with_metadata(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+        path: &str,
+        version: &str,
+        range: Option<(u64, u64)>,
+    ) -> Result<Traced<NativeFilesystemFileRead>, SdkError> {
         let snapshot = native_snapshot_id(version)?;
         let path = encode_native_path(path)?;
         let suffix = match snapshot {
@@ -672,8 +698,52 @@ impl ArtifactStorageClient {
             &credential.git_username,
             &credential.token,
         )?;
+        let request = match range {
+            Some((offset, length)) => {
+                if length == 0 {
+                    return Err(SdkError::ClientError(
+                        "filesystem read range length must be positive".to_string(),
+                    ));
+                }
+                let end = offset.checked_add(length - 1).ok_or_else(|| {
+                    SdkError::ClientError("filesystem read range overflow".to_string())
+                })?;
+                request.header(reqwest::header::RANGE, format!("bytes={offset}-{end}"))
+            }
+            None => request,
+        };
         let response = handle_response(send_idempotent(request).await?).await?;
-        Ok(Traced::new(trace_id, response.bytes().await?.to_vec()))
+        let content_id = response
+            .headers()
+            .get("x-tensorlake-content-id")
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                SdkError::ClientError(
+                    "filesystem read response omitted content identity".to_string(),
+                )
+            })?
+            .to_string();
+        let full_size = match response.headers().get(reqwest::header::CONTENT_RANGE) {
+            Some(value) => value
+                .to_str()
+                .ok()
+                .and_then(|value| value.rsplit_once('/'))
+                .and_then(|(_, total)| total.parse::<u64>().ok()),
+            None => response.content_length(),
+        }
+        .ok_or_else(|| {
+            SdkError::ClientError("filesystem read response omitted total size".to_string())
+        })?;
+        let data = response.bytes().await?.to_vec();
+        Ok(Traced::new(
+            trace_id,
+            NativeFilesystemFileRead {
+                data,
+                content_id,
+                full_size,
+            },
+        ))
     }
 
     pub async fn list_native_filesystem_entries_page(
@@ -1064,6 +1134,7 @@ impl ArtifactStorageClient {
         for result in target_results {
             targets.targets.extend(result?.targets);
         }
+        validate_native_direct_targets(&blob_requests, &targets.targets)?;
 
         let mut receipts = Vec::new();
         let mut uploads = Vec::new();
@@ -1375,6 +1446,74 @@ fn validate_native_direct_path(path: &str) -> Result<(), SdkError> {
     Ok(())
 }
 
+fn validate_native_direct_targets(
+    requested: &[NativeDirectBlobRequest],
+    targets: &[models::NativeDirectBlobTarget],
+) -> Result<(), SdkError> {
+    use base64::Engine;
+
+    let expected = requested
+        .iter()
+        .map(|blob| (blob.blob_id.as_str(), blob.logical_len))
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut seen = std::collections::HashSet::with_capacity(targets.len());
+    for target in targets {
+        let Some(expected_len) = expected.get(target.blob_id.as_str()) else {
+            return Err(SdkError::ClientError(format!(
+                "server returned an unrequested native blob target {}",
+                target.blob_id
+            )));
+        };
+        if !seen.insert(target.blob_id.as_str()) {
+            return Err(SdkError::ClientError(format!(
+                "server returned native blob target {} more than once",
+                target.blob_id
+            )));
+        }
+        if target.logical_len != *expected_len {
+            return Err(SdkError::ClientError(format!(
+                "server returned native blob target {} with length {}, expected {}",
+                target.blob_id, target.logical_len, expected_len
+            )));
+        }
+        if !target.already_present {
+            let checksum = target.checksum_sha256.as_deref().ok_or_else(|| {
+                SdkError::ClientError("direct upload target omitted SHA-256 header".to_string())
+            })?;
+            let digest = hex::decode(&target.blob_id).map_err(|error| {
+                SdkError::ClientError(format!(
+                    "server returned invalid native blob identity {}: {error}",
+                    target.blob_id
+                ))
+            })?;
+            let expected_checksum = base64::engine::general_purpose::STANDARD.encode(digest);
+            if checksum != expected_checksum {
+                return Err(SdkError::ClientError(format!(
+                    "server returned a checksum that does not match native blob target {}",
+                    target.blob_id
+                )));
+            }
+            if target.url.is_none() {
+                return Err(SdkError::ClientError(
+                    "direct upload target omitted URL".to_string(),
+                ));
+            }
+        }
+    }
+    if seen.len() != expected.len() {
+        let missing = expected
+            .keys()
+            .filter(|blob_id| !seen.contains(**blob_id))
+            .copied()
+            .collect::<Vec<_>>();
+        return Err(SdkError::ClientError(format!(
+            "server omitted native blob target(s): {}",
+            missing.join(", ")
+        )));
+    }
+    Ok(())
+}
+
 fn encode_native_path(path: &str) -> Result<String, SdkError> {
     validate_native_direct_path(path)?;
     Ok(path
@@ -1510,7 +1649,11 @@ async fn native_direct_request_body(
 
             let mut file = tokio::fs::File::open(path.as_ref()).await?;
             file.seek(std::io::SeekFrom::Start(*offset)).await?;
-            let stream = tokio_util::io::ReaderStream::new(file.take(*logical_len));
+            // ReaderStream's small default allocation creates excessive body frames for 64 MiB
+            // parts. A 1 MiB transport buffer keeps eight concurrent uploads memory-bounded while
+            // reaching object-store line rate with far less scheduler and HTTP framing overhead.
+            let stream =
+                tokio_util::io::ReaderStream::with_capacity(file.take(*logical_len), 1024 * 1024);
             Ok(reqwest::Body::wrap_stream(stream))
         }
     }
@@ -1616,12 +1759,12 @@ mod tests {
     use super::{
         ArtifactStorageClient, advance_pagination_cursor, encode_path_segment,
         git_credential_is_fresh, prepare_native_direct_publication, repo_list_query,
-        resolve_artifact_storage_url,
+        resolve_artifact_storage_url, validate_native_direct_targets,
     };
     use crate::ClientBuilder;
     use crate::artifact_storage::models::{
-        GitCredential, NativeDirectFilePathWrite, NativeDirectFileWrite, NativeDirectMutation,
-        REPO_KIND_FILESYSTEM,
+        GitCredential, NativeDirectBlobRequest, NativeDirectBlobTarget, NativeDirectFilePathWrite,
+        NativeDirectFileWrite, NativeDirectMutation, REPO_KIND_FILESYSTEM,
     };
 
     #[test]
@@ -1685,6 +1828,53 @@ mod tests {
     }
 
     #[test]
+    fn direct_upload_targets_must_exactly_match_the_request() {
+        use base64::Engine;
+
+        let blob_id = hex::encode(Sha256::digest(b"payload"));
+        let checksum = base64::engine::general_purpose::STANDARD.encode(Sha256::digest(b"payload"));
+        let request = NativeDirectBlobRequest {
+            blob_id: blob_id.clone(),
+            logical_len: 7,
+        };
+        let target = NativeDirectBlobTarget {
+            blob_id: blob_id.clone(),
+            logical_len: 7,
+            already_present: false,
+            url: Some("https://objects.example/upload".to_string()),
+            checksum_sha256: Some(checksum),
+        };
+        assert!(
+            validate_native_direct_targets(
+                std::slice::from_ref(&request),
+                std::slice::from_ref(&target)
+            )
+            .is_ok()
+        );
+
+        let mut wrong_len = target.clone();
+        wrong_len.logical_len += 1;
+        assert!(
+            validate_native_direct_targets(std::slice::from_ref(&request), &[wrong_len]).is_err()
+        );
+        assert!(
+            validate_native_direct_targets(
+                std::slice::from_ref(&request),
+                &[target.clone(), target.clone()]
+            )
+            .is_err()
+        );
+        assert!(validate_native_direct_targets(std::slice::from_ref(&request), &[]).is_err());
+
+        let mut wrong_checksum = target;
+        wrong_checksum.checksum_sha256 = Some("not-the-content-digest".to_string());
+        assert!(
+            validate_native_direct_targets(std::slice::from_ref(&request), &[wrong_checksum])
+                .is_err()
+        );
+    }
+
+    #[test]
     fn git_repo_url_uses_git_root_project_repo_shape() {
         let api_client = ClientBuilder::new("https://api.tensorlake.ai")
             .bearer_token("token")
@@ -1728,6 +1918,31 @@ mod tests {
         assert!(!git_credential_is_fresh(&credential(String::new())));
     }
 
+    #[tokio::test]
+    async fn project_credential_reuses_the_shared_expiry_checked_cache() {
+        let api_client = ClientBuilder::new("http://127.0.0.1:1").build().unwrap();
+        let client = ArtifactStorageClient::new(api_client, "http://127.0.0.1:1").unwrap();
+        let cached = GitCredential {
+            token: "cached-project-token".to_string(),
+            token_type: "bearer".to_string(),
+            expires_at: (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339(),
+            git_username: "project-user".to_string(),
+            repo_pattern: "*".to_string(),
+            scopes: vec!["project:admin".to_string()],
+        };
+        client
+            .repo_credentials
+            .lock()
+            .await
+            .insert(("project".to_string(), "*".to_string()), cached.clone());
+
+        assert_eq!(
+            client.git_credential_for_project("project").await.unwrap(),
+            cached,
+            "a cached project credential must avoid another control-plane mint"
+        );
+    }
+
     #[test]
     fn filesystem_inventory_fences_every_page() {
         assert_eq!(
@@ -1757,7 +1972,7 @@ mod tests {
         let server_blob_id = blob_id.clone();
         let server_payload = payload.clone();
         let server = tokio::spawn(async move {
-            for _ in 0..12 {
+            for _ in 0..13 {
                 let (mut stream, _) = listener.accept().await.unwrap();
                 let mut bytes = Vec::new();
                 let header_end = loop {
@@ -1778,6 +1993,11 @@ mod tests {
                             .then(|| value.trim().parse::<usize>().unwrap())
                     })
                     .unwrap_or(0);
+                let range_header = headers.lines().find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("range")
+                        .then(|| value.trim().to_string())
+                });
                 while bytes.len() < header_end + content_len {
                     let mut chunk = [0u8; 4096];
                     let read = stream.read(&mut chunk).await.unwrap();
@@ -1881,7 +2101,11 @@ mod tests {
                         "/project/project/repos/filesystem/fs/snapshots/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?expected_permanence_epoch=7",
                     ) => Vec::new(),
                     ("GET", "/project/project/repos/filesystem/fs/files/data/probe.bin") => {
-                        server_payload.clone()
+                        if range_header.as_deref() == Some("bytes=8-14") {
+                            server_payload[8..15].to_vec()
+                        } else {
+                            server_payload.clone()
+                        }
                     }
                     ("GET", path) if path.starts_with(
                         "/project/project/repos/filesystem/fs/entries?path=data&limit=1000",
@@ -1898,9 +2122,26 @@ mod tests {
                     .unwrap(),
                     other => panic!("unexpected request: {other:?}"),
                 };
+                let native_file_headers = if path
+                    == "/project/project/repos/filesystem/fs/files/data/probe.bin"
+                {
+                    let content_range = range_header
+                        .as_ref()
+                        .map(|_| format!("Content-Range: bytes 8-14/{}\r\n", server_payload.len()))
+                        .unwrap_or_default();
+                    format!("x-tensorlake-content-id: {server_blob_id}\r\n{content_range}")
+                } else {
+                    String::new()
+                };
+                let response_status = if range_header.is_some() {
+                    "206 Partial Content"
+                } else {
+                    "200 OK"
+                };
                 let response = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-                    response_body.len()
+                    "HTTP/1.1 {response_status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{}Connection: close\r\n\r\n",
+                    response_body.len(),
+                    native_file_headers,
                 );
                 stream.write_all(response.as_bytes()).await.unwrap();
                 stream.write_all(&response_body).await.unwrap();
@@ -1943,6 +2184,19 @@ mod tests {
                 .into_inner(),
             payload
         );
+        let ranged = client
+            .read_native_filesystem_file_with_metadata(
+                "project",
+                "filesystem",
+                "data/probe.bin",
+                "main",
+                Some((8, 7)),
+            )
+            .await
+            .unwrap();
+        assert_eq!(ranged.data, b"goes st");
+        assert_eq!(ranged.content_id, blob_id);
+        assert_eq!(ranged.full_size, payload.len() as u64);
         let entries = client
             .list_native_filesystem_entries_page(
                 "project",

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -1,6 +1,7 @@
 use reqwest::{Method, StatusCode};
 use serde::de::DeserializeOwned;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::{
     client::{Client, Traced},
@@ -14,7 +15,12 @@ pub mod workspaces;
 
 use models::{
     CreateRepoRequest, GitCredential, ListBranchesResponse, ListOperationsResponse,
-    ListRefsResponse, ListReposResponse, MintGitTokenRequest, REPO_KIND_FILESYSTEM, RepoInfo,
+    ListRefsResponse, ListReposResponse, MintGitTokenRequest, NativeDirectBlobRequest,
+    NativeDirectBlobTargetsRequest, NativeDirectBlobTargetsResponse, NativeDirectFilePathWrite,
+    NativeDirectFileWrite, NativeDirectMutation, NativeDirectPathTransfer,
+    NativeDirectPublishRequest, NativeDirectPublishResponse, NativeDirectUploadLeaseResponse,
+    NativeDirectUploadReceipt, NativeFilesystemSnapshot, NativeFilesystemSnapshotPage,
+    NativeFilesystemSnapshotRetentionResponse, NativeHeadResponse, REPO_KIND_FILESYSTEM, RepoInfo,
     RepoMetaInfo,
 };
 
@@ -23,6 +29,7 @@ pub struct ArtifactStorageClient {
     api_client: Client,
     git_client: reqwest::Client,
     git_base_url: String,
+    repo_credentials: Arc<tokio::sync::Mutex<HashMap<(String, String), GitCredential>>>,
 }
 
 impl ArtifactStorageClient {
@@ -33,6 +40,7 @@ impl ArtifactStorageClient {
                 .user_agent(concat!("tensorlake-rust-sdk/", env!("CARGO_PKG_VERSION")))
                 .build()?,
             git_base_url: trim_base_url(git_base_url.into()),
+            repo_credentials: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
         })
     }
 
@@ -97,10 +105,23 @@ impl ArtifactStorageClient {
         if let Some(credential) = Self::git_credential_from_env() {
             return Ok(credential);
         }
-        Ok(self
+        let key = (project_id.to_string(), repo.to_string());
+        if let Some(credential) = self.repo_credentials.lock().await.get(&key).cloned()
+            && git_credential_is_fresh(&credential)
+        {
+            return Ok(credential);
+        }
+        let credential = self
             .mint_token_for_repo(project_id, Some(repo))
             .await?
-            .into_inner())
+            .into_inner();
+        if git_credential_is_fresh(&credential) {
+            self.repo_credentials
+                .lock()
+                .await
+                .insert(key, credential.clone());
+        }
+        Ok(credential)
     }
 
     pub async fn git_credential_for_project(
@@ -205,6 +226,36 @@ impl ArtifactStorageClient {
         )?;
         let response = request.send().await?;
         decode_empty(response, trace_id).await
+    }
+
+    /// Create a metadata-only filesystem fork at the live head or a selected native snapshot.
+    pub async fn fork_filesystem(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+        base_filesystem: &str,
+        snapshot: Option<&str>,
+    ) -> Result<Traced<()>, SdkError> {
+        let credential = self.git_credential_for_project(project_id).await?;
+        let mut suffix = format!("fork/{}", encode_path_segment(base_filesystem));
+        if let Some(snapshot) = snapshot {
+            let snapshot = native_snapshot_id(snapshot)?.ok_or_else(|| {
+                SdkError::ClientError(
+                    "filesystem fork snapshot must be a 64-character snapshot id".to_string(),
+                )
+            })?;
+            suffix.push_str("?snapshot=");
+            suffix.push_str(&encode_path_segment(snapshot));
+        }
+        let (request, trace_id) = self.git_request(
+            Method::POST,
+            project_id,
+            filesystem,
+            Some(&suffix),
+            &credential.git_username,
+            &credential.token,
+        )?;
+        decode_empty(send_idempotent(request).await?, trace_id).await
     }
 
     pub async fn delete_repo(&self, project_id: &str, repo: &str) -> Result<Traced<()>, SdkError> {
@@ -582,6 +633,505 @@ impl ArtifactStorageClient {
         .await
     }
 
+    pub async fn native_filesystem_head(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+    ) -> Result<Traced<NativeHeadResponse>, SdkError> {
+        let credential = self.git_credential_for_repo(project_id, filesystem).await?;
+        let (request, trace_id) = self.git_request(
+            Method::GET,
+            project_id,
+            filesystem,
+            Some("fs/head"),
+            &credential.git_username,
+            &credential.token,
+        )?;
+        decode_json(send_idempotent(request).await?, trace_id).await
+    }
+
+    pub async fn read_native_filesystem_file(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+        path: &str,
+        version: &str,
+    ) -> Result<Traced<Vec<u8>>, SdkError> {
+        let snapshot = native_snapshot_id(version)?;
+        let path = encode_native_path(path)?;
+        let suffix = match snapshot {
+            Some(snapshot) => format!("fs/files/{path}?snapshot={snapshot}"),
+            None => format!("fs/files/{path}"),
+        };
+        let credential = self.git_credential_for_repo(project_id, filesystem).await?;
+        let (request, trace_id) = self.git_request(
+            Method::GET,
+            project_id,
+            filesystem,
+            Some(&suffix),
+            &credential.git_username,
+            &credential.token,
+        )?;
+        let response = handle_response(send_idempotent(request).await?).await?;
+        Ok(Traced::new(trace_id, response.bytes().await?.to_vec()))
+    }
+
+    pub async fn list_native_filesystem_entries_page(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+        path: &str,
+        version: &str,
+        after: Option<&str>,
+        limit: usize,
+    ) -> Result<Traced<workspaces::TreePage>, SdkError> {
+        if !path.is_empty() {
+            validate_native_direct_path(path)?;
+        }
+        let suffix = native_entries_suffix(path, native_snapshot_id(version)?, after, limit);
+        let credential = self.git_credential_for_repo(project_id, filesystem).await?;
+        let (request, trace_id) = self.git_request(
+            Method::GET,
+            project_id,
+            filesystem,
+            Some(&suffix),
+            &credential.git_username,
+            &credential.token,
+        )?;
+        decode_json(send_idempotent(request).await?, trace_id).await
+    }
+
+    /// Permanently retain the current filesystem head with a user-visible message. This publishes
+    /// no content or directory metadata: it changes only the snapshot's retention class.
+    pub async fn retain_current_native_filesystem_snapshot(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+        message: String,
+        request_id: String,
+    ) -> Result<Traced<NativeFilesystemSnapshotRetentionResponse>, SdkError> {
+        let credential = self.git_credential_for_repo(project_id, filesystem).await?;
+        let (request, trace_id) = self.git_request(
+            Method::POST,
+            project_id,
+            filesystem,
+            Some("fs/snapshots"),
+            &credential.git_username,
+            &credential.token,
+        )?;
+        let body = serde_json::json!({ "message": message, "request_id": request_id });
+        decode_json(send_idempotent(request.json(&body)).await?, trace_id).await
+    }
+
+    /// List every explicitly retained native snapshot in newest-first history order.
+    pub async fn list_native_filesystem_snapshots(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+    ) -> Result<Traced<Vec<NativeFilesystemSnapshot>>, SdkError> {
+        let credential = self.git_credential_for_repo(project_id, filesystem).await?;
+        let mut snapshots = Vec::new();
+        let mut after: Option<String> = None;
+        let mut seen = HashSet::new();
+        let trace_id = loop {
+            let suffix = match after.as_deref() {
+                Some(after) => format!(
+                    "fs/snapshots?limit=1000&after={}",
+                    encode_path_segment(after)
+                ),
+                None => "fs/snapshots?limit=1000".to_string(),
+            };
+            let (request, request_trace_id) = self.git_request(
+                Method::GET,
+                project_id,
+                filesystem,
+                Some(&suffix),
+                &credential.git_username,
+                &credential.token,
+            )?;
+            let page = decode_json::<NativeFilesystemSnapshotPage>(
+                send_idempotent(request).await?,
+                request_trace_id,
+            )
+            .await?;
+            snapshots.extend(
+                page.snapshots
+                    .iter()
+                    .filter(|snapshot| snapshot.snapshot_class == "permanent_snapshot")
+                    .cloned(),
+            );
+            match page.next_after.clone() {
+                Some(next) if !next.is_empty() && seen.insert(next.clone()) => after = Some(next),
+                Some(_) => {
+                    return Err(SdkError::ClientError(
+                        "native snapshot history returned a repeated or empty cursor".to_string(),
+                    ));
+                }
+                None => break page.trace_id.clone(),
+            }
+        };
+        Ok(Traced::new(trace_id, snapshots))
+    }
+
+    /// Drop one permanent snapshot retention root. Content still reachable from a head, fork, or
+    /// another snapshot remains durable.
+    pub async fn delete_native_filesystem_snapshot(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+        snapshot: &str,
+    ) -> Result<Traced<()>, SdkError> {
+        let snapshot = native_snapshot_id(snapshot)?.ok_or_else(|| {
+            SdkError::ClientError(
+                "filesystem snapshot must be a 64-character snapshot id".to_string(),
+            )
+        })?;
+        let credential = self.git_credential_for_repo(project_id, filesystem).await?;
+        let snapshot_suffix = format!("fs/snapshots/{}", encode_path_segment(snapshot));
+        let (snapshot_request, _) = self.git_request(
+            Method::GET,
+            project_id,
+            filesystem,
+            Some(&snapshot_suffix),
+            &credential.git_username,
+            &credential.token,
+        )?;
+        let current = decode_json::<NativeFilesystemSnapshot>(
+            send_idempotent(snapshot_request).await?,
+            String::new(),
+        )
+        .await?
+        .into_inner();
+        let suffix = format!(
+            "{snapshot_suffix}?expected_permanence_epoch={}",
+            current.permanence_epoch
+        );
+        let (request, trace_id) = self.git_request(
+            Method::DELETE,
+            project_id,
+            filesystem,
+            Some(&suffix),
+            &credential.git_username,
+            &credential.token,
+        )?;
+        decode_empty(send_idempotent(request).await?, trace_id).await
+    }
+
+    /// Publish complete files through the native SDK path: SHA-256 locally, upload missing bytes
+    /// directly to checksum-bound object-store targets, then atomically publish logical mutations.
+    /// Payload bytes never traverse Artifact Storage.
+    pub async fn publish_filesystem_files(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+        files: Vec<NativeDirectFileWrite>,
+        deletes: Vec<String>,
+        moves: Vec<NativeDirectPathTransfer>,
+        copies: Vec<NativeDirectPathTransfer>,
+        message: String,
+        operation_id: String,
+    ) -> Result<Traced<NativeDirectPublishResponse>, SdkError> {
+        let credential = self.git_credential_for_repo(project_id, filesystem).await?;
+        self.push_native_files_direct_with_credential(
+            project_id,
+            filesystem,
+            files,
+            Vec::new(),
+            deletes,
+            moves,
+            copies,
+            message,
+            operation_id,
+            &credential.git_username,
+            &credential.token,
+        )
+        .await
+    }
+
+    /// Publish complete files from local paths without retaining their payloads in SDK memory.
+    /// Each source is hashed and streamed in bounded direct-to-object-store parts.
+    pub async fn publish_filesystem_paths(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+        files: Vec<NativeDirectFilePathWrite>,
+        message: String,
+        operation_id: String,
+    ) -> Result<Traced<NativeDirectPublishResponse>, SdkError> {
+        let credential = self.git_credential_for_repo(project_id, filesystem).await?;
+        self.push_native_files_direct_with_credential(
+            project_id,
+            filesystem,
+            Vec::new(),
+            files,
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            message,
+            operation_id,
+            &credential.git_username,
+            &credential.token,
+        )
+        .await
+    }
+
+    /// Credential-explicit form used by callers that already cache or manage a repository token.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn push_native_files_direct_with_credential(
+        &self,
+        project_id: &str,
+        filesystem: &str,
+        files: Vec<NativeDirectFileWrite>,
+        path_files: Vec<NativeDirectFilePathWrite>,
+        deletes: Vec<String>,
+        moves: Vec<NativeDirectPathTransfer>,
+        copies: Vec<NativeDirectPathTransfer>,
+        message: String,
+        operation_id: String,
+        git_username: &str,
+        git_token: &str,
+    ) -> Result<Traced<NativeDirectPublishResponse>, SdkError> {
+        use futures::StreamExt;
+        if files.is_empty()
+            && path_files.is_empty()
+            && deletes.is_empty()
+            && moves.is_empty()
+            && copies.is_empty()
+        {
+            return Err(SdkError::ClientError(
+                "nothing to publish: no writes, deletions, moves, or copies given".to_string(),
+            ));
+        }
+        for file in &files {
+            validate_native_direct_path(&file.path)?;
+        }
+        for file in &path_files {
+            validate_native_direct_path(&file.path)?;
+        }
+        for path in &deletes {
+            validate_native_direct_path(path)?;
+        }
+        for transfer in moves.iter().chain(&copies) {
+            validate_native_direct_path(&transfer.from)?;
+            validate_native_direct_path(&transfer.to)?;
+        }
+        const DIRECT_PART_BYTES: usize = 64 * 1024 * 1024;
+        let prepare = tokio::task::spawn_blocking(move || {
+            prepare_native_direct_publication(
+                files,
+                path_files,
+                deletes,
+                moves,
+                copies,
+                DIRECT_PART_BYTES,
+            )
+        });
+
+        // Head and lease are independent control requests. Issuing them together keeps the
+        // fixed-cost portion of a small publication to three sequential data-plane round trips:
+        // (head+lease), targets, then publish after the parallel direct PUTs. SHA-256 preparation
+        // runs concurrently on the blocking pool, so multi-GiB inputs add no serial setup phase.
+        let head_request = send_idempotent(
+            self.git_request(
+                Method::GET,
+                project_id,
+                filesystem,
+                Some("fs/head"),
+                git_username,
+                git_token,
+            )?
+            .0,
+        );
+        let lease_request = send_idempotent(
+            self.git_request(
+                Method::POST,
+                project_id,
+                filesystem,
+                Some("fs/upload-leases"),
+                git_username,
+                git_token,
+            )?
+            .0
+            .json(&serde_json::json!({})),
+        );
+        let control = async {
+            let (head_response, lease_response) = tokio::try_join!(head_request, lease_request)?;
+            let head = decode_json::<NativeHeadResponse>(head_response, String::new())
+                .await?
+                .into_inner();
+            let lease =
+                decode_json::<NativeDirectUploadLeaseResponse>(lease_response, String::new())
+                    .await?
+                    .into_inner();
+            Ok::<_, SdkError>((head, lease))
+        };
+        let prepared = async {
+            prepare.await.map_err(|error| {
+                SdkError::ClientError(format!(
+                    "native direct publication preparation failed: {error}"
+                ))
+            })?
+        };
+        let ((head, lease), (mutations, unique_blobs)) = tokio::try_join!(control, prepared)?;
+        if head.snapshot_id.is_none()
+            && mutations
+                .iter()
+                .all(|mutation| matches!(mutation, NativeDirectMutation::Delete { .. }))
+        {
+            return Err(SdkError::ClientError(
+                "cannot delete from an empty filesystem".to_string(),
+            ));
+        }
+        if lease.transport != "checksum_presigned_put" || lease.checksum_algorithm != "sha256" {
+            return Err(SdkError::ClientError(format!(
+                "server returned unsupported direct upload transport {:?} with checksum {:?}",
+                lease.transport, lease.checksum_algorithm
+            )));
+        }
+        if lease.max_targets_per_request == 0 || lease.max_parts_per_file == 0 {
+            return Err(SdkError::ClientError(
+                "server returned a zero direct-upload batching limit".to_string(),
+            ));
+        }
+        if lease.max_blob_bytes < DIRECT_PART_BYTES as u64 {
+            return Err(SdkError::ClientError(format!(
+                "server direct-upload part limit {} is smaller than the SDK's {} byte part size",
+                lease.max_blob_bytes, DIRECT_PART_BYTES
+            )));
+        }
+        if let Some(part_count) = mutations.iter().find_map(|mutation| match mutation {
+            NativeDirectMutation::Put { blobs, .. } if blobs.len() > lease.max_parts_per_file => {
+                Some(blobs.len())
+            }
+            _ => None,
+        }) {
+            return Err(SdkError::ClientError(format!(
+                "native file has {part_count} parts, exceeding the server's {} part limit",
+                lease.max_parts_per_file
+            )));
+        }
+        if let Some((blob_id, data)) = unique_blobs
+            .iter()
+            .find(|(_, data)| data.logical_len() > lease.max_blob_bytes)
+        {
+            return Err(SdkError::ClientError(format!(
+                "native blob {blob_id} has {} bytes, exceeding the server's {} byte direct-upload limit",
+                data.logical_len(),
+                lease.max_blob_bytes
+            )));
+        }
+
+        let blob_requests = unique_blobs
+            .iter()
+            .map(|(blob_id, data)| NativeDirectBlobRequest {
+                blob_id: blob_id.clone(),
+                logical_len: data.logical_len(),
+            })
+            .collect::<Vec<_>>();
+        let mut targets = NativeDirectBlobTargetsResponse {
+            targets: Vec::with_capacity(blob_requests.len()),
+        };
+        let mut target_requests = Vec::new();
+        for batch in blob_requests.chunks(lease.max_targets_per_request) {
+            let targets_path = format!(
+                "fs/upload-leases/{}/targets",
+                encode_path_segment(&lease.lease_id)
+            );
+            let (request, trace_id) = self.git_request(
+                Method::POST,
+                project_id,
+                filesystem,
+                Some(&targets_path),
+                git_username,
+                git_token,
+            )?;
+            let body = NativeDirectBlobTargetsRequest {
+                blobs: batch.to_vec(),
+            };
+            target_requests.push(async move {
+                decode_json::<NativeDirectBlobTargetsResponse>(
+                    send_idempotent(request.json(&body)).await?,
+                    trace_id,
+                )
+                .await
+                .map(Traced::into_inner)
+            });
+        }
+        let target_results = futures::stream::iter(target_requests)
+            .buffer_unordered(4)
+            .collect::<Vec<_>>()
+            .await;
+        for result in target_results {
+            targets.targets.extend(result?.targets);
+        }
+
+        let mut receipts = Vec::new();
+        let mut uploads = Vec::new();
+        for target in targets.targets {
+            if target.already_present {
+                continue;
+            }
+            let data = unique_blobs.get(&target.blob_id).cloned().ok_or_else(|| {
+                SdkError::ClientError(format!(
+                    "server returned an unknown native blob target {}",
+                    target.blob_id
+                ))
+            })?;
+            let url = target.url.ok_or_else(|| {
+                SdkError::ClientError("direct upload target omitted URL".to_string())
+            })?;
+            let checksum = target.checksum_sha256.ok_or_else(|| {
+                SdkError::ClientError("direct upload target omitted SHA-256 header".to_string())
+            })?;
+            receipts.push(NativeDirectUploadReceipt {
+                blob_id: target.blob_id,
+                logical_len: target.logical_len,
+            });
+            let client = self.git_client.clone();
+            uploads.push(async move {
+                let response = upload_native_direct_source(&client, &url, &checksum, &data).await?;
+                if response.status().is_success() {
+                    Ok::<(), SdkError>(())
+                } else {
+                    Err(SdkError::ServerError {
+                        status: response.status(),
+                        message: body_message(response).await,
+                    })
+                }
+            });
+        }
+        let results = futures::stream::iter(uploads)
+            .buffer_unordered(8)
+            .collect::<Vec<_>>()
+            .await;
+        for result in results {
+            result?;
+        }
+
+        let publish = NativeDirectPublishRequest {
+            operation_id,
+            message,
+            expected_version_id: head.snapshot_id,
+            lease_id: lease.lease_id,
+            uploads: receipts,
+            mutations,
+            retain_as_snapshot: false,
+        };
+        let (publish_request, trace_id) = self.git_request(
+            Method::POST,
+            project_id,
+            filesystem,
+            Some("fs/publish"),
+            git_username,
+            git_token,
+        )?;
+        decode_json(
+            send_idempotent(publish_request.json(&publish)).await?,
+            trace_id,
+        )
+        .await
+    }
+
     fn git_request(
         &self,
         method: Method,
@@ -641,6 +1191,231 @@ impl ArtifactStorageClient {
     }
 }
 
+type NativeDirectPrepared = (
+    Vec<NativeDirectMutation>,
+    std::collections::BTreeMap<String, NativeDirectUploadSource>,
+);
+
+#[derive(Clone, Debug)]
+enum NativeDirectUploadSource {
+    Bytes(bytes::Bytes),
+    FileRange {
+        path: std::sync::Arc<std::path::PathBuf>,
+        offset: u64,
+        logical_len: u64,
+    },
+}
+
+impl NativeDirectUploadSource {
+    fn logical_len(&self) -> u64 {
+        match self {
+            Self::Bytes(bytes) => bytes.len() as u64,
+            Self::FileRange { logical_len, .. } => *logical_len,
+        }
+    }
+}
+
+fn prepare_native_direct_publication(
+    files: Vec<NativeDirectFileWrite>,
+    path_files: Vec<NativeDirectFilePathWrite>,
+    deletes: Vec<String>,
+    moves: Vec<NativeDirectPathTransfer>,
+    copies: Vec<NativeDirectPathTransfer>,
+    part_bytes: usize,
+) -> Result<NativeDirectPrepared, SdkError> {
+    use rayon::prelude::*;
+    use sha2::{Digest, Sha256};
+
+    if part_bytes == 0 {
+        return Err(SdkError::ClientError(
+            "native direct-upload part size must be non-zero".to_string(),
+        ));
+    }
+    let mut mutations = Vec::with_capacity(
+        files.len() + path_files.len() + deletes.len() + moves.len() + copies.len(),
+    );
+    let mut unique_blobs = std::collections::BTreeMap::<String, NativeDirectUploadSource>::new();
+    for file in files {
+        let content = bytes::Bytes::from(file.data);
+        let parts = if content.is_empty() {
+            vec![(hex::encode(Sha256::digest([])), bytes::Bytes::new())]
+        } else {
+            (0..content.len())
+                .step_by(part_bytes)
+                .map(|start| content.slice(start..(start + part_bytes).min(content.len())))
+                .collect::<Vec<_>>()
+                .into_par_iter()
+                .map(|part| (hex::encode(Sha256::digest(&part)), part))
+                .collect()
+        };
+        let mut blobs = Vec::with_capacity(parts.len());
+        for (blob_id, part) in parts {
+            blobs.push(NativeDirectBlobRequest {
+                blob_id: blob_id.clone(),
+                logical_len: part.len() as u64,
+            });
+            if !part.is_empty() {
+                unique_blobs
+                    .entry(blob_id)
+                    .or_insert(NativeDirectUploadSource::Bytes(part));
+            }
+        }
+        mutations.push(NativeDirectMutation::Put {
+            path: file.path,
+            blobs,
+        });
+    }
+    for file in path_files {
+        use std::io::Read;
+
+        let source_path = std::sync::Arc::new(file.source_path);
+        let mut source = std::fs::File::open(source_path.as_ref()).map_err(|error| {
+            SdkError::ClientError(format!(
+                "opening native publication source {}: {error}",
+                source_path.display()
+            ))
+        })?;
+        let logical_len = source
+            .metadata()
+            .map_err(|error| {
+                SdkError::ClientError(format!(
+                    "reading native publication source metadata {}: {error}",
+                    source_path.display()
+                ))
+            })?
+            .len();
+        let mut blobs = Vec::new();
+        if logical_len == 0 {
+            blobs.push(NativeDirectBlobRequest {
+                blob_id: hex::encode(Sha256::digest([])),
+                logical_len: 0,
+            });
+        } else {
+            let mut offset = 0u64;
+            let mut buffer = vec![0u8; part_bytes];
+            while offset < logical_len {
+                let part_len = usize::try_from(
+                    (logical_len - offset).min(u64::try_from(part_bytes).unwrap_or(u64::MAX)),
+                )
+                .map_err(|_| {
+                    SdkError::ClientError("native publication part length overflow".to_string())
+                })?;
+                source
+                    .read_exact(&mut buffer[..part_len])
+                    .map_err(|error| {
+                        SdkError::ClientError(format!(
+                            "reading native publication source {}: {error}",
+                            source_path.display()
+                        ))
+                    })?;
+                let blob_id = hex::encode(Sha256::digest(&buffer[..part_len]));
+                blobs.push(NativeDirectBlobRequest {
+                    blob_id: blob_id.clone(),
+                    logical_len: part_len as u64,
+                });
+                unique_blobs.entry(blob_id).or_insert_with(|| {
+                    NativeDirectUploadSource::FileRange {
+                        path: source_path.clone(),
+                        offset,
+                        logical_len: part_len as u64,
+                    }
+                });
+                offset += part_len as u64;
+            }
+        }
+        mutations.push(NativeDirectMutation::Put {
+            path: file.path,
+            blobs,
+        });
+    }
+    mutations.extend(
+        deletes
+            .into_iter()
+            .map(|path| NativeDirectMutation::Delete { path }),
+    );
+    mutations.extend(
+        moves
+            .into_iter()
+            .map(|transfer| NativeDirectMutation::Move {
+                from: transfer.from,
+                to: transfer.to,
+            }),
+    );
+    mutations.extend(
+        copies
+            .into_iter()
+            .map(|transfer| NativeDirectMutation::Copy {
+                from: transfer.from,
+                to: transfer.to,
+            }),
+    );
+    if unique_blobs.len() > 4_096 {
+        return Err(SdkError::ClientError(format!(
+            "native publication contains {} unique non-empty parts; the maximum is 4096",
+            unique_blobs.len()
+        )));
+    }
+    Ok((mutations, unique_blobs))
+}
+
+fn validate_native_direct_path(path: &str) -> Result<(), SdkError> {
+    if path.is_empty()
+        || path.starts_with('/')
+        || path.ends_with('/')
+        || path.contains('\\')
+        || path.contains('\0')
+        || path.split('/').any(|component| {
+            component.is_empty() || component == "." || component == ".." || component.contains(':')
+        })
+    {
+        return Err(SdkError::ClientError(format!(
+            "invalid native filesystem path {path:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn encode_native_path(path: &str) -> Result<String, SdkError> {
+    validate_native_direct_path(path)?;
+    Ok(path
+        .split('/')
+        .map(encode_path_segment)
+        .collect::<Vec<_>>()
+        .join("/"))
+}
+
+fn native_snapshot_id(version: &str) -> Result<Option<&str>, SdkError> {
+    match version {
+        "" | "main" | "refs/heads/main" => Ok(None),
+        snapshot
+            if snapshot.len() == 64 && snapshot.bytes().all(|byte| byte.is_ascii_hexdigit()) =>
+        {
+            Ok(Some(snapshot))
+        }
+        _ => Err(SdkError::ClientError(format!(
+            "native filesystems support the current head or a 64-character snapshot id, not {version:?}"
+        ))),
+    }
+}
+
+fn native_entries_suffix(
+    path: &str,
+    snapshot: Option<&str>,
+    after: Option<&str>,
+    limit: usize,
+) -> String {
+    let mut query = url::form_urlencoded::Serializer::new(String::new());
+    if let Some(snapshot) = snapshot {
+        query.append_pair("snapshot", snapshot);
+    }
+    query.append_pair("path", path);
+    if let Some(after) = after {
+        query.append_pair("after", after);
+    }
+    query.append_pair("limit", &limit.clamp(1, 10_000).to_string());
+    format!("fs/entries?{}", query.finish())
+}
+
 fn repo_list_query(kind: Option<&str>, after: Option<&str>) -> String {
     // `form_urlencoded::Serializer` contains a non-Send callback reference. Keep it in this
     // synchronous helper so napi/tonic callers can carry the async request future across workers.
@@ -683,6 +1458,15 @@ fn encode_path_segment(segment: &str) -> String {
     urlencoding::encode(segment).into_owned()
 }
 
+fn git_credential_is_fresh(credential: &GitCredential) -> bool {
+    chrono::DateTime::parse_from_rfc3339(&credential.expires_at)
+        .map(|expires_at| {
+            expires_at.timestamp_millis()
+                > chrono::Utc::now().timestamp_millis().saturating_add(30_000)
+        })
+        .unwrap_or(false)
+}
+
 /// A paged collection must always make forward progress. Treat an empty or repeated cursor as a
 /// malformed server response rather than spinning forever in an SDK call.
 fn advance_pagination_cursor(
@@ -710,6 +1494,86 @@ async fn decode_empty(
 ) -> Result<Traced<()>, SdkError> {
     handle_response(response).await?;
     Ok(Traced::new(trace_id, ()))
+}
+
+async fn native_direct_request_body(
+    source: &NativeDirectUploadSource,
+) -> Result<reqwest::Body, SdkError> {
+    match source {
+        NativeDirectUploadSource::Bytes(bytes) => Ok(reqwest::Body::from(bytes.clone())),
+        NativeDirectUploadSource::FileRange {
+            path,
+            offset,
+            logical_len,
+        } => {
+            use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+            let mut file = tokio::fs::File::open(path.as_ref()).await?;
+            file.seek(std::io::SeekFrom::Start(*offset)).await?;
+            let stream = tokio_util::io::ReaderStream::new(file.take(*logical_len));
+            Ok(reqwest::Body::wrap_stream(stream))
+        }
+    }
+}
+
+/// Upload a replayable source. File-backed parts reopen and seek the source for each transport
+/// attempt, avoiding both whole-file memory and reqwest's non-cloneable streaming-body limitation.
+async fn upload_native_direct_source(
+    client: &reqwest::Client,
+    url: &str,
+    checksum: &str,
+    source: &NativeDirectUploadSource,
+) -> Result<reqwest::Response, SdkError> {
+    const ATTEMPTS: usize = 3;
+    for attempt in 0..ATTEMPTS {
+        let body = native_direct_request_body(source).await?;
+        match client
+            .put(url)
+            .header(
+                reqwest::header::CONTENT_LENGTH,
+                source.logical_len().to_string(),
+            )
+            .header("x-amz-checksum-sha256", checksum)
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(response)
+                if attempt + 1 < ATTEMPTS
+                    && (response.status().is_server_error()
+                        || response.status() == StatusCode::TOO_MANY_REQUESTS) => {}
+            Ok(response) => return Ok(response),
+            Err(_) if attempt + 1 < ATTEMPTS => {}
+            Err(error) => return Err(error.into()),
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25 << attempt)).await;
+    }
+    unreachable!("the final direct upload attempt always returns")
+}
+
+/// Send an idempotent direct-publication step with a small transport retry budget. Every caller
+/// either uses a read, a lease/target allocation that reattaches by server key, an immutable PUT,
+/// or the operation-id-fenced publish endpoint.
+async fn send_idempotent(request: reqwest::RequestBuilder) -> Result<reqwest::Response, SdkError> {
+    const ATTEMPTS: usize = 3;
+    for attempt in 0..ATTEMPTS {
+        let current = request.try_clone().ok_or_else(|| {
+            SdkError::ClientError("direct upload request body cannot be retried".to_string())
+        })?;
+        match current.send().await {
+            Ok(response)
+                if attempt + 1 < ATTEMPTS
+                    && (response.status().is_server_error()
+                        || response.status() == StatusCode::TOO_MANY_REQUESTS) => {}
+            Ok(response) => return Ok(response),
+            Err(error) if attempt + 1 < ATTEMPTS => {
+                let _ = error;
+            }
+            Err(error) => return Err(error.into()),
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25 << attempt)).await;
+    }
+    unreachable!("the final direct request attempt always returns")
 }
 
 async fn decode_json<T: DeserializeOwned>(
@@ -743,13 +1607,22 @@ async fn body_message(response: reqwest::Response) -> String {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
+
+    use base64::Engine;
+    use sha2::{Digest, Sha256};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::{
-        ArtifactStorageClient, advance_pagination_cursor, encode_path_segment, repo_list_query,
+        ArtifactStorageClient, advance_pagination_cursor, encode_path_segment,
+        git_credential_is_fresh, prepare_native_direct_publication, repo_list_query,
         resolve_artifact_storage_url,
     };
     use crate::ClientBuilder;
-    use crate::artifact_storage::models::REPO_KIND_FILESYSTEM;
+    use crate::artifact_storage::models::{
+        GitCredential, NativeDirectFilePathWrite, NativeDirectFileWrite, NativeDirectMutation,
+        REPO_KIND_FILESYSTEM,
+    };
 
     #[test]
     fn resolves_git_url_from_api_url() {
@@ -771,6 +1644,44 @@ mod tests {
     fn encodes_path_segments() {
         assert_eq!(encode_path_segment("project_123"), "project_123");
         assert_eq!(encode_path_segment("repo/name"), "repo%2Fname");
+    }
+
+    #[test]
+    fn direct_publication_splits_memory_and_file_sources_into_bounded_parts() {
+        let temp = tempfile::tempdir().unwrap();
+        let source_path = temp.path().join("large.bin");
+        std::fs::write(&source_path, b"abcdefgh").unwrap();
+        let (mutations, unique) = prepare_native_direct_publication(
+            vec![NativeDirectFileWrite {
+                path: "memory.bin".into(),
+                data: b"abcdefgh".to_vec(),
+            }],
+            vec![NativeDirectFilePathWrite {
+                path: "disk.bin".into(),
+                source_path,
+            }],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            3,
+        )
+        .unwrap();
+
+        assert_eq!(mutations.len(), 2);
+        for mutation in mutations {
+            let NativeDirectMutation::Put { blobs, .. } = mutation else {
+                panic!("expected put mutation");
+            };
+            assert_eq!(
+                blobs
+                    .iter()
+                    .map(|blob| blob.logical_len)
+                    .collect::<Vec<_>>(),
+                vec![3, 3, 2]
+            );
+        }
+        // Identical memory/file content deduplicates to one source per part identity.
+        assert_eq!(unique.len(), 3);
     }
 
     #[test]
@@ -799,6 +1710,25 @@ mod tests {
     }
 
     #[test]
+    fn repository_credential_cache_keeps_an_expiry_safety_margin() {
+        let credential = |expires_at: String| GitCredential {
+            token: "token".to_string(),
+            token_type: "bearer".to_string(),
+            expires_at,
+            git_username: "user".to_string(),
+            repo_pattern: "filesystem".to_string(),
+            scopes: vec!["fs:write".to_string()],
+        };
+        assert!(git_credential_is_fresh(&credential(
+            (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339()
+        )));
+        assert!(!git_credential_is_fresh(&credential(
+            (chrono::Utc::now() + chrono::Duration::seconds(10)).to_rfc3339()
+        )));
+        assert!(!git_credential_is_fresh(&credential(String::new())));
+    }
+
+    #[test]
     fn filesystem_inventory_fences_every_page() {
         assert_eq!(
             repo_list_query(Some(REPO_KIND_FILESYSTEM), None),
@@ -811,6 +1741,292 @@ mod tests {
         assert_eq!(
             repo_list_query(Some("repository"), None),
             "kind=repository&limit=1000"
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_native_push_uploads_payload_only_to_the_presigned_target() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let payload = b"payload goes straight to object storage".to_vec();
+        let blob_id = hex::encode(Sha256::digest(&payload));
+        let checksum = base64::engine::general_purpose::STANDARD.encode(Sha256::digest(&payload));
+        let requests = Arc::new(Mutex::new(Vec::<(String, String, Vec<u8>)>::new()));
+        let captured = requests.clone();
+        let server_base = base.clone();
+        let server_blob_id = blob_id.clone();
+        let server_payload = payload.clone();
+        let server = tokio::spawn(async move {
+            for _ in 0..12 {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut bytes = Vec::new();
+                let header_end = loop {
+                    let mut chunk = [0u8; 4096];
+                    let read = stream.read(&mut chunk).await.unwrap();
+                    assert_ne!(read, 0, "request ended before its headers");
+                    bytes.extend_from_slice(&chunk[..read]);
+                    if let Some(offset) = bytes.windows(4).position(|part| part == b"\r\n\r\n") {
+                        break offset + 4;
+                    }
+                };
+                let headers = String::from_utf8(bytes[..header_end].to_vec()).unwrap();
+                let content_len = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().unwrap())
+                    })
+                    .unwrap_or(0);
+                while bytes.len() < header_end + content_len {
+                    let mut chunk = [0u8; 4096];
+                    let read = stream.read(&mut chunk).await.unwrap();
+                    assert_ne!(read, 0, "request ended before its body");
+                    bytes.extend_from_slice(&chunk[..read]);
+                }
+                let request_line = headers.lines().next().unwrap();
+                let mut request_parts = request_line.split_whitespace();
+                let method = request_parts.next().unwrap().to_string();
+                let path = request_parts.next().unwrap().to_string();
+                let body = bytes[header_end..header_end + content_len].to_vec();
+                captured
+                    .lock()
+                    .unwrap()
+                    .push((method.clone(), path.clone(), body));
+
+                let response_body = match (method.as_str(), path.as_str()) {
+                    ("POST", "/artifact-storage/v1/token") => {
+                        serde_json::to_vec(&serde_json::json!({
+                            "token": "repo-token",
+                            "tokenType": "bearer",
+                            "expiresAt": "2099-01-01T00:00:00Z",
+                            "gitUsername": "repo-user",
+                            "repoPattern": "filesystem",
+                            "scopes": ["fs:read", "fs:write"],
+                        }))
+                        .unwrap()
+                    }
+                    ("GET", "/project/project/repos/filesystem/fs/head") => {
+                        serde_json::to_vec(
+                            &serde_json::json!({"snapshot_id": null, "generation": 0}),
+                        )
+                        .unwrap()
+                    }
+                    ("POST", "/project/project/repos/filesystem/fs/upload-leases") => {
+                        serde_json::to_vec(&serde_json::json!({
+                            "lease_id": "lease-1",
+                            "expires_at_ms": 9_999_999_999_999_u64,
+                            "max_blob_bytes": 268_435_456_u64,
+                            "max_targets_per_request": 256,
+                            "max_parts_per_file": 4096,
+                            "transport": "checksum_presigned_put",
+                            "checksum_algorithm": "sha256",
+                        }))
+                        .unwrap()
+                    }
+                    (
+                        "POST",
+                        "/project/project/repos/filesystem/fs/upload-leases/lease-1/targets",
+                    ) => serde_json::to_vec(&serde_json::json!({
+                        "targets": [{
+                            "blob_id": server_blob_id,
+                            "logical_len": server_payload.len(),
+                            "already_present": false,
+                            "url": format!("{server_base}/object-store/stage-1"),
+                            "checksum_sha256": checksum,
+                        }],
+                    }))
+                    .unwrap(),
+                    ("PUT", "/object-store/stage-1") => b"{}".to_vec(),
+                    ("POST", "/project/project/repos/filesystem/fs/publish") => {
+                        serde_json::to_vec(&serde_json::json!({
+                            "version_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                            "previous_version_id": null,
+                        }))
+                        .unwrap()
+                    }
+                    ("POST", "/project/project/repos/filesystem/fs/snapshots") => {
+                        serde_json::to_vec(&serde_json::json!({
+                            "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                            "snapshot_class": "permanent_snapshot",
+                            "message": "retained by SDK",
+                        }))
+                        .unwrap()
+                    }
+                    ("GET", "/project/project/repos/filesystem/fs/snapshots?limit=1000") => {
+                        serde_json::to_vec(&serde_json::json!({
+                            "snapshots": [{
+                                "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "created_at_ms": 1234,
+                                "message": "retained by SDK",
+                                "snapshot_class": "permanent_snapshot",
+                            }],
+                            "next_after": null,
+                        }))
+                        .unwrap()
+                    }
+                    (
+                        "GET",
+                        "/project/project/repos/filesystem/fs/snapshots/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    ) => serde_json::to_vec(&serde_json::json!({
+                        "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "created_at_ms": 1234,
+                        "message": "retained by SDK",
+                        "snapshot_class": "permanent_snapshot",
+                        "permanence_epoch": 7,
+                    }))
+                    .unwrap(),
+                    (
+                        "DELETE",
+                        "/project/project/repos/filesystem/fs/snapshots/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?expected_permanence_epoch=7",
+                    ) => Vec::new(),
+                    ("GET", "/project/project/repos/filesystem/fs/files/data/probe.bin") => {
+                        server_payload.clone()
+                    }
+                    ("GET", path) if path.starts_with(
+                        "/project/project/repos/filesystem/fs/entries?path=data&limit=1000",
+                    ) => serde_json::to_vec(&serde_json::json!({
+                        "entries": [{
+                            "name": "probe.bin",
+                            "oid": server_blob_id,
+                            "mode": 33188,
+                            "size": server_payload.len(),
+                        }],
+                        "truncated": false,
+                        "next_after": null,
+                    }))
+                    .unwrap(),
+                    other => panic!("unexpected request: {other:?}"),
+                };
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    response_body.len()
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+                stream.write_all(&response_body).await.unwrap();
+            }
+        });
+
+        let api_client = ClientBuilder::new(&base).build().unwrap();
+        let client = ArtifactStorageClient::new(api_client, &base).unwrap();
+        let result = client
+            .publish_filesystem_files(
+                "project",
+                "filesystem",
+                vec![
+                    NativeDirectFileWrite {
+                        path: "data/probe.bin".to_string(),
+                        data: payload.clone(),
+                    },
+                    NativeDirectFileWrite {
+                        path: "data/empty.txt".to_string(),
+                        data: Vec::new(),
+                    },
+                ],
+                vec!["old.txt".to_string()],
+                Vec::new(),
+                Vec::new(),
+                "SDK publication".to_string(),
+                "operation-1".to_string(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            result.version_id,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        assert_eq!(
+            client
+                .read_native_filesystem_file("project", "filesystem", "data/probe.bin", "main")
+                .await
+                .unwrap()
+                .into_inner(),
+            payload
+        );
+        let entries = client
+            .list_native_filesystem_entries_page(
+                "project",
+                "filesystem",
+                "data",
+                "main",
+                None,
+                1000,
+            )
+            .await
+            .unwrap();
+        assert_eq!(entries.entries.len(), 1);
+        assert_eq!(entries.entries[0].name, "probe.bin");
+        let retained = client
+            .retain_current_native_filesystem_snapshot(
+                "project",
+                "filesystem",
+                "retained by SDK".to_string(),
+                "retain-1".to_string(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(retained.snapshot_class, "permanent_snapshot");
+        let snapshots = client
+            .list_native_filesystem_snapshots("project", "filesystem")
+            .await
+            .unwrap();
+        assert_eq!(snapshots.len(), 1);
+        client
+            .delete_native_filesystem_snapshot(
+                "project",
+                "filesystem",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        let requests = requests.lock().unwrap();
+        let upload = requests
+            .iter()
+            .find(|(method, path, _)| method == "PUT" && path == "/object-store/stage-1")
+            .unwrap();
+        assert_eq!(upload.2, payload);
+        let targets = requests
+            .iter()
+            .find(|(_, path, _)| path.ends_with("/targets"))
+            .unwrap();
+        let targets: serde_json::Value = serde_json::from_slice(&targets.2).unwrap();
+        assert_eq!(targets["blobs"].as_array().unwrap().len(), 1);
+        assert_eq!(targets["blobs"][0]["blob_id"], blob_id);
+        let publish = requests
+            .iter()
+            .find(|(_, path, _)| path.ends_with("/publish"))
+            .unwrap();
+        assert!(
+            !String::from_utf8_lossy(&publish.2).contains("payload goes straight"),
+            "control-plane publish body must not contain file payload bytes"
+        );
+        let publish: serde_json::Value = serde_json::from_slice(&publish.2).unwrap();
+        assert_eq!(publish["operation_id"], "operation-1");
+        assert_eq!(publish["message"], "SDK publication");
+        assert_eq!(publish["retain_as_snapshot"], false);
+        assert_eq!(publish["uploads"].as_array().unwrap().len(), 1);
+        assert_eq!(publish["mutations"].as_array().unwrap().len(), 3);
+        let retain = requests
+            .iter()
+            .find(|(method, path, _)| method == "POST" && path.ends_with("/fs/snapshots"))
+            .unwrap();
+        let retain: serde_json::Value = serde_json::from_slice(&retain.2).unwrap();
+        assert_eq!(retain["request_id"], "retain-1");
+        assert!(
+            requests.iter().any(|(method, path, _)| {
+                method == "DELETE" && path.ends_with("expected_permanence_epoch=7")
+            }),
+            "snapshot deletion must fence the server-observed permanence epoch"
+        );
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|(_, path, _)| path == "/artifact-storage/v1/token")
+                .count(),
+            1,
+            "the repository credential should be reused across write and reads"
         );
     }
 }

--- a/crates/cloud-sdk/src/artifact_storage/models.rs
+++ b/crates/cloud-sdk/src/artifact_storage/models.rs
@@ -165,3 +165,129 @@ pub struct ListOperationsResponse {
     #[serde(default)]
     pub next_after: Option<String>,
 }
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct NativeHeadResponse {
+    pub snapshot_id: Option<String>,
+    pub generation: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct NativeDirectUploadLeaseResponse {
+    pub lease_id: String,
+    pub expires_at_ms: u64,
+    pub transport: String,
+    pub checksum_algorithm: String,
+    pub max_blob_bytes: u64,
+    pub max_targets_per_request: usize,
+    pub max_parts_per_file: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct NativeDirectBlobRequest {
+    pub blob_id: String,
+    pub logical_len: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct NativeDirectBlobTargetsRequest {
+    pub blobs: Vec<NativeDirectBlobRequest>,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct NativeDirectBlobTarget {
+    pub blob_id: String,
+    pub logical_len: u64,
+    pub already_present: bool,
+    pub url: Option<String>,
+    pub checksum_sha256: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct NativeDirectBlobTargetsResponse {
+    pub targets: Vec<NativeDirectBlobTarget>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct NativeDirectUploadReceipt {
+    pub blob_id: String,
+    pub logical_len: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum NativeDirectMutation {
+    Put {
+        path: String,
+        blobs: Vec<NativeDirectBlobRequest>,
+    },
+    Delete {
+        path: String,
+    },
+    Move {
+        from: String,
+        to: String,
+    },
+    Copy {
+        from: String,
+        to: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct NativeDirectPublishRequest {
+    pub operation_id: String,
+    pub message: String,
+    pub expected_version_id: Option<String>,
+    pub lease_id: String,
+    pub uploads: Vec<NativeDirectUploadReceipt>,
+    pub mutations: Vec<NativeDirectMutation>,
+    pub retain_as_snapshot: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct NativeDirectPublishResponse {
+    pub version_id: String,
+    pub previous_version_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct NativeFilesystemSnapshot {
+    pub snapshot_id: String,
+    pub created_at_ms: u64,
+    pub message: String,
+    pub snapshot_class: String,
+    #[serde(default)]
+    pub permanence_epoch: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize)]
+pub struct NativeFilesystemSnapshotPage {
+    pub snapshots: Vec<NativeFilesystemSnapshot>,
+    pub next_after: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct NativeFilesystemSnapshotRetentionResponse {
+    pub snapshot_id: String,
+    pub snapshot_class: String,
+    pub message: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeDirectFileWrite {
+    pub path: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeDirectFilePathWrite {
+    pub path: String,
+    pub source_path: std::path::PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeDirectPathTransfer {
+    pub from: String,
+    pub to: String,
+}

--- a/crates/cloud-sdk/src/artifact_storage/models.rs
+++ b/crates/cloud-sdk/src/artifact_storage/models.rs
@@ -172,6 +172,13 @@ pub struct NativeHeadResponse {
     pub generation: u64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NativeFilesystemFileRead {
+    pub data: Vec<u8>,
+    pub content_id: String,
+    pub full_size: u64,
+}
+
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct NativeDirectUploadLeaseResponse {
     pub lease_id: String,

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -76,10 +76,11 @@ impl From<&str> for ProcessRef {
     fn from(s: &str) -> Self {
         // An all-ASCII-digit string is a pid; anything else is a managed name. This mirrors
         // the daemon's route disambiguation, so a stringified pid still hits the pid branch.
-        if !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()) {
-            if let Ok(pid) = s.parse::<u64>() {
-                return ProcessRef::Pid(pid);
-            }
+        if !s.is_empty()
+            && s.bytes().all(|b| b.is_ascii_digit())
+            && let Ok(pid) = s.parse::<u64>()
+        {
+            return ProcessRef::Pid(pid);
         }
         ProcessRef::Name(s.to_string())
     }

--- a/crates/cloud-sdk/tests/repositories.rs
+++ b/crates/cloud-sdk/tests/repositories.rs
@@ -74,10 +74,10 @@ async fn test_repository_structural_operations() {
         cleanup_repo = None;
     }
     // Best-effort cleanup when the flow failed before its delete.
-    if let Some(repo) = cleanup_repo {
-        if let Err(e) = client.delete_repo(&project_id, &repo).await {
-            eprintln!("Cleanup failed for repo {repo}: {e}");
-        }
+    if let Some(repo) = cleanup_repo
+        && let Err(e) = client.delete_repo(&project_id, &repo).await
+    {
+        eprintln!("Cleanup failed for repo {repo}: {e}");
     }
 
     if let Err(err) = result {

--- a/crates/gsvc-codec/Cargo.toml
+++ b/crates/gsvc-codec/Cargo.toml
@@ -16,6 +16,8 @@
 # Name and edition MUST match the real crate (artifact_storage crates/gsvc-codec), and the
 # dependency list below MUST mirror the real crate's — the swapped-in source compiles against
 # THIS manifest. If the real crate's dependencies change upstream, update this list to match.
+[workspace]
+
 [package]
 name = "gsvc-codec"
 version = "0.1.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -1,5 +1,7 @@
 # Resolution-only placeholder for the private filesystem client engine. Official builds replace
 # only `src/`, keeping this workspace-adapted dependency manifest.
+[workspace]
+
 [package]
 name = "gsvc-fs-client"
 version = "0.5.88"

--- a/crates/gsvc-mount/Cargo.toml
+++ b/crates/gsvc-mount/Cargo.toml
@@ -13,6 +13,8 @@
 # explains exactly what to do.
 #
 # Name and version MUST match the real crate for the `paths` override to apply.
+[workspace]
+
 [package]
 name = "gsvc-mount"
 version = "0.1.0"

--- a/crates/rust-cloud-sdk-node/Cargo.toml
+++ b/crates/rust-cloud-sdk-node/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { workspace = true }
 reqwest = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
+uuid = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/rust-cloud-sdk-node/src/repositories.rs
+++ b/crates/rust-cloud-sdk-node/src/repositories.rs
@@ -5,9 +5,12 @@ use std::path::PathBuf;
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 use tensorlake::artifact_storage::ArtifactStorageClient;
-use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
+use tensorlake::artifact_storage::ingest::PushOptions;
 use tensorlake::artifact_storage::merge::MergeRequest;
 use tensorlake::artifact_storage::models::REPO_KIND_FILESYSTEM;
+use tensorlake::artifact_storage::models::{
+    NativeDirectFilePathWrite, NativeDirectFileWrite, NativeDirectPathTransfer,
+};
 use tensorlake::{ClientBuilder, error::SdkError};
 
 use crate::sandbox::{
@@ -20,6 +23,20 @@ pub struct FilesystemFileWrite {
     /// Path inside the filesystem (forward-slash separated).
     pub path: String,
     pub content: Buffer,
+}
+
+/// One metadata-only path transfer in a filesystem publication.
+#[napi(object)]
+pub struct FilesystemPathTransfer {
+    pub from: String,
+    pub to: String,
+}
+
+/// One local file streamed into a filesystem publication.
+#[napi(object)]
+pub struct FilesystemFilePathWrite {
+    pub path: String,
+    pub local_path: String,
 }
 
 /// Whether a failed request may nonetheless have been processed server-side.
@@ -513,6 +530,33 @@ impl NativeRepositoryClient {
         .await
     }
 
+    /// Create a metadata-only filesystem fork at a live head or retained snapshot.
+    #[napi]
+    pub async fn fork_filesystem(
+        &self,
+        name: String,
+        base: String,
+        snapshot: Option<String>,
+    ) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        let report = self
+            .client
+            .fork_filesystem(&project_id, &name, &base, snapshot.as_deref())
+            .await
+            .map_err(into_napi_error)?;
+        let json = serde_json::to_string(&serde_json::json!({
+            "name": name,
+            "base": base,
+            "snapshot": snapshot,
+            "default_branch": "main",
+        }))
+        .map_err(|error| into_napi_error(error.into()))?;
+        Ok(TracedJson {
+            trace_id: report.trace_id,
+            json,
+        })
+    }
+
     /// List every filesystem in the project (all pages, cache-fenced).
     #[napi]
     pub async fn list_filesystems(&self) -> napi::Result<TracedJson> {
@@ -607,38 +651,86 @@ impl NativeRepositoryClient {
         .await
     }
 
-    /// One ref's head + movement generation for a filesystem branch.
+    /// One native head + movement generation for a filesystem.
     #[napi]
     pub async fn filesystem_ref_status(
         &self,
         name: String,
         refspec: String,
     ) -> napi::Result<TracedJson> {
+        if !matches!(refspec.as_str(), "" | "main" | "refs/heads/main") {
+            return Err(usage_error(
+                "native filesystem status must target the main head".to_string(),
+            ));
+        }
         let project_id = self.project_id()?.to_string();
         with_retry(self.client.clone(), 5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
-            let refspec = refspec.clone();
             async move {
-                let credential = client.git_credential_for_repo(&project_id, &name).await?;
-                let traced = client
-                    .ref_status(
-                        &project_id,
-                        &name,
-                        &credential.git_username,
-                        &credential.token,
-                        &refspec,
-                    )
-                    .await?;
-                let trace_id = traced.trace_id.clone();
-                let json = serde_json::to_string(&*traced)?;
-                Ok(TracedJson { trace_id, json })
+                let status = client.native_filesystem_head(&project_id, &name).await?;
+                let json = serde_json::to_string(&serde_json::json!({
+                    "resolved_commit": status.snapshot_id,
+                    "generation": status.generation,
+                }))?;
+                Ok(TracedJson {
+                    trace_id: status.trace_id.clone(),
+                    json,
+                })
             }
         })
         .await
     }
 
-    /// Raw file bytes at `version` (branch, ref, or commit).
+    /// Pin the current native head as a permanent snapshot without copying content.
+    #[napi]
+    pub async fn retain_filesystem_snapshot(
+        &self,
+        name: String,
+        message: String,
+        request_id: String,
+    ) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        let report = self
+            .client
+            .retain_current_native_filesystem_snapshot(&project_id, &name, message, request_id)
+            .await
+            .map_err(into_napi_error)?;
+        let trace_id = report.trace_id.clone();
+        let json =
+            serde_json::to_string(&*report).map_err(|error| into_napi_error(error.into()))?;
+        Ok(TracedJson { trace_id, json })
+    }
+
+    #[napi]
+    pub async fn list_filesystem_snapshots(&self, name: String) -> napi::Result<TracedJson> {
+        let project_id = self.project_id()?.to_string();
+        let report = self
+            .client
+            .list_native_filesystem_snapshots(&project_id, &name)
+            .await
+            .map_err(into_napi_error)?;
+        let trace_id = report.trace_id.clone();
+        let json = serde_json::to_string(&serde_json::json!({ "snapshots": &*report }))
+            .map_err(|error| into_napi_error(error.into()))?;
+        Ok(TracedJson { trace_id, json })
+    }
+
+    #[napi]
+    pub async fn delete_filesystem_snapshot(
+        &self,
+        name: String,
+        snapshot: String,
+    ) -> napi::Result<String> {
+        let project_id = self.project_id()?.to_string();
+        self.client
+            .delete_native_filesystem_snapshot(&project_id, &name, &snapshot)
+            .await
+            .map(|report| report.trace_id)
+            .map_err(into_napi_error)
+    }
+
+    /// Raw native file bytes at the current head or one snapshot.
     #[napi]
     pub async fn read_filesystem_file(
         &self,
@@ -653,27 +745,19 @@ impl NativeRepositoryClient {
             let path = path.clone();
             let version = version.clone();
             async move {
-                let credential = client.git_credential_for_repo(&project_id, &name).await?;
-                let traced = client
-                    .get_file_bytes(
-                        &project_id,
-                        &name,
-                        &credential.git_username,
-                        &credential.token,
-                        &version,
-                        &path,
-                    )
+                let data = client
+                    .read_native_filesystem_file(&project_id, &name, &path, &version)
                     .await?;
-                let trace_id = traced.trace_id.clone();
-                let data = Buffer::from(traced.into_inner());
-                Ok(TracedBytes { trace_id, data })
+                Ok(TracedBytes {
+                    trace_id: data.trace_id.clone(),
+                    data: Buffer::from(data.into_inner()),
+                })
             }
         })
         .await
     }
 
-    /// One directory's full listing at `version` (all pages), as
-    /// `{"entries": [...]}`.
+    /// One native directory's full listing at the current head or one snapshot.
     #[napi]
     pub async fn list_filesystem_tree(
         &self,
@@ -688,32 +772,28 @@ impl NativeRepositoryClient {
             let dir_path = dir_path.clone();
             let version = version.clone();
             async move {
-                let credential = client.git_credential_for_repo(&project_id, &name).await?;
                 let mut entries = Vec::new();
-                let mut after: Option<String> = None;
+                let mut after = None;
                 let mut seen = std::collections::HashSet::new();
-                let mut trace_id;
                 loop {
-                    let traced = client
-                        .list_tree_page(
+                    let page = client
+                        .list_native_filesystem_entries_page(
                             &project_id,
                             &name,
-                            &credential.git_username,
-                            &credential.token,
-                            &version,
                             &dir_path,
+                            &version,
                             after.as_deref(),
                             1000,
                         )
                         .await?;
-                    trace_id = traced.trace_id.clone();
-                    let page = traced.into_inner();
+                    let trace_id = page.trace_id.clone();
+                    let page = page.into_inner();
                     entries.extend(page.entries);
                     if !page.truncated {
-                        break;
+                        let json =
+                            serde_json::to_string(&serde_json::json!({ "entries": entries }))?;
+                        return Ok(TracedJson { trace_id, json });
                     }
-                    // A truncated page must carry a fresh cursor; anything else
-                    // would silently drop entries or loop forever.
                     match page.next_after {
                         Some(next) if !next.is_empty() && seen.insert(next.clone()) => {
                             after = Some(next);
@@ -726,71 +806,115 @@ impl NativeRepositoryClient {
                         }
                     }
                 }
-                let json = serde_json::to_string(&serde_json::json!({ "entries": entries }))?;
-                Ok(TracedJson { trace_id, json })
             }
         })
         .await
     }
 
-    /// Write `files` and delete `deletes` in one atomic commit on `branch`.
-    ///
-    /// `idempotency_key` must be stable for one logical write: it is what
-    /// makes a retried submit reattach to the same durable commit job.
+    /// Write `files` and delete `deletes` in one native snapshot publication.
     #[napi]
+    #[allow(clippy::too_many_arguments)]
     pub async fn push_filesystem_files(
         &self,
         name: String,
         files: Vec<FilesystemFileWrite>,
         deletes: Vec<String>,
+        moves: Vec<FilesystemPathTransfer>,
+        copies: Vec<FilesystemPathTransfer>,
         message: String,
         branch: String,
         idempotency_key: Option<String>,
     ) -> napi::Result<TracedJson> {
+        if !matches!(branch.as_str(), "" | "main" | "refs/heads/main") {
+            return Err(usage_error(
+                "native filesystem writes must target the main head".to_string(),
+            ));
+        }
         let project_id = self.project_id()?.to_string();
-        // Single-shot on purpose: `push_files` already retries every step
-        // internally (idempotent chunk uploads, commit reattachment through
-        // the caller's stable idempotency key), and an outer whole-push retry
-        // would force a full deep clone of the payload per attempt.
         let client = self.client.clone();
         let result: Result<TracedJson, SdkError> = async move {
-            let credential = client.git_credential_for_repo(&project_id, &name).await?;
-            let push_files: Vec<PushFile> = files
+            let operation_id =
+                idempotency_key.unwrap_or_else(|| format!("sdk-{}", uuid::Uuid::new_v4()));
+            let writes = files
                 .into_iter()
-                .map(|file| PushFile {
-                    repo_path: file.path,
-                    source: PushSource::Bytes(file.content.to_vec()),
-                    mode: None,
-                    delete: false,
+                .map(|file| NativeDirectFileWrite {
+                    path: file.path,
+                    data: file.content.to_vec(),
                 })
-                .chain(deletes.into_iter().map(|repo_path| PushFile {
-                    repo_path,
-                    source: PushSource::Bytes(Vec::new()),
-                    mode: None,
-                    delete: true,
-                }))
                 .collect();
-            let opts = PushOptions {
-                branch,
-                message,
-                idempotency_key,
-                ..Default::default()
-            };
-            let traced = client
-                .push_files(
+            let moves = moves
+                .into_iter()
+                .map(|transfer| NativeDirectPathTransfer {
+                    from: transfer.from,
+                    to: transfer.to,
+                })
+                .collect();
+            let copies = copies
+                .into_iter()
+                .map(|transfer| NativeDirectPathTransfer {
+                    from: transfer.from,
+                    to: transfer.to,
+                })
+                .collect();
+            let report = client
+                .publish_filesystem_files(
                     &project_id,
                     &name,
-                    &credential.git_username,
-                    &credential.token,
-                    push_files,
-                    opts,
+                    writes,
+                    deletes,
+                    moves,
+                    copies,
+                    message,
+                    operation_id,
                 )
                 .await?;
-            let trace_id = traced.trace_id.clone();
-            let json = serde_json::to_string(&*traced)?;
+            let trace_id = report.trace_id.clone();
+            let json = serde_json::to_string(&serde_json::json!({
+                "version_id": report.version_id,
+                "previous_version_id": report.previous_version_id,
+            }))?;
             Ok(TracedJson { trace_id, json })
         }
         .await;
         result.map_err(into_napi_error)
+    }
+
+    /// Stream local files through bounded client-to-object-store parts.
+    #[napi]
+    pub async fn push_filesystem_paths(
+        &self,
+        name: String,
+        files: Vec<FilesystemFilePathWrite>,
+        message: String,
+        branch: String,
+        idempotency_key: Option<String>,
+    ) -> napi::Result<TracedJson> {
+        if !matches!(branch.as_str(), "" | "main" | "refs/heads/main") {
+            return Err(usage_error(
+                "native filesystem writes must target the main head".to_string(),
+            ));
+        }
+        let project_id = self.project_id()?.to_string();
+        let operation_id =
+            idempotency_key.unwrap_or_else(|| format!("sdk-{}", uuid::Uuid::new_v4()));
+        let writes = files
+            .into_iter()
+            .map(|file| NativeDirectFilePathWrite {
+                path: file.path,
+                source_path: PathBuf::from(file.local_path),
+            })
+            .collect();
+        let report = self
+            .client
+            .publish_filesystem_paths(&project_id, &name, writes, message, operation_id)
+            .await
+            .map_err(into_napi_error)?;
+        let trace_id = report.trace_id.clone();
+        let json = serde_json::to_string(&serde_json::json!({
+            "version_id": report.version_id,
+            "previous_version_id": report.previous_version_id,
+        }))
+        .map_err(|error| into_napi_error(error.into()))?;
+        Ok(TracedJson { trace_id, json })
     }
 }

--- a/crates/rust-cloud-sdk-node/src/repositories.rs
+++ b/crates/rust-cloud-sdk-node/src/repositories.rs
@@ -737,7 +737,30 @@ impl NativeRepositoryClient {
         name: String,
         path: String,
         version: String,
+        offset: Option<f64>,
+        length: Option<f64>,
     ) -> napi::Result<TracedBytes> {
+        let range = match (offset, length) {
+            (None, None) => None,
+            (Some(offset), Some(length))
+                if offset.is_finite()
+                    && length.is_finite()
+                    && offset >= 0.0
+                    && length > 0.0
+                    && offset.fract() == 0.0
+                    && length.fract() == 0.0
+                    && offset <= u64::MAX as f64
+                    && length <= u64::MAX as f64 =>
+            {
+                Some((offset as u64, length as u64))
+            }
+            _ => {
+                return Err(usage_error(
+                    "filesystem range requires a non-negative integer offset and positive integer length"
+                        .to_string(),
+                ));
+            }
+        };
         let project_id = self.project_id()?.to_string();
         with_retry(self.client.clone(), 5, move |client| {
             let project_id = project_id.clone();
@@ -745,12 +768,22 @@ impl NativeRepositoryClient {
             let path = path.clone();
             let version = version.clone();
             async move {
-                let data = client
-                    .read_native_filesystem_file(&project_id, &name, &path, &version)
+                let read = client
+                    .read_native_filesystem_file_with_metadata(
+                        &project_id,
+                        &name,
+                        &path,
+                        &version,
+                        range,
+                    )
                     .await?;
+                let trace_id = read.trace_id.clone();
+                let read = read.into_inner();
                 Ok(TracedBytes {
-                    trace_id: data.trace_id.clone(),
-                    data: Buffer::from(data.into_inner()),
+                    trace_id,
+                    data: Buffer::from(read.data),
+                    content_id: Some(read.content_id),
+                    full_size: Some(read.full_size as f64),
                 })
             }
         })

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -1099,6 +1099,7 @@ impl NativeSandboxProxyClient {
 /// Validate a managed-process name client-side; throws on failure. Wraps the single
 /// source-of-truth rule in the Rust cloud SDK so the TS layer need not reimplement it.
 #[napi]
+#[allow(dead_code)]
 pub fn validate_managed_name(name: String) -> napi::Result<()> {
     tensorlake::sandboxes::validate_managed_name(&name).map_err(into_napi_error)
 }

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -48,6 +48,8 @@ pub struct TracedJson {
 pub struct TracedBytes {
     pub trace_id: String,
     pub data: Buffer,
+    pub content_id: Option<String>,
+    pub full_size: Option<f64>,
 }
 
 /// A list of JSON-encoded events paired with the request's W3C trace id.
@@ -1000,6 +1002,8 @@ impl NativeSandboxProxyClient {
         Ok(TracedBytes {
             trace_id,
             data: data.into(),
+            content_id: None,
+            full_size: None,
         })
     }
 

--- a/crates/rust-cloud-sdk-py/Cargo.toml
+++ b/crates/rust-cloud-sdk-py/Cargo.toml
@@ -19,6 +19,7 @@ reqwest = { workspace = true }
 pyo3 = { workspace = true }
 pyo3-async-runtimes = { workspace = true }
 urlencoding = { workspace = true }
+uuid = { workspace = true }
 
 [build-dependencies]
 pyo3-build-config = "0.28.3"

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -21,9 +21,11 @@ use reqwest::multipart::{Form, Part};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tensorlake::artifact_storage::ArtifactStorageClient;
-use tensorlake::artifact_storage::ingest::{PushFile, PushOptions, PushSource};
+use tensorlake::artifact_storage::ingest::PushOptions;
 use tensorlake::artifact_storage::merge::MergeRequest;
-use tensorlake::artifact_storage::models::REPO_KIND_FILESYSTEM;
+use tensorlake::artifact_storage::models::{
+    NativeDirectFilePathWrite, NativeDirectFileWrite, REPO_KIND_FILESYSTEM,
+};
 use tensorlake::document_ai::DocumentAiClient;
 use tensorlake::file_systems::FileSystemsClient;
 use tensorlake::file_systems::models::CreateFileSystemRequest;
@@ -674,6 +676,37 @@ impl CloudApiClient {
         })
     }
 
+    #[pyo3(signature = (project_id, name, base, snapshot=None))]
+    fn fork_filesystem(
+        &self,
+        project_id: String,
+        name: String,
+        base: String,
+        snapshot: Option<String>,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let base = base.clone();
+            let snapshot = snapshot.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client
+                    .fork_filesystem(&project_id, &name, &base, snapshot.as_deref())
+                    .await?;
+                serde_json::to_string(&serde_json::json!({
+                    "trace_id": traced.trace_id,
+                    "default_branch": "main",
+                }))
+                .map_err(SdkError::from)
+            }
+        })
+    }
+
     /// List every filesystem in the project (all pages, cache-fenced).
     fn list_filesystems(&self, project_id: String) -> PyResult<String> {
         self.run_with_retry(5, move |api_client| {
@@ -776,27 +809,100 @@ impl CloudApiClient {
         name: String,
         refspec: String,
     ) -> PyResult<String> {
+        if !matches!(refspec.as_str(), "" | "main" | "refs/heads/main") {
+            return Err(into_py_error(SdkError::ClientError(
+                "native filesystem status must target the main head".to_string(),
+            )));
+        }
         self.run_with_retry(5, move |api_client| {
             let api_url = self.api_url.clone();
             let project_id = project_id.clone();
             let name = name.clone();
-            let refspec = refspec.clone();
             async move {
                 let client = ArtifactStorageClient::new(
                     api_client,
                     tensorlake::resolve_artifact_storage_url(&api_url),
                 )?;
-                let credential = client.git_credential_for_repo(&project_id, &name).await?;
+                let traced = client.native_filesystem_head(&project_id, &name).await?;
+                serde_json::to_string(&serde_json::json!({
+                    "resolved_commit": traced.snapshot_id,
+                    "generation": traced.generation,
+                }))
+                .map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn retain_filesystem_snapshot(
+        &self,
+        project_id: String,
+        name: String,
+        message: String,
+        request_id: String,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let message = message.clone();
+            let request_id = request_id.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
                 let traced = client
-                    .ref_status(
+                    .retain_current_native_filesystem_snapshot(
                         &project_id,
                         &name,
-                        &credential.git_username,
-                        &credential.token,
-                        &refspec,
+                        message,
+                        request_id,
                     )
                     .await?;
                 serde_json::to_string(&*traced).map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn list_filesystem_snapshots(&self, project_id: String, name: String) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let traced = client
+                    .list_native_filesystem_snapshots(&project_id, &name)
+                    .await?;
+                serde_json::to_string(&serde_json::json!({ "snapshots": &*traced }))
+                    .map_err(SdkError::from)
+            }
+        })
+    }
+
+    fn delete_filesystem_snapshot(
+        &self,
+        project_id: String,
+        name: String,
+        snapshot: String,
+    ) -> PyResult<String> {
+        self.run_with_retry(5, move |api_client| {
+            let api_url = self.api_url.clone();
+            let project_id = project_id.clone();
+            let name = name.clone();
+            let snapshot = snapshot.clone();
+            async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                client
+                    .delete_native_filesystem_snapshot(&project_id, &name, &snapshot)
+                    .await
+                    .map(|traced| traced.trace_id)
             }
         })
     }
@@ -820,16 +926,8 @@ impl CloudApiClient {
                     api_client,
                     tensorlake::resolve_artifact_storage_url(&api_url),
                 )?;
-                let credential = client.git_credential_for_repo(&project_id, &name).await?;
                 let traced = client
-                    .get_file_bytes(
-                        &project_id,
-                        &name,
-                        &credential.git_username,
-                        &credential.token,
-                        &version,
-                        &path,
-                    )
+                    .read_native_filesystem_file(&project_id, &name, &path, &version)
                     .await?;
                 Ok(traced.into_inner())
             }
@@ -856,19 +954,16 @@ impl CloudApiClient {
                     api_client,
                     tensorlake::resolve_artifact_storage_url(&api_url),
                 )?;
-                let credential = client.git_credential_for_repo(&project_id, &name).await?;
                 let mut entries = Vec::new();
                 let mut after: Option<String> = None;
                 let mut seen = std::collections::HashSet::new();
                 loop {
                     let page = client
-                        .list_tree_page(
+                        .list_native_filesystem_entries_page(
                             &project_id,
                             &name,
-                            &credential.git_username,
-                            &credential.token,
-                            &version,
                             &dir_path,
+                            &version,
                             after.as_deref(),
                             1000,
                         )
@@ -902,21 +997,24 @@ impl CloudApiClient {
     ///
     /// `idempotency_key` must be stable for one logical write: it is what
     /// makes a retried submit reattach to the same durable commit job.
-    #[pyo3(signature = (project_id, name, files, deletes, message, branch, idempotency_key=None))]
+    #[pyo3(signature = (project_id, name, files, deletes, moves, copies, message, branch, idempotency_key=None))]
     fn push_filesystem_files(
         &self,
         project_id: String,
         name: String,
         files: Vec<(String, Vec<u8>)>,
         deletes: Vec<String>,
+        moves: Vec<(String, String)>,
+        copies: Vec<(String, String)>,
         message: String,
         branch: String,
         idempotency_key: Option<String>,
     ) -> PyResult<String> {
-        // Single-shot on purpose: `push_files` already retries every step
-        // internally (idempotent chunk uploads, commit reattachment through
-        // the caller's stable idempotency key), and an outer whole-push retry
-        // would force a full deep clone of the payload per attempt.
+        if !matches!(branch.as_str(), "" | "main" | "refs/heads/main") {
+            return Err(into_py_error(SdkError::ClientError(
+                "native filesystem writes must target the main head".to_string(),
+            )));
+        }
         let api_client = self.client.clone();
         let api_url = self.api_url.clone();
         shared_runtime()
@@ -925,39 +1023,85 @@ impl CloudApiClient {
                     api_client,
                     tensorlake::resolve_artifact_storage_url(&api_url),
                 )?;
-                let credential = client.git_credential_for_repo(&project_id, &name).await?;
-                let push_files: Vec<PushFile> = files
+                let writes = files
                     .into_iter()
-                    .map(|(repo_path, data)| PushFile {
-                        repo_path,
-                        source: PushSource::Bytes(data),
-                        mode: None,
-                        delete: false,
-                    })
-                    .chain(deletes.into_iter().map(|repo_path| PushFile {
-                        repo_path,
-                        source: PushSource::Bytes(Vec::new()),
-                        mode: None,
-                        delete: true,
-                    }))
+                    .map(|(path, data)| NativeDirectFileWrite { path, data })
                     .collect();
-                let opts = PushOptions {
-                    branch,
-                    message,
-                    idempotency_key,
-                    ..Default::default()
-                };
-                let traced = client
-                    .push_files(
+                let moves = moves
+                    .into_iter()
+                    .map(|(from, to)| {
+                        tensorlake::artifact_storage::models::NativeDirectPathTransfer { from, to }
+                    })
+                    .collect();
+                let copies = copies
+                    .into_iter()
+                    .map(|(from, to)| {
+                        tensorlake::artifact_storage::models::NativeDirectPathTransfer { from, to }
+                    })
+                    .collect();
+                let operation_id =
+                    idempotency_key.unwrap_or_else(|| format!("sdk-{}", uuid::Uuid::new_v4()));
+                let report = client
+                    .publish_filesystem_files(
                         &project_id,
                         &name,
-                        &credential.git_username,
-                        &credential.token,
-                        push_files,
-                        opts,
+                        writes,
+                        deletes,
+                        moves,
+                        copies,
+                        message,
+                        operation_id,
                     )
                     .await?;
-                serde_json::to_string(&*traced).map_err(SdkError::from)
+                serde_json::to_string(&serde_json::json!({
+                    "version_id": report.version_id,
+                    "previous_version_id": report.previous_version_id,
+                }))
+                .map_err(SdkError::from)
+            })
+            .map_err(into_py_error)
+    }
+
+    #[pyo3(signature = (project_id, name, files, message, branch, idempotency_key=None))]
+    fn push_filesystem_paths(
+        &self,
+        project_id: String,
+        name: String,
+        files: Vec<(String, String)>,
+        message: String,
+        branch: String,
+        idempotency_key: Option<String>,
+    ) -> PyResult<String> {
+        if !matches!(branch.as_str(), "" | "main" | "refs/heads/main") {
+            return Err(into_py_error(SdkError::ClientError(
+                "native filesystem writes must target the main head".to_string(),
+            )));
+        }
+        let api_client = self.client.clone();
+        let api_url = self.api_url.clone();
+        shared_runtime()
+            .block_on(async move {
+                let client = ArtifactStorageClient::new(
+                    api_client,
+                    tensorlake::resolve_artifact_storage_url(&api_url),
+                )?;
+                let writes = files
+                    .into_iter()
+                    .map(|(path, source_path)| NativeDirectFilePathWrite {
+                        path,
+                        source_path: PathBuf::from(source_path),
+                    })
+                    .collect();
+                let operation_id =
+                    idempotency_key.unwrap_or_else(|| format!("sdk-{}", uuid::Uuid::new_v4()));
+                let report = client
+                    .publish_filesystem_paths(&project_id, &name, writes, message, operation_id)
+                    .await?;
+                serde_json::to_string(&serde_json::json!({
+                    "version_id": report.version_id,
+                    "previous_version_id": report.previous_version_id,
+                }))
+                .map_err(SdkError::from)
             })
             .map_err(into_py_error)
     }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -74,6 +74,7 @@ fn request_may_have_executed(err: &SdkError) -> bool {
 #[pyclass]
 pub struct CloudApiClient {
     client: Client,
+    artifact_storage: ArtifactStorageClient,
     api_url: String,
     namespace: String,
 }
@@ -106,9 +107,15 @@ impl CloudApiClient {
         }
 
         let client = builder.build().map_err(into_py_error)?;
+        let artifact_storage = ArtifactStorageClient::new(
+            client.clone(),
+            tensorlake::resolve_artifact_storage_url(&api_url),
+        )
+        .map_err(into_py_error)?;
 
         Ok(Self {
             client,
+            artifact_storage,
             api_url,
             namespace: namespace.unwrap_or_else(|| "default".to_string()),
         })
@@ -283,7 +290,7 @@ impl CloudApiClient {
     }
 
     fn git_repo_url(&self, project_id: String, repo: String) -> PyResult<String> {
-        let client = self.artifact_storage_client().map_err(into_py_error)?;
+        let client = self.artifact_storage_client();
         Ok(client.git_repo_url(&project_id, &repo))
     }
 
@@ -599,16 +606,11 @@ impl CloudApiClient {
     /// pre-existing filesystem.
     fn create_filesystem(&self, project_id: String, name: String) -> PyResult<String> {
         let maybe_executed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             let maybe_executed = maybe_executed.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 // Minted before the forgiveness-tracked call: a mint failure
                 // says nothing about whether a create reached the server, so
                 // it must never arm the 409 forgiveness below.
@@ -684,17 +686,12 @@ impl CloudApiClient {
         base: String,
         snapshot: Option<String>,
     ) -> PyResult<String> {
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             let base = base.clone();
             let snapshot = snapshot.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 let traced = client
                     .fork_filesystem(&project_id, &name, &base, snapshot.as_deref())
                     .await?;
@@ -709,14 +706,9 @@ impl CloudApiClient {
 
     /// List every filesystem in the project (all pages, cache-fenced).
     fn list_filesystems(&self, project_id: String) -> PyResult<String> {
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 let traced = client
                     .list_repos_of_kind(&project_id, Some(REPO_KIND_FILESYSTEM))
                     .await?;
@@ -727,15 +719,10 @@ impl CloudApiClient {
 
     /// Point-read one filesystem's identity (name, status, kind, default branch).
     fn filesystem_meta(&self, project_id: String, name: String) -> PyResult<String> {
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 // A project-scoped credential: repo-scoped mints can fail for a
                 // repo that does not exist, which would mask the 404 callers
                 // need to distinguish "no such filesystem".
@@ -755,16 +742,11 @@ impl CloudApiClient {
 
     fn delete_filesystem(&self, project_id: String, name: String) -> PyResult<String> {
         let maybe_executed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             let maybe_executed = maybe_executed.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 // Minted before the forgiveness-tracked call: a mint failure
                 // says nothing about whether a delete reached the server, so
                 // it must never arm the 404 forgiveness below.
@@ -814,15 +796,10 @@ impl CloudApiClient {
                 "native filesystem status must target the main head".to_string(),
             )));
         }
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 let traced = client.native_filesystem_head(&project_id, &name).await?;
                 serde_json::to_string(&serde_json::json!({
                     "resolved_commit": traced.snapshot_id,
@@ -840,17 +817,12 @@ impl CloudApiClient {
         message: String,
         request_id: String,
     ) -> PyResult<String> {
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             let message = message.clone();
             let request_id = request_id.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 let traced = client
                     .retain_current_native_filesystem_snapshot(
                         &project_id,
@@ -865,15 +837,10 @@ impl CloudApiClient {
     }
 
     fn list_filesystem_snapshots(&self, project_id: String, name: String) -> PyResult<String> {
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 let traced = client
                     .list_native_filesystem_snapshots(&project_id, &name)
                     .await?;
@@ -889,16 +856,11 @@ impl CloudApiClient {
         name: String,
         snapshot: String,
     ) -> PyResult<String> {
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             let snapshot = snapshot.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 client
                     .delete_native_filesystem_snapshot(&project_id, &name, &snapshot)
                     .await
@@ -915,17 +877,12 @@ impl CloudApiClient {
         path: String,
         version: String,
     ) -> PyResult<Vec<u8>> {
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             let path = path.clone();
             let version = version.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 let traced = client
                     .read_native_filesystem_file(&project_id, &name, &path, &version)
                     .await?;
@@ -943,17 +900,12 @@ impl CloudApiClient {
         dir_path: String,
         version: String,
     ) -> PyResult<String> {
-        self.run_with_retry(5, move |api_client| {
-            let api_url = self.api_url.clone();
+        self.run_artifact_with_retry(5, move |client| {
             let project_id = project_id.clone();
             let name = name.clone();
             let dir_path = dir_path.clone();
             let version = version.clone();
             async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 let mut entries = Vec::new();
                 let mut after: Option<String> = None;
                 let mut seen = std::collections::HashSet::new();
@@ -1015,14 +967,9 @@ impl CloudApiClient {
                 "native filesystem writes must target the main head".to_string(),
             )));
         }
-        let api_client = self.client.clone();
-        let api_url = self.api_url.clone();
+        let client = self.artifact_storage.clone();
         shared_runtime()
             .block_on(async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 let writes = files
                     .into_iter()
                     .map(|(path, data)| NativeDirectFileWrite { path, data })
@@ -1077,14 +1024,9 @@ impl CloudApiClient {
                 "native filesystem writes must target the main head".to_string(),
             )));
         }
-        let api_client = self.client.clone();
-        let api_url = self.api_url.clone();
+        let client = self.artifact_storage.clone();
         shared_runtime()
             .block_on(async move {
-                let client = ArtifactStorageClient::new(
-                    api_client,
-                    tensorlake::resolve_artifact_storage_url(&api_url),
-                )?;
                 let writes = files
                     .into_iter()
                     .map(|(path, source_path)| NativeDirectFilePathWrite {
@@ -3528,11 +3470,8 @@ where
 }
 
 impl CloudApiClient {
-    fn artifact_storage_client(&self) -> Result<ArtifactStorageClient, SdkError> {
-        ArtifactStorageClient::new(
-            self.client.clone(),
-            tensorlake::resolve_artifact_storage_url(&self.api_url),
-        )
+    fn artifact_storage_client(&self) -> ArtifactStorageClient {
+        self.artifact_storage.clone()
     }
 
     fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
@@ -3544,6 +3483,20 @@ impl CloudApiClient {
             self.client.clone(),
             max_retries,
             "rust cloud API request",
+            into_py_error,
+            operation,
+        )
+    }
+
+    fn run_artifact_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
+    where
+        F: FnMut(ArtifactStorageClient) -> Fut,
+        Fut: Future<Output = Result<T, SdkError>>,
+    {
+        run_with_retry_blocking(
+            self.artifact_storage.clone(),
+            max_retries,
+            "artifact storage request",
             into_py_error,
             operation,
         )

--- a/justfile
+++ b/justfile
@@ -183,6 +183,15 @@ test-cli-full *ARGS:
     CARGO_TARGET_DIR="$PWD/target" cargo test --manifest-path crates/gsvc-fs-client/Cargo.toml {{ARGS}}
     cargo test --workspace --features tensorlake-cli/mount,tensorlake-cli/git-clone {{ARGS}}
 
+# Validate the server-side filesystem SDK. It deliberately has no dependency on the private mount
+# engine: reads use native HTTP routes and writes upload directly to object storage.
+test-node-filesystem-full:
+    cargo clippy -p tensorlake-rust-cloud-sdk-node --no-deps -- -D warnings
+    cargo test -p tensorlake-rust-cloud-sdk-node
+    cd typescript && npm run typecheck
+    cd typescript && npm test -- tests/filesystem.test.ts
+    cd typescript && npm run build:native
+
 # Authoritative validation for the private filesystem client integration. Run the complete
 # full-feature CLI suite so changes exercise every consumer of the private crate.
 test-fs-journal:

--- a/src/tensorlake/filesystem/__init__.py
+++ b/src/tensorlake/filesystem/__init__.py
@@ -18,9 +18,11 @@ from .exceptions import (
 from .models import (
     FileEntry,
     FilesystemInfo,
+    FilesystemSnapshot,
+    FilesystemSnapshotInfo,
     FilesystemStatus,
+    FilesystemVersion,
     MountStatus,
-    Snapshot,
 )
 
 __all__ = [
@@ -28,9 +30,11 @@ __all__ = [
     "Filesystem",
     "Mount",
     "FilesystemInfo",
+    "FilesystemVersion",
+    "FilesystemSnapshot",
+    "FilesystemSnapshotInfo",
     "FilesystemStatus",
     "FileEntry",
-    "Snapshot",
     "MountStatus",
     "FilesystemException",
     "FilesystemError",

--- a/src/tensorlake/filesystem/_native.py
+++ b/src/tensorlake/filesystem/_native.py
@@ -1,11 +1,11 @@
 """Bridge to the Rust cloud-sdk core for filesystem operations.
 
-All wire-protocol work (credential minting, chunked ingest with
-content-defined chunking and dedup, commit-job polling, transient retries,
-pagination) lives in the shared Rust `ArtifactStorageClient`, exposed through
-the ``tensorlake._cloud_sdk`` native module. This bridge only builds the
-native client and translates its exceptions into the filesystem exception
-hierarchy.
+All wire-protocol work (cached repository credential minting, checksum-bound
+direct object-store uploads, atomic native publication, transient retries,
+and pagination) lives in the shared Rust ``ArtifactStorageClient``, exposed
+through the ``tensorlake._cloud_sdk`` native module. This bridge only builds
+the long-lived native client and translates its exceptions into the
+filesystem exception hierarchy.
 """
 
 from __future__ import annotations

--- a/src/tensorlake/filesystem/_native.py
+++ b/src/tensorlake/filesystem/_native.py
@@ -89,6 +89,17 @@ class NativeFilesystems:
         )
         return str(json.loads(raw).get("default_branch") or "main")
 
+    def fork_filesystem(
+        self, name: str, base: str, snapshot: Optional[str] = None
+    ) -> str:
+        raw = self._call(
+            lambda: self._client.fork_filesystem(
+                self._project_id, name, base, snapshot
+            ),
+            not_found=FilesystemNotFoundError(base),
+        )
+        return str(json.loads(raw).get("default_branch") or "main")
+
     def filesystem_meta(self, name: str) -> Dict[str, Any]:
         raw = self._call(
             lambda: self._client.filesystem_meta(self._project_id, name),
@@ -119,6 +130,32 @@ class NativeFilesystems:
         )
         return json.loads(raw)
 
+    def retain_snapshot(
+        self, name: str, message: str, request_id: str
+    ) -> Dict[str, Any]:
+        raw = self._call(
+            lambda: self._client.retain_filesystem_snapshot(
+                self._project_id, name, message, request_id
+            ),
+            not_found=FilesystemNotFoundError(name),
+        )
+        return json.loads(raw)
+
+    def list_snapshots(self, name: str) -> List[Dict[str, Any]]:
+        raw = self._call(
+            lambda: self._client.list_filesystem_snapshots(self._project_id, name),
+            not_found=FilesystemNotFoundError(name),
+        )
+        return json.loads(raw).get("snapshots", [])
+
+    def delete_snapshot(self, name: str, snapshot: str) -> None:
+        self._call(
+            lambda: self._client.delete_filesystem_snapshot(
+                self._project_id, name, snapshot
+            ),
+            not_found=FilesystemNotFoundError(name),
+        )
+
     def read_file(self, name: str, path: str, version: str) -> bytes:
         return bytes(
             self._call(
@@ -143,6 +180,8 @@ class NativeFilesystems:
         name: str,
         files: List[Tuple[str, bytes]],
         deletes: List[str],
+        moves: List[Tuple[str, str]],
+        copies: List[Tuple[str, str]],
         message: str,
         idempotency_key: str,
         branch: str = "main",
@@ -153,6 +192,29 @@ class NativeFilesystems:
                 name,
                 files,
                 deletes,
+                moves,
+                copies,
+                message,
+                branch,
+                idempotency_key,
+            ),
+            not_found=FilesystemNotFoundError(name),
+        )
+        return json.loads(raw)
+
+    def push_paths(
+        self,
+        name: str,
+        files: List[Tuple[str, str]],
+        message: str,
+        idempotency_key: str,
+        branch: str = "main",
+    ) -> Dict[str, Any]:
+        raw = self._call(
+            lambda: self._client.push_filesystem_paths(
+                self._project_id,
+                name,
+                files,
                 message,
                 branch,
                 idempotency_key,

--- a/src/tensorlake/filesystem/client.py
+++ b/src/tensorlake/filesystem/client.py
@@ -6,9 +6,10 @@ Cloud. Every write produces a
 at any version, and a filesystem can
 be mounted to a local path through the ``tl`` CLI's FUSE/FSKit daemon.
 
-Reads and writes are served by the shared Rust cloud-sdk core (the same
-engine behind the ``tl`` CLI), so uploads get content-defined chunking,
-dedup, transient retries, and idempotent commit reattachment for free.
+Reads and writes are served by the shared Rust cloud-sdk core. Writes split
+large files into bounded checksum-addressed parts, upload missing bytes
+directly to object storage, and atomically publish the resulting metadata.
+Payload bytes never pass through the Tensorlake API service.
 
 Example::
 
@@ -371,8 +372,8 @@ class Filesystem:
     # -- reads ------------------------------------------------------------------
 
     def read_file(self, path: str, version: Optional[str] = None) -> bytes:
-        """Read a file's bytes at ``version`` (branch, ref, or snapshot
-        commit; defaults to the filesystem's default branch)."""
+        """Read a file's bytes at ``version`` (the current ``main`` head or
+        a retained snapshot id); defaults to the filesystem's current head."""
         if not path.strip("/"):
             raise FilesystemError("file path must not be empty")
         return self._native.read_file(self._name, path, version or self._branch())

--- a/src/tensorlake/filesystem/client.py
+++ b/src/tensorlake/filesystem/client.py
@@ -1,8 +1,9 @@
 """Client for Tensorlake filesystems.
 
 A filesystem is a durable, versioned file tree that lives in Tensorlake
-Cloud. Every write produces a :class:`~tensorlake.filesystem.models.Snapshot`
-(a durable version), files can be read at any version, and a filesystem can
+Cloud. Every write produces a
+:class:`~tensorlake.filesystem.models.FilesystemVersion`, files can be read
+at any version, and a filesystem can
 be mounted to a local path through the ``tl`` CLI's FUSE/FSKit daemon.
 
 Reads and writes are served by the shared Rust cloud-sdk core (the same
@@ -26,7 +27,10 @@ Example::
 
 from __future__ import annotations
 
+import os
 import secrets
+from datetime import datetime, timezone
+from os import PathLike
 from typing import Dict, Iterable, List, Optional, Union
 
 from tensorlake.cli._common import build_context_from_env
@@ -37,9 +41,11 @@ from .exceptions import FilesystemAPIError, FilesystemError, FilesystemNotFoundE
 from .models import (
     FileEntry,
     FilesystemInfo,
+    FilesystemSnapshot,
+    FilesystemSnapshotInfo,
     FilesystemStatus,
+    FilesystemVersion,
     MountStatus,
-    Snapshot,
 )
 
 _FILESYSTEM_KIND = "filesystem"
@@ -125,6 +131,15 @@ class FilesystemClient:
             self, name, default_branch=meta.get("default_branch") or "main"
         )
 
+    def fork(
+        self, name: str, base_filesystem: str, snapshot: Optional[str] = None
+    ) -> "Filesystem":
+        """Create a metadata-only fork at a live head or retained snapshot."""
+        if not name or not base_filesystem:
+            raise FilesystemError("fork and base filesystem names must not be empty")
+        default_branch = self._native.fork_filesystem(name, base_filesystem, snapshot)
+        return Filesystem(self, name, default_branch=default_branch)
+
     def list(self) -> List[FilesystemInfo]:
         """List all filesystems in the project."""
         return [
@@ -189,8 +204,8 @@ class Filesystem:
 
     def write_file(
         self, path: str, data: _FileData, message: Optional[str] = None
-    ) -> Snapshot:
-        """Write one file. Returns the snapshot (version) the write produced."""
+    ) -> FilesystemVersion:
+        """Write one file. Returns the durable live version produced."""
         return self.write_files({path: data}, message=message)
 
     def write_files(
@@ -198,54 +213,160 @@ class Filesystem:
         files: Dict[str, _FileData],
         message: Optional[str] = None,
         deletes: Iterable[str] = (),
-    ) -> Snapshot:
-        """Write several files (and/or delete paths) in one atomic snapshot."""
+    ) -> FilesystemVersion:
+        """Write several files (and/or delete paths) in one atomic publication."""
         writes = [(path, _to_bytes(data)) for path, data in files.items()]
         delete_paths = list(deletes)
         if not writes and not delete_paths:
             raise FilesystemError("nothing to write: no files or deletions given")
         resolved_message = message or f"write {len(writes)} file(s) via SDK"
+        return self._publish_changes(
+            writes=writes,
+            deletes=delete_paths,
+            moves=[],
+            copies=[],
+            message=resolved_message,
+        )
+
+    def move_file(
+        self, source: str, destination: str, message: Optional[str] = None
+    ) -> FilesystemVersion:
+        """Atomically move a file or directory without transferring its bytes."""
+        return self._publish_changes(
+            writes=[],
+            deletes=[],
+            moves=[(source, destination)],
+            copies=[],
+            message=message or f"move {source} to {destination} via SDK",
+        )
+
+    def write_file_from_path(
+        self,
+        path: str,
+        local_path: Union[str, PathLike[str]],
+        message: Optional[str] = None,
+    ) -> FilesystemVersion:
+        """Stream one local file directly to object storage in bounded parts."""
+        return self.write_files_from_paths(
+            {path: local_path},
+            message=message,
+        )
+
+    def write_files_from_paths(
+        self,
+        files: Dict[str, Union[str, PathLike[str]]],
+        message: Optional[str] = None,
+    ) -> FilesystemVersion:
+        """Atomically publish local files without loading them fully into memory."""
+        writes = [(path, os.fspath(local_path)) for path, local_path in files.items()]
+        if not writes:
+            raise FilesystemError("nothing to write: no local files given")
+        resolved_message = message or f"write {len(writes)} local file(s) via SDK"
+        report = self._native.push_paths(
+            self._name,
+            files=writes,
+            message=resolved_message,
+            idempotency_key=secrets.token_hex(16),
+            branch=self._branch(),
+        )
+        version_id = str(report.get("version_id") or "")
+        previous_version_id = report.get("previous_version_id")
+        return FilesystemVersion(
+            version_id=version_id,
+            previous_version_id=(
+                str(previous_version_id) if previous_version_id is not None else None
+            ),
+            created=previous_version_id != version_id,
+            message=resolved_message,
+        )
+
+    def copy_file(
+        self, source: str, destination: str, message: Optional[str] = None
+    ) -> FilesystemVersion:
+        """Copy a file or directory by reusing its immutable content references."""
+        return self._publish_changes(
+            writes=[],
+            deletes=[],
+            moves=[],
+            copies=[(source, destination)],
+            message=message or f"copy {source} to {destination} via SDK",
+        )
+
+    def _publish_changes(
+        self,
+        *,
+        writes: List[tuple[str, bytes]],
+        deletes: List[str],
+        moves: List[tuple[str, str]],
+        copies: List[tuple[str, str]],
+        message: str,
+    ) -> FilesystemVersion:
         report = self._native.push_files(
             self._name,
             files=writes,
-            deletes=delete_paths,
-            message=resolved_message,
+            deletes=deletes,
+            moves=moves,
+            copies=copies,
+            message=message,
             # One key per logical write: a retried submit reattaches to the
             # same durable commit job instead of double-committing.
             idempotency_key=secrets.token_hex(16),
             branch=self._branch(),
         )
-        return Snapshot(
-            commit=report.get("commit") or "",
-            tree=report.get("tree") or "",
-            ref_name=report.get("ref_name") or "",
-            created=bool(report.get("created", True)),
-            message=resolved_message,
+        version_id = str(report.get("version_id") or "")
+        previous_version_id = report.get("previous_version_id")
+        return FilesystemVersion(
+            version_id=version_id,
+            previous_version_id=(
+                str(previous_version_id) if previous_version_id is not None else None
+            ),
+            created=previous_version_id != version_id,
+            message=message,
         )
 
-    def delete_file(self, path: str, message: Optional[str] = None) -> Snapshot:
-        """Delete one file. Returns the snapshot the deletion produced."""
+    def delete_file(
+        self, path: str, message: Optional[str] = None
+    ) -> FilesystemVersion:
+        """Delete one file. Returns the durable live version produced."""
         return self.write_files(
             {}, message=message or f"delete {path} via SDK", deletes=[path]
         )
 
-    def snapshot(self, message: str = "") -> Snapshot:
-        """Return the filesystem's current version as a snapshot.
+    def snapshot(self, message: str = "snapshot via SDK") -> FilesystemSnapshot:
+        """Permanently retain the filesystem's current version.
 
-        Writes already create snapshots implicitly; this pins the current
-        head without changing any content.
+        Writes publish durable live versions. This retains the current head
+        permanently in one metadata-only server operation without changing
+        or copying any content.
         """
-        status = self.status()
-        if not status.head_commit:
-            raise FilesystemError(
-                f"filesystem {self._name} is empty: write files first"
-            )
-        return Snapshot(
-            commit=status.head_commit,
-            ref_name=f"refs/heads/{status.default_branch}",
-            created=False,
-            message=message,
+        resolved_message = message or "snapshot via SDK"
+        retained = self._native.retain_snapshot(
+            self._name,
+            resolved_message,
+            secrets.token_hex(16),
         )
+        return FilesystemSnapshot(
+            id=retained.get("snapshot_id") or "",
+            message=retained.get("message") or resolved_message,
+        )
+
+    def list_snapshots(self) -> List[FilesystemSnapshotInfo]:
+        """List explicitly retained snapshots without reading file content."""
+        return [
+            FilesystemSnapshotInfo(
+                id=str(snapshot.get("snapshot_id") or ""),
+                created_at=datetime.fromtimestamp(
+                    float(snapshot.get("created_at_ms") or 0) / 1000,
+                    tz=timezone.utc,
+                ),
+                message=str(snapshot.get("message") or ""),
+            )
+            for snapshot in self._native.list_snapshots(self._name)
+        ]
+
+    def delete_snapshot(self, snapshot: str) -> None:
+        """Delete one permanent retention point."""
+        self._native.delete_snapshot(self._name, snapshot)
 
     # -- reads ------------------------------------------------------------------
 
@@ -271,23 +392,36 @@ class Filesystem:
         for entry in self._native.list_tree(
             self._name, dir_path, version or self._branch()
         ):
-            model = FileEntry.model_validate(entry)
-            model.path = f"{prefix}/{model.name}" if prefix else model.name
-            entries.append(model)
+            mode = int(entry.get("mode", 0o100644))
+            name = str(entry["name"])
+            entries.append(
+                FileEntry(
+                    name=name,
+                    path=f"{prefix}/{name}" if prefix else name,
+                    content_id=str(entry.get("oid") or ""),
+                    kind=(
+                        "directory"
+                        if mode == 0o40000
+                        else "symlink" if mode == 0o120000 else "file"
+                    ),
+                    executable=mode == 0o100755,
+                    size=entry.get("size"),
+                )
+            )
         return entries
 
     # -- status -------------------------------------------------------------------
 
     def status(self) -> FilesystemStatus:
-        """Remote status: identity plus the current head snapshot."""
+        """Remote status: identity plus the current native version."""
         meta = self._native.filesystem_meta(self._name)
-        head_commit: Optional[str] = None
+        version_id: Optional[str] = None
         generation: Optional[int] = None
         default_branch = meta.get("default_branch") or "main"
         self._default_branch = default_branch
         try:
             ref = self._native.ref_status(self._name, default_branch)
-            head_commit = ref.get("resolved_commit") or ref.get("oid") or None
+            version_id = ref.get("resolved_commit") or ref.get("oid") or None
             generation = ref.get("generation")
         except FilesystemAPIError as e:
             # Only "no such ref yet" means an empty filesystem; anything else
@@ -297,8 +431,7 @@ class Filesystem:
         return FilesystemStatus(
             name=self._name,
             status=meta.get("status", ""),
-            default_branch=default_branch,
-            head_commit=head_commit,
+            version_id=version_id,
             generation=generation,
         )
 

--- a/src/tensorlake/filesystem/models.py
+++ b/src/tensorlake/filesystem/models.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from datetime import datetime
+from typing import Any, Dict, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
-
-# Git tree entry mode for a directory (0o40000 rendered by the server as an int).
-_GIT_MODE_DIR = 0o40000
-_GIT_MODE_SYMLINK = 0o120000
 
 
 class FilesystemInfo(BaseModel):
@@ -18,7 +15,6 @@ class FilesystemInfo(BaseModel):
 
     name: str
     full_name: str = ""
-    default_branch: str = "main"
     status: str = ""
     kind: str = "filesystem"
 
@@ -30,12 +26,11 @@ class FilesystemStatus(BaseModel):
 
     name: str
     status: str = ""
-    default_branch: str = "main"
-    #: Commit hash the default branch currently points at (None for an empty
-    #: filesystem that has never been written to).
-    head_commit: Optional[str] = None
-    #: Server-side movement counter for the default branch; bumps whenever the
-    #: head advances. None on servers that do not report it.
+    #: Current native version id (None for an empty filesystem that has never
+    #: been written to).
+    version_id: Optional[str] = None
+    #: Server-side movement counter for the live version; bumps whenever it
+    #: advances. None on servers that do not report it.
     generation: Optional[int] = None
 
 
@@ -45,11 +40,12 @@ class FileEntry(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     name: str
-    #: Git blob/tree object id.
-    oid: str = ""
-    #: Raw git mode (0o100644 file, 0o100755 executable, 0o120000 symlink,
-    #: 0o40000 directory).
-    mode: int = 0o100644
+    #: Stable native content identity for the file or directory.
+    content_id: str = ""
+    #: Native entry kind.
+    kind: Literal["file", "directory", "symlink"] = "file"
+    #: Whether a regular file is executable.
+    executable: bool = False
     #: Blob size in bytes when cheaply known server-side.
     size: Optional[int] = None
     #: Path of the entry relative to the filesystem root.
@@ -57,25 +53,43 @@ class FileEntry(BaseModel):
 
     @property
     def is_dir(self) -> bool:
-        return self.mode == _GIT_MODE_DIR
+        return self.kind == "directory"
 
     @property
     def is_symlink(self) -> bool:
-        return self.mode == _GIT_MODE_SYMLINK
+        return self.kind == "symlink"
 
 
-class Snapshot(BaseModel):
-    """A durable version of the filesystem (a commit)."""
+class FilesystemVersion(BaseModel):
+    """The durable live version produced by one atomic publication."""
 
     model_config = ConfigDict(extra="ignore")
 
-    #: Commit hash — pass as ``version=`` to read the filesystem at this point.
-    commit: str
-    tree: str = ""
-    ref_name: str = ""
-    parent: Optional[str] = None
+    #: Native version id — pass as ``version=`` to read this point in time.
+    version_id: str
+    #: Version replaced by this publication, or None for the first publication.
+    previous_version_id: Optional[str] = None
     #: False when the write was a no-op (content identical to the parent).
     created: bool = True
+    message: str = ""
+
+
+class FilesystemSnapshot(BaseModel):
+    """One newly retained native filesystem snapshot."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    message: str = ""
+
+
+class FilesystemSnapshotInfo(BaseModel):
+    """One explicitly retained native filesystem snapshot."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    created_at: datetime
     message: str = ""
 
 

--- a/tests/filesystem/test_filesystem_unit.py
+++ b/tests/filesystem/test_filesystem_unit.py
@@ -24,7 +24,7 @@ from tensorlake.filesystem import (
     FilesystemError,
     FilesystemInfo,
     FilesystemNotFoundError,
-    Snapshot,
+    FilesystemVersion,
 )
 from tensorlake.filesystem.client import mount_status_from_raw
 
@@ -77,16 +77,8 @@ class _StubNative:
         self.entries = entries or []
         self.file_bytes = file_bytes
         self.push_report = push_report or {
-            "commit": _COMMIT,
-            "tree": "t" * 40,
-            "ref_name": "refs/heads/main",
-            "created": True,
-            "files": 1,
-            "bytes_total": 1,
-            "chunks_total": 1,
-            "chunks_uploaded": 1,
-            "bytes_uploaded": 1,
-            "file_blob_oids": [],
+            "version_id": _COMMIT,
+            "previous_version_id": None,
         }
         self.errors = errors or {}
         self.calls: List[Tuple[str, tuple]] = []
@@ -103,6 +95,11 @@ class _StubNative:
         self.calls.append(("create_filesystem", (project_id, name)))
         self._maybe_fail("create_filesystem")
         return json.dumps({"trace_id": "trace-1", "default_branch": self.create_branch})
+
+    def fork_filesystem(self, project_id, name, base, snapshot=None):
+        self.calls.append(("fork_filesystem", (project_id, name, base, snapshot)))
+        self._maybe_fail("fork_filesystem")
+        return json.dumps({"trace_id": "trace-1", "default_branch": "main"})
 
     def filesystem_meta(self, project_id, name):
         self.calls.append(("filesystem_meta", (project_id, name)))
@@ -126,6 +123,53 @@ class _StubNative:
         self._maybe_fail("filesystem_ref_status")
         return json.dumps(self.ref)
 
+    def retain_filesystem_snapshot(self, project_id, name, message, request_id):
+        self.calls.append(
+            (
+                "retain_filesystem_snapshot",
+                (project_id, name, message, request_id),
+            )
+        )
+        self._maybe_fail("retain_filesystem_snapshot")
+        snapshot_id = self.ref.get("resolved_commit")
+        if not snapshot_id:
+            raise CloudApiClientError(
+                "internal", None, f"filesystem {name} is empty: write files first"
+            )
+        return json.dumps(
+            {
+                "snapshot_id": snapshot_id,
+                "snapshot_class": "permanent_snapshot",
+                "message": message,
+            }
+        )
+
+    def list_filesystem_snapshots(self, project_id, name):
+        self.calls.append(("list_filesystem_snapshots", (project_id, name)))
+        self._maybe_fail("list_filesystem_snapshots")
+        return json.dumps(
+            {
+                "snapshots": [
+                    {
+                        "snapshot_id": _COMMIT,
+                        "created_at_ms": 1_700_000_000_000,
+                        "message": "pin",
+                        "snapshot_class": "permanent_snapshot",
+                    }
+                ]
+            }
+        )
+
+    def delete_filesystem_snapshot(self, project_id, name, snapshot):
+        self.calls.append(
+            (
+                "delete_filesystem_snapshot",
+                (project_id, name, snapshot),
+            )
+        )
+        self._maybe_fail("delete_filesystem_snapshot")
+        return "trace-delete"
+
     def read_filesystem_file(self, project_id, name, path, version):
         self.calls.append(("read_filesystem_file", (project_id, name, path, version)))
         self._maybe_fail("read_filesystem_file")
@@ -139,15 +183,46 @@ class _StubNative:
         return json.dumps({"entries": self.entries})
 
     def push_filesystem_files(
-        self, project_id, name, files, deletes, message, branch, idempotency_key
+        self,
+        project_id,
+        name,
+        files,
+        deletes,
+        moves,
+        copies,
+        message,
+        branch,
+        idempotency_key,
     ):
         self.calls.append(
             (
                 "push_filesystem_files",
-                (project_id, name, files, deletes, message, branch, idempotency_key),
+                (
+                    project_id,
+                    name,
+                    files,
+                    deletes,
+                    moves,
+                    copies,
+                    message,
+                    branch,
+                    idempotency_key,
+                ),
             )
         )
         self._maybe_fail("push_filesystem_files")
+        return json.dumps(self.push_report)
+
+    def push_filesystem_paths(
+        self, project_id, name, files, message, branch, idempotency_key
+    ):
+        self.calls.append(
+            (
+                "push_filesystem_paths",
+                (project_id, name, files, message, branch, idempotency_key),
+            )
+        )
+        self._maybe_fail("push_filesystem_paths")
         return json.dumps(self.push_report)
 
 
@@ -164,9 +239,9 @@ class TestModels(unittest.TestCase):
             }
         )
         self.assertEqual(info.name, "skills")
-        entry = FileEntry.model_validate({"name": "d", "oid": "x", "mode": 0o40000})
+        entry = FileEntry(name="d", content_id="x", kind="directory")
         self.assertTrue(entry.is_dir)
-        entry = FileEntry.model_validate({"name": "f", "oid": "y", "mode": 0o100644})
+        entry = FileEntry(name="f", content_id="y", kind="file")
         self.assertFalse(entry.is_dir)
 
 
@@ -215,24 +290,67 @@ class TestFilesystemClient(unittest.TestCase):
         stub = _StubNative()
         client = _client_with_stub(stub)
         fs = client.create("my-fs")
-        snapshot = fs.write_files(
+        version = fs.write_files(
             {"a.txt": "hello", "b.bin": b"\x00\x01"}, deletes=["old.txt"]
         )
-        self.assertIsInstance(snapshot, Snapshot)
-        self.assertEqual(snapshot.commit, _COMMIT)
-        self.assertTrue(snapshot.created)
+        self.assertIsInstance(version, FilesystemVersion)
+        self.assertEqual(version.version_id, _COMMIT)
+        self.assertIsNone(version.previous_version_id)
+        self.assertTrue(version.created)
 
         method, args = stub.calls[-1]
         self.assertEqual(method, "push_filesystem_files")
-        _, name, files, deletes, _message, branch, idempotency_key = args
+        (
+            _,
+            name,
+            files,
+            deletes,
+            moves,
+            copies,
+            _message,
+            branch,
+            idempotency_key,
+        ) = args
         self.assertEqual(name, "my-fs")
         # Strings are encoded to bytes; bytes pass through.
         self.assertEqual(dict(files), {"a.txt": b"hello", "b.bin": b"\x00\x01"})
         self.assertEqual(deletes, ["old.txt"])
+        self.assertEqual(moves, [])
+        self.assertEqual(copies, [])
         self.assertEqual(branch, "main")
         # A fresh stable key per logical write (the Rust core reuses it across
         # its retries so a lost response cannot double-commit).
         self.assertRegex(idempotency_key, r"^[0-9a-f]{32}$")
+
+    def test_move_and_copy_publish_metadata_only_mutations(self):
+        stub = _StubNative()
+        fs = _client_with_stub(stub).create("my-fs")
+
+        fs.move_file("large.bin", "archive/large.bin")
+        args = stub.calls[-1][1]
+        self.assertEqual(args[2], [])
+        self.assertEqual(args[3], [])
+        self.assertEqual(args[4], [("large.bin", "archive/large.bin")])
+        self.assertEqual(args[5], [])
+
+        fs.copy_file("archive/large.bin", "copies/large.bin")
+        args = stub.calls[-1][1]
+        self.assertEqual(args[2], [])
+        self.assertEqual(args[3], [])
+        self.assertEqual(args[4], [])
+        self.assertEqual(args[5], [("archive/large.bin", "copies/large.bin")])
+
+    def test_write_files_from_paths_uses_memory_bounded_native_api(self):
+        stub = _StubNative()
+        fs = _client_with_stub(stub).create("my-fs")
+
+        version = fs.write_files_from_paths({"models/weights.bin": "/tmp/weights.bin"})
+        self.assertEqual(version.version_id, _COMMIT)
+        method, args = stub.calls[-1]
+        self.assertEqual(method, "push_filesystem_paths")
+        self.assertEqual(args[2], [("models/weights.bin", "/tmp/weights.bin")])
+        self.assertEqual(args[4], "main")
+        self.assertRegex(args[5], r"^[0-9a-f]{32}$")
 
     def test_empty_write_rejected(self):
         client = _client_with_stub(_StubNative())
@@ -267,13 +385,12 @@ class TestFilesystemClient(unittest.TestCase):
         self.assertTrue(entries[0].is_dir)
         self.assertEqual(entries[1].size, 3)
 
-    def test_status_maps_head_and_generation(self):
+    def test_status_maps_version_and_generation(self):
         client = _client_with_stub(_StubNative())
         fs = client.create("my-fs")
         status = fs.status()
-        self.assertEqual(status.head_commit, _COMMIT)
+        self.assertEqual(status.version_id, _COMMIT)
         self.assertEqual(status.generation, 3)
-        self.assertEqual(status.default_branch, "main")
 
     def test_status_of_empty_filesystem(self):
         stub = _StubNative(
@@ -286,7 +403,7 @@ class TestFilesystemClient(unittest.TestCase):
         )
         client = _client_with_stub(stub)
         fs = client.create("my-fs")
-        self.assertIsNone(fs.status().head_commit)
+        self.assertIsNone(fs.status().version_id)
         with self.assertRaises(FilesystemError):
             fs.snapshot("nothing yet")
 
@@ -296,7 +413,7 @@ class TestFilesystemClient(unittest.TestCase):
         )
         client = _client_with_stub(stub)
         fs = client.create("my-fs")
-        self.assertIsNone(fs.status().head_commit)
+        self.assertIsNone(fs.status().version_id)
 
         stub.errors["filesystem_ref_status"] = ("remote_api", 503, "unavailable")
         with self.assertRaises(FilesystemAPIError) as caught:
@@ -304,11 +421,39 @@ class TestFilesystemClient(unittest.TestCase):
         self.assertEqual(caught.exception.status_code, 503)
 
     def test_snapshot_pins_current_head(self):
-        client = _client_with_stub(_StubNative())
+        stub = _StubNative()
+        client = _client_with_stub(stub)
         fs = client.create("my-fs")
         snapshot = fs.snapshot("pin")
-        self.assertEqual(snapshot.commit, _COMMIT)
-        self.assertFalse(snapshot.created)
+        self.assertEqual(snapshot.id, _COMMIT)
+        self.assertEqual(stub.calls[-1][0], "retain_filesystem_snapshot")
+
+    def test_snapshot_list_delete_and_metadata_only_fork(self):
+        stub = _StubNative()
+        client = _client_with_stub(stub)
+        fs = client.create("my-fs")
+        snapshots = fs.list_snapshots()
+        self.assertEqual([snapshot.id for snapshot in snapshots], [_COMMIT])
+        self.assertEqual(snapshots[0].message, "pin")
+
+        fs.delete_snapshot(_COMMIT)
+        self.assertEqual(
+            stub.calls[-1],
+            (
+                "delete_filesystem_snapshot",
+                (_PROJECT, "my-fs", _COMMIT),
+            ),
+        )
+
+        fork = client.fork("forked", "my-fs", _COMMIT)
+        self.assertEqual(fork.name, "forked")
+        self.assertEqual(
+            stub.calls[-1],
+            (
+                "fork_filesystem",
+                (_PROJECT, "forked", "my-fs", _COMMIT),
+            ),
+        )
 
     def test_create_seeds_branch_reported_by_binding(self):
         stub = _StubNative()
@@ -316,8 +461,8 @@ class TestFilesystemClient(unittest.TestCase):
         client = _client_with_stub(stub)
         fs = client.create("my-fs")
         fs.write_file("a.txt", b"x")
-        # (project, name, files, deletes, message, branch, idempotency_key)
-        self.assertEqual(stub.calls[-1][1][5], "trunk")
+        # (project, name, files, deletes, moves, copies, message, branch, idempotency_key)
+        self.assertEqual(stub.calls[-1][1][7], "trunk")
 
     def test_non_main_default_branch_followed_by_writes_and_reads(self):
         stub = _StubNative()
@@ -325,8 +470,8 @@ class TestFilesystemClient(unittest.TestCase):
         client = _client_with_stub(stub)
         fs = client.get("my-fs")
         fs.write_file("a.txt", b"x")
-        # (project, name, files, deletes, message, branch, idempotency_key)
-        self.assertEqual(stub.calls[-1][1][5], "trunk")
+        # (project, name, files, deletes, moves, copies, message, branch, idempotency_key)
+        self.assertEqual(stub.calls[-1][1][7], "trunk")
         fs.read_file("a.txt")
         # (project, name, path, version)
         self.assertEqual(stub.calls[-1][1][3], "trunk")
@@ -342,7 +487,7 @@ class TestFilesystemClient(unittest.TestCase):
         fs = client.create("my-fs")
         # Explicit "" gets the default too — parity with the TypeScript SDK.
         snapshot = fs.write_file("a.txt", b"x", message="")
-        message = stub.calls[-1][1][4]
+        message = stub.calls[-1][1][6]
         self.assertEqual(message, "write 1 file(s) via SDK")
         self.assertEqual(snapshot.message, "write 1 file(s) via SDK")
 

--- a/typescript/scripts/build-native.mjs
+++ b/typescript/scripts/build-native.mjs
@@ -12,6 +12,11 @@ const targetId =
   process.env.TENSORLAKE_NODE_TARGET_ID ?? `${process.platform}-${process.arch}`;
 const targetTriple = process.env.TENSORLAKE_NODE_TARGET_TRIPLE || undefined;
 const buildTool = process.env.TENSORLAKE_NODE_BUILD_TOOL ?? "cargo";
+const scriptArgs = process.argv.slice(2);
+if (scriptArgs.length > 0) {
+  console.error(`Unsupported argument(s): ${scriptArgs.join(", ")}`);
+  process.exit(1);
+}
 
 const outputDir = path.join(
   packageRoot,

--- a/typescript/src/filesystem-models.ts
+++ b/typescript/src/filesystem-models.ts
@@ -54,6 +54,22 @@ export interface FileEntry {
   isSymlink: boolean;
 }
 
+/** Bytes plus immutable identity/size returned by one file request. */
+export interface FilesystemFileRead {
+  data: Uint8Array;
+  /** Stable native identity for the complete file content. */
+  contentId: string;
+  /** Size of the complete file, even when `data` is a requested range. */
+  size: number;
+}
+
+export interface FilesystemReadOptions {
+  /** Current `main` head when omitted; otherwise one retained snapshot id. */
+  version?: string;
+  /** Half-open byte selection expressed as offset + length. */
+  range?: { offset: number; length: number };
+}
+
 export function fileEntryFromWire(
   entry: { name: string; oid?: string; mode?: number; size?: number | null },
   dirPath: string,

--- a/typescript/src/filesystem-models.ts
+++ b/typescript/src/filesystem-models.ts
@@ -20,7 +20,6 @@ export function trimSlashes(path: string): string {
 export interface FilesystemInfo {
   name: string;
   fullName: string;
-  defaultBranch: string;
   status: string;
   kind: string;
 }
@@ -29,13 +28,12 @@ export interface FilesystemInfo {
 export interface FilesystemStatus {
   name: string;
   status: string;
-  defaultBranch: string;
   /**
-   * Commit hash the default branch currently points at; null for an empty
-   * filesystem that has never been written to.
+   * Current native version id; null for an empty filesystem that has never
+   * been written to.
    */
-  headCommit: string | null;
-  /** Server-side movement counter for the default branch, when reported. */
+  versionId: string | null;
+  /** Server-side movement counter for the live version, when reported. */
   generation: number | null;
 }
 
@@ -44,10 +42,12 @@ export interface FileEntry {
   name: string;
   /** Path of the entry relative to the filesystem root. */
   path: string;
-  /** Git blob/tree object id. */
-  oid: string;
-  /** Raw git mode (0o100644 file, 0o100755 executable, 0o120000 symlink, 0o40000 dir). */
-  mode: number;
+  /** Stable native content identity for the file or directory. */
+  contentId: string;
+  /** Native entry kind. */
+  kind: "file" | "directory" | "symlink";
+  /** Whether a regular file is executable. */
+  executable: boolean;
   /** Blob size in bytes when cheaply known server-side. */
   size: number | null;
   isDir: boolean;
@@ -63,23 +63,41 @@ export function fileEntryFromWire(
   return {
     name: entry.name,
     path: prefix ? `${prefix}/${entry.name}` : entry.name,
-    oid: entry.oid ?? "",
-    mode,
+    contentId: entry.oid ?? "",
+    kind:
+      mode === GIT_MODE_DIR
+        ? "directory"
+        : mode === GIT_MODE_SYMLINK
+          ? "symlink"
+          : "file",
+    executable: mode === 0o100755,
     size: entry.size ?? null,
     isDir: mode === GIT_MODE_DIR,
     isSymlink: mode === GIT_MODE_SYMLINK,
   };
 }
 
-/** A durable version of the filesystem (a commit). */
-export interface Snapshot {
-  /** Commit hash — pass as `version` to read the filesystem at this point. */
-  commit: string;
-  tree: string;
-  refName: string;
-  parent: string | null;
+/** The durable live version produced by one atomic filesystem publication. */
+export interface FilesystemVersion {
+  /** Native version id — pass as `version` to read the filesystem at this point. */
+  versionId: string;
+  /** Version replaced by this publication, or null for the first publication. */
+  previousVersionId: string | null;
   /** False when the write was a no-op (content identical to the parent). */
   created: boolean;
+  message: string;
+}
+
+/** One newly retained native filesystem snapshot. */
+export interface FilesystemSnapshot {
+  id: string;
+  message: string;
+}
+
+/** One explicitly retained native filesystem snapshot. */
+export interface FilesystemSnapshotInfo {
+  id: string;
+  createdAt: Date;
   message: string;
 }
 

--- a/typescript/src/filesystem.ts
+++ b/typescript/src/filesystem.ts
@@ -2,13 +2,14 @@
  * Client for Tensorlake filesystems.
  *
  * A filesystem is a durable, versioned file tree that lives in Tensorlake
- * Cloud. Every write produces a {@link Snapshot} (a durable version), files
- * can be read at any version, and a filesystem can be mounted to a local
- * path through the `tl` CLI's FUSE/FSKit daemon.
+ * Cloud. Every write publishes a durable live version; {@link Filesystem.snapshot}
+ * retains the current version permanently. Files can be read at any retained
+ * version, and a filesystem can be mounted to a local path through the `tl`
+ * CLI's FUSE/FSKit daemon.
  *
- * Reads and writes are served by the shared Rust cloud-sdk core (the same
- * engine behind the `tl` CLI), so uploads get content-defined chunking,
- * dedup, transient retries, and idempotent commit reattachment for free.
+ * Server-side SDK writes hash complete files locally, upload missing bytes
+ * directly to checksum-bound object-store targets, and atomically publish
+ * one durable snapshot. Payload bytes never transit the API service.
  *
  * @example
  * const client = new FilesystemClient();   // env-based auth
@@ -41,9 +42,11 @@ import {
   trimSlashes,
   type FileEntry,
   type FilesystemInfo,
+  type FilesystemSnapshot,
+  type FilesystemSnapshotInfo,
   type FilesystemStatus,
+  type FilesystemVersion,
   type MountStatus,
-  type Snapshot,
 } from "./filesystem-models.js";
 import {
   loadNativeSandboxBinding,
@@ -307,6 +310,32 @@ export class FilesystemClient {
     );
   }
 
+  /**
+   * Fork a filesystem at its live head or an explicit retained snapshot.
+   * The server shares immutable content and publishes only metadata.
+   */
+  async fork(
+    name: string,
+    baseFilesystem: string,
+    snapshot?: string,
+  ): Promise<Filesystem> {
+    if (!name || !baseFilesystem) {
+      throw new FilesystemError(
+        "fork and base filesystem names must not be empty",
+      );
+    }
+    await callNative(
+      () =>
+        this.native.forkFilesystem(
+          name,
+          baseFilesystem,
+          snapshot ?? null,
+        ),
+      new FilesystemNotFoundError(baseFilesystem),
+    );
+    return new Filesystem(this, this.native, this.cli, name, "main");
+  }
+
   /** Return a handle to an existing filesystem (verifies it exists). */
   async get(name: string): Promise<Filesystem> {
     const traced = await callNative(
@@ -338,7 +367,6 @@ export class FilesystemClient {
     return (page.repos ?? []).map((repo) => ({
       name: String(repo.name ?? ""),
       fullName: String(repo.full_name ?? ""),
-      defaultBranch: String(repo.default_branch ?? "main"),
       status: String(repo.status ?? ""),
       kind: String(repo.kind ?? FILESYSTEM_REPO_KIND),
     }));
@@ -432,7 +460,7 @@ export class Filesystem {
     path: string,
     data: FileData,
     message?: string,
-  ): Promise<Snapshot> {
+  ): Promise<FilesystemVersion> {
     return await this.writeFiles(new Map([[path, data]]), message);
   }
 
@@ -441,7 +469,7 @@ export class Filesystem {
     files: Map<string, FileData> | Record<string, FileData>,
     message?: string,
     deletes: string[] = [],
-  ): Promise<Snapshot> {
+  ): Promise<FilesystemVersion> {
     const entries =
       files instanceof Map ? [...files.entries()] : Object.entries(files);
     if (entries.length === 0 && deletes.length === 0) {
@@ -454,6 +482,118 @@ export class Filesystem {
     // Truthiness, not nullish: an explicit "" gets the default too (parity
     // with the Python SDK).
     const resolvedMessage = message || `write ${writes.length} file(s) via SDK`;
+    return await this.publishChanges(
+      writes,
+      deletes,
+      [],
+      [],
+      resolvedMessage,
+    );
+  }
+
+  /**
+   * Stream one local file directly to object storage in bounded parts.
+   * This is the memory-bounded API for multi-GiB files.
+   */
+  async writeFileFromPath(
+    path: string,
+    localPath: string,
+    message?: string,
+  ): Promise<FilesystemVersion> {
+    return await this.writeFilesFromPaths(
+      new Map([[path, localPath]]),
+      message,
+    );
+  }
+
+  /**
+   * Atomically publish local files without loading their complete payloads
+   * into JavaScript or Rust memory.
+   */
+  async writeFilesFromPaths(
+    files: Map<string, string> | Record<string, string>,
+    message?: string,
+  ): Promise<FilesystemVersion> {
+    const entries =
+      files instanceof Map ? [...files.entries()] : Object.entries(files);
+    if (entries.length === 0) {
+      throw new FilesystemError("nothing to write: no local files given");
+    }
+    const writes = entries.map(([path, localPath]) => ({ path, localPath }));
+    const resolvedMessage =
+      message || `write ${writes.length} local file(s) via SDK`;
+    const branch = await this.branch();
+    const traced = await callNative(
+      () =>
+        this.native.pushFilesystemPaths(
+          this.name,
+          writes,
+          resolvedMessage,
+          branch,
+          randomBytes(16).toString("hex"),
+        ),
+      new FilesystemNotFoundError(this.name),
+    );
+    const report = JSON.parse(traced.json) as {
+      version_id?: string;
+      previous_version_id?: string | null;
+    };
+    const versionId = String(report.version_id ?? "");
+    const previousVersionId =
+      report.previous_version_id == null
+        ? null
+        : String(report.previous_version_id);
+    return {
+      versionId,
+      previousVersionId,
+      created: previousVersionId !== versionId,
+      message: resolvedMessage,
+    };
+  }
+
+  /**
+   * Move a file or directory without downloading or re-uploading its bytes.
+   * The source removal and destination creation publish as one atomic snapshot.
+   */
+  async moveFile(
+    from: string,
+    to: string,
+    message?: string,
+  ): Promise<FilesystemVersion> {
+    return await this.publishChanges(
+      [],
+      [],
+      [{ from, to }],
+      [],
+      message || `move ${from} to ${to} via SDK`,
+    );
+  }
+
+  /**
+   * Copy a file or directory by reusing immutable content references. No
+   * payload bytes traverse the client, API server, or object store.
+   */
+  async copyFile(
+    from: string,
+    to: string,
+    message?: string,
+  ): Promise<FilesystemVersion> {
+    return await this.publishChanges(
+      [],
+      [],
+      [],
+      [{ from, to }],
+      message || `copy ${from} to ${to} via SDK`,
+    );
+  }
+
+  private async publishChanges(
+    writes: Array<{ path: string; content: Buffer }>,
+    deletes: string[],
+    moves: Array<{ from: string; to: string }>,
+    copies: Array<{ from: string; to: string }>,
+    message: string,
+  ): Promise<FilesystemVersion> {
     const branch = await this.branch();
     const traced = await callNative(
       () =>
@@ -461,7 +601,9 @@ export class Filesystem {
           this.name,
           writes,
           deletes,
-          resolvedMessage,
+          moves,
+          copies,
+          message,
           branch,
           // One key per logical write: a retried submit reattaches to the
           // same durable commit job instead of double-committing.
@@ -469,19 +611,25 @@ export class Filesystem {
         ),
       new FilesystemNotFoundError(this.name),
     );
-    const report = JSON.parse(traced.json) as Record<string, unknown>;
+    const report = JSON.parse(traced.json) as {
+      version_id?: string;
+      previous_version_id?: string | null;
+    };
+    const versionId = String(report.version_id ?? "");
+    const previousVersionId =
+      report.previous_version_id == null
+        ? null
+        : String(report.previous_version_id);
     return {
-      commit: String(report.commit ?? ""),
-      tree: String(report.tree ?? ""),
-      refName: String(report.ref_name ?? ""),
-      parent: null,
-      created: report.created === undefined ? true : Boolean(report.created),
-      message: resolvedMessage,
+      versionId,
+      previousVersionId,
+      created: previousVersionId !== versionId,
+      message,
     };
   }
 
-  /** Delete one file. Returns the snapshot the deletion produced. */
-  async deleteFile(path: string, message?: string): Promise<Snapshot> {
+  /** Delete one file. Returns the durable version the deletion produced. */
+  async deleteFile(path: string, message?: string): Promise<FilesystemVersion> {
     return await this.writeFiles(
       new Map(),
       message || `delete ${path} via SDK`,
@@ -492,24 +640,57 @@ export class Filesystem {
   /**
    * Return the filesystem's current version as a snapshot.
    *
-   * Writes already create snapshots implicitly; this pins the current head
-   * without changing any content.
+   * Writes publish durable live versions. This retains the current head
+   * permanently in one metadata-only server operation without changing or
+   * copying any content.
    */
-  async snapshot(message = ""): Promise<Snapshot> {
-    const status = await this.status();
-    if (!status.headCommit) {
-      throw new FilesystemError(
-        `filesystem ${this.name} is empty: write files first`,
-      );
-    }
-    return {
-      commit: status.headCommit,
-      tree: "",
-      refName: `refs/heads/${status.defaultBranch}`,
-      parent: null,
-      created: false,
-      message,
+  async snapshot(message = "snapshot via SDK"): Promise<FilesystemSnapshot> {
+    const resolvedMessage = message || "snapshot via SDK";
+    const traced = await callNative(
+      () =>
+        this.native.retainFilesystemSnapshot(
+          this.name,
+          resolvedMessage,
+          randomBytes(16).toString("hex"),
+        ),
+      new FilesystemNotFoundError(this.name),
+    );
+    const retained = JSON.parse(traced.json) as {
+      snapshot_id?: string;
+      message?: string;
     };
+    return {
+      id: String(retained.snapshot_id ?? ""),
+      message: retained.message || resolvedMessage,
+    };
+  }
+
+  /** List explicitly retained snapshots without reading filesystem contents. */
+  async listSnapshots(): Promise<FilesystemSnapshotInfo[]> {
+    const traced = await callNative(
+      () => this.native.listFilesystemSnapshots(this.name),
+      new FilesystemNotFoundError(this.name),
+    );
+    const payload = JSON.parse(traced.json) as {
+      snapshots?: Array<{
+        snapshot_id?: string;
+        created_at_ms?: number;
+        message?: string;
+      }>;
+    };
+    return (payload.snapshots ?? []).map((snapshot) => ({
+      id: String(snapshot.snapshot_id ?? ""),
+      createdAt: new Date(Number(snapshot.created_at_ms ?? 0)),
+      message: String(snapshot.message ?? ""),
+    }));
+  }
+
+  /** Delete one permanent retention point; shared/head-reachable bytes remain. */
+  async deleteSnapshot(snapshot: string): Promise<void> {
+    await callNative(
+      () => this.native.deleteFilesystemSnapshot(this.name, snapshot),
+      new FilesystemNotFoundError(this.name),
+    );
   }
 
   // -- reads --------------------------------------------------------------------
@@ -555,7 +736,7 @@ export class Filesystem {
 
   // -- status -------------------------------------------------------------------
 
-  /** Remote status: identity plus the current head snapshot. */
+  /** Remote status: identity plus the current native version. */
   async status(): Promise<FilesystemStatus> {
     const metaTraced = await callNative(
       () => this.native.filesystemMeta(this.name),
@@ -564,7 +745,7 @@ export class Filesystem {
     const meta = JSON.parse(metaTraced.json) as Record<string, unknown>;
     const defaultBranch = String(meta.default_branch || "main");
     this.defaultBranch = defaultBranch;
-    let headCommit: string | null = null;
+    let versionId: string | null = null;
     let generation: number | null = null;
     try {
       // A 404 here means "no such ref yet" (an empty filesystem), so it is
@@ -573,7 +754,7 @@ export class Filesystem {
         this.native.filesystemRefStatus(this.name, defaultBranch),
       );
       const ref = JSON.parse(refTraced.json) as Record<string, unknown>;
-      headCommit =
+      versionId =
         (ref.resolved_commit as string) || (ref.oid as string) || null;
       generation = typeof ref.generation === "number" ? ref.generation : null;
     } catch (error) {
@@ -586,8 +767,7 @@ export class Filesystem {
     return {
       name: this.name,
       status: String(meta.status ?? ""),
-      defaultBranch,
-      headCommit,
+      versionId,
       generation,
     };
   }

--- a/typescript/src/filesystem.ts
+++ b/typescript/src/filesystem.ts
@@ -41,7 +41,9 @@ import {
   mountStatusFromRaw,
   trimSlashes,
   type FileEntry,
+  type FilesystemFileRead,
   type FilesystemInfo,
+  type FilesystemReadOptions,
   type FilesystemSnapshot,
   type FilesystemSnapshotInfo,
   type FilesystemStatus,
@@ -410,6 +412,9 @@ export class FilesystemClient {
 type FileData = Uint8Array | string;
 
 function toBuffer(data: FileData): Buffer {
+  // Copy Uint8Array inputs before crossing the async N-API boundary. Sharing
+  // the caller's backing store would let a post-call mutation change the
+  // bytes being hashed and published.
   return typeof data === "string" ? Buffer.from(data, "utf-8") : Buffer.from(data);
 }
 
@@ -696,19 +701,65 @@ export class Filesystem {
   // -- reads --------------------------------------------------------------------
 
   /**
-   * Read a file's bytes at `version` (branch, ref, or snapshot commit;
-   * defaults to the filesystem's default branch).
+   * Read a file's bytes at `version` (the current `main` head or a retained
+   * snapshot id; defaults to the filesystem's current head).
    */
   async readFile(path: string, version?: string): Promise<Uint8Array> {
+    return (await this.readFileWithMetadata(path, { version })).data;
+  }
+
+  /**
+   * Read bytes and immutable metadata in one request. A range is executed by
+   * Artifact Storage, so callers never download the unrequested remainder.
+   */
+  async readFileWithMetadata(
+    path: string,
+    options: FilesystemReadOptions = {},
+  ): Promise<FilesystemFileRead> {
     if (trimSlashes(path) === "") {
       throw new FilesystemError("file path must not be empty");
     }
-    const resolvedVersion = version || (await this.branch());
+    const range = options.range;
+    if (
+      range !== undefined &&
+      (!Number.isSafeInteger(range.offset) ||
+        range.offset < 0 ||
+        !Number.isSafeInteger(range.length) ||
+        range.length <= 0)
+    ) {
+      throw new FilesystemError(
+        "range requires a non-negative integer offset and positive integer length",
+      );
+    }
+    const resolvedVersion = options.version || (await this.branch());
     const traced = await callNative(
-      () => this.native.readFilesystemFile(this.name, path, resolvedVersion),
+      () =>
+        this.native.readFilesystemFile(
+          this.name,
+          path,
+          resolvedVersion,
+          range?.offset,
+          range?.length,
+        ),
       new FileNotFoundInFilesystemError(this.name, path),
     );
-    return new Uint8Array(traced.data);
+    const fullSize = traced.fullSize;
+    if (
+      !traced.contentId ||
+      fullSize === undefined ||
+      !Number.isSafeInteger(fullSize) ||
+      fullSize < 0 ||
+      traced.data.byteLength > fullSize
+    ) {
+      throw new FilesystemError(
+        "filesystem read response omitted content identity or total size",
+      );
+    }
+    return {
+      data: new Uint8Array(traced.data),
+      contentId: traced.contentId,
+      size: fullSize,
+    };
   }
 
   /** Read a file as UTF-8 text at `version`. Throws on non-UTF-8 content. */

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -37,7 +37,9 @@ export type {
   FilesystemInfo,
   FilesystemStatus,
   FileEntry,
-  Snapshot,
+  FilesystemVersion,
+  FilesystemSnapshot,
+  FilesystemSnapshotInfo,
   MountStatus,
 } from "./filesystem-models.js";
 export { Image, dockerfileContent, ImageBuildOperationType } from "./image.js";

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -37,6 +37,8 @@ export type {
   FilesystemInfo,
   FilesystemStatus,
   FileEntry,
+  FilesystemFileRead,
+  FilesystemReadOptions,
   FilesystemVersion,
   FilesystemSnapshot,
   FilesystemSnapshotInfo,

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -165,10 +165,22 @@ export interface NativeRepositoryClient {
   ): Promise<TracedJson>;
   commitConflicts(repo: string, commit: string): Promise<TracedJson>;
   createFilesystem(name: string): Promise<string>;
+  forkFilesystem(
+    name: string,
+    base: string,
+    snapshot?: string | null,
+  ): Promise<TracedJson>;
   listFilesystems(): Promise<TracedJson>;
   filesystemMeta(name: string): Promise<TracedJson>;
   deleteFilesystem(name: string): Promise<string>;
   filesystemRefStatus(name: string, refspec: string): Promise<TracedJson>;
+  retainFilesystemSnapshot(
+    name: string,
+    message: string,
+    requestId: string,
+  ): Promise<TracedJson>;
+  listFilesystemSnapshots(name: string): Promise<TracedJson>;
+  deleteFilesystemSnapshot(name: string, snapshot: string): Promise<string>;
   readFilesystemFile(
     name: string,
     path: string,
@@ -183,6 +195,15 @@ export interface NativeRepositoryClient {
     name: string,
     files: Array<{ path: string; content: Buffer }>,
     deletes: string[],
+    moves: Array<{ from: string; to: string }>,
+    copies: Array<{ from: string; to: string }>,
+    message: string,
+    branch: string,
+    idempotencyKey?: string | null,
+  ): Promise<TracedJson>;
+  pushFilesystemPaths(
+    name: string,
+    files: Array<{ path: string; localPath: string }>,
     message: string,
     branch: string,
     idempotencyKey?: string | null,

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -33,6 +33,8 @@ export interface TracedJson {
 export interface TracedBytes {
   traceId: string;
   data: Buffer;
+  contentId?: string;
+  fullSize?: number;
 }
 
 export interface TracedEvents {
@@ -185,6 +187,8 @@ export interface NativeRepositoryClient {
     name: string,
     path: string,
     version: string,
+    offset?: number,
+    length?: number,
   ): Promise<TracedBytes>;
   listFilesystemTree(
     name: string,

--- a/typescript/tests/filesystem.test.ts
+++ b/typescript/tests/filesystem.test.ts
@@ -74,6 +74,15 @@ class StubNative {
     });
   }
 
+  async forkFilesystem(
+    name: string,
+    base: string,
+    snapshot?: string | null,
+  ): Promise<TracedJson> {
+    this.record("forkFilesystem", [name, base, snapshot]);
+    return traced({ name, base, snapshot, default_branch: "main" });
+  }
+
   async listFilesystems(): Promise<TracedJson> {
     this.record("listFilesystems", []);
     return traced({
@@ -113,6 +122,52 @@ class StubNative {
     );
   }
 
+  async retainFilesystemSnapshot(
+    name: string,
+    message: string,
+    requestId: string,
+  ): Promise<TracedJson> {
+    this.record("retainFilesystemSnapshot", [name, message, requestId]);
+    const snapshotId =
+      this.options.ref === undefined
+        ? COMMIT
+        : (this.options.ref.resolved_commit as string | null | undefined);
+    if (!snapshotId) {
+      throw nativeError({
+        category: "internal",
+        status: null,
+        message: `filesystem ${name} is empty: write files first`,
+      });
+    }
+    return traced({
+      snapshot_id: snapshotId,
+      snapshot_class: "permanent_snapshot",
+      message,
+    });
+  }
+
+  async listFilesystemSnapshots(name: string): Promise<TracedJson> {
+    this.record("listFilesystemSnapshots", [name]);
+    return traced({
+      snapshots: [
+        {
+          snapshot_id: COMMIT,
+          created_at_ms: 1_700_000_000_000,
+          message: "pin",
+          snapshot_class: "permanent_snapshot",
+        },
+      ],
+    });
+  }
+
+  async deleteFilesystemSnapshot(
+    name: string,
+    snapshot: string,
+  ): Promise<string> {
+    this.record("deleteFilesystemSnapshot", [name, snapshot]);
+    return "trace-delete";
+  }
+
   async readFilesystemFile(
     name: string,
     path: string,
@@ -135,6 +190,8 @@ class StubNative {
     name: string,
     files: Array<{ path: string; content: Buffer }>,
     deletes: string[],
+    moves: Array<{ from: string; to: string }>,
+    copies: Array<{ from: string; to: string }>,
     message: string,
     branch: string,
     idempotencyKey?: string | null,
@@ -143,16 +200,38 @@ class StubNative {
       name,
       files,
       deletes,
+      moves,
+      copies,
       message,
       branch,
       idempotencyKey,
     ]);
     return traced(
       this.options.pushReport ?? {
-        commit: COMMIT,
-        tree: "t".repeat(40),
-        ref_name: "refs/heads/main",
-        created: true,
+        version_id: COMMIT,
+        previous_version_id: null,
+      },
+    );
+  }
+
+  async pushFilesystemPaths(
+    name: string,
+    files: Array<{ path: string; localPath: string }>,
+    message: string,
+    branch: string,
+    idempotencyKey?: string | null,
+  ): Promise<TracedJson> {
+    this.record("pushFilesystemPaths", [
+      name,
+      files,
+      message,
+      branch,
+      idempotencyKey,
+    ]);
+    return traced(
+      this.options.pushReport ?? {
+        version_id: COMMIT,
+        previous_version_id: null,
       },
     );
   }
@@ -173,9 +252,13 @@ describe("filesystem models", () => {
     const dir = fileEntryFromWire({ name: "d", oid: "x", mode: 0o40000 }, "docs");
     expect(dir.isDir).toBe(true);
     expect(dir.path).toBe("docs/d");
-    const file = fileEntryFromWire({ name: "f", mode: 0o100644, size: 3 }, "");
+    expect(dir.contentId).toBe("x");
+    expect(dir.kind).toBe("directory");
+    const file = fileEntryFromWire({ name: "f", mode: 0o100755, size: 3 }, "");
     expect(file.isDir).toBe(false);
     expect(file.path).toBe("f");
+    expect(file.kind).toBe("file");
+    expect(file.executable).toBe(true);
   });
 
   it("trims slashes in linear time with Python strip('/') semantics", () => {
@@ -256,11 +339,11 @@ describe("FilesystemClient", () => {
     );
   });
 
-  it("maps push reports to snapshots and sets a stable idempotency key", async () => {
+  it("maps native publication reports and sets a stable idempotency key", async () => {
     const stub = new StubNative();
     const client = clientWith(stub);
     const fs = await client.create("my-fs");
-    const snapshot = await fs.writeFiles(
+    const version = await fs.writeFiles(
       new Map<string, Uint8Array | string>([
         ["a.txt", "hello"],
         ["b.bin", new Uint8Array([0, 1])],
@@ -268,15 +351,18 @@ describe("FilesystemClient", () => {
       undefined,
       ["old.txt"],
     );
-    expect(snapshot.commit).toBe(COMMIT);
-    expect(snapshot.created).toBe(true);
+    expect(version.versionId).toBe(COMMIT);
+    expect(version.previousVersionId).toBeNull();
+    expect(version.created).toBe(true);
 
     const push = stub.calls.at(-1)!;
     expect(push.method).toBe("pushFilesystemFiles");
-    const [name, files, deletes, , branch, idempotencyKey] = push.args as [
+    const [name, files, deletes, moves, copies, , branch, idempotencyKey] = push.args as [
       string,
       Array<{ path: string; content: Buffer }>,
       string[],
+      Array<{ from: string; to: string }>,
+      Array<{ from: string; to: string }>,
       string,
       string,
       string,
@@ -286,10 +372,52 @@ describe("FilesystemClient", () => {
     expect(files[0].content.toString()).toBe("hello");
     expect([...files[1].content]).toEqual([0, 1]);
     expect(deletes).toEqual(["old.txt"]);
+    expect(moves).toEqual([]);
+    expect(copies).toEqual([]);
     expect(branch).toBe("main");
     // A fresh stable key per logical write (the Rust core reuses it across
     // its retries so a lost response cannot double-commit).
     expect(idempotencyKey).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("moves and copies by publishing metadata-only mutations", async () => {
+    const stub = new StubNative();
+    const fs = await clientWith(stub).create("my-fs");
+
+    await fs.moveFile("large.bin", "archive/large.bin");
+    let args = stub.calls.at(-1)!.args;
+    expect(args[1]).toEqual([]);
+    expect(args[2]).toEqual([]);
+    expect(args[3]).toEqual([
+      { from: "large.bin", to: "archive/large.bin" },
+    ]);
+    expect(args[4]).toEqual([]);
+
+    await fs.copyFile("archive/large.bin", "copies/large.bin");
+    args = stub.calls.at(-1)!.args;
+    expect(args[1]).toEqual([]);
+    expect(args[2]).toEqual([]);
+    expect(args[3]).toEqual([]);
+    expect(args[4]).toEqual([
+      { from: "archive/large.bin", to: "copies/large.bin" },
+    ]);
+  });
+
+  it("publishes local paths through the memory-bounded native API", async () => {
+    const stub = new StubNative();
+    const fs = await clientWith(stub).create("my-fs");
+
+    const version = await fs.writeFilesFromPaths({
+      "models/weights.bin": "/tmp/weights.bin",
+    });
+    expect(version.versionId).toBe(COMMIT);
+    const push = stub.calls.at(-1)!;
+    expect(push.method).toBe("pushFilesystemPaths");
+    expect(push.args[1]).toEqual([
+      { path: "models/weights.bin", localPath: "/tmp/weights.bin" },
+    ]);
+    expect(push.args[3]).toBe("main");
+    expect(push.args[4]).toMatch(/^[0-9a-f]{32}$/);
   });
 
   it("rejects an empty write", async () => {
@@ -342,14 +470,14 @@ describe("FilesystemClient", () => {
     const client = clientWith(new StubNative());
     const fs = await client.create("my-fs");
     const status = await fs.status();
-    expect(status.headCommit).toBe(COMMIT);
+    expect(status.versionId).toBe(COMMIT);
     expect(status.generation).toBe(3);
 
     const empty = new StubNative({
       ref: { ref_name: "refs/heads/main", oid: null, resolved_commit: null, generation: 0 },
     });
     const emptyFs = await clientWith(empty).create("my-fs");
-    expect((await emptyFs.status()).headCommit).toBeNull();
+    expect((await emptyFs.status()).versionId).toBeNull();
     await expect(emptyFs.snapshot("nothing yet")).rejects.toThrow(
       FilesystemError,
     );
@@ -362,7 +490,7 @@ describe("FilesystemClient", () => {
       },
     });
     const fs = await clientWith(notFound).create("my-fs");
-    expect((await fs.status()).headCommit).toBeNull();
+    expect((await fs.status()).versionId).toBeNull();
 
     const unavailable = new StubNative({
       errors: {
@@ -378,18 +506,47 @@ describe("FilesystemClient", () => {
   });
 
   it("pins the current head as a snapshot", async () => {
-    const fs = await clientWith(new StubNative()).create("my-fs");
+    const stub = new StubNative();
+    const fs = await clientWith(stub).create("my-fs");
     const snapshot = await fs.snapshot("pin");
-    expect(snapshot.commit).toBe(COMMIT);
-    expect(snapshot.created).toBe(false);
+    expect(snapshot.id).toBe(COMMIT);
+    expect(stub.calls.at(-1)!.method).toBe("retainFilesystemSnapshot");
+  });
+
+  it("lists and deletes retained snapshots through metadata APIs", async () => {
+    const stub = new StubNative();
+    const fs = await clientWith(stub).create("my-fs");
+    const snapshots = await fs.listSnapshots();
+    expect(snapshots).toEqual([
+      {
+        id: COMMIT,
+        createdAt: new Date(1_700_000_000_000),
+        message: "pin",
+      },
+    ]);
+    await fs.deleteSnapshot(COMMIT);
+    expect(stub.calls.at(-1)).toEqual({
+      method: "deleteFilesystemSnapshot",
+      args: ["my-fs", COMMIT],
+    });
+  });
+
+  it("forks a filesystem without copying its bytes", async () => {
+    const stub = new StubNative();
+    const fork = await clientWith(stub).fork("forked", "base", COMMIT);
+    expect(fork.name).toBe("forked");
+    expect(stub.calls.at(-1)).toEqual({
+      method: "forkFilesystem",
+      args: ["forked", "base", COMMIT],
+    });
   });
 
   it("seeds the branch reported by the create binding", async () => {
     const stub = new StubNative({ createBranch: "trunk" });
     const fs = await clientWith(stub).create("my-fs");
     await fs.writeFile("a.txt", "x");
-    // (name, files, deletes, message, branch, idempotencyKey)
-    expect(stub.calls.at(-1)!.args[4]).toBe("trunk");
+    // (name, files, deletes, moves, copies, message, branch, idempotencyKey)
+    expect(stub.calls.at(-1)!.args[6]).toBe("trunk");
   });
 
   it("follows a non-main default branch for writes and reads", async () => {
@@ -404,8 +561,8 @@ describe("FilesystemClient", () => {
     const client = clientWith(stub);
     const fs = await client.get("my-fs");
     await fs.writeFile("a.txt", "x");
-    // (name, files, deletes, message, branch, idempotencyKey)
-    expect(stub.calls.at(-1)!.args[4]).toBe("trunk");
+    // (name, files, deletes, moves, copies, message, branch, idempotencyKey)
+    expect(stub.calls.at(-1)!.args[6]).toBe("trunk");
     await fs.readFile("a.txt");
     // (name, path, version)
     expect(stub.calls.at(-1)!.args[2]).toBe("trunk");
@@ -435,7 +592,7 @@ describe("FilesystemClient", () => {
     const stub = new StubNative();
     const fs = await clientWith(stub).create("my-fs");
     const snapshot = await fs.writeFile("a.txt", "x", "");
-    const message = stub.calls.at(-1)!.args[3];
+    const message = stub.calls.at(-1)!.args[5];
     expect(message).toBe("write 1 file(s) via SDK");
     expect(snapshot.message).toBe("write 1 file(s) via SDK");
   });

--- a/typescript/tests/filesystem.test.ts
+++ b/typescript/tests/filesystem.test.ts
@@ -172,9 +172,26 @@ class StubNative {
     name: string,
     path: string,
     version: string,
+    offset?: number,
+    length?: number,
   ): Promise<TracedBytes> {
-    this.record("readFilesystemFile", [name, path, version]);
-    return { traceId: "trace-1", data: this.options.fileBytes ?? Buffer.alloc(0) };
+    this.record("readFilesystemFile", [
+      name,
+      path,
+      version,
+      ...(offset !== undefined ? [offset, length] : []),
+    ]);
+    const full = this.options.fileBytes ?? Buffer.alloc(0);
+    const data =
+      offset !== undefined && length !== undefined
+        ? full.subarray(offset, offset + length)
+        : full;
+    return {
+      traceId: "trace-1",
+      data,
+      contentId: COMMIT,
+      fullSize: full.byteLength,
+    };
   }
 
   async listFilesystemTree(
@@ -449,6 +466,26 @@ describe("FilesystemClient", () => {
       FileNotFoundInFilesystemError,
     );
     await expect(failingFs.readFile("//")).rejects.toThrow(FilesystemError);
+  });
+
+  it("reads a server-side range with identity and full size in one request", async () => {
+    const stub = new StubNative({ fileBytes: Buffer.from("0123456789") });
+    const fs = await clientWith(stub).create("my-fs");
+
+    const read = await fs.readFileWithMetadata("data.bin", {
+      range: { offset: 3, length: 4 },
+    });
+
+    expect(Buffer.from(read.data).toString()).toBe("3456");
+    expect(read.contentId).toBe(COMMIT);
+    expect(read.size).toBe(10);
+    expect(stub.calls.at(-1)!.args).toEqual([
+      "my-fs",
+      "data.bin",
+      "main",
+      3,
+      4,
+    ]);
   });
 
   it("lists files with paths and modes", async () => {

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -135,7 +135,16 @@ function randomSuffix(): string {
   return Math.random().toString(36).slice(2, 10);
 }
 
-describe(
+const filesystemIntegrationConfigured = Boolean(
+  process.env.TENSORLAKE_API_KEY &&
+    process.env.TENSORLAKE_ORGANIZATION_ID &&
+    process.env.TENSORLAKE_PROJECT_ID,
+);
+const describeFilesystemIntegration = filesystemIntegrationConfigured
+  ? describe
+  : describe.skip;
+
+describeFilesystemIntegration(
   "Native filesystem SDK",
   () => {
     it("creates, gets, writes, reads, lists, versions, and deletes a filesystem", async () => {

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -15,6 +15,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   PoolInUseError,
   PoolNotFoundError,
+  FilesystemClient,
   SandboxClient,
   SandboxError,
   SandboxNotFoundError,
@@ -133,6 +134,93 @@ function sleep(ms: number): Promise<void> {
 function randomSuffix(): string {
   return Math.random().toString(36).slice(2, 10);
 }
+
+describe(
+  "Native filesystem SDK",
+  () => {
+    it("creates, gets, writes, reads, lists, versions, and deletes a filesystem", async () => {
+      const client = new FilesystemClient();
+      const name = `ts-sdk-${Date.now().toString(36)}-${randomSuffix()}`;
+      const forkName = `${name}-fork`;
+      try {
+        await client.create(name);
+        const filesystem = await client.get(name);
+
+        const first = await filesystem.writeFiles(
+          {
+            "probe.txt": "first",
+            "nested/data.bin": new Uint8Array([0, 1, 2, 255]),
+          },
+          "typescript SDK native filesystem integration",
+        );
+        expect(first.versionId).toMatch(/^[0-9a-f]{64}$/);
+        expect(await filesystem.readText("probe.txt")).toBe("first");
+        expect(await filesystem.readFile("nested/data.bin")).toEqual(
+          new Uint8Array([0, 1, 2, 255]),
+        );
+
+        const root = await filesystem.listFiles();
+        expect(root.find((entry) => entry.path === "nested")?.isDir).toBe(true);
+        expect(root.find((entry) => entry.path === "probe.txt")?.contentId).toMatch(
+          /^[0-9a-f]{64}$/,
+        );
+        expect((await filesystem.listFiles("nested"))[0]?.path).toBe(
+          "nested/data.bin",
+        );
+
+        const second = await filesystem.writeFiles(
+          { "nested/data.bin": new Uint8Array([3, 4, 5]) },
+          "replace nested data and remove probe",
+          ["probe.txt"],
+        );
+        expect(second.versionId).toMatch(/^[0-9a-f]{64}$/);
+        expect(second.versionId).not.toBe(first.versionId);
+        expect(await filesystem.readText("probe.txt", first.versionId)).toBe(
+          "first",
+        );
+        expect(await filesystem.readFile("nested/data.bin")).toEqual(
+          new Uint8Array([3, 4, 5]),
+        );
+
+        await filesystem.copyFile("nested/data.bin", "nested/copy.bin");
+        await filesystem.moveFile("nested/copy.bin", "archive/data.bin");
+        expect(await filesystem.readFile("archive/data.bin")).toEqual(
+          new Uint8Array([3, 4, 5]),
+        );
+
+        const retained = await filesystem.snapshot("integration retention");
+        expect(retained.id).toMatch(/^[0-9a-f]{64}$/);
+        expect(
+          (await filesystem.listSnapshots()).some(
+            (snapshot) => snapshot.id === retained.id,
+          ),
+        ).toBe(true);
+
+        const fork = await client.fork(forkName, name, retained.id);
+        expect(await fork.readFile("archive/data.bin")).toEqual(
+          new Uint8Array([3, 4, 5]),
+        );
+        await fork.writeFile("fork-only.txt", "fork");
+        await expect(filesystem.readFile("fork-only.txt")).rejects.toThrow();
+
+        const status = await filesystem.status();
+        expect(status.versionId).toMatch(/^[0-9a-f]{64}$/);
+        expect(status.generation).toBeGreaterThanOrEqual(2);
+
+        await filesystem.deleteSnapshot(retained.id);
+        expect(
+          (await filesystem.listSnapshots()).some(
+            (snapshot) => snapshot.id === retained.id,
+          ),
+        ).toBe(false);
+      } finally {
+        await client.delete(forkName).catch(() => undefined);
+        await client.delete(name).catch(() => undefined);
+      }
+    });
+  },
+  { timeout: 300_000 },
+);
 
 function createTestClient(): SandboxClient {
   return new SandboxClient({


### PR DESCRIPTION
## Summary

- exchange API keys and PATs for short-lived, repo-scoped Artifact Storage credentials instead of sending platform credentials to the Git data plane
- publish filesystem writes through checksum-bound presigned object-store PUTs with 64 MiB bounded parts, parallel dedup/upload, CAS head publication, and operation-id retry fencing
- add memory-bounded local-path writes, metadata-only copy/move/snapshot/fork APIs, and persistent credential/HTTP connection reuse across TypeScript and Python filesystem clients
- return bytes, immutable content identity, and total size in one file request; execute byte ranges server-side
- fail closed on malformed, duplicated, omitted, or mismatched direct-upload targets and preserve typed filesystem errors

Companion server PR: tensorlakeai/artifact_storage#166
Tracking design: tensorlakeai/artifact_storage#164

## Review follow-ups included

- project and repo credentials share the expiry-checked cache
- Python reuses one ArtifactStorageClient instead of rebuilding its connection pool per operation
- file-backed uploads use 1 MiB transport frames while remaining bounded across eight concurrent uploads
- TypeScript copies caller-owned Uint8Array data before the async native boundary
- public docs now describe current-head and snapshot reads accurately

## Validation

- just test-node-filesystem-full
- cargo test -p tensorlake artifact_storage
- cargo clippy -p tensorlake-rust-cloud-sdk-py --no-deps -- -D warnings
- cargo fmt --all -- --check
- npm run typecheck (TypeScript SDK)
- python3 -m compileall -q src/tensorlake/filesystem

The companion StorageSDK adapter passes install, formatting/lint, typecheck, build, full tests, and publint; it remains uncommitted pending its repository-required explicit commit approval.
