### PR TITLE
Bump Tensorlake packages to 0.5.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.88"
+version = "0.5.89"
 dependencies = [
  "anyhow",
  "base64",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.88"
+version = "0.5.89"
 dependencies = [
  "anyhow",
  "base64",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.88"
+version = "0.5.89"
 dependencies = [
  "anyhow",
  "base64",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.88"
+version = "0.5.89"
 dependencies = [
  "napi",
  "napi-build",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.88"
+version = "0.5.89"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.88"
+version = "0.5.89"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.88"
+version = "0.5.89"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.88"
+version = "0.5.89"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.88"
+version = "0.5.89"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.88",
+  "version": "0.5.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.88",
+      "version": "0.5.89",
       "license": "Apache-2.0",
       "dependencies": {
         "undici": "8.3.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.88",
+  "version": "0.5.89",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## What changed

- Bump the shared Rust workspace version from `0.5.88` to `0.5.89`, covering `tensorlake`, `tensorlake-cli`, and the Node/Python native SDK crates.
- Bump the public Python SDK and its native-binding package metadata to `0.5.89`.
- Bump the TypeScript/npm SDK manifest and lockfile to `0.5.89`.
- Bump the private filesystem-client resolution placeholder and refresh Cargo package versions in `Cargo.lock`.

## Why

The merged Cloud Volume release adds direct-to-blob-store writes and reads, integrity-checked signed range plans, low-latency metadata-only copy/move, snapshot/fork APIs, and the related SDK/binding changes. A coordinated package and CLI version is required before the npm, PyPI, and standalone CLI release workflows can publish those changes.

## Impact

This is a version-only release preparation change: seven metadata/lock files, with no source-code changes. After merge, the existing release workflows can publish Python, npm, and CLI artifacts as `0.5.89`.

## Validation

- `make bump_version VERSION=0.5.89`
- `cargo check -p tensorlake-cli -p tensorlake-rust-cloud-sdk-node -p tensorlake-rust-cloud-sdk-py`
- `cargo run -q -p tensorlake-cli --bin tensorlake -- --version` → `tl 0.5.89`
- `cargo metadata --no-deps --format-version 1` confirms the Rust SDK, CLI, and native bindings are `0.5.89`
- `npm pack --dry-run --ignore-scripts --json` reports `tensorlake@0.5.89`
- `npm ci --ignore-scripts --no-audit --no-fund && npm run typecheck`
- `git diff --check`
