### PR TITLE
Route filesystem and Git mounts through logical-v1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '01bb90c03fb76b293ece15cb1f9ecc9136bd763e' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '70be9e2771d6e74ed4af55bb89b77951b3348fb3' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '01bb90c03fb76b293ece15cb1f9ecc9136bd763e' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '70be9e2771d6e74ed4af55bb89b77951b3348fb3' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '34d7c988ded586f7217684f071290358da1f41fb' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '8b92256672b0a7693dec3f98b5321596ee1b230d' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '34d7c988ded586f7217684f071290358da1f41fb' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '8b92256672b0a7693dec3f98b5321596ee1b230d' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '5f1ce573722e7074d223241e7f460cb8d240e790' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '27d6f18ea3361ac482cb4f576d5a1ab597d2a5e5' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '5f1ce573722e7074d223241e7f460cb8d240e790' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '27d6f18ea3361ac482cb4f576d5a1ab597d2a5e5' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '8b92256672b0a7693dec3f98b5321596ee1b230d' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '8b92256672b0a7693dec3f98b5321596ee1b230d' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '70be9e2771d6e74ed4af55bb89b77951b3348fb3' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '8f8a9e1a8350ad6812ab7abc00fe4b8ef70c00ae' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '70be9e2771d6e74ed4af55bb89b77951b3348fb3' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '8f8a9e1a8350ad6812ab7abc00fe4b8ef70c00ae' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '9a5f8374dad34c4d70daf799d345d11ceb22771b' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '63fdbf1b8c738128ca4ec880f971907b87a260c6' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '9a5f8374dad34c4d70daf799d345d11ceb22771b' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '63fdbf1b8c738128ca4ec880f971907b87a260c6' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '8f8a9e1a8350ad6812ab7abc00fe4b8ef70c00ae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '34d7c988ded586f7217684f071290358da1f41fb' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '8f8a9e1a8350ad6812ab7abc00fe4b8ef70c00ae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '34d7c988ded586f7217684f071290358da1f41fb' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '27d6f18ea3361ac482cb4f576d5a1ab597d2a5e5' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '08bb7d4c2063fd962d24c982a4595febb798785b' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '27d6f18ea3361ac482cb4f576d5a1ab597d2a5e5' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '08bb7d4c2063fd962d24c982a4595febb798785b' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '08bb7d4c2063fd962d24c982a4595febb798785b' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '01bb90c03fb76b293ece15cb1f9ecc9136bd763e' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '08bb7d4c2063fd962d24c982a4595febb798785b' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '01bb90c03fb76b293ece15cb1f9ecc9136bd763e' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '65394cb2ccd4144a8afc6e18daf0350c40faf4c8' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '9a5f8374dad34c4d70daf799d345d11ceb22771b' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '65394cb2ccd4144a8afc6e18daf0350c40faf4c8' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '9a5f8374dad34c4d70daf799d345d11ceb22771b' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '63fdbf1b8c738128ca4ec880f971907b87a260c6' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '5f1ce573722e7074d223241e7f460cb8d240e790' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '63fdbf1b8c738128ca4ec880f971907b87a260c6' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '5f1ce573722e7074d223241e7f460cb8d240e790' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
           # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
           # Pin its exact code commit only for this head branch; main and every other PR continue
           # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '7fadb497fe6318932e3dd6ee89ec74862bb45746' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '65394cb2ccd4144a8afc6e18daf0350c40faf4c8' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +91,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '7fadb497fe6318932e3dd6ee89ec74862bb45746' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '65394cb2ccd4144a8afc6e18daf0350c40faf4c8' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,6 +46,10 @@ jobs:
         with:
           app-id: ${{ secrets.ARTIFACT_STORAGE_APP_ID }}
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
+          # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
+          # Pin its exact code commit only for this head branch; main and every other PR continue
+          # integrating against artifact_storage/main.
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '7fadb497fe6318932e3dd6ee89ec74862bb45746' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -86,6 +90,8 @@ jobs:
           app-id: ${{ secrets.ARTIFACT_STORAGE_APP_ID }}
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
+          # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && '7fadb497fe6318932e3dd6ee89ec74862bb45746' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "base64",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "base64",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,10 +318,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "byteview"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "bzip2"
@@ -488,6 +500,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "compare"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +618,16 @@ version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -738,6 +766,20 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1035,6 +1077,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "env-file-reader"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1171,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fjall"
+version = "3.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420a84699b8ccbb1ed573e38e88f4f23637b45beab6432066452f834be469c57"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "dashmap",
+ "flume",
+ "log",
+ "lsm-tree",
+ "tempfile",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1195,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -1377,6 +1456,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "filetime",
+ "fjall",
  "flate2",
  "fuser",
  "futures",
@@ -1389,7 +1469,6 @@ dependencies = [
  "postcard",
  "rand 0.9.4",
  "rayon",
- "redb",
  "reqwest",
  "serde",
  "serde_json",
@@ -1408,6 +1487,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "xattr",
+ "xxhash-rust",
  "zstd 0.13.3",
 ]
 
@@ -1461,6 +1541,12 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -1853,6 +1939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "interval-heap"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11274e5e8e89b8607cfedc2910b6626e998779b48a019151c7604d0adcb86ac6"
+dependencies = [
+ "compare",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,6 +2246,27 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lsm-tree"
+version = "3.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055a908d502129cf63bedae52f2db222e4436d2da32a69df9b84ac9fb9147761"
+dependencies = [
+ "byteorder-lite",
+ "byteview",
+ "crossbeam-skiplist",
+ "enum_dispatch",
+ "interval-heap",
+ "log",
+ "quick_cache",
+ "rustc-hash 2.1.3",
+ "self_cell",
+ "sfa",
+ "tempfile",
+ "varint-rs",
+ "xxhash-rust",
+]
 
 [[package]]
 name = "malachite"
@@ -2785,6 +2901,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick_cache"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,15 +3091,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redb"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -3406,6 +3523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,6 +3649,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sfa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1296838937cab56cd6c4eeeb8718ec777383700c33f060e2869867bd01d1175"
+dependencies = [
+ "byteorder-lite",
+ "log",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -4510,6 +4644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "varint-rs"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa6c38708f6257f1ec2ca7e5a11f9bbf58a27d7060078b6b333624968183d96"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,6 +5218,12 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.90"
+version = "0.5.91"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -55,22 +55,6 @@ fn map<T>(result: gsvc_fs_client::Result<T>) -> Result<T> {
     result.map_err(Into::into)
 }
 
-pub mod plaindir {
-    use std::path::PathBuf;
-
-    use crate::error::Result;
-
-    pub fn binding_for_lenient(path: &std::path::Path) -> Option<(String, PathBuf)> {
-        gsvc_fs_client::plaindir::binding_for_lenient(path)
-    }
-
-    pub async fn unbind(path: Option<PathBuf>) -> Result<()> {
-        gsvc_fs_client::plaindir::unbind(path)
-            .await
-            .map_err(Into::into)
-    }
-}
-
 pub mod daemon {
     use std::path::Path;
 
@@ -82,25 +66,10 @@ pub mod daemon {
             .await
             .map_err(Into::into)
     }
-
-    /// Run one macOS kernel-cache convergence probe as a separate process from the mount daemon.
-    ///
-    /// The private client owns the versioned JSON stdin/stdout protocol and the filesystem work.
-    /// Keeping this adapter argument-free prevents the hidden command from becoming a second
-    /// user-facing mount surface or inheriting authentication/configuration concerns.
-    pub async fn converge() -> Result<()> {
-        gsvc_fs_client::run_kernel_convergence_helper()
-            .await
-            .map_err(Into::into)
-    }
 }
 
 pub async fn setup(from: Option<&str>, check_only: bool) -> Result<()> {
     map(gsvc_fs_client::setup(from, check_only).await)
-}
-
-pub fn is_tracked_directory(path: &Path) -> Result<bool> {
-    map(gsvc_fs_client::is_tracked_directory(path))
 }
 
 pub fn require_native_filesystem_attachment(path: &Path) -> Result<()> {
@@ -179,7 +148,6 @@ pub async fn mount_filesystem(
     ctx: &CliContext,
     target: &str,
     path: &Path,
-    ro: bool,
     foreground: bool,
     trace_ops: bool,
     log_level: &str,
@@ -189,7 +157,6 @@ pub async fn mount_filesystem(
         &private_context(ctx),
         target,
         path,
-        ro,
         foreground,
         trace_ops,
         log_level,
@@ -203,7 +170,6 @@ pub async fn mount_repo(
     target: &str,
     workspace: Option<&str>,
     path: &Path,
-    ro: bool,
     publish: bool,
     foreground: bool,
     trace_ops: bool,
@@ -215,7 +181,6 @@ pub async fn mount_repo(
         target,
         workspace,
         path,
-        ro,
         publish,
         foreground,
         trace_ops,
@@ -248,30 +213,16 @@ mod tests {
     }
 }
 
-pub async fn snapshot(
-    ctx: &CliContext,
-    path: &Path,
-    message: Option<&str>,
-    clear: bool,
-) -> Result<()> {
-    map(gsvc_fs_client::snapshot(&private_context(ctx), path, message, clear).await)
+pub async fn snapshot(ctx: &CliContext, path: &Path, message: Option<&str>) -> Result<()> {
+    map(gsvc_fs_client::snapshot(&private_context(ctx), path, message).await)
 }
 
 pub async fn status(ctx: &CliContext, path: &Path, json: bool) -> Result<()> {
     map(gsvc_fs_client::status(&private_context(ctx), path, json).await)
 }
 
-pub async fn doctor(
-    path: &Path,
-    json: bool,
-    repair_journal: bool,
-    repair_base: Option<&str>,
-) -> Result<()> {
-    map(gsvc_fs_client::doctor(path, json, repair_journal, repair_base).await)
-}
-
-pub async fn restore(ctx: &CliContext, path: &Path, version: &str, discard: bool) -> Result<()> {
-    map(gsvc_fs_client::restore(&private_context(ctx), path, version, discard).await)
+pub async fn doctor(path: &Path, json: bool) -> Result<()> {
+    map(gsvc_fs_client::doctor(path, json).await)
 }
 
 pub async fn unmount(ctx: &CliContext, path: &Path, delete: bool, discard: bool) -> Result<()> {
@@ -316,21 +267,4 @@ pub async fn promote(
         message,
     )
     .await)
-}
-
-pub async fn git_status(ctx: &CliContext, path: &Path, json: bool) -> Result<()> {
-    map(gsvc_fs_client::git_status(&private_context(ctx), path, json).await)
-}
-
-pub async fn git_log(ctx: &CliContext, subject: Option<&str>, json: bool) -> Result<()> {
-    map(gsvc_fs_client::git_log(&private_context(ctx), subject, json).await)
-}
-
-pub async fn git_smartlog(
-    ctx: &CliContext,
-    subject: Option<&str>,
-    project: bool,
-    json: bool,
-) -> Result<()> {
-    map(gsvc_fs_client::git_smartlog(&private_context(ctx), subject, project, json).await)
 }

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -68,6 +68,14 @@ pub mod daemon {
     }
 }
 
+pub async fn run_macos_kernel_refresh_helper(
+    state_dir: &Path,
+    through: &str,
+    batch: u64,
+) -> Result<()> {
+    map(gsvc_fs_client::run_macos_kernel_refresh_helper(state_dir, through, batch).await)
+}
+
 pub async fn setup(from: Option<&str>, check_only: bool) -> Result<()> {
     map(gsvc_fs_client::setup(from, check_only).await)
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -2,8 +2,8 @@ pub mod applications;
 pub mod build_images;
 pub mod cron;
 pub mod deploy;
-// Local FUSE/overlay mount stack — depends on the private gsvc-mount core, so it is only
-// compiled into official `--features mount` release builds. See crates/cli/Cargo.toml.
+// Logical-v1 FUSE/FSKit mount stack — private implementation sources are swapped into official
+// `--features mount` release builds. See crates/cli/Cargo.toml.
 #[cfg(feature = "mount")]
 pub mod fs;
 pub mod git;

--- a/crates/cli/src/commands/sbx/exec.rs
+++ b/crates/cli/src/commands/sbx/exec.rs
@@ -28,7 +28,8 @@ pub struct ExecOptions<'a> {
     pub health_interval_ms: Option<u64>,
     pub health_timeout_ms: Option<u64>,
     pub health_failure_threshold: Option<u32>,
-    /// Promote a directly-invoked `tl fs mount` or `tl git mount` to a detached sandbox process.
+    /// Promote a directly-invoked `tl fs mount` or logical-v1 `tl git mount` to a detached
+    /// sandbox process.
     /// The mount daemon must be the process-unit leader: a daemon forked by `/processes/run`
     /// remains in that one-shot unit's cgroup and is reaped when the unit finishes.
     pub protect_long_lived_mounts: bool,
@@ -266,7 +267,7 @@ fn rewrite_direct_mount(command: &str, args: &[String]) -> Option<DetachedMountC
         return None;
     }
 
-    let mountpoint = parse_mountpoint(&args[mount_index], mount_args)?;
+    let mountpoint = parse_mountpoint(surface, mount_args)?;
     let mut detached_args = args.to_vec();
     // Insert before the mount operands (and, importantly, before a possible `--` sentinel).
     // Appending after `--` would turn this into a third positional argument instead of a flag.
@@ -318,15 +319,15 @@ fn parse_mountpoint(surface: &str, args: &[String]) -> Option<String> {
     while index < args.len() {
         let arg = &args[index];
         match arg.as_str() {
-            "--ro" | "--trace-ops" => index += 1,
-            "--publish" if surface == "git" => index += 1,
+            "--trace-ops" => index += 1,
+            "--publish" if surface == "repository" => index += 1,
             "--log-level" => {
                 if index + 1 == args.len() {
                     return None;
                 }
                 index += 2;
             }
-            "--workspace" if surface == "git" => {
+            "--workspace" if surface == "repository" => {
                 if index + 1 == args.len() {
                     return None;
                 }
@@ -337,7 +338,7 @@ fn parse_mountpoint(surface: &str, args: &[String]) -> Option<String> {
                 break;
             }
             _ if arg.starts_with("--log-level=")
-                || (surface == "git" && arg.starts_with("--workspace=")) =>
+                || (surface == "repository" && arg.starts_with("--workspace=")) =>
             {
                 index += 1;
             }
@@ -1187,7 +1188,6 @@ mod tests {
                 "mount".to_string(),
                 "drive".to_string(),
                 "mnt/drive".to_string(),
-                "--ro".to_string(),
                 "--log-level=debug".to_string(),
             ],
         )
@@ -1199,7 +1199,7 @@ mod tests {
     }
 
     #[test]
-    fn direct_git_mount_parses_workspace_option() {
+    fn direct_logical_git_mount_parses_workspace_option() {
         let command = rewrite_direct_mount(
             "tl",
             &[
@@ -1207,7 +1207,7 @@ mod tests {
                 "mount".to_string(),
                 "repo:main".to_string(),
                 "--workspace".to_string(),
-                "workspace-1".to_string(),
+                "0123456789012345678901234567890123456789".to_string(),
                 "/code".to_string(),
             ],
         )
@@ -1215,6 +1215,7 @@ mod tests {
 
         assert_eq!(command.surface, "repository");
         assert_eq!(command.mountpoint, "/code");
+        assert!(command.args.iter().any(|arg| arg == "--foreground"));
     }
 
     #[test]
@@ -1225,9 +1226,9 @@ mod tests {
                 "--debug".to_string(),
                 "--project".to_string(),
                 "project-a".to_string(),
-                "git".to_string(),
+                "fs".to_string(),
                 "mount".to_string(),
-                "repo:main".to_string(),
+                "drive".to_string(),
                 "/code".to_string(),
             ],
         )

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -339,6 +339,19 @@ enum FsCommands {
         log_level: String,
     },
 
+    /// (internal) Refresh one committed logical head through FSKit's kernel caches
+    #[command(hide = true)]
+    KernelRefresh {
+        #[arg(long)]
+        state_dir: PathBuf,
+
+        #[arg(long)]
+        through: String,
+
+        #[arg(long)]
+        batch: u64,
+    },
+
     /// Create a permanent, billed snapshot of the drive (a clean tree is a quiet no-op)
     Snapshot {
         /// A mounted directory (default: the attachment containing the current directory)
@@ -2387,10 +2400,20 @@ fn purge_credentials_on_auth_failure(result: &error::Result<()>) {
 // with a clear "not available" error.
 #[cfg(feature = "mount")]
 async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Result<()> {
-    // Setup installs a local app bundle and does not require project authentication.
+    // Setup and the daemon-owned FSKit refresh helper are local operations and do not require
+    // project authentication. The latter receives only a state path plus immutable head token;
+    // it fetches exact path facts from the already-authenticated local daemon.
     let subcmd = match subcmd {
         FsCommands::Setup { from, check } => {
             return commands::fs::setup(from.as_deref(), check).await;
+        }
+        FsCommands::KernelRefresh {
+            state_dir,
+            through,
+            batch,
+        } => {
+            return commands::fs::run_macos_kernel_refresh_helper(&state_dir, &through, batch)
+                .await;
         }
         other => other,
     };
@@ -2453,6 +2476,9 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
     let mount_dir = move || mount_dir.expect("resolved for every path-addressed command above");
     let result = match subcmd {
         FsCommands::Setup { .. } => unreachable!("handled before the auth guard"),
+        FsCommands::KernelRefresh { .. } => {
+            unreachable!("handled before the auth guard")
+        }
         FsCommands::Create { name, json } => {
             commands::fs::create_filesystem(ctx, &name, json).await
         }
@@ -3125,6 +3151,29 @@ mod tests {
     #[test]
     fn logical_git_mount_and_fs_commands_are_surface_centric() {
         assert!(Cli::try_parse_from(["tl", "fs", "converge"]).is_err());
+
+        match parse_command([
+            "tl",
+            "fs",
+            "kernel-refresh",
+            "--state-dir",
+            "/tmp/tlfs-state",
+            "--through",
+            "11",
+            "--batch",
+            "7",
+        ]) {
+            Commands::Fs(FsCommands::KernelRefresh {
+                state_dir,
+                through,
+                batch,
+            }) => {
+                assert_eq!(state_dir, PathBuf::from("/tmp/tlfs-state"));
+                assert_eq!(through, "11");
+                assert_eq!(batch, 7);
+            }
+            _ => panic!("expected internal FSKit kernel refresh command"),
+        }
 
         // The filesystem surface is writable logical-v1 only: a bare name and mountpoint.
         match parse_command(["tl", "fs", "mount", "scratch", "./w"]) {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -229,19 +229,15 @@ enum FsCommands {
         json: bool,
     },
 
-    /// Mount a filesystem: reads stream lazily and autosaves publish to the shared drive.
-    /// Use `filesystem:snapshot-id` for a fixed read-only time-travel view.
-    /// Remounting a filesystem this machine has a detached session for resumes that session
+    /// Mount a filesystem through the logical-v1 engine. Reads stream lazily and autosaves
+    /// publish to the shared drive. Remounting a filesystem this machine has a detached session
+    /// for resumes that session.
     Mount {
-        /// Filesystem name, optionally followed by `:<snapshot-id>` (see `tl fs history`)
+        /// Filesystem name
         target: String,
 
         /// Mountpoint directory (created; must be empty)
         path: PathBuf,
-
-        /// Read-only: look, don't touch (follows the filesystem's current state)
-        #[arg(long)]
-        ro: bool,
 
         /// Run the mount daemon in the foreground (debugging)
         #[arg(long, hide = true)]
@@ -343,30 +339,18 @@ enum FsCommands {
         log_level: String,
     },
 
-    /// (internal) Probe FSKit cache convergence outside the mount daemon process
-    #[command(hide = true)]
-    Converge,
-
     /// Create a permanent, billed snapshot of the drive (a clean tree is a quiet no-op)
     Snapshot {
-        /// A mounted or pushed directory (default: the attachment containing the current
-        /// directory)
+        /// A mounted directory (default: the attachment containing the current directory)
         path: Option<PathBuf>,
 
         /// Snapshot message
         #[arg(short, long)]
         message: Option<String>,
-
-        /// After publishing, trim that generation's retained byte cache. Later writes and
-        /// ignored/local-only files are preserved; pending preparation completes this in background
-        #[arg(long)]
-        clear: bool,
     },
-
     /// Show local changes, last autosave, and permanent snapshot count
     Status {
-        /// A mounted or tracked directory (default: the attachment containing the current
-        /// directory)
+        /// A mounted directory (default: the attachment containing the current directory)
         path: Option<PathBuf>,
 
         /// Print status as JSON
@@ -374,45 +358,14 @@ enum FsCommands {
         json: bool,
     },
 
-    /// Inspect the crash-safe local autosave journal of a native mount or tracked directory
+    /// Inspect the crash-safe logical-v1 state of a native mount
     Doctor {
-        /// A mounted or tracked directory (default: the attachment containing the current
-        /// directory)
+        /// A mounted directory (default: the attachment containing the current directory)
         path: Option<PathBuf>,
 
         /// Print the diagnostic report as JSON
         #[arg(long)]
         json: bool,
-
-        /// Rebuild a corrupt or missing native-mount journal from the raw local overlay.
-        /// The mount must be detached; the original journal and staging metadata are exported
-        /// before replacement, and the repair never contacts the server
-        #[arg(long)]
-        repair_journal: bool,
-
-        /// Required repair baseline when the existing journal cannot prove one. Pass a snapshot
-        /// or recent autosave ID, or `empty` only for a filesystem that has never been saved.
-        #[arg(
-            long,
-            value_name = "SNAPSHOT_OR_AUTOSAVE_ID|empty",
-            requires = "repair_journal"
-        )]
-        base: Option<String>,
-    },
-
-    /// Restore a writable filesystem mount to a snapshot or recent autosave
-    #[command(allow_missing_positional = true)]
-    Restore {
-        /// A mounted directory (default: the mount containing the current directory)
-        path: Option<PathBuf>,
-
-        /// Snapshot or recent autosave ID, or an unambiguous hexadecimal prefix
-        version: String,
-
-        /// Drop the local overlay to apply the restore. Destructive: unsaved changes AND
-        /// ignored files under the mount are deleted — `tl fs snapshot` first to keep them
-        #[arg(long)]
-        discard: bool,
     },
 
     /// Detach a mounted filesystem (the session survives; remounting resumes it) or stop
@@ -620,148 +573,89 @@ enum GitCommands {
         /// Operation requested by git: get, store, or erase
         operation: String,
     },
-    /// Mount a repo as a lazy working tree. Writes autosave durably into a private workspace.
-    /// Branches change only through `tl git promote`, or each snapshot when `--publish` is set
+    /// Mount a repo through the logical-v1/Fjall engine. Writes autosave into a private
+    /// checkpoint; explicit snapshots create Git commits.
     Mount {
-        /// `<repo>[:<ref-or-full-commit>][//<subtree>]` — selects the base view and optionally
-        /// exposes one directory as the mount root; the workspace is created on first write
+        /// `<repo>[:<ref-or-full-commit>][//<subtree>]`
         target: String,
-
         /// Mountpoint directory (created; must be empty)
         path: PathBuf,
-
-        /// A stateless read-only view (branches and tags follow; full commits stay pinned)
-        #[arg(long, conflicts_with_all = ["publish", "workspace"])]
-        ro: bool,
-
-        /// Every explicit snapshot also promotes onto the mounted branch. Autosaves never
-        /// publish. Requires `<repo>:<branch>`
+        /// Publish each explicit snapshot onto the mounted branch
         #[arg(long)]
         publish: bool,
-
-        /// Resume an existing workspace, including its unsnapshotted autosave WAL
+        /// Resume an existing private workspace
         #[arg(long, conflicts_with = "publish")]
         workspace: Option<String>,
-
-        /// Run the mount daemon in the foreground (debugging)
+        /// Run the logical mount daemon in the foreground
         #[arg(long, hide = true)]
         foreground: bool,
-
-        /// Log every VFS operation the mount serves to stderr (macOS; requires --foreground)
+        /// Log every VFS operation (macOS; requires --foreground)
         #[arg(long, requires = "foreground", hide = true)]
         trace_ops: bool,
-
-        /// Daemon + CLI log level (off, error, warn, info, debug, trace)
+        /// Daemon + CLI log level
         #[arg(long, default_value = "info", hide = true)]
         log_level: String,
     },
-
-    /// Unmount a repo working tree; its durable WAL and snapshots survive unless --delete
+    /// Unmount a logical-v1 repository working tree
     Unmount {
-        /// A mounted directory (default: the mount containing the current directory)
+        /// Mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
-
-        /// Also delete the server-side workspace (promoted work is unaffected)
+        /// Delete the private server workspace after detaching
         #[arg(long)]
         delete: bool,
-
-        /// Drop unsealed local changes (and ignored files) with the mount; without it,
-        /// unmount refuses when unsealed work would be lost
+        /// Drop unpublished local state when recovery is impossible
         #[arg(long)]
         discard: bool,
     },
-
-    /// Materialize the current autosaved state as one commit on the private workspace line
+    /// Materialize the accepted logical checkpoint as one Git commit
     Snapshot {
-        /// A mounted directory (default: the mount containing the current directory)
+        /// Mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
-
         /// Commit message
         #[arg(short, long)]
         message: Option<String>,
-
-        /// Drop the WHOLE local overlay after sealing (disk-reclaim escape hatch;
-        /// destructive to ignored files and concurrent writes)
-        #[arg(long, hide = true)]
-        clear: bool,
     },
-
-    /// Refresh or switch the base view, carrying any unsnapshotted autosave state forward
+    /// Refresh or switch a pristine logical-v1 workspace base
     Sync {
-        /// A mounted directory (default: the mount containing the current directory)
+        /// Mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
-
-        /// Ref or full commit to switch to (default: refresh the current source)
+        /// Ref or full commit to switch to
         target: Option<String>,
     },
-
-    /// Replay the workspace snapshots and unsnapshotted autosave tail onto another base
+    /// Rebase the logical workspace and its checkpoint tail onto another Git base
     #[command(allow_missing_positional = true)]
     Rebase {
-        /// A mounted directory (default: the mount containing the current directory)
+        /// Mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
-
         /// Ref or full commit to rebase onto
         target: String,
-
-        /// Report conflicts without materializing them into the workspace
+        /// Report conflicts without materializing them
         #[arg(long)]
         fail_on_conflict: bool,
     },
-
-    /// Autosave live changes, materialize a snapshot, then squash-land it on a branch
+    /// Materialize the logical checkpoint and publish the workspace onto a branch
     #[command(allow_missing_positional = true)]
     Promote {
-        /// A mounted directory (default: the mount containing the current directory)
+        /// Mounted directory (default: the mount containing the current directory)
         path: Option<PathBuf>,
-
         /// Target branch
         branch: String,
-
-        /// If the branch moved, land a two-parent merge instead of failing; conflicts
-        /// publish nothing
+        /// Land a merge when the target moved
         #[arg(long)]
         merge: bool,
     },
-
+    /// Show logical-v1 workspace and autosave status
+    Status {
+        /// Mounted directory (default: the mount containing the current directory)
+        path: Option<PathBuf>,
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// List a repository's durable workspaces, autosave state, snapshots, and attachments
     Workspaces {
         /// Repository name
         repo: String,
-
-        /// Output JSON
-        #[arg(long)]
-        json: bool,
-    },
-
-    /// Show workspace and local-change status for a mounted working tree
-    Status {
-        /// A mounted directory (default: the mount containing the current directory)
-        path: Option<PathBuf>,
-
-        /// Output JSON
-        #[arg(long)]
-        json: bool,
-    },
-
-    /// Show the active workspace snapshot chain and retained recovery chains
-    Log {
-        /// Mounted directory or repository name (default: mount containing the current directory)
-        subject: Option<String>,
-
-        /// Output JSON
-        #[arg(long)]
-        json: bool,
-    },
-
-    /// Show branch, tag, workspace, snapshot, and retained-chain positions
-    Smartlog {
-        /// Mounted directory or repository name (default: mount containing the current directory)
-        subject: Option<String>,
-
-        /// Show the bounded project-wide repository/workspace graph
-        #[arg(long)]
-        project: bool,
 
         /// Output JSON
         #[arg(long)]
@@ -1964,9 +1858,6 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
             run_ssh_keys_command(ctx, subcmd).await
         }
         Commands::Git(subcmd) => {
-            // The mount family resolves auth AFTER hydrating project scope from the mount's
-            // own state (so the commands work from any CWD), exactly like `tl fs` — route it
-            // before the eager auth guard below.
             if matches!(
                 subcmd,
                 GitCommands::Mount { .. }
@@ -1976,8 +1867,6 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                     | GitCommands::Rebase { .. }
                     | GitCommands::Promote { .. }
                     | GitCommands::Status { .. }
-                    | GitCommands::Log { .. }
-                    | GitCommands::Smartlog { .. }
             ) {
                 return run_git_mount_command(ctx, subcmd).await;
             }
@@ -2492,68 +2381,24 @@ fn purge_credentials_on_auth_failure(result: &error::Result<()>) {
     }
 }
 
-// `tl fs` drives the local FUSE/overlay mount stack, which is backed by the private gsvc-mount
-// core and therefore only compiled into `--features mount` release builds. The command surface
-// (FsCommands) is always parsed so `tl fs --help` documents it, but a build without the feature
-// answers with a clear "not available" error instead of the real implementation.
+// `tl fs` and the `tl git mount` lifecycle both drive the private logical-v1/Fjall engine through
+// thin FUSE/FSKit adapters, so they are compiled only into `--features mount` release builds. The
+// command surface is always parsed so help remains complete; a build without the feature answers
+// with a clear "not available" error.
 #[cfg(feature = "mount")]
 async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Result<()> {
-    // Setup installs a local app bundle, and the FSKit convergence child speaks only a versioned
-    // stdin/stdout protocol with its parent daemon. Both must run before auth/project discovery:
-    // a nested CLI init would touch user state and can itself traverse the mount being repaired.
+    // Setup installs a local app bundle and does not require project authentication.
     let subcmd = match subcmd {
         FsCommands::Setup { from, check } => {
             return commands::fs::setup(from.as_deref(), check).await;
         }
-        FsCommands::Converge => return commands::fs::daemon::converge().await,
         other => other,
     };
-    // Unmounting a pushed (bound) directory only removes local tracking state — the directory
-    // and the filesystem are untouched — so, like setup, it works without auth.
-    if let FsCommands::Unmount {
-        path,
-        delete,
-        discard,
-    } = &subcmd
-    {
-        let probe = match path {
-            Some(p) => p.clone(),
-            None => std::env::current_dir()?,
-        };
-        if commands::fs::plaindir::binding_for_lenient(&probe).is_some() {
-            if *delete || *discard {
-                return Err(CliError::usage(
-                    "a pushed directory is your own files; unmount just stops tracking it \
-                     (--discard/--delete do not apply)",
-                ));
-            }
-            return commands::fs::plaindir::unbind(path.clone()).await;
-        }
-        if commands::fs::is_tracked_directory(&probe)? {
-            if *delete || *discard {
-                return Err(CliError::usage(
-                    "a tracked ordinary directory is your own files; unmount only stops local \
-                     tracking (--discard/--delete do not apply)",
-                ));
-            }
-            return commands::fs::unmount(ctx, &probe, false, false).await;
-        }
-    }
     // Path-addressed commands default their mounted-directory argument to the mount containing
     // the CWD; resolve it up front so scope hydration and the command agree on the path.
     let mut subcmd = subcmd;
     let mut mount_dir: Option<std::path::PathBuf> = None;
     match &mut subcmd {
-        FsCommands::Restore { path, version, .. } => {
-            if path.is_none() {
-                commands::fs::reject_mount_like_positional(
-                    version,
-                    "snapshot or autosave ID",
-                    "tl fs restore [PATH] <VERSION>",
-                )?;
-            }
-            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
-        }
         FsCommands::Snapshot { path, .. }
         | FsCommands::Status { path, .. }
         | FsCommands::Doctor { path, .. }
@@ -2565,31 +2410,20 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
     if let Some(path) = mount_dir.as_ref()
         && matches!(
             &subcmd,
-            FsCommands::Snapshot { .. }
-                | FsCommands::Status { .. }
-                | FsCommands::Restore { .. }
-                | FsCommands::Unmount { .. }
+            FsCommands::Snapshot { .. } | FsCommands::Status { .. } | FsCommands::Unmount { .. }
         )
     {
         commands::fs::require_native_filesystem_attachment(path)?;
     }
     // Doctor is intentionally local-only: it must remain usable when authentication or the
-    // server is unavailable. Inspection is read-only; the explicit repair mode mutates only
-    // exported local journal artifacts and never publishes anything.
-    if let FsCommands::Doctor {
-        json,
-        repair_journal,
-        base,
-        ..
-    } = &subcmd
-    {
+    // server is unavailable. Logical-v1 recovery is automatic and fail-closed; there is no
+    // legacy journal-repair mutation mode.
+    if let FsCommands::Doctor { json, .. } = &subcmd {
         return commands::fs::doctor(
             &mount_dir
                 .as_ref()
                 .expect("resolved for every path-addressed command"),
             *json,
-            *repair_journal,
-            base.as_deref(),
         )
         .await;
     }
@@ -2619,7 +2453,6 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
     let mount_dir = move || mount_dir.expect("resolved for every path-addressed command above");
     let result = match subcmd {
         FsCommands::Setup { .. } => unreachable!("handled before the auth guard"),
-        FsCommands::Converge => unreachable!("handled before the auth guard"),
         FsCommands::Create { name, json } => {
             commands::fs::create_filesystem(ctx, &name, json).await
         }
@@ -2643,28 +2476,22 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
         FsCommands::Mount {
             target,
             path,
-            ro,
             foreground,
             trace_ops,
             log_level,
         } => {
-            commands::fs::mount_filesystem(
-                ctx, &target, &path, ro, foreground, trace_ops, &log_level,
-            )
-            .await
+            commands::fs::mount_filesystem(ctx, &target, &path, foreground, trace_ops, &log_level)
+                .await
         }
         FsCommands::Daemon {
             state_dir,
             log_level,
         } => commands::fs::daemon::run(ctx, &state_dir, &log_level).await,
-        FsCommands::Snapshot { message, clear, .. } => {
-            commands::fs::snapshot(ctx, &mount_dir(), message.as_deref(), clear).await
+        FsCommands::Snapshot { message, .. } => {
+            commands::fs::snapshot(ctx, &mount_dir(), message.as_deref()).await
         }
         FsCommands::Status { json, .. } => commands::fs::status(ctx, &mount_dir(), json).await,
         FsCommands::Doctor { .. } => unreachable!("handled before the auth guard"),
-        FsCommands::Restore {
-            version, discard, ..
-        } => commands::fs::restore(ctx, &mount_dir(), &version, discard).await,
         FsCommands::Unmount {
             delete, discard, ..
         } => commands::fs::unmount(ctx, &mount_dir(), delete, discard).await,
@@ -2684,25 +2511,22 @@ async fn run_fs_command(_ctx: &mut CliContext, _subcmd: FsCommands) -> error::Re
     ))
 }
 
-/// The `tl git` mount family: the same journal and autosave engine as `tl fs`, with Git
-/// publication policy (autosave checkpoints are durable but only snapshots create commits,
-/// and only promote advances a branch).
 #[cfg(feature = "mount")]
-async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> error::Result<()> {
-    // Path-addressed commands carry their scope in the mount state; resolve it before auth so
-    // they work from any CWD (mirrors run_fs_command).
-    let mut subcmd = subcmd;
-    let mut mount_dir: Option<std::path::PathBuf> = None;
-    match &mut subcmd {
-        GitCommands::Promote { path, branch, .. } => {
-            if path.is_none() {
-                commands::fs::reject_mount_like_positional(
-                    branch,
-                    "branch",
-                    "tl git promote [PATH] <BRANCH>",
-                )?;
+async fn run_git_mount_command(ctx: &mut CliContext, mut subcmd: GitCommands) -> error::Result<()> {
+    let mount_dir = match &mut subcmd {
+        GitCommands::Snapshot { path, .. }
+        | GitCommands::Status { path, .. }
+        | GitCommands::Unmount { path, .. } => Some(commands::fs::resolve_mount_path(path.take())?),
+        GitCommands::Mount { .. } => None,
+        GitCommands::Sync { path, target } => {
+            if target.is_none()
+                && let Some(candidate) = path.as_ref()
+                && !commands::fs::positional_is_mount_path(candidate)?
+            {
+                *target = Some(candidate.to_string_lossy().into_owned());
+                *path = None;
             }
-            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
+            Some(commands::fs::resolve_mount_path(path.take())?)
         }
         GitCommands::Rebase { path, target, .. } => {
             if path.is_none() {
@@ -2712,66 +2536,29 @@ async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> err
                     "tl git rebase [PATH] <REF-OR-COMMIT>",
                 )?;
             }
-            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
+            Some(commands::fs::resolve_mount_path(path.take())?)
         }
-        GitCommands::Sync { path, target } => {
-            // With two optional positionals clap assigns a lone argument to PATH. Reinterpret a
-            // branch/tag/commit-shaped value as TARGET; explicit/existing paths remain paths.
-            if target.is_none()
-                && let Some(candidate) = path.as_ref()
-                && !commands::fs::positional_is_mount_path(candidate)?
-            {
-                *target = Some(candidate.to_string_lossy().into_owned());
-                *path = None;
+        GitCommands::Promote { path, branch, .. } => {
+            if path.is_none() {
+                commands::fs::reject_mount_like_positional(
+                    branch,
+                    "branch",
+                    "tl git promote [PATH] <BRANCH>",
+                )?;
             }
-            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
+            Some(commands::fs::resolve_mount_path(path.take())?)
         }
-        GitCommands::Snapshot { path, .. }
-        | GitCommands::Status { path, .. }
-        | GitCommands::Unmount { path, .. } => {
-            mount_dir = Some(commands::fs::resolve_mount_path(path.take())?);
-        }
-        GitCommands::Log { subject, .. } => {
-            let candidate = subject.as_deref().map(std::path::Path::new);
-            if candidate.is_none()
-                || commands::fs::positional_is_mount_path(
-                    candidate.expect("checked Some").as_ref(),
-                )?
-            {
-                mount_dir = Some(commands::fs::resolve_mount_path(
-                    candidate.map(std::path::Path::to_path_buf),
-                )?);
-            }
-        }
-        GitCommands::Smartlog {
-            subject, project, ..
-        } => {
-            let candidate = subject.as_deref().map(std::path::Path::new);
-            let candidate_is_path = match candidate {
-                Some(path) => commands::fs::positional_is_mount_path(path)?,
-                None => false,
-            };
-            if candidate_is_path || (!*project && candidate.is_none()) {
-                mount_dir = Some(commands::fs::resolve_mount_path(
-                    candidate.map(std::path::Path::to_path_buf),
-                )?);
-            }
-        }
-        _ => {}
-    }
+        _ => unreachable!("only logical Git mount commands are routed here"),
+    };
     if let Some(path) = mount_dir.as_ref() {
         commands::fs::require_repository_mount_attachment(path)?;
-    }
-    if let Some(mount_dir) = &mount_dir {
-        commands::fs::hydrate_scope_from_mount(ctx, mount_dir)?;
+        commands::fs::hydrate_scope_from_mount(ctx, path)?;
     }
     ensure_auth_and_project(ctx).await?;
-    let mount_dir = move || mount_dir.expect("resolved for every path-addressed command above");
     let result = match subcmd {
         GitCommands::Mount {
             target,
             path,
-            ro,
             publish,
             workspace,
             foreground,
@@ -2783,7 +2570,6 @@ async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> err
                 &target,
                 workspace.as_deref(),
                 &path,
-                ro,
                 publish,
                 foreground,
                 trace_ops,
@@ -2791,33 +2577,62 @@ async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> err
             )
             .await
         }
-        GitCommands::Snapshot { message, clear, .. } => {
-            commands::fs::snapshot(ctx, &mount_dir(), message.as_deref(), clear).await
+        GitCommands::Snapshot { message, .. } => {
+            commands::fs::snapshot(
+                ctx,
+                mount_dir.as_ref().expect("snapshot mount path"),
+                message.as_deref(),
+            )
+            .await
+        }
+        GitCommands::Status { json, .. } => {
+            commands::fs::status(ctx, mount_dir.as_ref().expect("status mount path"), json).await
+        }
+        GitCommands::Unmount {
+            delete, discard, ..
+        } => {
+            commands::fs::unmount(
+                ctx,
+                mount_dir.as_ref().expect("unmount mount path"),
+                delete,
+                discard,
+            )
+            .await
         }
         GitCommands::Sync { target, .. } => {
-            commands::fs::git_sync(ctx, &mount_dir(), target.as_deref()).await
+            commands::fs::git_sync(
+                ctx,
+                mount_dir.as_ref().expect("sync mount path"),
+                target.as_deref(),
+            )
+            .await
         }
         GitCommands::Rebase {
             target,
             fail_on_conflict,
             ..
-        } => commands::fs::git_rebase(ctx, &mount_dir(), &target, fail_on_conflict, None).await,
+        } => {
+            commands::fs::git_rebase(
+                ctx,
+                mount_dir.as_ref().expect("rebase mount path"),
+                &target,
+                fail_on_conflict,
+                None,
+            )
+            .await
+        }
         GitCommands::Promote { branch, merge, .. } => {
-            commands::fs::promote(ctx, &mount_dir(), &branch, false, merge, None).await
+            commands::fs::promote(
+                ctx,
+                mount_dir.as_ref().expect("promote mount path"),
+                &branch,
+                false,
+                merge,
+                None,
+            )
+            .await
         }
-        GitCommands::Status { json, .. } => commands::fs::git_status(ctx, &mount_dir(), json).await,
-        GitCommands::Log { subject, json } => {
-            commands::fs::git_log(ctx, subject.as_deref(), json).await
-        }
-        GitCommands::Smartlog {
-            subject,
-            project,
-            json,
-        } => commands::fs::git_smartlog(ctx, subject.as_deref(), project, json).await,
-        GitCommands::Unmount {
-            delete, discard, ..
-        } => commands::fs::unmount(ctx, &mount_dir(), delete, discard).await,
-        _ => unreachable!("routed only for the mount family"),
+        _ => unreachable!("only logical Git mount commands are routed here"),
     };
     purge_credentials_on_auth_failure(&result);
     result
@@ -2849,10 +2664,8 @@ async fn run_git_command(ctx: &CliContext, subcmd: GitCommands) -> error::Result
         | GitCommands::Sync { .. }
         | GitCommands::Rebase { .. }
         | GitCommands::Promote { .. }
-        | GitCommands::Status { .. }
-        | GitCommands::Log { .. }
-        | GitCommands::Smartlog { .. } => {
-            unreachable!("the mount family is routed to run_git_mount_command before auth")
+        | GitCommands::Status { .. } => {
+            unreachable!("the logical Git mount family is routed before ordinary Git commands")
         }
         GitCommands::Clone {
             repo,
@@ -3211,14 +3024,12 @@ mod tests {
             _ => panic!("expected git info command"),
         }
 
-        // `tl git status` is the mount-status command now (the old Info alias is gone);
-        // a positional parses as the mounted path, not a repo name.
         match parse_command(["tl", "git", "status", "./w", "--json"]) {
             Commands::Git(GitCommands::Status { path, json }) => {
                 assert_eq!(path, Some(PathBuf::from("./w")));
                 assert!(json);
             }
-            _ => panic!("expected git mount-status command"),
+            _ => panic!("expected logical Git mount status command"),
         }
 
         // `tl git url` merged into `tl git info` (which prints the remote URL).
@@ -3312,35 +3123,20 @@ mod tests {
     }
 
     #[test]
-    fn fs_commands_are_filesystem_centric() {
-        // The FSKit cache prober is an internal child-process entry point. It remains parseable
-        // for the mount daemon but has no arguments or public help surface of its own.
-        match parse_command(["tl", "fs", "converge"]) {
-            Commands::Fs(FsCommands::Converge) => {}
-            _ => panic!("expected hidden fs convergence helper"),
-        }
-        assert!(Cli::try_parse_from(["tl", "fs", "converge", "./w"]).is_err());
-        let mut command = Cli::command();
-        let fs = command.find_subcommand_mut("fs").unwrap();
-        assert!(
-            fs.find_subcommand("converge")
-                .expect("internal convergence helper is registered")
-                .is_hide_set()
-        );
+    fn logical_git_mount_and_fs_commands_are_surface_centric() {
+        assert!(Cli::try_parse_from(["tl", "fs", "converge"]).is_err());
 
-        // The filesystem surface: a bare name plus --ro. Nothing else.
-        match parse_command(["tl", "fs", "mount", "scratch", "./w", "--ro"]) {
+        // The filesystem surface is writable logical-v1 only: a bare name and mountpoint.
+        match parse_command(["tl", "fs", "mount", "scratch", "./w"]) {
             Commands::Fs(FsCommands::Mount {
                 target,
                 path,
-                ro,
                 foreground,
                 trace_ops,
                 log_level,
             }) => {
                 assert_eq!(target, "scratch");
                 assert_eq!(path, PathBuf::from("./w"));
-                assert!(ro);
                 assert!(!foreground);
                 assert!(!trace_ops);
                 assert_eq!(log_level, "info");
@@ -3488,79 +3284,42 @@ mod tests {
             Commands::Fs(FsCommands::Snapshot {
                 path: None,
                 message: None,
-                clear: false,
             }) => {}
             _ => panic!("expected fs snapshot command"),
         }
 
-        match parse_command(["tl", "fs", "snapshot", "./w", "-m", "wip", "--clear"]) {
-            Commands::Fs(FsCommands::Snapshot {
-                path,
-                message,
-                clear,
-            }) => {
+        match parse_command(["tl", "fs", "snapshot", "./w", "-m", "wip"]) {
+            Commands::Fs(FsCommands::Snapshot { path, message }) => {
                 assert_eq!(path, Some(PathBuf::from("./w")));
                 assert_eq!(message.as_deref(), Some("wip"));
-                assert!(clear);
             }
             _ => panic!("expected fs snapshot command"),
         }
+        assert!(Cli::try_parse_from(["tl", "fs", "snapshot", "--clear"]).is_err());
 
-        match parse_command([
-            "tl",
-            "fs",
-            "doctor",
-            "./w",
-            "--json",
-            "--repair-journal",
-            "--base",
-            "snapshot-1",
-        ]) {
-            Commands::Fs(FsCommands::Doctor {
-                path,
-                json,
-                repair_journal,
-                base,
-            }) => {
+        match parse_command(["tl", "fs", "doctor", "./w", "--json"]) {
+            Commands::Fs(FsCommands::Doctor { path, json }) => {
                 assert_eq!(path, Some(PathBuf::from("./w")));
                 assert!(json);
-                assert!(repair_journal);
-                assert_eq!(base.as_deref(), Some("snapshot-1"));
             }
             _ => panic!("expected fs doctor command"),
         }
+        assert!(Cli::try_parse_from(["tl", "fs", "doctor", "./w", "--repair-journal"]).is_err());
 
         // Promote, sync, diff, and init left the fs surface entirely. Filesystem saves publish
-        // directly; push binds a directory and unmount forgets it.
+        // directly; push is a one-shot upload and unmount handles kernel attachments only.
         assert!(Cli::try_parse_from(["tl", "fs", "promote", "main"]).is_err());
         assert!(Cli::try_parse_from(["tl", "fs", "sync"]).is_err());
         assert!(Cli::try_parse_from(["tl", "fs", "diff"]).is_err());
         assert!(Cli::try_parse_from(["tl", "fs", "init"]).is_err());
         assert!(Cli::try_parse_from(["tl", "fs", "unbind"]).is_err());
-        // `tl git snapshot --clear` keeps the disk-reclaim hatch (hidden).
-        match parse_command(["tl", "git", "snapshot", "--clear"]) {
-            Commands::Git(GitCommands::Snapshot { clear: true, .. }) => {}
-            _ => panic!("expected git snapshot --clear command"),
-        }
+        assert!(Cli::try_parse_from(["tl", "git", "snapshot", "--clear"]).is_err());
 
-        match parse_command(["tl", "fs", "restore", "0a1b2c3d"]) {
-            Commands::Fs(FsCommands::Restore {
-                path,
-                version,
-                discard,
-            }) => {
-                assert_eq!(path, None);
-                assert_eq!(version, "0a1b2c3d");
-                assert!(!discard, "overlay-dropping restore is opt-in");
-            }
-            _ => panic!("expected fs restore command"),
-        }
-
-        // The overlay-destroying flag is an explicit opt-in.
-        match parse_command(["tl", "fs", "restore", "--discard", "0a1b2c3d"]) {
-            Commands::Fs(FsCommands::Restore { discard: true, .. }) => {}
-            _ => panic!("expected fs restore --discard command"),
-        }
+        // Unimplemented compatibility surfaces are absent rather than falling back to the
+        // retired mount engine.
+        assert!(Cli::try_parse_from(["tl", "fs", "mount", "scratch", "./w", "--ro"]).is_err());
+        assert!(Cli::try_parse_from(["tl", "git", "mount", "demo:main", "./w", "--ro"]).is_err());
+        assert!(Cli::try_parse_from(["tl", "fs", "restore", "0a1b2c3d"]).is_err());
         match parse_command(["tl", "fs", "unmount", "./w"]) {
             Commands::Fs(FsCommands::Unmount {
                 delete: false,
@@ -3578,92 +3337,95 @@ mod tests {
             _ => panic!("expected fs unmount --discard command"),
         }
 
-        // The git mount family parses with git vocabulary.
-        match parse_command(["tl", "git", "mount", "demo:main", "./w", "--publish"]) {
+        match parse_command(["tl", "git", "mount", "demo:main//src", "./w"]) {
             Commands::Git(GitCommands::Mount {
                 target,
                 path,
-                ro: false,
-                publish: true,
+                publish: false,
                 workspace: None,
-                ..
+                foreground: false,
+                trace_ops: false,
+                log_level,
             }) => {
-                assert_eq!(target, "demo:main");
+                assert_eq!(target, "demo:main//src");
                 assert_eq!(path, PathBuf::from("./w"));
+                assert_eq!(log_level, "info");
             }
-            _ => panic!("expected git mount command"),
+            _ => panic!("expected logical-v1 git mount command"),
+        }
+        match parse_command(["tl", "git", "mount", "demo:main", "./w", "--publish"]) {
+            Commands::Git(GitCommands::Mount { publish: true, .. }) => {}
+            _ => panic!("expected publishing logical-v1 git mount command"),
+        }
+        match parse_command([
+            "tl",
+            "git",
+            "mount",
+            "demo:main",
+            "./w",
+            "--workspace",
+            "0123456789012345678901234567890123456789",
+        ]) {
+            Commands::Git(GitCommands::Mount {
+                workspace: Some(workspace),
+                ..
+            }) => assert_eq!(workspace, "0123456789012345678901234567890123456789"),
+            _ => panic!("expected resumed logical-v1 git mount command"),
         }
         assert!(
             Cli::try_parse_from([
                 "tl",
                 "git",
                 "mount",
-                "demo",
+                "demo:main",
                 "./w",
-                "--ro",
+                "--publish",
                 "--workspace",
-                "0123456789abcdef0123456789abcdef01234567",
+                "0123456789012345678901234567890123456789",
             ])
-            .is_err(),
-            "read-only workspace resume would silently omit the unmaterialized WAL"
+            .is_err()
         );
-        match parse_command(["tl", "git", "promote", "main", "--merge"]) {
-            Commands::Git(GitCommands::Promote {
-                path: None,
-                branch,
-                merge: true,
-                ..
-            }) => {
-                assert_eq!(branch, "main");
+        match parse_command(["tl", "git", "snapshot", "./w", "-m", "checkpoint"]) {
+            Commands::Git(GitCommands::Snapshot { path, message, .. }) => {
+                assert_eq!(path, Some(PathBuf::from("./w")));
+                assert_eq!(message.as_deref(), Some("checkpoint"));
             }
-            _ => panic!("expected git promote command"),
+            _ => panic!("expected logical-v1 git snapshot command"),
         }
-        let mut command = Cli::command();
-        let promote = command
-            .find_subcommand_mut("git")
-            .unwrap()
-            .find_subcommand_mut("promote")
-            .unwrap();
-        let mut promote_help = Vec::new();
-        promote.write_long_help(&mut promote_help).unwrap();
-        let promote_help = String::from_utf8(promote_help).unwrap();
-        assert!(promote_help.contains("Autosave live changes"));
-        assert!(promote_help.contains("squash-land"));
-        match parse_command(["tl", "git", "sync"]) {
-            Commands::Git(GitCommands::Sync {
-                path: None,
-                target: None,
-            }) => {}
-            _ => panic!("expected git sync command"),
-        }
-        match parse_command(["tl", "git", "sync", "./w", "refs/tags/v2"]) {
+        match parse_command(["tl", "git", "sync", "./w", "main"]) {
             Commands::Git(GitCommands::Sync { path, target }) => {
                 assert_eq!(path, Some(PathBuf::from("./w")));
-                assert_eq!(target.as_deref(), Some("refs/tags/v2"));
+                assert_eq!(target.as_deref(), Some("main"));
             }
-            _ => panic!("expected git sync path and target"),
-        }
-        match parse_command(["tl", "git", "rebase", "main", "--fail-on-conflict"]) {
-            Commands::Git(GitCommands::Rebase {
-                path: None,
-                target,
-                fail_on_conflict: true,
-            }) => assert_eq!(target, "main"),
-            _ => panic!("expected git rebase command"),
+            _ => panic!("expected logical-v1 git sync command"),
         }
         match parse_command(["tl", "git", "rebase", "./w", "main"]) {
             Commands::Git(GitCommands::Rebase { path, target, .. }) => {
                 assert_eq!(path, Some(PathBuf::from("./w")));
                 assert_eq!(target, "main");
             }
-            _ => panic!("expected git rebase path and target"),
+            _ => panic!("expected logical-v1 git rebase command"),
         }
-        match parse_command(["tl", "git", "log", "demo", "--json"]) {
-            Commands::Git(GitCommands::Log { subject, json }) => {
-                assert_eq!(subject.as_deref(), Some("demo"));
-                assert!(json);
+        match parse_command(["tl", "git", "promote", "./w", "main"]) {
+            Commands::Git(GitCommands::Promote { path, branch, .. }) => {
+                assert_eq!(path, Some(PathBuf::from("./w")));
+                assert_eq!(branch, "main");
             }
-            _ => panic!("expected git log command"),
+            _ => panic!("expected logical-v1 git promote command"),
+        }
+        assert!(matches!(
+            parse_command(["tl", "git", "status"]),
+            Commands::Git(GitCommands::Status { path: None, .. })
+        ));
+        assert!(matches!(
+            parse_command(["tl", "git", "unmount"]),
+            Commands::Git(GitCommands::Unmount { path: None, .. })
+        ));
+        for removed in [
+            vec!["tl", "git", "log", "demo"],
+            vec!["tl", "git", "smartlog", "demo"],
+        ] {
+            assert!(Cli::try_parse_from(removed).is_err());
         }
         match parse_command(["tl", "git", "workspaces", "demo", "--json"]) {
             Commands::Git(GitCommands::Workspaces { repo, json }) => {
@@ -3672,24 +3434,6 @@ mod tests {
             }
             _ => panic!("expected git workspaces command"),
         }
-        match parse_command(["tl", "git", "smartlog", "demo", "--project", "--json"]) {
-            Commands::Git(GitCommands::Smartlog {
-                subject,
-                project,
-                json,
-            }) => {
-                assert_eq!(subject.as_deref(), Some("demo"));
-                assert!(project);
-                assert!(json);
-            }
-            _ => panic!("expected git smartlog command"),
-        }
-        // `tl git status` is the mount status now; repo info keeps its `url` alias only.
-        match parse_command(["tl", "git", "status"]) {
-            Commands::Git(GitCommands::Status { path: None, .. }) => {}
-            _ => panic!("expected git status command"),
-        }
-
         assert!(Cli::try_parse_from(["tl", "fs", "promote"]).is_err());
         assert!(Cli::try_parse_from(["tl", "fs", "restore"]).is_err());
 

--- a/crates/cli/tests/fs_status_scope.rs
+++ b/crates/cli/tests/fs_status_scope.rs
@@ -5,26 +5,36 @@ use std::fs;
 use std::process::Command;
 
 #[test]
-fn human_fs_status_hydrates_mount_scope_and_remains_offline_safe() {
+fn human_fs_status_reads_strict_logical_v1_state_and_remains_offline_safe() {
     let temp = tempfile::tempdir().expect("temporary test root");
     let home = temp.path().join("home");
     let mountpoint = temp.path().join("mounted-drive");
     let state_dir = temp.path().join("mount-state");
     fs::create_dir_all(home.join(".config/tensorlake")).expect("config directory");
     fs::create_dir_all(&mountpoint).expect("mountpoint");
-    fs::create_dir_all(state_dir.join("upper")).expect("upper directory");
-    fs::create_dir_all(state_dir.join("wh")).expect("whiteout directory");
+    fs::create_dir_all(&state_dir).expect("logical-v1 state directory");
 
     let state = serde_json::json!({
+        "format_version": 1,
         "project_id": "project-from-mount",
         "organization_id": "organization-from-mount",
+        "owner_uid": 501,
+        "owner_gid": 20,
         "repo": "drive-from-mount",
-        "native_filesystem": true,
         "workspace_id": "workspace-from-mount",
-        "ref_name": "refs/workspaces/workspace-from-mount",
+        "store_uuid": "0dc6f553-6ef4-4b58-a99f-94d4d7509285",
         "mountpoint": mountpoint,
+        "source": {
+            "surface": "native_filesystem",
+            "start_snapshot": "0000000000000000000000000000000000000000000000000000000000000000"
+        },
         "created_at_secs": 1_700_000_000_u64,
     });
+    fs::write(
+        state_dir.join("mount-engine.format-v1"),
+        b"tensorlake-mount-engine:logical-v1\n",
+    )
+    .expect("write logical-v1 engine marker");
     fs::write(
         state_dir.join("state.json"),
         serde_json::to_vec_pretty(&state).expect("serialize mount state"),
@@ -73,14 +83,10 @@ fn human_fs_status_hydrates_mount_scope_and_remains_offline_safe() {
         stdout.contains("filesystem: drive-from-mount"),
         "local mount facts must still render\nstdout:\n{stdout}"
     );
+    assert!(stdout.contains("engine: logical-v1"), "stdout:\n{stdout}");
     assert!(
-        !stdout.contains("missing project ID"),
-        "status must hydrate the project ID from mount state before reading the server head\n\
-         stdout:\n{stdout}"
-    );
-    assert!(
-        stdout.contains("last autosave: unknown ("),
-        "the unreachable test server should degrade the server summary without failing local status\n\
+        stdout.contains("publication: unavailable ("),
+        "a missing local daemon must degrade without network access or a legacy-state fallback\n\
          stdout:\n{stdout}"
     );
 }

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -25,12 +25,14 @@ use models::{
     REPO_KIND_FILESYSTEM, RepoInfo, RepoMetaInfo,
 };
 
+type GitCredentialCache = HashMap<(String, Option<String>), GitCredential>;
+
 #[derive(Clone)]
 pub struct ArtifactStorageClient {
     api_client: Client,
     git_client: reqwest::Client,
     git_base_url: String,
-    git_credentials: Arc<tokio::sync::Mutex<HashMap<(String, Option<String>), GitCredential>>>,
+    git_credentials: Arc<tokio::sync::Mutex<GitCredentialCache>>,
 }
 
 #[derive(Clone)]

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -26,6 +26,7 @@ console = "0.16"
 dirs = "6"
 dialoguer = "0.12"
 filetime = "0.2"
+fjall = { version = "3.1.8", default-features = false }
 flate2 = { version = "1", features = ["zlib-rs"] }
 futures = "0.3"
 gethostname = "0.5"
@@ -36,7 +37,6 @@ libc = "0.2"
 postcard = { version = "1", features = ["alloc"] }
 rand = "0.9"
 rayon = "1"
-redb = "4"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -54,10 +54,14 @@ url = "2"
 urlencoding = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 xattr = "1"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zstd = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 fuser = { version = "0.17", default-features = false }
+
+[dev-dependencies]
+proptest = "1"
 
 [lints.clippy]
 large_enum_variant = "allow"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.90"
+version = "0.5.91"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/gsvc-fs-client/proptest-regressions/logical_v1.txt
+++ b/crates/gsvc-fs-client/proptest-regressions/logical_v1.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 31c6a4d36e55667427e5869399841f8ef8744850a8e578c43e9ddbbb0c5142c6 # shrinks to operations = [Create { name: 0 }]

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.90"
+version = "0.5.91"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.90"
+version = "0.5.91"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.90",
+  "version": "0.5.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.90",
+      "version": "0.5.91",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.90",
+  "version": "0.5.91",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## What changed

- routes both `tl fs mount` and `tl git mount` through the strict logical-v1/Fjall engine supplied by the private source-swap build
- preserves the Git mount product surface, including mount, unmount, status, snapshot, sync, rebase, promote, and workspace selection
- removes old Git log/smartlog and filesystem convergence CLI routes that depended on the deleted mount implementation
- teaches `tl sbx exec <sandbox> -- tl fs mount ...` and `tl sbx exec <sandbox> -- tl git mount ...` to promote the foreground mount daemon into a sandbox-owned process unit, avoiding cgroup reaping
- mirrors the logical-v1 Fjall, hashing, property-test, and Linux FUSE dependency resolution in the public placeholder
- updates status scope and CLI parsing tests for the new surface-centric commands
- bumps the CLI, Rust SDK, Python SDK, and TypeScript SDK to `0.5.91`

## Dependency and rollout

Depends on tensorlakeai/artifact_storage#173 and pins the private source swap to artifact commit `c77631e7247159516e99bbaf3e68900b2ea86eae`.

Deploy the Artifact Storage server from #173 first. The new client requires generation-one checkpoint object-index sidecars, logical-v1 publication endpoints, and the exact repository-scoped Git blob route for fresh Git workspace reattachment.

This intentionally does not migrate or interpret old local mount state. The private engine rejects unmarked and legacy state because the old implementation has been deleted.

## Validation

- rebased onto current `main` (`5ec242e0de471826c189a01ffb10a80f86bcaeb0`)
- authoritative full private `just test-cli-full`: 229/229 private filesystem-client tests, 174/174 SDK unit tests (plus integration targets), 223/223 CLI library tests, 223/223 CLI binary tests, offline status integration test, and doctests
- artifact-storage `make test-server-check`, `make test-macos-fskit-check`, `make test-macos-fskit-regressions`, `make test-linux-fuse-check`, logical-v1 phase-0, property, crash, concurrent-crash, publication, scheduler, remote Git, activation, and deletion suites
- live macOS FSKit POSIX coverage: hardlinks, xattrs, symlinks, executable bits, open-unlink, rename-over-open, shared writers, append atomicity, mmap, sparse/truncate, SQLite WAL, and concurrent namespace-cache churn
- exact Linux sandbox Git mount: writable FUSE passthrough, 1,040.47 MiB/s versus 1,078.28 MiB/s rootfs (96.5%), zero FUSE `WRITE` requests, create p95 0.513 ms, rename p95 0.187 ms, and 4,238 mutations/s
- exact macOS FSKit Xcode gate: first-compile median 2.018 s versus 1.766 s native (1.143x), passing the accepted 1.20x release criterion

The mandatory Envoy history was not refreshed for this mount-only stack at the user's explicit direction.
