### PR TITLE
fix(sandbox-pools): expose pool network policy across SDKs and release 0.5.90

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "base64",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "base64",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "anyhow",
  "base64",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "napi",
  "napi-build",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.89"
+version = "0.5.90"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.89"
+version = "0.5.90"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -124,10 +124,13 @@ with client.create_and_connect(snapshot_id=snapshot.snapshot_id) as sandbox:
 Pre-warm containers for fast startup:
 
 ```python
-# Create a pool with warm containers
+from tensorlake.sandbox import NetworkConfig
+
+# Create a pool with warm containers and no internet access
 pool = client.create_pool(
     image="tensorlake/ubuntu-minimal",
     warm_containers=3,
+    network=NetworkConfig(allow_internet_access=False),
 )
 
 # Claim a sandbox instantly from the pool
@@ -138,6 +141,9 @@ sandbox = client.connect(resp.sandbox_id)
 named = client.create(image="tensorlake/ubuntu-minimal", name="stable-name")
 sandbox = client.connect("stable-name")
 ```
+
+Set the pool network policy when you create the pool. Create a new pool to use a
+different network policy.
 
 ---
 

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -22,12 +22,12 @@ pub use desktop::SandboxDesktopClient;
 
 use models::{
     ArchivedSandboxInfo, ArchivedSandboxesPaginationDirection, CopySandboxResponse,
-    CreateSandboxPoolResponse, CreateSandboxRequest, CreateSandboxResponse, CreateSnapshotRequest,
-    CreateSnapshotResponse, DaemonInfo, DetachFileSystemRequest, FileSystemMount,
-    GetSandboxLogsRequest, HealthResponse, ListArchivedSandboxesParams,
-    ListArchivedSandboxesResponse, ListDirectoryResponse, ListProcessesResponse,
-    ListSandboxPoolsResponse, ListSandboxesResponse, ListSnapshotsResponse, OutputEvent,
-    OutputResponse, ProcessInfo, RunProcessEvent, SandboxInfo, SandboxLogsResponse,
+    CreateSandboxPoolRequest, CreateSandboxPoolResponse, CreateSandboxRequest,
+    CreateSandboxResponse, CreateSnapshotRequest, CreateSnapshotResponse, DaemonInfo,
+    DetachFileSystemRequest, FileSystemMount, GetSandboxLogsRequest, HealthResponse,
+    ListArchivedSandboxesParams, ListArchivedSandboxesResponse, ListDirectoryResponse,
+    ListProcessesResponse, ListSandboxPoolsResponse, ListSandboxesResponse, ListSnapshotsResponse,
+    OutputEvent, OutputResponse, ProcessInfo, RunProcessEvent, SandboxInfo, SandboxLogsResponse,
     SandboxPoolInfo, SandboxPoolRequest, SandboxProcessLogFiltersResponse, SendSignalResponse,
     SignBlobRequest, SnapshotInfo, SnapshotType, UpdateSandboxRequest,
 };
@@ -557,6 +557,18 @@ impl SandboxesClient {
         &self,
         request: &SandboxPoolRequest,
     ) -> Result<Traced<CreateSandboxPoolResponse>, SdkError> {
+        self.create_pool_with_network(&CreateSandboxPoolRequest {
+            pool: request.clone(),
+            network: None,
+        })
+        .await
+    }
+
+    /// Creates a pool with an optional network policy for each container.
+    pub async fn create_pool_with_network(
+        &self,
+        request: &CreateSandboxPoolRequest,
+    ) -> Result<Traced<CreateSandboxPoolResponse>, SdkError> {
         let uri = self.endpoint("sandbox-pools");
         let req = self
             .client
@@ -585,10 +597,16 @@ impl SandboxesClient {
         pool_id: &str,
         request: &SandboxPoolRequest,
     ) -> Result<Traced<SandboxPoolInfo>, SdkError> {
+        let current = self.get_pool(pool_id).await?;
+        let request = CreateSandboxPoolRequest {
+            pool: request.clone(),
+            network: current.network_policy.clone(),
+        };
+
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}"));
         let req = self
             .client
-            .build_post_json_request(Method::PUT, &uri, request)?;
+            .build_post_json_request(Method::PUT, &uri, &request)?;
         self.client.execute_json(req).await
     }
 

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -211,6 +211,15 @@ pub struct SandboxPoolRequest {
     pub warm_containers: Option<i64>,
 }
 
+/// A pool creation request with an optional container network policy.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CreateSandboxPoolRequest {
+    #[serde(flatten)]
+    pub pool: SandboxPoolRequest,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<NetworkConfig>,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CreateSandboxResponse {
     pub sandbox_id: String,
@@ -354,6 +363,8 @@ pub struct SandboxPoolInfo {
     pub max_containers: Option<i64>,
     #[serde(default)]
     pub warm_containers: Option<i64>,
+    #[serde(default)]
+    pub network_policy: Option<NetworkConfig>,
     #[serde(default)]
     pub containers: Option<Vec<PoolContainerInfo>>,
     #[serde(default)]
@@ -672,6 +683,35 @@ pub struct MultipartHint {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn create_pool_request_deserializes_flat_network_policy() {
+        let request: CreateSandboxPoolRequest = serde_json::from_value(serde_json::json!({
+            "image": "alpine",
+            "resources": {
+                "cpus": 1.0,
+                "memory_mb": 1024,
+                "ephemeral_disk_mb": 1024
+            },
+            "timeout_secs": 0,
+            "network": {
+                "allow_internet_access": false,
+                "allow_out": [],
+                "deny_out": []
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(request.pool.image.as_deref(), Some("alpine"));
+        assert_eq!(
+            request.network,
+            Some(NetworkConfig {
+                allow_internet_access: false,
+                allow_out: vec![],
+                deny_out: vec![],
+            })
+        );
+    }
 
     #[test]
     fn snapshot_type_serializes_as_snake_case() {

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -1,6 +1,11 @@
 use tensorlake::{
     ClientBuilder,
-    sandboxes::{SandboxProxyClient, SandboxesClient},
+    sandboxes::{
+        SandboxProxyClient, SandboxesClient,
+        models::{
+            ContainerResourcesInfo, CreateSandboxPoolRequest, NetworkConfig, SandboxPoolRequest,
+        },
+    },
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -93,6 +98,114 @@ async fn direct_empty_post_helper_sends_content_length_zero() {
     let request_text = String::from_utf8_lossy(&request);
     assert!(request_text.starts_with("POST /sandbox-pools/pool-1/sandboxes HTTP/1.1\r\n"));
     assert!(request_text.contains("\r\ncontent-length: 0\r\n"));
+}
+
+#[tokio::test]
+async fn pool_network_policy_is_sent_and_preserved_on_update() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept create");
+        let create = read_http_request(&mut socket).await;
+        write_json_response(&mut socket, r#"{"pool_id":"pool-1","namespace":"default"}"#).await;
+
+        let (mut socket, _) = listener.accept().await.expect("accept get");
+        let get = read_http_request(&mut socket).await;
+        write_json_response(
+            &mut socket,
+            r#"{
+                "pool_id":"pool-1",
+                "namespace":"default",
+                "image":"alpine",
+                "resources":{"cpus":1.0,"memory_mb":1024,"ephemeral_disk_mb":1024},
+                "network_policy":{
+                    "allow_internet_access":false,
+                    "allow_out":["10.0.0.0/8"],
+                    "deny_out":["192.0.2.0/24"]
+                }
+            }"#,
+        )
+        .await;
+
+        let (mut socket, _) = listener.accept().await.expect("accept update");
+        let update = read_http_request(&mut socket).await;
+        write_json_response(
+            &mut socket,
+            r#"{
+                "pool_id":"pool-1",
+                "namespace":"default",
+                "image":"alpine",
+                "resources":{"cpus":1.0,"memory_mb":2048,"ephemeral_disk_mb":1024},
+                "network_policy":{
+                    "allow_internet_access":false,
+                    "allow_out":["10.0.0.0/8"],
+                    "deny_out":["192.0.2.0/24"]
+                }
+            }"#,
+        )
+        .await;
+
+        (create, get, update)
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .build()
+        .expect("build client");
+    let sandboxes = SandboxesClient::new(client, "default", false);
+    let policy = NetworkConfig {
+        allow_internet_access: false,
+        allow_out: vec!["10.0.0.0/8".to_string()],
+        deny_out: vec!["192.0.2.0/24".to_string()],
+    };
+
+    sandboxes
+        .create_pool_with_network(&CreateSandboxPoolRequest {
+            pool: SandboxPoolRequest {
+                image: Some("alpine".to_string()),
+                resources: ContainerResourcesInfo {
+                    cpus: 1.0,
+                    memory_mb: 1024,
+                    ephemeral_disk_mb: 1024,
+                },
+                timeout_secs: 0,
+                entrypoint: None,
+                max_containers: None,
+                warm_containers: Some(1),
+            },
+            network: Some(policy.clone()),
+        })
+        .await
+        .expect("create pool");
+
+    sandboxes
+        .update_pool(
+            "pool-1",
+            &SandboxPoolRequest {
+                image: Some("alpine".to_string()),
+                resources: ContainerResourcesInfo {
+                    cpus: 1.0,
+                    memory_mb: 2048,
+                    ephemeral_disk_mb: 1024,
+                },
+                timeout_secs: 0,
+                entrypoint: None,
+                max_containers: None,
+                warm_containers: Some(1),
+            },
+        )
+        .await
+        .expect("update pool");
+
+    let (create, get, update) = server.await.expect("server join");
+    let create_text = String::from_utf8_lossy(&create);
+    let get_text = String::from_utf8_lossy(&get);
+    let update_text = String::from_utf8_lossy(&update);
+    assert!(create_text.contains(r#""network":{"allow_internet_access":false"#));
+    assert!(get_text.starts_with("GET /sandbox-pools/pool-1 HTTP/1.1\r\n"));
+    assert!(update_text.contains(r#""network":{"allow_internet_access":false"#));
 }
 
 async fn read_http_request(socket: &mut TcpStream) -> Vec<u8> {

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.89"
+version = "0.5.90"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -25,8 +25,9 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use tensorlake::sandboxes::models::{
-    ArchivedSandboxesPaginationDirection, CreateSandboxRequest, GetSandboxLogsRequest,
-    ListArchivedSandboxesParams, SandboxPoolRequest, SnapshotType, UpdateSandboxRequest,
+    ArchivedSandboxesPaginationDirection, CreateSandboxPoolRequest, CreateSandboxRequest,
+    GetSandboxLogsRequest, ListArchivedSandboxesParams, SandboxPoolRequest, SnapshotType,
+    UpdateSandboxRequest,
 };
 use tensorlake::sandboxes::{
     SandboxProxyClient, SandboxesClient, resolve_sandbox_proxy_target, select_sandbox_proxy_url,
@@ -636,11 +637,11 @@ impl NativeSandboxClient {
 
     #[napi]
     pub async fn create_pool(&self, request_json: String) -> napi::Result<TracedJson> {
-        let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
+        let request: CreateSandboxPoolRequest = parse_json_payload(&request_json)?;
         with_retry(self.client.clone(), 5, move |c| {
             let request = request.clone();
             async move {
-                let traced = c.create_pool(&request).await?;
+                let traced = c.create_pool_with_network(&request).await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced)?;
                 Ok(TracedJson { trace_id, json })

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.89"
+version = "0.5.90"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -34,8 +34,9 @@ use tensorlake::images::models::{ApplicationBuildContext, CreateApplicationBuild
 use tensorlake::sandbox_images::SandboxImageBuildEvent;
 use tensorlake::sandbox_templates::SandboxTemplatesClient;
 use tensorlake::sandboxes::models::{
-    ArchivedSandboxesPaginationDirection, CreateSandboxRequest, GetSandboxLogsRequest,
-    ListArchivedSandboxesParams, SandboxPoolRequest, SnapshotType, UpdateSandboxRequest,
+    ArchivedSandboxesPaginationDirection, CreateSandboxPoolRequest, CreateSandboxRequest,
+    GetSandboxLogsRequest, ListArchivedSandboxesParams, SandboxPoolRequest, SnapshotType,
+    UpdateSandboxRequest,
 };
 use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
@@ -1840,11 +1841,11 @@ impl CloudSandboxClient {
     }
 
     fn create_pool(&self, request_json: String) -> PyResult<(String, String)> {
-        let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
+        let request: CreateSandboxPoolRequest = parse_json_payload(&request_json)?;
         self.run_with_retry(5, move |client| {
             let request = request.clone();
             async move {
-                let traced = client.create_pool(&request).await?;
+                let traced = client.create_pool_with_network(&request).await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
                 Ok((trace_id, json))
@@ -2269,12 +2270,12 @@ impl CloudSandboxClient {
         py: Python<'py>,
         request_json: String,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
+        let request: CreateSandboxPoolRequest = parse_json_payload(&request_json)?;
         let client = self.client.clone();
         future_into_py(py, async move {
             let traced = retry_async_op(client, 5, move |c| {
                 let request = request.clone();
-                async move { c.create_pool(&request).await }
+                async move { c.create_pool_with_network(&request).await }
             })
             .await
             .map_err(into_sandbox_py_error)?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.89"
+version = "0.5.90"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -700,7 +700,13 @@ class AsyncSandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
+        network: NetworkConfig | None = None,
     ) -> Traced[CreateSandboxPoolResponse]:
+        """Create a sandbox pool.
+
+        Set ``network`` to apply a network policy to each pool container. Create
+        a new pool to use a different network policy.
+        """
         request_model = SandboxPoolRequest(
             image=image,
             resources=ContainerResourcesInfo(
@@ -710,6 +716,7 @@ class AsyncSandboxClient:
             entrypoint=entrypoint,
             max_containers=max_containers,
             warm_containers=warm_containers,
+            network=network,
         )
         try:
             trace_id, response_json = await self._rust_client.create_pool_async(
@@ -752,6 +759,7 @@ class AsyncSandboxClient:
         max_containers: int | None = None,
         warm_containers: int | None = None,
     ) -> Traced[SandboxPoolInfo]:
+        """Update a pool and keep its current network policy."""
         request_model = SandboxPoolRequest(
             image=image,
             resources=ContainerResourcesInfo(

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1165,6 +1165,7 @@ class SandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
+        network: NetworkConfig | None = None,
     ) -> Traced[CreateSandboxPoolResponse]:
         """Create a new sandbox pool.
 
@@ -1178,6 +1179,7 @@ class SandboxClient:
             entrypoint: Custom entrypoint command (optional)
             max_containers: Maximum number of containers in pool
             warm_containers: Number of warm containers to maintain
+            network: Network policy for each container in the pool
 
         Returns:
             CreateSandboxPoolResponse with pool_id and namespace
@@ -1195,6 +1197,7 @@ class SandboxClient:
             entrypoint=entrypoint,
             max_containers=max_containers,
             warm_containers=warm_containers,
+            network=network,
         )
 
         try:
@@ -1259,6 +1262,9 @@ class SandboxClient:
         warm_containers: int | None = None,
     ) -> Traced[SandboxPoolInfo]:
         """Update a sandbox pool configuration.
+
+        This operation keeps the current network policy. Create a new pool to
+        use a different network policy.
 
         Args:
             pool_id: ID of the pool to update

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -272,6 +272,7 @@ class SandboxPoolRequest(BaseModel):
     entrypoint: list[str] | None = None
     max_containers: int | None = None
     warm_containers: int | None = None
+    network: NetworkConfig | None = None
 
 
 # --- Response models ---
@@ -429,6 +430,7 @@ class SandboxPoolInfo(BaseModel):
     entrypoint: list[str] | None = None
     max_containers: int | None = None
     warm_containers: int | None = None
+    network_policy: NetworkConfig | None = None
     containers: list[PoolContainerInfo] | None = None
     created_at: OptionalTimestamp = None
     updated_at: OptionalTimestamp = None

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from tensorlake.sandbox import (
+    NetworkConfig,
     PoolInUseError,
     SandboxNotFoundError,
     SnapshotStatus,
@@ -1205,6 +1206,64 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                 client.delete_pool("pool-1")
         finally:
             sandbox_client_module.RustCloudSandboxClientError = previous
+
+    def test_pool_network_policy_is_sent_and_returned(self):
+        captured: dict[str, str] = {}
+
+        class _PoolRustClient:
+            def close(self):
+                return None
+
+            def create_pool(self, request_json):
+                captured["request_json"] = request_json
+                return (
+                    "trace-create",
+                    '{"pool_id":"pool-1","namespace":"default"}',
+                )
+
+            def get_pool_json(self, pool_id):
+                return (
+                    "trace-get",
+                    json.dumps(
+                        {
+                            "pool_id": pool_id,
+                            "namespace": "default",
+                            "image": "alpine",
+                            "resources": {
+                                "cpus": 1.0,
+                                "memory_mb": 1024,
+                                "ephemeral_disk_mb": 1024,
+                            },
+                            "network_policy": {
+                                "allow_internet_access": False,
+                                "allow_out": ["10.0.0.0/8"],
+                                "deny_out": ["192.0.2.0/24"],
+                            },
+                        }
+                    ),
+                )
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _PoolRustClient()
+        policy = NetworkConfig(
+            allow_internet_access=False,
+            allow_out=["10.0.0.0/8"],
+            deny_out=["192.0.2.0/24"],
+        )
+
+        client.create_pool(image="alpine", network=policy)
+        request = json.loads(captured["request_json"])
+        self.assertEqual(
+            request["network"],
+            {
+                "allow_internet_access": False,
+                "allow_out": ["10.0.0.0/8"],
+                "deny_out": ["192.0.2.0/24"],
+            },
+        )
+
+        pool = client.get_pool("pool-1")
+        self.assertEqual(pool.network_policy, policy)
 
     def test_snapshot_threads_snapshot_type_to_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch
 
 from tensorlake.sandbox import (
+    NetworkConfig,
     PoolInUseError,
     SandboxNotFoundError,
     SnapshotStatus,
@@ -1218,6 +1219,63 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
                 await client.delete_pool("pool-1")
         finally:
             sandbox_client_module.RustCloudSandboxClientError = previous
+
+    async def test_pool_network_policy_is_sent_and_returned(self):
+        captured: dict[str, str] = {}
+
+        class _PoolRustClient:
+            def close(self):
+                return None
+
+            async def create_pool_async(self, *, request_json):
+                captured["request_json"] = request_json
+                return (
+                    "trace-create",
+                    '{"pool_id":"pool-1","namespace":"default"}',
+                )
+
+            async def get_pool_json_async(self, *, pool_id):
+                return (
+                    "trace-get",
+                    json.dumps(
+                        {
+                            "pool_id": pool_id,
+                            "namespace": "default",
+                            "image": "alpine",
+                            "resources": {
+                                "cpus": 1.0,
+                                "memory_mb": 1024,
+                                "ephemeral_disk_mb": 1024,
+                            },
+                            "network_policy": {
+                                "allow_internet_access": False,
+                                "allow_out": ["10.0.0.0/8"],
+                                "deny_out": ["192.0.2.0/24"],
+                            },
+                        }
+                    ),
+                )
+
+        client = _make_client(_PoolRustClient())
+        policy = NetworkConfig(
+            allow_internet_access=False,
+            allow_out=["10.0.0.0/8"],
+            deny_out=["192.0.2.0/24"],
+        )
+
+        await client.create_pool(image="alpine", network=policy)
+        request = json.loads(captured["request_json"])
+        self.assertEqual(
+            request["network"],
+            {
+                "allow_internet_access": False,
+                "allow_out": ["10.0.0.0/8"],
+                "deny_out": ["192.0.2.0/24"],
+            },
+        )
+
+        pool = await client.get_pool("pool-1")
+        self.assertEqual(pool.network_policy, policy)
 
     async def test_snapshot_threads_snapshot_type_to_rust_backend(self):
         fake = _FakeAsyncRustClient()

--- a/tests/sandbox/test_lifecycle.py
+++ b/tests/sandbox/test_lifecycle.py
@@ -22,6 +22,7 @@ from tensorlake.image.sandbox_builder import (
     delete_sandbox_image,
 )
 from tensorlake.sandbox import (
+    NetworkConfig,
     PoolContainerInfo,
     PoolInUseError,
     PoolNotFoundError,
@@ -446,6 +447,7 @@ class TestPoolLifecycle(BaseSandboxTest):
             memory_mb=_SANDBOX_MEMORY_MB,
             ephemeral_disk_mb=_SANDBOX_DISK_MB,
             entrypoint=["sleep", "300"],
+            network=NetworkConfig(allow_internet_access=False),
         )
         self.assertIsNotNone(resp.pool_id)
         self.__class__.pool_id = resp.pool_id
@@ -457,12 +459,21 @@ class TestPoolLifecycle(BaseSandboxTest):
         self.assertEqual(info.image, _SANDBOX_IMAGE)
         self.assertAlmostEqual(info.resources.cpus, _SANDBOX_CPUS, places=2)
         self.assertEqual(info.resources.memory_mb, _SANDBOX_MEMORY_MB)
+        self.assertEqual(
+            info.network_policy,
+            NetworkConfig(allow_internet_access=False),
+        )
 
     def test_3_list_pools(self):
         self.assertIsNotNone(self.__class__.pool_id, "Depends on test_1")
         pools = self.client.list_pools()
         ids = [p.pool_id for p in pools]
         self.assertIn(self.__class__.pool_id, ids)
+        pool = next(p for p in pools if p.pool_id == self.__class__.pool_id)
+        self.assertEqual(
+            pool.network_policy,
+            NetworkConfig(allow_internet_access=False),
+        )
 
     def test_4_update_pool(self):
         self.assertIsNotNone(self.__class__.pool_id, "Depends on test_1")
@@ -476,6 +487,10 @@ class TestPoolLifecycle(BaseSandboxTest):
         )
         self.assertEqual(updated.resources.memory_mb, 2048)
         self.assertEqual(updated.warm_containers, 1)
+        self.assertEqual(
+            updated.network_policy,
+            NetworkConfig(allow_internet_access=False),
+        )
 
     def test_5_delete_pool(self):
         self.assertIsNotNone(self.__class__.pool_id, "Depends on test_1")

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.89",
+  "version": "0.5.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.89",
+      "version": "0.5.90",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.89",
+  "version": "0.5.90",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -36,6 +36,7 @@ import {
   type UpdatePoolOptions,
   type UpdateSandboxOptions,
   fromSnakeKeys,
+  toSnakeKeys,
 } from "./models.js";
 import { Sandbox } from "./sandbox.js";
 import { nowMs, logSdkTimingEvent, logSdkTiming } from "./sdk-timings.js";
@@ -607,6 +608,7 @@ export class SandboxClient {
     if (options.entrypoint != null) body.entrypoint = options.entrypoint;
     if (options.maxContainers != null) body.max_containers = options.maxContainers;
     if (options.warmContainers != null) body.warm_containers = options.warmContainers;
+    if (options.network != null) body.network = toSnakeKeys(options.network);
 
     return this.plainJson<CreateSandboxPoolResponse>(
       () => this.native.createPool(JSON.stringify(body)),
@@ -633,11 +635,17 @@ export class SandboxClient {
     return Object.assign(pools, { traceId });
   }
 
-  /** Replace the configuration of an existing sandbox pool. */
+  /** Replace a pool configuration and keep its current network policy. */
   async updatePool(
     poolId: string,
     options: UpdatePoolOptions,
   ): Promise<SandboxPoolInfo> {
+    if ((options as UpdatePoolOptions & { network?: unknown }).network != null) {
+      throw new SandboxError(
+        "Network policy updates are not supported. Create a new pool to change the network policy.",
+      );
+    }
+
     const body: Record<string, unknown> = {
       image: options.image,
       resources: {

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -322,6 +322,8 @@ export interface CreatePoolOptions {
   entrypoint?: string[];
   maxContainers?: number;
   warmContainers?: number;
+  /** Network policy for each container. Create a new pool to change this policy. */
+  network?: NetworkConfig;
 }
 
 export interface UpdatePoolOptions {
@@ -358,6 +360,8 @@ export interface SandboxPoolInfo {
   entrypoint?: string[];
   maxContainers?: number;
   warmContainers?: number;
+  /** The network policy that applies to each container in the pool. */
+  networkPolicy?: NetworkConfig;
   containers?: PoolContainerInfo[];
   createdAt?: Date;
   updatedAt?: Date;

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SandboxClient } from "../src/client.js";
-import { SandboxStatus, SnapshotStatus } from "../src/models.js";
+import {
+  type NetworkConfig,
+  SandboxStatus,
+  SnapshotStatus,
+  type UpdatePoolOptions,
+} from "../src/models.js";
 import { clearNativeStub, installNativeStub } from "./native-stub.js";
 
 /** Build the native error a non-2xx HTTP response now surfaces from Rust. */
@@ -1108,6 +1113,11 @@ describe("SandboxClient", () => {
             const body = JSON.parse(json);
             expect(body.image).toBe("node:20");
             expect(body.max_containers).toBe(5);
+            expect(body.network).toEqual({
+              allow_internet_access: false,
+              allow_out: ["10.0.0.0/8"],
+              deny_out: ["192.0.2.0/24"],
+            });
             return {
               traceId: "t",
               json: JSON.stringify({ pool_id: "pool-1", namespace: "default" }),
@@ -1120,6 +1130,11 @@ describe("SandboxClient", () => {
       const result = await client.createPool({
         image: "node:20",
         maxContainers: 5,
+        network: {
+          allowInternetAccess: false,
+          allowOut: ["10.0.0.0/8"],
+          denyOut: ["192.0.2.0/24"],
+        },
       });
       expect(result.poolId).toBe("pool-1");
       client.close();
@@ -1136,6 +1151,11 @@ describe("SandboxClient", () => {
               image: "node:20",
               resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
               timeout_secs: 0,
+              network_policy: {
+                allow_internet_access: false,
+                allow_out: ["10.0.0.0/8"],
+                deny_out: ["192.0.2.0/24"],
+              },
             }),
           })),
         },
@@ -1145,6 +1165,11 @@ describe("SandboxClient", () => {
       const info = await client.getPool("pool-1");
       expect(info.poolId).toBe("pool-1");
       expect(info.image).toBe("node:20");
+      expect(info.networkPolicy).toEqual({
+        allowInternetAccess: false,
+        allowOut: ["10.0.0.0/8"],
+        denyOut: ["192.0.2.0/24"],
+      });
       expect(stub.client.getPool).toHaveBeenCalledWith("pool-1");
       client.close();
     });
@@ -1164,6 +1189,27 @@ describe("SandboxClient", () => {
       expect(Array.isArray(pools)).toBe(true);
       expect(typeof pools.traceId).toBe("string");
       expect(pools.traceId.length).toBeGreaterThan(0);
+      client.close();
+    });
+
+    it("rejects a network policy on pool update", async () => {
+      const updatePool = vi.fn();
+      installNativeStub({ client: { updatePool } });
+
+      const client = SandboxClient.forLocalhost();
+      await expect(
+        client.updatePool("pool-1", {
+          image: "node:20",
+          network: {
+            allowInternetAccess: true,
+            allowOut: [],
+            denyOut: [],
+          },
+        } as UpdatePoolOptions & { network: NetworkConfig }),
+      ).rejects.toThrow(
+        "Network policy updates are not supported. Create a new pool to change the network policy.",
+      );
+      expect(updatePool).not.toHaveBeenCalled();
       client.close();
     });
   });

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -544,11 +544,6 @@ describe(
         memoryMb: SANDBOX_MEMORY_MB,
         ephemeralDiskMb: SANDBOX_DISK_MB,
         entrypoint: ["sleep", "300"],
-        network: {
-          allowInternetAccess: false,
-          allowOut: [],
-          denyOut: [],
-        },
         warmContainers: 1,
       });
       poolId = pool.poolId;
@@ -745,6 +740,11 @@ describe(
         memoryMb: SANDBOX_MEMORY_MB,
         ephemeralDiskMb: SANDBOX_DISK_MB,
         entrypoint: ["sleep", "300"],
+        network: {
+          allowInternetAccess: false,
+          allowOut: [],
+          denyOut: [],
+        },
       });
       expect(resp.poolId).toBeTruthy();
       poolId = resp.poolId;

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -544,6 +544,11 @@ describe(
         memoryMb: SANDBOX_MEMORY_MB,
         ephemeralDiskMb: SANDBOX_DISK_MB,
         entrypoint: ["sleep", "300"],
+        network: {
+          allowInternetAccess: false,
+          allowOut: [],
+          denyOut: [],
+        },
         warmContainers: 1,
       });
       poolId = pool.poolId;
@@ -750,12 +755,22 @@ describe(
       expect(info.poolId).toBe(poolId);
       expect(info.image).toBe(sandboxImage);
       expect(info.resources.memoryMb).toBe(SANDBOX_MEMORY_MB);
+      expect(info.networkPolicy).toEqual({
+        allowInternetAccess: false,
+        allowOut: [],
+        denyOut: [],
+      });
     });
 
     it("lists pools", async () => {
       const pools = await client.listPools();
       const ids = pools.map((p) => p.poolId);
       expect(ids).toContain(poolId);
+      expect(pools.find((p) => p.poolId === poolId)?.networkPolicy).toEqual({
+        allowInternetAccess: false,
+        allowOut: [],
+        denyOut: [],
+      });
     });
 
     it("updates a pool", async () => {
@@ -768,6 +783,11 @@ describe(
       });
       expect(updated.resources.memoryMb).toBe(2048);
       expect(updated.warmContainers).toBe(1);
+      expect(updated.networkPolicy).toEqual({
+        allowInternetAccess: false,
+        allowOut: [],
+        denyOut: [],
+      });
     });
 
     it("deletes a pool", async () => {


### PR DESCRIPTION
## Summary

Sandbox pool users can now set a network policy before the service creates warm containers. The Rust, Python, and TypeScript SDKs send `network` during pool creation and expose the returned `network_policy`.

The SDK keeps the current policy during pool configuration updates. A user must create a new pool to change the policy. This design prevents an update from removing a policy without replacing the existing warm containers.

The Rust SDK keeps `SandboxPoolRequest` source compatible. It uses a create-only request type for the new field.

## Validation

- `cargo test -p tensorlake`
- `cargo check -p tensorlake-rust-cloud-sdk-py`
- `cargo check -p tensorlake-rust-cloud-sdk-node`
- `cargo fmt --all -- --check`
- `cargo clippy -p tensorlake --all-targets`
- Python Rust-backend tests: 93 passed
- TypeScript unit tests: 58 passed
- `npm run typecheck`
- `npm run build:sdk`

Clippy reports one existing `type_complexity` warning in `artifact_storage`. ESLint cannot run because this repository does not have an ESLint v9 configuration file. Live service tests did not run because the required Tensorlake credentials are not available.

## Release

This PR bumps the shared SDK version from `0.5.89` to `0.5.90` so the network policy change ships without a separate release PR. `python .github/scripts/bump_version.py 0.5.90` updated:

- `pyproject.toml` — public Python SDK on PyPI
- `Cargo.toml` — Rust workspace version, inherited by `tensorlake`, `tensorlake-cli`, and the Node/Python native SDK crates
- `crates/gsvc-fs-client/Cargo.toml`
- `crates/rust-cloud-sdk-py/pyproject.toml`
- `typescript/package.json` — npm SDK manifest

`Cargo.lock` was regenerated with `cargo update -w`, which touched only the five workspace entries. `typescript/package-lock.json` carries the two version fields, matching the previous bump in #872.

After this merges to `main`, dispatch the four `workflow_dispatch` release workflows against `main`: `publish_pypi.yaml`, `publish_crates_io.yaml`, `publish_npm.yaml`, and `publish_cli.yaml`. They read the version from the files above, so they must run after the bump lands.

## Post-Deploy Monitoring & Validation

- Create a pool with `allow_internet_access=False`.
- Read the pool and confirm that `network_policy` contains the requested policy.
- Claim a sandbox from the pool and confirm that an external HTTP request fails.
- Check SDK errors for pool create and update operations.

A missing `network_policy` or successful external access is a failure. Stop claims from the affected pool and create a replacement pool with the correct policy. Revert the SDK release if request serialization caused the failure. Because the pool policy is create-only by design, existing pools keep whatever policy they were created with, so rollback also means recreating any affected pool.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
