### PR TITLE
Hydrate mount scope before human fs status

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2596,16 +2596,17 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
     // Human status is a local diagnostic: the private engine reads cached immutable session
     // facts plus the local journal/control socket, so it must remain available when auth or the
     // platform is unavailable. `--json` deliberately keeps its live server-record contract and
-    // therefore continues through the auth guard below.
+    // therefore continues through the auth guard below. Scope hydration is local-only (it reads
+    // the mount's cached attach-time facts, never the network), so it runs before this early
+    // return. Without it, status run outside a project directory has no project ID and reports
+    // the server head as unavailable even when the server is healthy. Best-effort: a mount whose
+    // state cannot hydrate a scope still gets the offline diagnostics instead of an error.
     if let FsCommands::Status { json: false, .. } = &subcmd {
-        return commands::fs::status(
-            ctx,
-            mount_dir
-                .as_ref()
-                .expect("resolved for every path-addressed command"),
-            false,
-        )
-        .await;
+        let mount_dir = mount_dir
+            .as_ref()
+            .expect("resolved for every path-addressed command");
+        let _ = commands::fs::hydrate_scope_from_mount(ctx, mount_dir);
+        return commands::fs::status(ctx, mount_dir, false).await;
     }
     // Path-addressed commands carry their scope in the mount state; resolve it from there so
     // they work from any CWD instead of triggering the interactive init flow (which, run from

--- a/crates/cli/tests/fs_status_scope.rs
+++ b/crates/cli/tests/fs_status_scope.rs
@@ -1,0 +1,86 @@
+#![cfg(feature = "mount")]
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::process::Command;
+
+#[test]
+fn human_fs_status_hydrates_mount_scope_and_remains_offline_safe() {
+    let temp = tempfile::tempdir().expect("temporary test root");
+    let home = temp.path().join("home");
+    let mountpoint = temp.path().join("mounted-drive");
+    let state_dir = temp.path().join("mount-state");
+    fs::create_dir_all(home.join(".config/tensorlake")).expect("config directory");
+    fs::create_dir_all(&mountpoint).expect("mountpoint");
+    fs::create_dir_all(state_dir.join("upper")).expect("upper directory");
+    fs::create_dir_all(state_dir.join("wh")).expect("whiteout directory");
+
+    let state = serde_json::json!({
+        "project_id": "project-from-mount",
+        "organization_id": "organization-from-mount",
+        "repo": "drive-from-mount",
+        "native_filesystem": true,
+        "workspace_id": "workspace-from-mount",
+        "ref_name": "refs/workspaces/workspace-from-mount",
+        "mountpoint": mountpoint,
+        "created_at_secs": 1_700_000_000_u64,
+    });
+    fs::write(
+        state_dir.join("state.json"),
+        serde_json::to_vec_pretty(&state).expect("serialize mount state"),
+    )
+    .expect("write mount state");
+
+    let canonical_mountpoint = mountpoint.canonicalize().expect("canonical mountpoint");
+    let mut registry = BTreeMap::new();
+    registry.insert(
+        canonical_mountpoint.to_string_lossy().into_owned(),
+        state_dir.to_string_lossy().into_owned(),
+    );
+    fs::write(
+        home.join(".config/tensorlake/mounts.toml"),
+        toml::to_string_pretty(&registry).expect("serialize mount registry"),
+    )
+    .expect("write mount registry");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tl"))
+        .args([
+            "--api-url",
+            "http://127.0.0.1:9",
+            "--api-key",
+            "invalid-test-key",
+            "fs",
+            "status",
+        ])
+        .arg(&canonical_mountpoint)
+        .current_dir(temp.path())
+        .env("HOME", &home)
+        .env("NO_COLOR", "1")
+        .env_remove("TENSORLAKE_API_KEY")
+        .env_remove("TENSORLAKE_PAT")
+        .env_remove("TENSORLAKE_ORGANIZATION_ID")
+        .env_remove("TENSORLAKE_PROJECT_ID")
+        .output()
+        .expect("run tl fs status");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "human status must remain an offline-safe local diagnostic\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("filesystem: drive-from-mount"),
+        "local mount facts must still render\nstdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("missing project ID"),
+        "status must hydrate the project ID from mount state before reading the server head\n\
+         stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("last autosave: unknown ("),
+        "the unreachable test server should degrade the server summary without failing local status\n\
+         stdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## What changed

- hydrate organization/project scope from cached mount state before the human `tl fs status` early return
- keep hydration best-effort so local status remains available when authentication or the platform is unavailable
- add a feature-gated subprocess regression using an isolated mount registry and an unreachable server

## Root cause

Human `tl fs status` returns before the common path-addressed scope hydration. When it is invoked outside a Tensorlake project directory, the status client therefore has no project ID and reports the server summary as `unknown (missing project ID)` even though the mount already contains the correct attach-time scope.

JSON status intentionally continues through the authenticated path and is unchanged.

## User impact

`tl fs status <mount>` now uses the mount's cached project scope from any working directory while preserving its offline-safe local diagnostic behavior.

This extracts the remaining mount-status fix from #865. The filesystem SDK work in that PR was superseded by #868.

## Validation

- `ARTIFACT_STORAGE_DIR=$HOME/Projects/artifact_storage just test-cli-full`
- `ARTIFACT_STORAGE_DIR=$HOME/Projects/artifact_storage just test-cli-full human_fs_status_hydrates_mount_scope_and_remains_offline_safe -- --exact`
- `cargo fmt --all`
- `git diff --check`
