### PR TITLE
cloud-sdk: route --cas builds through the Image Service build plane

### DIFF
--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -23,8 +23,17 @@ pub async fn run(
     is_public: bool,
     docker_compat: bool,
     cas: bool,
+    build_args: &[String],
     output_json: bool,
 ) -> Result<()> {
+    let build_args = build_args
+        .iter()
+        .map(|raw| {
+            raw.split_once('=')
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .ok_or_else(|| CliError::usage(format!("--build-arg {raw:?} must be KEY=VALUE")))
+        })
+        .collect::<Result<Vec<_>>>()?;
     let options = SandboxImageBuildOptions {
         common: CommonBuildOptions {
             api_url: ctx.api_url.clone(),
@@ -49,6 +58,7 @@ pub async fn run(
         dockerfile_path: PathBuf::from(dockerfile_path),
         dockerfile_text: None,
         context_dir: None,
+        build_args,
     };
 
     let mut renderer = ImageBuildEventRenderer::new();

--- a/crates/cli/src/commands/sbx/image/create.rs
+++ b/crates/cli/src/commands/sbx/image/create.rs
@@ -57,10 +57,8 @@ pub async fn run(
         .map_err(|error| CliError::Other(error.into()))?;
 
     if output_json || cas {
-        // Simulation: --cas must expose the unregistered, builder-local CAS
-        // receipt even when --json was not requested.
-        // Final implementation: this prints the normal registered Platform
-        // image response, while --json remains the durable-path opt-in.
+        // --cas prints the published Image Service image record; --json
+        // remains the opt-in for the legacy platform path.
         println!("{}", serde_json::to_string_pretty(&registered)?);
     }
 

--- a/crates/cli/src/commands/sbx/image/import.rs
+++ b/crates/cli/src/commands/sbx/image/import.rs
@@ -56,10 +56,8 @@ pub async fn run(
         .map_err(|error| CliError::Other(error.into()))?;
 
     if output_json || cas {
-        // Simulation: --cas must expose the unregistered, builder-local CAS
-        // receipt even when --json was not requested.
-        // Final implementation: this prints the normal registered Platform
-        // image response, while --json remains the durable-path opt-in.
+        // --cas prints the published Image Service image record; --json
+        // remains the opt-in for the legacy platform path.
         println!("{}", serde_json::to_string_pretty(&registered)?);
     }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1469,9 +1469,10 @@ enum ImageCommands {
         #[arg(long = "docker_compat")]
         docker_compat: bool,
 
-        /// Build a CAS (content-addressed streaming) image (non-default). CAS
-        /// images cold-boot by faulting content on demand instead of
-        /// localizing a monolithic snapshot.
+        /// Build a CAS (content-addressed streaming) image through the Image
+        /// Service build plane (non-default). CAS images cold-boot by
+        /// faulting content on demand instead of localizing a monolithic
+        /// snapshot. Requires TENSORLAKE_IMAGE_SERVICE_URL.
         #[arg(long, hide = true)]
         cas: bool,
 
@@ -1516,9 +1517,10 @@ enum ImageCommands {
         #[arg(long = "docker_compat")]
         docker_compat: bool,
 
-        /// Import as a CAS (content-addressed streaming) image (non-default).
-        /// CAS images cold-boot by faulting content on demand instead of
-        /// localizing a monolithic snapshot.
+        /// Import as a CAS (content-addressed streaming) image through the
+        /// Image Service build plane (non-default). CAS images cold-boot by
+        /// faulting content on demand instead of localizing a monolithic
+        /// snapshot. Requires TENSORLAKE_IMAGE_SERVICE_URL.
         #[arg(long, hide = true)]
         cas: bool,
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1472,7 +1472,7 @@ enum ImageCommands {
         /// Build a CAS (content-addressed streaming) image through the Image
         /// Service build plane (non-default). CAS images cold-boot by
         /// faulting content on demand instead of localizing a monolithic
-        /// snapshot. Requires TENSORLAKE_IMAGE_SERVICE_URL.
+        /// snapshot. Routed through the API host's /images/v4 path.
         #[arg(long, hide = true)]
         cas: bool,
 
@@ -1524,7 +1524,7 @@ enum ImageCommands {
         /// Import as a CAS (content-addressed streaming) image through the
         /// Image Service build plane (non-default). CAS images cold-boot by
         /// faulting content on demand instead of localizing a monolithic
-        /// snapshot. Requires TENSORLAKE_IMAGE_SERVICE_URL.
+        /// snapshot. Routed through the API host's /images/v4 path.
         #[arg(long, hide = true)]
         cas: bool,
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1476,6 +1476,10 @@ enum ImageCommands {
         #[arg(long, hide = true)]
         cas: bool,
 
+        /// Dockerfile build arg, KEY=VALUE. Repeatable. CAS builds only.
+        #[arg(long = "build-arg")]
+        build_arg: Vec<String>,
+
         /// Print the sandbox image result JSON to stdout
         #[arg(long = "json", hide = true)]
         json: bool,
@@ -2247,6 +2251,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             public,
                             docker_compat,
                             cas,
+                            build_arg,
                             json,
                         } => {
                             let disk_mb = if let Some(value) = disk_mb {
@@ -2271,6 +2276,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 public,
                                 docker_compat,
                                 cas,
+                                &build_arg,
                                 json,
                             )
                             .await

--- a/crates/cloud-sdk/src/image_service_builds.rs
+++ b/crates/cloud-sdk/src/image_service_builds.rs
@@ -20,7 +20,7 @@ use crate::{
     Client,
     sandbox_images::{
         CommonBuildOptions, DockerfileBuildPlan, SandboxImageBuildError, SandboxImageBuildEvent,
-        client_builder, collect_dir_files, resolve_build_context,
+        client_builder, collect_dir_files, resolve_build_context, resolved_docker_config_json,
     },
 };
 
@@ -63,6 +63,16 @@ where
 {
     let image_service_url = image_service_url()?;
     warn_ignored_options(&options, &mut emit);
+    // Forward the local `docker login` state for the guest's registry pulls,
+    // the same source the legacy path ships into its builder. The service
+    // stages it write-only and the reconciler hands the guest a short-lived
+    // fetch URL; the document never enters the catalog.
+    let registry_credentials_json = resolved_docker_config_json().await?;
+    if registry_credentials_json.is_some() {
+        emit(SandboxImageBuildEvent::Status(
+            "Forwarding local registry credentials to the build".to_string(),
+        ));
+    }
     let ctx = resolve_build_context(options).await?;
     let project = ctx.project_id.clone();
     let client = client_builder(
@@ -78,12 +88,15 @@ where
     if let Some(import_reference) = plan.import_image_reference.clone() {
         let created = create_build(
             &client,
-            json!({
-                "kind": "import",
-                "image_ref": import_reference,
-                "name": plan.registered_name,
-                "project": project,
-            }),
+            with_registry_credentials(
+                json!({
+                    "kind": "import",
+                    "image_ref": import_reference,
+                    "name": plan.registered_name,
+                    "project": project,
+                }),
+                registry_credentials_json,
+            ),
             &mut emit,
         )
         .await?;
@@ -95,13 +108,16 @@ where
     let (dockerfile_in_context, injected_dockerfile) = context_dockerfile(&plan, dockerfile_path)?;
     let created = create_build(
         &client,
-        json!({
-            "kind": "dockerfile",
-            "dockerfile_path": dockerfile_in_context,
-            "parents": parents,
-            "name": plan.registered_name,
-            "project": project,
-        }),
+        with_registry_credentials(
+            json!({
+                "kind": "dockerfile",
+                "dockerfile_path": dockerfile_in_context,
+                "parents": parents,
+                "name": plan.registered_name,
+                "project": project,
+            }),
+            registry_credentials_json,
+        ),
         &mut emit,
     )
     .await?;
@@ -137,6 +153,18 @@ fn image_service_url() -> Result<String> {
                  its base URL"
             ))
         })
+}
+
+/// Attach the forwarded docker config to a build-creation body. The field is
+/// write-only on the service side; it is never echoed back.
+fn with_registry_credentials(mut body: Value, registry_credentials_json: Option<String>) -> Value {
+    if let (Some(credentials), Some(object)) = (registry_credentials_json, body.as_object_mut()) {
+        object.insert(
+            "registry_credentials_json".to_string(),
+            Value::String(credentials),
+        );
+    }
+    body
 }
 
 /// Builder resource and visibility knobs belong to the legacy platform-api
@@ -591,6 +619,17 @@ mod tests {
     use std::io::Read as _;
 
     use super::*;
+
+    #[test]
+    fn registry_credentials_attach_only_when_present() {
+        let body = with_registry_credentials(
+            serde_json::json!({ "kind": "import" }),
+            Some(r#"{"auths":{}}"#.to_string()),
+        );
+        assert_eq!(body["registry_credentials_json"], r#"{"auths":{}}"#);
+        let body = with_registry_credentials(serde_json::json!({ "kind": "import" }), None);
+        assert!(body.get("registry_credentials_json").is_none());
+    }
 
     #[test]
     fn direct_pins_accept_only_lowercase_hex_ids() {

--- a/crates/cloud-sdk/src/image_service_builds.rs
+++ b/crates/cloud-sdk/src/image_service_builds.rs
@@ -1,0 +1,695 @@
+//! CAS image builds through the Image Service build plane.
+//!
+//! The SDK owns Dockerfile parsing and reference resolution: the build
+//! plan's external references are resolved against the Image Service
+//! catalog here, client-side, and submitted already resolved with the build
+//! request. The Image Service validates each pin against the caller's
+//! project and its reconciler drives the builder sandbox, mounting one
+//! read-only parent volume per pin beside the writable target volume and
+//! snapshotting the target through the CAS filesystem daemon. The client
+//! only creates the build, uploads and seals the context, and polls the
+//! build to completion; it never talks to the builder sandbox.
+
+use std::{path::Path, time::Duration};
+
+use reqwest::{Method, StatusCode, header::CONTENT_LENGTH};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    Client,
+    sandbox_images::{
+        CommonBuildOptions, DockerfileBuildPlan, SandboxImageBuildError, SandboxImageBuildEvent,
+        client_builder, collect_dir_files, resolve_build_context,
+    },
+};
+
+type Result<T> = std::result::Result<T, SandboxImageBuildError>;
+
+/// Base URL of the Image Service. Until the platform gateway routes to the
+/// service, CAS builds require this to be set explicitly.
+pub const IMAGE_SERVICE_URL_ENV: &str = "TENSORLAKE_IMAGE_SERVICE_URL";
+
+/// Immutable image reference prefix (`cas-v1:<64 hex sha256>`). A Dockerfile
+/// reference written in this form pins the image id directly, with no
+/// catalog name lookup.
+const CAS_IMAGE_REF_PREFIX: &str = "cas-v1:";
+
+/// Where the Dockerfile text is injected into the context tar when the
+/// Dockerfile does not live inside the context directory (`-f` outside the
+/// context, or inline Dockerfile text).
+const INJECTED_DOCKERFILE_PATH: &str = ".tensorlake/Dockerfile";
+
+/// The Image Service caps pinned parents so they always fit the sandbox
+/// volume budget beside the target volume. Enforced client-side too for a
+/// clearer error than a rejected build request.
+const MAX_PINNED_PARENTS: usize = 3;
+
+const BUILD_POLL_INTERVAL: Duration = Duration::from_secs(3);
+const BUILD_POLL_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Run a build plan through the Image Service. `dockerfile_path` is the
+/// local Dockerfile path for Dockerfile builds (used only to decide whether
+/// the file already lives inside the context directory); import plans carry
+/// no Dockerfile.
+pub(crate) async fn run_image_service_build<F>(
+    plan: DockerfileBuildPlan,
+    dockerfile_path: Option<&Path>,
+    options: CommonBuildOptions,
+    mut emit: F,
+) -> Result<Value>
+where
+    F: FnMut(SandboxImageBuildEvent),
+{
+    let image_service_url = image_service_url()?;
+    warn_ignored_options(&options, &mut emit);
+    let ctx = resolve_build_context(options).await?;
+    let project = ctx.project_id.clone();
+    let client = client_builder(
+        &image_service_url,
+        &ctx.bearer_token,
+        ctx.use_scope_headers,
+        Some(&ctx.organization_id),
+        Some(&project),
+        ctx.user_agent.as_deref(),
+    )
+    .build()?;
+
+    if let Some(import_reference) = plan.import_image_reference.clone() {
+        let created = create_build(
+            &client,
+            json!({
+                "kind": "import",
+                "image_ref": import_reference,
+                "name": plan.registered_name,
+                "project": project,
+            }),
+            &mut emit,
+        )
+        .await?;
+        return wait_for_publication(&client, &project, &created, &plan.registered_name, emit)
+            .await;
+    }
+
+    let parents = resolve_parents(&client, &project, &plan, &mut emit).await?;
+    let (dockerfile_in_context, injected_dockerfile) = context_dockerfile(&plan, dockerfile_path)?;
+    let created = create_build(
+        &client,
+        json!({
+            "kind": "dockerfile",
+            "dockerfile_path": dockerfile_in_context,
+            "parents": parents,
+            "name": plan.registered_name,
+            "project": project,
+        }),
+        &mut emit,
+    )
+    .await?;
+    let build_id = build_id_of(&created)?;
+
+    let upload = created.get("context_upload").cloned().ok_or_else(|| {
+        SandboxImageBuildError::other(
+            "Image Service build creation returned no context upload capability",
+        )
+    })?;
+    upload_and_seal_context(
+        &client,
+        &project,
+        &build_id,
+        &upload,
+        &plan,
+        injected_dockerfile.as_deref(),
+        &mut emit,
+    )
+    .await?;
+
+    wait_for_publication(&client, &project, &created, &plan.registered_name, emit).await
+}
+
+fn image_service_url() -> Result<String> {
+    std::env::var(IMAGE_SERVICE_URL_ENV)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            SandboxImageBuildError::usage(format!(
+                "CAS image builds go through the Image Service; set {IMAGE_SERVICE_URL_ENV} to \
+                 its base URL"
+            ))
+        })
+}
+
+/// Builder resource and visibility knobs belong to the legacy platform-api
+/// rootfs builder; the Image Service reconciler sizes builder sandboxes from
+/// service configuration and the catalog has no public/private bit yet.
+fn warn_ignored_options(
+    options: &CommonBuildOptions,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) {
+    let mut ignored = Vec::new();
+    if options.disk_mb.is_some() {
+        ignored.push("disk_mb");
+    }
+    if options.builder_disk_mb.is_some() {
+        ignored.push("builder_disk_mb");
+    }
+    if options.cpus.is_some() {
+        ignored.push("cpus");
+    }
+    if options.memory_mb.is_some() {
+        ignored.push("memory_mb");
+    }
+    if options.is_public {
+        ignored.push("public");
+    }
+    if options.docker_compat {
+        ignored.push("docker_compat");
+    }
+    if !ignored.is_empty() {
+        emit(SandboxImageBuildEvent::Warning(format!(
+            "Image Service builds ignore: {}. Builder resources come from service configuration.",
+            ignored.join(", ")
+        )));
+    }
+}
+
+/// Resolve the plan's external references against the Image Service catalog
+/// and return the resolved parents the build request submits. A
+/// `cas-v1:<64 hex>` reference pins the image id directly; every other
+/// plain reference is looked up as a catalog name, and a miss means the
+/// guest pulls the reference from a registry. References the plan already
+/// marked unresolvable (`$` expansions, `@` digest pins) never reach here.
+async fn resolve_parents(
+    client: &Client,
+    project: &str,
+    plan: &DockerfileBuildPlan,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) -> Result<Vec<Value>> {
+    let mut candidates: Vec<&str> = Vec::new();
+    if !plan.base_image_is_internal_stage
+        && !plan.base_image.eq_ignore_ascii_case("scratch")
+        && !plan.base_image.contains('$')
+        && !plan.base_image.contains('@')
+    {
+        candidates.push(plan.base_image.as_str());
+    }
+    candidates.extend(plan.additional_image_references.iter().map(String::as_str));
+
+    let mut parents = Vec::new();
+    let mut pinned_references = Vec::new();
+    for reference in candidates {
+        let image_id = match direct_pin_image_id(reference)? {
+            Some(image_id) => Some(image_id),
+            None => lookup_catalog_name(client, project, reference).await?,
+        };
+        let Some(image_id) = image_id else {
+            continue; // external registry reference, pulled by the guest
+        };
+        emit(SandboxImageBuildEvent::Status(format!(
+            "Resolved '{reference}' to registered image {CAS_IMAGE_REF_PREFIX}{image_id}"
+        )));
+        pinned_references.push(reference.to_string());
+        parents.push(json!({ "reference": reference, "image_id": image_id }));
+    }
+    if parents.len() > MAX_PINNED_PARENTS {
+        return Err(SandboxImageBuildError::usage(format!(
+            "the Dockerfile references {} registered images ({}) but a build may pin at most \
+             {MAX_PINNED_PARENTS}",
+            parents.len(),
+            pinned_references.join(", "),
+        )));
+    }
+    Ok(parents)
+}
+
+/// `cas-v1:<64 lowercase hex>` pins an image id directly. The prefix with a
+/// malformed id is an error rather than a registry fallthrough: no registry
+/// image can live under the reserved scheme.
+fn direct_pin_image_id(reference: &str) -> Result<Option<String>> {
+    let Some(image_id) = reference.strip_prefix(CAS_IMAGE_REF_PREFIX) else {
+        return Ok(None);
+    };
+    if image_id.len() != 64
+        || !image_id
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return Err(SandboxImageBuildError::usage(format!(
+            "reference '{reference}' uses the reserved {CAS_IMAGE_REF_PREFIX} scheme but is not \
+             a 64-lowercase-hex image id"
+        )));
+    }
+    Ok(Some(image_id.to_string()))
+}
+
+/// Look up a reference as a catalog name in the caller's project. `404` and
+/// `400` both mean "not a registered image" (absent, or a reference shape
+/// the name grammar rejects) and fall through to a registry pull, matching
+/// how the legacy path treats template-registry misses.
+async fn lookup_catalog_name(
+    client: &Client,
+    project: &str,
+    reference: &str,
+) -> Result<Option<String>> {
+    let path = format!(
+        "/v1/names/{reference}?project={}",
+        urlencoding_encode(project)
+    );
+    let request = client.request(Method::GET, &path).build()?;
+    let response = client.execute_raw(request).await?;
+    match response.status() {
+        StatusCode::NOT_FOUND | StatusCode::BAD_REQUEST => Ok(None),
+        status if status.is_success() => {
+            let body: Value = response.json().await?;
+            body.get("image_id")
+                .and_then(Value::as_str)
+                .map(|image_id| Some(image_id.to_string()))
+                .ok_or_else(|| {
+                    SandboxImageBuildError::other(format!(
+                        "Image Service name lookup for '{reference}' returned no image_id"
+                    ))
+                })
+        }
+        status => {
+            let body = response.text().await.unwrap_or_default();
+            Err(SandboxImageBuildError::other(format!(
+                "Image Service name lookup for '{reference}' failed (HTTP {status}): {body}"
+            )))
+        }
+    }
+}
+
+/// Minimal query-value encoding; project identifiers are constrained but
+/// encode defensively.
+fn urlencoding_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
+/// Decide where the Dockerfile lives in the uploaded context: its own
+/// relative path when the file sits inside the context directory, or an
+/// injected `.tensorlake/Dockerfile` entry carrying the plan's Dockerfile
+/// text otherwise (`-f` outside the context, inline text).
+fn context_dockerfile(
+    plan: &DockerfileBuildPlan,
+    dockerfile_path: Option<&Path>,
+) -> Result<(String, Option<String>)> {
+    if let Some(dockerfile_path) = dockerfile_path
+        && let (Ok(dockerfile), Ok(context_dir)) = (
+            dockerfile_path.canonicalize(),
+            plan.context_dir.canonicalize(),
+        )
+        && let Ok(relative) = dockerfile.strip_prefix(&context_dir)
+    {
+        let relative = relative
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        if !relative.is_empty() {
+            return Ok((relative, None));
+        }
+    }
+    Ok((
+        INJECTED_DOCKERFILE_PATH.to_string(),
+        Some(plan.dockerfile_text.clone()),
+    ))
+}
+
+fn build_id_of(build: &Value) -> Result<String> {
+    build
+        .get("build_id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            SandboxImageBuildError::other("Image Service build response carries no build_id")
+        })
+}
+
+async fn create_build(
+    client: &Client,
+    body: Value,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) -> Result<Value> {
+    emit(SandboxImageBuildEvent::Status(
+        "Creating Image Service build...".to_string(),
+    ));
+    let request = client
+        .request(Method::POST, "/v1/builds")
+        .json(&body)
+        .build()?;
+    let response = client.execute_raw(request).await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(SandboxImageBuildError::other(format!(
+            "Image Service rejected the build (HTTP {status}): {body}"
+        )));
+    }
+    let created: Value = response.json().await?;
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Build {} accepted",
+        created
+            .get("build_id")
+            .and_then(Value::as_str)
+            .unwrap_or("-")
+    )));
+    Ok(created)
+}
+
+/// Create the plain (uncompressed) context tar, honoring `.dockerignore`,
+/// upload it through the sealed capability, and seal the build with the
+/// tar's sha256. The capability URL is presigned (or the service's direct
+/// dev route); the upload deliberately uses a bare HTTP client so no
+/// Authorization header corrupts a presigned request.
+async fn upload_and_seal_context(
+    client: &Client,
+    project: &str,
+    build_id: &str,
+    upload: &Value,
+    plan: &DockerfileBuildPlan,
+    injected_dockerfile: Option<&str>,
+    emit: &mut impl FnMut(SandboxImageBuildEvent),
+) -> Result<()> {
+    emit(SandboxImageBuildEvent::Status(
+        "Creating build context archive...".to_string(),
+    ));
+    let tar_file = tempfile::Builder::new()
+        .prefix("tensorlake-image-context-")
+        .suffix(".tar")
+        .tempfile()?;
+    let (tar_bytes, digest) =
+        create_context_tar(&plan.context_dir, injected_dockerfile, tar_file.path())?;
+
+    let max_bytes = upload.get("max_bytes").and_then(Value::as_u64);
+    if let Some(max_bytes) = max_bytes
+        && tar_bytes > max_bytes
+    {
+        return Err(SandboxImageBuildError::usage(format!(
+            "build context is {tar_bytes} bytes, above the Image Service cap of {max_bytes}"
+        )));
+    }
+
+    let url = upload
+        .get("url")
+        .and_then(Value::as_str)
+        .ok_or_else(|| SandboxImageBuildError::other("context upload capability carries no url"))?;
+    let method = upload
+        .get("method")
+        .and_then(Value::as_str)
+        .unwrap_or("PUT")
+        .parse::<Method>()
+        .map_err(|_| {
+            SandboxImageBuildError::other("context upload capability method is invalid")
+        })?;
+
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Uploading build context ({tar_bytes} bytes)..."
+    )));
+    let file = tokio::fs::File::open(tar_file.path()).await?;
+    let stream = tokio_util::io::ReaderStream::new(file);
+    let response = reqwest::Client::new()
+        .request(method, url)
+        .header(CONTENT_LENGTH, tar_bytes)
+        .body(reqwest::Body::wrap_stream(stream))
+        .send()
+        .await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(SandboxImageBuildError::other(format!(
+            "context upload failed (HTTP {status}): {body}"
+        )));
+    }
+
+    emit(SandboxImageBuildEvent::Status(
+        "Sealing build context...".to_string(),
+    ));
+    let request = client
+        .request(Method::POST, &format!("/v1/builds/{build_id}/context/seal"))
+        .json(&json!({ "project": project, "digest": digest }))
+        .build()?;
+    let response = client.execute_raw(request).await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(SandboxImageBuildError::other(format!(
+            "context seal failed (HTTP {status}): {body}"
+        )));
+    }
+    Ok(())
+}
+
+/// Write the plain context tar to `tar_path` and return its byte length and
+/// sha256. Entries honor `.dockerignore` via the shared context walker; the
+/// optional injected Dockerfile is appended last and collides with nothing
+/// because its reserved path is rejected if present in the context.
+fn create_context_tar(
+    context_dir: &Path,
+    injected_dockerfile: Option<&str>,
+    tar_path: &Path,
+) -> Result<(u64, String)> {
+    let mut tar = tar::Builder::new(std::fs::File::create(tar_path)?);
+    if context_dir.is_dir() {
+        for (full_path, relative_path) in collect_dir_files(context_dir, context_dir)? {
+            if injected_dockerfile.is_some() && relative_path == INJECTED_DOCKERFILE_PATH {
+                return Err(SandboxImageBuildError::usage(format!(
+                    "the build context already contains {INJECTED_DOCKERFILE_PATH}, which is \
+                     reserved for the injected Dockerfile"
+                )));
+            }
+            let mut file = std::fs::File::open(&full_path)?;
+            tar.append_file(&relative_path, &mut file)?;
+        }
+    }
+    if let Some(dockerfile_text) = injected_dockerfile {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(dockerfile_text.len() as u64);
+        header.set_mode(0o644);
+        header.set_mtime(0);
+        header.set_cksum();
+        tar.append_data(
+            &mut header,
+            INJECTED_DOCKERFILE_PATH,
+            dockerfile_text.as_bytes(),
+        )?;
+    }
+    tar.finish()?;
+    drop(tar);
+
+    let mut file = std::fs::File::open(tar_path)?;
+    let mut hasher = Sha256::new();
+    let bytes = std::io::copy(&mut file, &mut hasher)?;
+    Ok((bytes, format!("{:x}", hasher.finalize())))
+}
+
+/// Poll the build to a terminal status, then fetch and return the published
+/// image record.
+async fn wait_for_publication(
+    client: &Client,
+    project: &str,
+    created: &Value,
+    registered_name: &str,
+    mut emit: impl FnMut(SandboxImageBuildEvent),
+) -> Result<Value> {
+    let build_id = build_id_of(created)?;
+    let path = format!(
+        "/v1/builds/{build_id}?project={}",
+        urlencoding_encode(project)
+    );
+    let deadline = tokio::time::Instant::now() + BUILD_POLL_TIMEOUT;
+    let mut last_reported = String::new();
+    let image_id = loop {
+        if tokio::time::Instant::now() > deadline {
+            return Err(SandboxImageBuildError::other(format!(
+                "build {build_id} did not finish within {}s",
+                BUILD_POLL_TIMEOUT.as_secs()
+            )));
+        }
+        let request = client.request(Method::GET, &path).build()?;
+        let response = client.execute_raw(request).await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(SandboxImageBuildError::other(format!(
+                "build status poll failed (HTTP {status}): {body}"
+            )));
+        }
+        let build: Value = response.json().await?;
+        let status = build
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+        let attempt = build.get("attempt_no").and_then(Value::as_u64).unwrap_or(0);
+        let progress = format!("{status}/{attempt}");
+        if progress != last_reported {
+            emit(SandboxImageBuildEvent::Status(format!(
+                "Build {build_id}: {status} (attempt {attempt})"
+            )));
+            last_reported = progress;
+        }
+        match status.as_str() {
+            "succeeded" => {
+                break build
+                    .get("image_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .ok_or_else(|| {
+                        SandboxImageBuildError::other(format!(
+                            "build {build_id} succeeded but reports no image_id"
+                        ))
+                    })?;
+            }
+            "failed" => {
+                let error = build
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("no error recorded");
+                return Err(SandboxImageBuildError::other(format!(
+                    "build {build_id} failed: {error}"
+                )));
+            }
+            _ => tokio::time::sleep(BUILD_POLL_INTERVAL).await,
+        }
+    };
+
+    let request = client
+        .request(
+            Method::GET,
+            &format!(
+                "/v1/images/{image_id}?project={}",
+                urlencoding_encode(project)
+            ),
+        )
+        .build()?;
+    let response = client.execute_raw(request).await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(SandboxImageBuildError::other(format!(
+            "published image lookup failed (HTTP {status}): {body}"
+        )));
+    }
+    let image: Value = response.json().await?;
+    emit(SandboxImageBuildEvent::Status(format!(
+        "Image '{registered_name}' published ({CAS_IMAGE_REF_PREFIX}{image_id})"
+    )));
+    Ok(image)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read as _;
+
+    use super::*;
+
+    #[test]
+    fn direct_pins_accept_only_lowercase_hex_ids() {
+        let hex = "a".repeat(64);
+        assert_eq!(
+            direct_pin_image_id(&format!("cas-v1:{hex}")).unwrap(),
+            Some(hex)
+        );
+        assert_eq!(direct_pin_image_id("alpine:3.20").unwrap(), None);
+        assert_eq!(direct_pin_image_id("team/base").unwrap(), None);
+        assert!(direct_pin_image_id("cas-v1:NOT-HEX").is_err());
+        assert!(direct_pin_image_id(&format!("cas-v1:{}", "a".repeat(63))).is_err());
+    }
+
+    #[test]
+    fn context_dockerfile_uses_the_relative_path_inside_the_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("build");
+        std::fs::create_dir(&nested).unwrap();
+        let dockerfile = nested.join("prod.Dockerfile");
+        std::fs::write(&dockerfile, "FROM scratch\n").unwrap();
+
+        let plan = plan_with_context(dir.path().to_path_buf());
+        let (path, injected) = context_dockerfile(&plan, Some(&dockerfile)).unwrap();
+        assert_eq!(path, "build/prod.Dockerfile");
+        assert!(injected.is_none());
+    }
+
+    #[test]
+    fn context_dockerfile_injects_text_when_outside_the_context() {
+        let context = tempfile::tempdir().unwrap();
+        let elsewhere = tempfile::tempdir().unwrap();
+        let dockerfile = elsewhere.path().join("Dockerfile");
+        std::fs::write(&dockerfile, "FROM scratch\n").unwrap();
+
+        let plan = plan_with_context(context.path().to_path_buf());
+        let (path, injected) = context_dockerfile(&plan, Some(&dockerfile)).unwrap();
+        assert_eq!(path, INJECTED_DOCKERFILE_PATH);
+        assert_eq!(injected.as_deref(), Some("FROM scratch\n"));
+    }
+
+    #[test]
+    fn context_tar_is_plain_and_carries_the_injected_dockerfile() {
+        let dir = tempfile::tempdir().unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("app.py"), "print('hi')\n").unwrap();
+
+        let tar_path = scratch.path().join("out.tar");
+        let (bytes, digest) =
+            create_context_tar(dir.path(), Some("FROM scratch\n"), &tar_path).unwrap();
+        assert_eq!(bytes, std::fs::metadata(&tar_path).unwrap().len());
+        assert_eq!(digest.len(), 64);
+
+        let mut names = Vec::new();
+        let mut archive = tar::Archive::new(std::fs::File::open(&tar_path).unwrap());
+        for entry in archive.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let name = entry.path().unwrap().to_string_lossy().to_string();
+            if name == INJECTED_DOCKERFILE_PATH {
+                let mut text = String::new();
+                entry.read_to_string(&mut text).unwrap();
+                assert_eq!(text, "FROM scratch\n");
+            }
+            names.push(name);
+        }
+        names.sort();
+        assert_eq!(
+            names,
+            vec![INJECTED_DOCKERFILE_PATH.to_string(), "app.py".to_string()]
+        );
+    }
+
+    #[test]
+    fn context_tar_rejects_a_colliding_reserved_dockerfile_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".tensorlake")).unwrap();
+        std::fs::write(dir.path().join(INJECTED_DOCKERFILE_PATH), "FROM x\n").unwrap();
+
+        let tar_path = scratch.path().join("out.tar");
+        let error = create_context_tar(dir.path(), Some("FROM scratch\n"), &tar_path)
+            .expect_err("reserved path must collide");
+        assert!(
+            error.to_string().contains(".tensorlake/Dockerfile"),
+            "{error}"
+        );
+    }
+
+    fn plan_with_context(context_dir: std::path::PathBuf) -> DockerfileBuildPlan {
+        DockerfileBuildPlan {
+            context_dir,
+            registered_name: "img".to_string(),
+            dockerfile_text: "FROM scratch\n".to_string(),
+            base_image: "scratch".to_string(),
+            base_image_is_internal_stage: false,
+            additional_image_references: Vec::new(),
+            unresolvable_image_references: Vec::new(),
+            ignored_instructions: Vec::new(),
+            import_image_reference: None,
+        }
+    }
+}

--- a/crates/cloud-sdk/src/image_service_builds.rs
+++ b/crates/cloud-sdk/src/image_service_builds.rs
@@ -55,6 +55,7 @@ const BUILD_POLL_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 pub(crate) async fn run_image_service_build<F>(
     plan: DockerfileBuildPlan,
     dockerfile_path: Option<&Path>,
+    build_args: Vec<(String, String)>,
     options: CommonBuildOptions,
     mut emit: F,
 ) -> Result<Value>
@@ -113,6 +114,10 @@ where
                 "kind": "dockerfile",
                 "dockerfile_path": dockerfile_in_context,
                 "parents": parents,
+                "build_args": build_args
+                    .iter()
+                    .cloned()
+                    .collect::<std::collections::BTreeMap<String, String>>(),
                 "name": plan.registered_name,
                 "project": project,
             }),

--- a/crates/cloud-sdk/src/image_service_builds.rs
+++ b/crates/cloud-sdk/src/image_service_builds.rs
@@ -30,6 +30,12 @@ type Result<T> = std::result::Result<T, SandboxImageBuildError>;
 /// service, CAS builds require this to be set explicitly.
 pub const IMAGE_SERVICE_URL_ENV: &str = "TENSORLAKE_IMAGE_SERVICE_URL";
 
+/// Ingress route that fronts the Image Service. The ingress authenticates,
+/// replaces any client-supplied identity headers with verified ones, and maps
+/// this prefix onto the service's own routes -- so the paths below are
+/// prefix-relative (`/builds`, not `/v1/builds`).
+const IMAGE_SERVICE_INGRESS_PATH: &str = "/images/v4";
+
 /// Immutable image reference prefix (`cas-v1:<64 hex sha256>`). A Dockerfile
 /// reference written in this form pins the image id directly, with no
 /// catalog name lookup.
@@ -62,7 +68,6 @@ pub(crate) async fn run_image_service_build<F>(
 where
     F: FnMut(SandboxImageBuildEvent),
 {
-    let image_service_url = image_service_url()?;
     warn_ignored_options(&options, &mut emit);
     // Forward the local `docker login` state for the guest's registry pulls,
     // the same source the legacy path ships into its builder. The service
@@ -76,6 +81,7 @@ where
     }
     let ctx = resolve_build_context(options).await?;
     let project = ctx.project_id.clone();
+    let image_service_url = image_service_url(&ctx.api_url);
     let client = client_builder(
         &image_service_url,
         &ctx.bearer_token,
@@ -147,17 +153,35 @@ where
     wait_for_publication(&client, &project, &created, &plan.registered_name, emit).await
 }
 
-fn image_service_url() -> Result<String> {
-    std::env::var(IMAGE_SERVICE_URL_ENV)
-        .ok()
+/// Base URL for the Image Service.
+///
+/// Defaults to the ingress route on the configured API host, so a normal
+/// client needs no extra configuration: `https://api.tensorlake.ai` yields
+/// `https://api.tensorlake.ai/images/v4`, and the ingress authenticates the
+/// request, injects verified identity headers, and strips the prefix before
+/// the Image Service sees it. The service performs no authentication of its
+/// own, so reaching it any other way in a deployed environment would bypass
+/// the only auth boundary there is.
+///
+/// `TENSORLAKE_IMAGE_SERVICE_URL` overrides it for pointing at a local
+/// Image Service directly during development.
+fn image_service_url(api_url: &str) -> String {
+    resolve_image_service_url(api_url, std::env::var(IMAGE_SERVICE_URL_ENV).ok())
+}
+
+/// Pure form, so the defaulting rule is testable without mutating process
+/// environment (which races across parallel tests).
+fn resolve_image_service_url(api_url: &str, override_url: Option<String>) -> String {
+    if let Some(override_url) = override_url
         .map(|value| value.trim().trim_end_matches('/').to_string())
         .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            SandboxImageBuildError::usage(format!(
-                "CAS image builds go through the Image Service; set {IMAGE_SERVICE_URL_ENV} to \
-                 its base URL"
-            ))
-        })
+    {
+        return override_url;
+    }
+    format!(
+        "{}{IMAGE_SERVICE_INGRESS_PATH}",
+        api_url.trim_end_matches('/')
+    )
 }
 
 /// Attach the forwarded docker config to a build-creation body. The field is
@@ -284,10 +308,7 @@ async fn lookup_catalog_name(
     project: &str,
     reference: &str,
 ) -> Result<Option<String>> {
-    let path = format!(
-        "/v1/names/{reference}?project={}",
-        urlencoding_encode(project)
-    );
+    let path = format!("/names/{reference}?project={}", urlencoding_encode(project));
     let request = client.request(Method::GET, &path).build()?;
     let response = client.execute_raw(request).await?;
     match response.status() {
@@ -376,7 +397,7 @@ async fn create_build(
         "Creating Image Service build...".to_string(),
     ));
     let request = client
-        .request(Method::POST, "/v1/builds")
+        .request(Method::POST, "/builds")
         .json(&body)
         .build()?;
     let response = client.execute_raw(request).await?;
@@ -467,7 +488,7 @@ async fn upload_and_seal_context(
         "Sealing build context...".to_string(),
     ));
     let request = client
-        .request(Method::POST, &format!("/v1/builds/{build_id}/context/seal"))
+        .request(Method::POST, &format!("/builds/{build_id}/context/seal"))
         .json(&json!({ "project": project, "digest": digest }))
         .build()?;
     let response = client.execute_raw(request).await?;
@@ -534,10 +555,7 @@ async fn wait_for_publication(
     mut emit: impl FnMut(SandboxImageBuildEvent),
 ) -> Result<Value> {
     let build_id = build_id_of(created)?;
-    let path = format!(
-        "/v1/builds/{build_id}?project={}",
-        urlencoding_encode(project)
-    );
+    let path = format!("/builds/{build_id}?project={}", urlencoding_encode(project));
     let deadline = tokio::time::Instant::now() + BUILD_POLL_TIMEOUT;
     let mut last_reported = String::new();
     let image_id = loop {
@@ -617,6 +635,50 @@ async fn wait_for_publication(
         "Image '{registered_name}' published ({CAS_IMAGE_REF_PREFIX}{image_id})"
     )));
     Ok(image)
+}
+
+#[cfg(test)]
+mod url_tests {
+    use super::*;
+
+    /// A normal client needs no configuration: the Image Service is reached
+    /// through the API host's ingress path, which is the only place requests
+    /// are authenticated.
+    #[test]
+    fn defaults_to_the_ingress_path_on_the_api_host() {
+        assert_eq!(
+            resolve_image_service_url("https://api.tensorlake.ai", None),
+            "https://api.tensorlake.ai/images/v4"
+        );
+        // A trailing slash on the API URL must not double up.
+        assert_eq!(
+            resolve_image_service_url("https://api.tensorlake.ai/", None),
+            "https://api.tensorlake.ai/images/v4"
+        );
+    }
+
+    #[test]
+    fn the_override_wins_and_is_trimmed() {
+        assert_eq!(
+            resolve_image_service_url(
+                "https://api.tensorlake.ai",
+                Some("  http://127.0.0.1:8843/  ".to_string())
+            ),
+            "http://127.0.0.1:8843"
+        );
+    }
+
+    /// An empty or whitespace override is ignored rather than producing a
+    /// client with an empty base URL.
+    #[test]
+    fn a_blank_override_falls_back_to_the_default() {
+        for blank in ["", "   "] {
+            assert_eq!(
+                resolve_image_service_url("https://api.tensorlake.ai", Some(blank.to_string())),
+                "https://api.tensorlake.ai/images/v4"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -72,6 +72,7 @@ pub mod cron;
 pub mod document_ai;
 pub mod error;
 pub mod file_systems;
+mod image_service_builds;
 pub mod images;
 pub mod sandbox_images;
 pub mod sandbox_templates;

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -233,6 +233,12 @@ pub struct SandboxImageBuildOptions {
     pub dockerfile_path: PathBuf,
     pub dockerfile_text: Option<String>,
     pub context_dir: Option<PathBuf>,
+    /// Dockerfile build args (`--build-arg KEY=VALUE`), forwarded to
+    /// BuildKit inside the builder. CAS builds only: the legacy platform
+    /// rootfs builder has no build-arg channel, so a non-CAS build with
+    /// build args is rejected up front. Build args never participate in
+    /// parent-reference resolution.
+    pub build_args: Vec<(String, String)>,
 }
 
 /// Options for importing a registry image directly into a rootfs (no
@@ -427,10 +433,17 @@ where
         return crate::image_service_builds::run_image_service_build(
             plan,
             Some(&options.dockerfile_path),
+            options.build_args,
             options.common,
             emit,
         )
         .await;
+    }
+    if !options.build_args.is_empty() {
+        return Err(SandboxImageBuildError::usage(
+            "build args are only supported for CAS image builds; the platform rootfs builder \
+             has no build-arg channel",
+        ));
     }
     run_build_plan(plan, options.common, emit).await
 }
@@ -457,6 +470,7 @@ where
         return crate::image_service_builds::run_image_service_build(
             plan,
             None,
+            Vec::new(),
             options.common,
             emit,
         )

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -1433,7 +1433,7 @@ const MULTIPART_PART_SIZE_BYTES: u64 = MULTIPART_PART_SIZE_MB * 1024 * 1024;
 /// `indexify/crates/dataplane/src/sign_blob.rs`); keep these in sync.
 const MULTIPART_MAX_PARTS: u32 = 10_000;
 
-async fn resolved_docker_config_json() -> Result<Option<String>> {
+pub(crate) async fn resolved_docker_config_json() -> Result<Option<String>> {
     let docker_config = DockerConfig::load().await.map_err(|error| {
         SandboxImageBuildError::other(format!("Failed to load Docker config: {error}"))
     })?;

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -12,7 +12,6 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use reqwest::{Method, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
-use sha2::{Digest, Sha256};
 use shlex::split as shlex_split;
 use thiserror::Error;
 
@@ -66,8 +65,6 @@ const DIAGNOSTIC_COMMAND_TIMEOUT_SECS: i64 = 5;
 const BUILDER_DISK_USAGE_DIAGNOSTIC_THRESHOLD_PERCENT: u8 = 95;
 const ARCHIVE_PROGRESS_BYTE_INTERVAL_BYTES: u64 = 64 * 1024 * 1024;
 const CAS_SNAPSHOT_FORMAT_VERSION: &str = "content_addressed_streaming_v1";
-const SIMULATED_CAS_BLOB_STORE_ROOT: &str =
-    "/var/lib/tensorlake/rootfs-builder/work/cas-blob-store";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ProcessTerminalStatus {
@@ -182,15 +179,15 @@ pub enum SandboxImageBuildError {
 }
 
 impl SandboxImageBuildError {
-    fn usage(message: impl Into<String>) -> Self {
+    pub(crate) fn usage(message: impl Into<String>) -> Self {
         Self::Usage(message.into())
     }
 
-    fn auth(message: impl Into<String>) -> Self {
+    pub(crate) fn auth(message: impl Into<String>) -> Self {
         Self::Auth(message.into())
     }
 
-    fn other(message: impl Into<String>) -> Self {
+    pub(crate) fn other(message: impl Into<String>) -> Self {
         Self::Other(message.into())
     }
 }
@@ -213,12 +210,12 @@ pub struct CommonBuildOptions {
     pub cpus: Option<f64>,
     pub memory_mb: Option<i64>,
     pub is_public: bool,
-    /// Non-default opt-in: build a CAS (content-addressed streaming,
-    /// `cas-streaming` on the wire) image.
-    ///
-    /// During the local-store simulation, CAS results are returned to the
-    /// caller without Platform registration. The final implementation will
-    /// complete registration using the builder's CAS filesystem receipt.
+    /// Non-default opt-in: build a CAS (content-addressed streaming) image
+    /// through the Image Service build plane instead of the platform-api
+    /// rootfs builder. The SDK resolves the Dockerfile plan's references
+    /// against the Image Service catalog and submits them with the build;
+    /// the service reconciler drives the builder sandbox. Requires
+    /// `TENSORLAKE_IMAGE_SERVICE_URL`.
     pub cas: bool,
     pub user_agent: Option<String>,
     pub docker_compat: bool,
@@ -260,30 +257,30 @@ pub enum SandboxImageBuildEvent {
 }
 
 #[derive(Debug, Clone)]
-struct ResolvedBuildContext {
-    api_url: String,
-    bearer_token: String,
-    use_scope_headers: bool,
-    organization_id: String,
-    project_id: String,
-    namespace: String,
-    user_agent: Option<String>,
+pub(crate) struct ResolvedBuildContext {
+    pub(crate) api_url: String,
+    pub(crate) bearer_token: String,
+    pub(crate) use_scope_headers: bool,
+    pub(crate) organization_id: String,
+    pub(crate) project_id: String,
+    pub(crate) namespace: String,
+    pub(crate) user_agent: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct DockerfileBuildPlan {
-    context_dir: PathBuf,
-    registered_name: String,
-    dockerfile_text: String,
+pub(crate) struct DockerfileBuildPlan {
+    pub(crate) context_dir: PathBuf,
+    pub(crate) registered_name: String,
+    pub(crate) dockerfile_text: String,
     /// The final-stage FROM image reference — the exact string the user wrote.
     /// Determines the snapshot's lineage parent when it resolves to a
     /// registered Tensorlake template.
-    base_image: String,
+    pub(crate) base_image: String,
     /// True when `base_image` matches a stage alias defined earlier in the
     /// Dockerfile (`FROM ubuntu AS base; FROM base`). In that case the
     /// final FROM is an internal reference to an earlier stage and we do
     /// not look it up as an external template.
-    base_image_is_internal_stage: bool,
+    pub(crate) base_image_is_internal_stage: bool,
     /// Every external image reference encountered in the Dockerfile other
     /// than `base_image`: earlier-stage FROMs, `COPY --from=<image>`, and
     /// `RUN --mount=type=cache,from=<image>`. Excludes `scratch`, internal
@@ -291,32 +288,32 @@ struct DockerfileBuildPlan {
     /// containing `$` variable expansions or `@` digest pins, and the
     /// final-stage FROM itself (which lives in `base_image`). Deduped, in
     /// first-seen order.
-    additional_image_references: Vec<String>,
+    pub(crate) additional_image_references: Vec<String>,
     /// References the SDK could not resolve at planning time and forwarded
     /// to Docker for registry pull at build time. Tagged with a reason so
     /// the caller can emit an appropriate warning.
-    unresolvable_image_references: Vec<UnresolvableImageReference>,
+    pub(crate) unresolvable_image_references: Vec<UnresolvableImageReference>,
     /// Instructions that hit `IGNORED_DOCKERFILE_INSTRUCTIONS` during parse.
     /// Surfaced as warnings by the caller; preserved in `dockerfile_text` and
     /// forwarded to `docker build`.
-    ignored_instructions: Vec<(usize, String)>,
+    pub(crate) ignored_instructions: Vec<(usize, String)>,
     /// When set, this is an image-import build rather than a Dockerfile build:
     /// the builder pulls this registry reference directly into the rootfs with
     /// no Docker daemon. There is no build context to upload and the base is
     /// never resolved against the template registry (import always pulls from
     /// the registry, producing a fresh base rootfs).
-    import_image_reference: Option<String>,
+    pub(crate) import_image_reference: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct UnresolvableImageReference {
-    line_number: usize,
-    reference: String,
-    reason: UnresolvableImageReferenceReason,
+pub(crate) struct UnresolvableImageReference {
+    pub(crate) line_number: usize,
+    pub(crate) reference: String,
+    pub(crate) reason: UnresolvableImageReferenceReason,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum UnresolvableImageReferenceReason {
+pub(crate) enum UnresolvableImageReferenceReason {
     /// Reference contained `$VAR` / `${VAR}` expansion. The SDK does not
     /// resolve build-args at planning time.
     BuildArgExpansion,
@@ -377,55 +374,11 @@ struct PreparedRootfsParent {
 struct ResolvedTemplateSource {
     prepare_payload: Value,
     snapshot_format_version: Option<String>,
-    snapshot_uri: Option<String>,
-    rootfs_disk_bytes: Option<u64>,
 }
 
 impl ResolvedTemplateSource {
     fn is_cas(&self) -> bool {
         self.snapshot_format_version.as_deref() == Some(CAS_SNAPSHOT_FORMAT_VERSION)
-    }
-
-    fn simulated_cas_builder_entry(&self) -> Result<Value> {
-        let mut entry = self.prepare_payload.clone();
-        let object = entry.as_object_mut().ok_or_else(|| {
-            SandboxImageBuildError::other("resolved CAS source payload is not an object")
-        })?;
-        let identity = format!(
-            "{}:{}:{}",
-            object
-                .get("templateId")
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-            object
-                .get("snapshotId")
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-            self.snapshot_uri.as_deref().unwrap_or_default(),
-        );
-        let digest = format!("{:x}", Sha256::digest(identity.as_bytes()));
-        // Simulation: the source snapshot id is useful to derive a stable fake
-        // URI in the SDK, but the builder receives only that URI and format.
-        // Final implementation: Platform supplies the canonical CAS manifest
-        // URI and still keeps its snapshot id outside the builder sandbox.
-        object.remove("snapshotId");
-        object.insert(
-            "snapshotFormatVersion".to_string(),
-            Value::String(CAS_SNAPSHOT_FORMAT_VERSION.to_string()),
-        );
-        object.insert(
-            "snapshotUri".to_string(),
-            Value::String(format!(
-                "file://{SIMULATED_CAS_BLOB_STORE_ROOT}/filesystems/{digest}/manifest.json"
-            )),
-        );
-        if let Some(rootfs_disk_bytes) = self.rootfs_disk_bytes {
-            object.insert(
-                "rootfsDiskBytes".to_string(),
-                Value::Number(rootfs_disk_bytes.into()),
-            );
-        }
-        Ok(entry)
     }
 }
 
@@ -467,6 +420,18 @@ where
             options.common.registered_name.as_deref(),
         )?
     };
+    if options.common.cas {
+        // CAS images build through the Image Service: the SDK resolves the
+        // plan's references and submits them; the service reconciler drives
+        // the builder sandbox.
+        return crate::image_service_builds::run_image_service_build(
+            plan,
+            Some(&options.dockerfile_path),
+            options.common,
+            emit,
+        )
+        .await;
+    }
     run_build_plan(plan, options.common, emit).await
 }
 
@@ -488,6 +453,15 @@ where
         &options.image_reference,
         options.common.registered_name.as_deref(),
     )?;
+    if options.common.cas {
+        return crate::image_service_builds::run_image_service_build(
+            plan,
+            None,
+            options.common,
+            emit,
+        )
+        .await;
+    }
     run_build_plan(plan, options.common, emit).await
 }
 
@@ -546,21 +520,13 @@ where
         "Preparing rootfs build...".to_string(),
     ));
     let platform_client = platform_client(&ctx)?;
-    let (prepared, mut prepared_spec, has_cas_sources) =
+    let (prepared, mut prepared_spec) =
         prepare_rootfs_build(&ctx, &platform_client, &plan, options.is_public).await?;
     emit(SandboxImageBuildEvent::Status(format!(
-        "Build mode: Rootfs{}{}",
-        match (options.cas, prepared.rootfs_node_kind.as_str(),) {
-            (true, _) => "Base",
-            (false, "diff") => "Diff",
+        "Build mode: Rootfs{}",
+        match prepared.rootfs_node_kind.as_str() {
+            "diff" => "Diff",
             _ => "Base",
-        },
-        if options.cas {
-            " (CAS destination)"
-        } else if has_cas_sources {
-            " (CAS source)"
-        } else {
-            ""
         }
     )));
 
@@ -661,18 +627,7 @@ where
             //
             // Legacy path: `snapshot_rel_path` is absent, the upload block is
             // already in `prepared_spec`, and we do nothing here.
-            let signed_snapshot_uri = if options.cas {
-                // Simulation: Platform prepared a durable destination, but a
-                // CAS output writes only into the daemon's builder-local
-                // file:// store. Do not mint or pass the unused durable upload.
-                // Final implementation: the daemon will mint scoped remote
-                // object operations with the Platform build capability.
-                if prepared.snapshot_rel_path.is_some() {
-                    sign_prepared_parent_download(&proxy, &prepared, &mut prepared_spec).await?;
-                    sign_prepared_local_image_downloads(&proxy, &mut prepared_spec).await?;
-                }
-                None
-            } else if let Some(rel_path) = prepared.snapshot_rel_path.clone() {
+            let signed_snapshot_uri = if let Some(rel_path) = prepared.snapshot_rel_path.clone() {
                 let disk_mb = rootfs_disk_bytes_to_mb(rootfs_disk_bytes)?;
                 let parts: u32 = disk_mb
                     .div_ceil(MULTIPART_PART_SIZE_MB)
@@ -707,7 +662,6 @@ where
                 &prepared_spec,
                 options.disk_mb,
                 options.docker_compat,
-                options.cas,
                 &mut emit,
             )
             .await?;
@@ -732,37 +686,6 @@ where
             builder_result?;
 
             let metadata = read_build_metadata(&proxy).await?;
-            if options.cas {
-                // Simulation: return the local receipt and deliberately skip
-                // Platform completion because its file:// objects disappear
-                // with this builder sandbox.
-                // Final implementation: submit this receipt with the retained
-                // Platform snapshot id and return the registered image.
-                let result = simulated_cas_build_result(
-                    &plan.registered_name,
-                    &prepared,
-                    &metadata,
-                    rootfs_disk_bytes,
-                )?;
-                emit(SandboxImageBuildEvent::Warning(format!(
-                    "CAS image '{}' was built in the builder-local simulation but was not \
-                     registered. Platform build {} remains prepared, and the CAS data is \
-                     deleted with the builder sandbox.",
-                    plan.registered_name, prepared.build_id
-                )));
-                return Ok(result);
-            }
-            if has_cas_sources {
-                // Simulation safety invariant: Platform did not authorize the
-                // hidden CAS source, so even an unexpectedly successful local
-                // mount must never produce a registered durable image.
-                // Final implementation removes this stop after Platform
-                // authorizes and returns all CAS source identities.
-                return Err(SandboxImageBuildError::other(
-                    "simulated CAS source unexpectedly materialized; refusing Platform \
-                     completion because Platform did not authorize that source",
-                ));
-            }
             let complete_request = complete_request_from_metadata(
                 &prepared,
                 &metadata,
@@ -812,7 +735,9 @@ where
     })
 }
 
-async fn resolve_build_context(options: CommonBuildOptions) -> Result<ResolvedBuildContext> {
+pub(crate) async fn resolve_build_context(
+    options: CommonBuildOptions,
+) -> Result<ResolvedBuildContext> {
     let client = unscoped_client(&options)?;
     let (organization_id, project_id) = if options.use_scope_headers {
         match (options.organization_id.clone(), options.project_id.clone()) {
@@ -900,7 +825,7 @@ fn sandbox_lifecycle_client(ctx: &ResolvedBuildContext) -> Result<Client> {
     .map_err(Into::into)
 }
 
-fn client_builder(
+pub(crate) fn client_builder(
     base_url: &str,
     bearer_token: &str,
     use_scope_headers: bool,
@@ -988,8 +913,6 @@ async fn resolve_template_source(
     Ok(Some(ResolvedTemplateSource {
         prepare_payload: template_build_payload(&template, reference)?,
         snapshot_format_version: template.snapshot_format_version,
-        snapshot_uri: template.snapshot_uri,
-        rootfs_disk_bytes: template.rootfs_disk_bytes,
     }))
 }
 
@@ -1033,7 +956,7 @@ async fn prepare_rootfs_build(
     client: &Client,
     plan: &DockerfileBuildPlan,
     is_public: bool,
-) -> Result<(PreparedSandboxTemplateBuild, Value, bool)> {
+) -> Result<(PreparedSandboxTemplateBuild, Value)> {
     // Resolve every external image reference against the platform's template
     // registry. The final-stage FROM is treated separately so its resolution
     // becomes the lineage parent; the additional references (earlier stages,
@@ -1068,26 +991,33 @@ async fn prepare_rootfs_build(
         }
     }
 
-    let has_cas_sources = parent_source
+    // The platform-api rootfs builder cannot mount CAS templates as local
+    // build images; those builds belong to the Image Service build plane.
+    // Fail early with guidance instead of preparing a build that the
+    // builder would reject at materialization.
+    let cas_source_reference = parent_source
         .as_ref()
-        .is_some_and(ResolvedTemplateSource::is_cas)
-        || additional_sources
-            .iter()
-            .any(ResolvedTemplateSource::is_cas);
-
-    // Simulation: current Platform rejects CAS templates as local build images,
-    // so only durable sources are authorized/prepared there. We inject CAS
-    // source identities into the in-sandbox spec after prepare; every such
-    // source intentionally points at a missing local manifest.
-    // Final implementation: Platform will authorize every source format and
-    // return its real canonical manifest URI in the prepare response.
+        .filter(|source| source.is_cas())
+        .or_else(|| additional_sources.iter().find(|source| source.is_cas()))
+        .and_then(|source| {
+            source
+                .prepare_payload
+                .get("reference")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        });
+    if let Some(reference) = cas_source_reference {
+        return Err(SandboxImageBuildError::usage(format!(
+            "'{reference}' resolves to a CAS (content-addressed streaming) image, which the \
+             platform rootfs builder cannot use as a build source; build with the CAS option \
+             enabled to run this build through the Image Service"
+        )));
+    }
     let platform_parent_payload = parent_source
         .as_ref()
-        .filter(|source| !source.is_cas())
         .map(|source| source.prepare_payload.clone());
     let platform_additional_payload = additional_sources
         .iter()
-        .filter(|source| !source.is_cas())
         .map(|source| source.prepare_payload.clone())
         .collect();
     let prepare_body = prepare_request_body(
@@ -1111,67 +1041,9 @@ async fn prepare_rootfs_build(
         )));
     }
 
-    let mut raw: Value = response.json().await?;
+    let raw: Value = response.json().await?;
     let prepared = serde_json::from_value(raw.clone())?;
-    inject_simulated_cas_sources(&mut raw, parent_source.as_ref(), &additional_sources)?;
-    Ok((prepared, raw, has_cas_sources))
-}
-
-fn inject_simulated_cas_sources(
-    prepared_spec: &mut Value,
-    parent_source: Option<&ResolvedTemplateSource>,
-    additional_sources: &[ResolvedTemplateSource],
-) -> Result<()> {
-    let object = prepared_spec.as_object_mut().ok_or_else(|| {
-        SandboxImageBuildError::other("platform API returned a non-object rootfs build spec")
-    })?;
-
-    if let Some(parent_source) = parent_source
-        && parent_source.is_cas()
-    {
-        object.insert(
-            "parent".to_string(),
-            parent_source.simulated_cas_builder_entry()?,
-        );
-    }
-
-    if additional_sources
-        .iter()
-        .any(ResolvedTemplateSource::is_cas)
-    {
-        let platform_entries = object
-            .get("additionalLocalImages")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-        let mut final_entries = Vec::with_capacity(additional_sources.len());
-        for source in additional_sources {
-            if source.is_cas() {
-                final_entries.push(source.simulated_cas_builder_entry()?);
-                continue;
-            }
-            let reference = source
-                .prepare_payload
-                .get("reference")
-                .and_then(Value::as_str)
-                .unwrap_or_default();
-            let platform_entry = platform_entries
-                .iter()
-                .find(|entry| entry.get("reference").and_then(Value::as_str) == Some(reference))
-                .cloned()
-                .ok_or_else(|| {
-                    SandboxImageBuildError::other(format!(
-                        "platform prepare response omitted durable local image '{reference}'"
-                    ))
-                })?;
-            final_entries.push(platform_entry);
-        }
-        object.insert(
-            "additionalLocalImages".to_string(),
-            Value::Array(final_entries),
-        );
-    }
-    Ok(())
+    Ok((prepared, raw))
 }
 
 /// Assemble the prepare-request body from the plan and the resolved
@@ -1334,7 +1206,6 @@ async fn upload_build_inputs(
     prepared_spec: &Value,
     disk_mb: Option<u64>,
     docker_compat: bool,
-    cas_destination: bool,
     emit: &mut impl FnMut(SandboxImageBuildEvent),
 ) -> Result<()> {
     // Pre-create REMOTE_BUILD_DIR with permissive mode as root so the
@@ -1359,7 +1230,6 @@ async fn upload_build_inputs(
         disk_mb,
         docker_config_json,
         docker_compat,
-        cas_destination,
     )?;
     ensure_remote_parent_dir(proxy, REMOTE_SPEC_PATH).await?;
     proxy
@@ -1375,7 +1245,6 @@ fn build_rootfs_spec(
     disk_mb: Option<u64>,
     docker_config_json: Option<String>,
     docker_compat: bool,
-    cas_destination: bool,
 ) -> Result<Value> {
     let mut spec = prepared_spec.clone();
     let object = spec.as_object_mut().ok_or_else(|| {
@@ -1415,33 +1284,6 @@ fn build_rootfs_spec(
     if docker_compat {
         object.insert("dockerCompat".to_string(), Value::Bool(true));
     }
-    if cas_destination {
-        // Simulation: the current prepare response is durable-shaped. Strip
-        // every destination field that the local CAS daemon neither consumes
-        // nor may mistake for an upload instruction, and do not expose the
-        // Platform snapshot id inside the builder sandbox.
-        // Final implementation: Platform will return rootfsFormat, casBaseUri,
-        // and the opaque build capability directly in this prepared spec.
-        for key in [
-            "snapshotId",
-            "snapshotUri",
-            "snapshotRelPath",
-            "upload",
-            "manifestUpload",
-            "fileManifestUpload",
-        ] {
-            object.remove(key);
-        }
-        object.insert(
-            "rootfsFormat".to_string(),
-            Value::String("cas-streaming".to_string()),
-        );
-        object.insert(
-            "rootfsNodeKind".to_string(),
-            Value::String("base".to_string()),
-        );
-    }
-
     Ok(spec)
 }
 
@@ -1552,74 +1394,6 @@ async fn sign_prepared_local_image_downloads(
             .insert("download".to_string(), signed);
     }
     Ok(())
-}
-
-fn simulated_cas_build_result(
-    registered_name: &str,
-    prepared: &PreparedSandboxTemplateBuild,
-    metadata: &Value,
-    rootfs_disk_bytes: u64,
-) -> Result<Value> {
-    // Simulation: shape the daemon receipt like a completion result, while
-    // marking its builder-local lifetime and lack of registration explicitly.
-    // Final implementation: Platform completion returns the authoritative
-    // registered image instead of this locally assembled value.
-    let receipt = metadata
-        .get("casFilesystemReceipt")
-        .and_then(Value::as_object)
-        .ok_or_else(|| {
-            SandboxImageBuildError::other(
-                "CAS rootfs builder metadata is missing casFilesystemReceipt",
-            )
-        })?;
-    let receipt_string = |key: &str| {
-        receipt
-            .get(key)
-            .and_then(Value::as_str)
-            .map(str::to_string)
-            .ok_or_else(|| {
-                SandboxImageBuildError::other(format!(
-                    "CAS rootfs builder receipt is missing {key}"
-                ))
-            })
-    };
-    let receipt_u64 = |key: &str| {
-        receipt.get(key).and_then(Value::as_u64).ok_or_else(|| {
-            SandboxImageBuildError::other(format!("CAS rootfs builder receipt is missing {key}"))
-        })
-    };
-    let cas_filesystem_id = receipt_string("casFilesystemId")?;
-    let manifest_uri = receipt_string("manifestUri")?;
-    let stored_bytes = receipt_u64("storedBytes")?;
-    let logical_bytes = receipt_u64("logicalBytes")?;
-    let novel_bytes_uploaded = receipt_u64("novelBytesUploaded")?;
-    let dedup_bytes_reused = receipt_u64("dedupBytesReused")?;
-    if metadata.get("snapshotUri").and_then(Value::as_str) != Some(manifest_uri.as_str()) {
-        return Err(SandboxImageBuildError::other(
-            "CAS rootfs builder metadata snapshotUri does not match its receipt",
-        ));
-    }
-    Ok(json!({
-        "registered": false,
-        "ephemeral": true,
-        "name": registered_name,
-        "buildId": prepared.build_id,
-        "snapshotId": prepared.snapshot_id,
-        "snapshotFormatVersion": CAS_SNAPSHOT_FORMAT_VERSION,
-        "snapshotUri": manifest_uri,
-        "rootfsFormat": "cas-streaming",
-        "rootfsNodeKind": "base",
-        "rootfsDiskBytes": rootfs_disk_bytes,
-        "snapshotSizeBytes": stored_bytes,
-        "casFilesystemReceipt": {
-            "casFilesystemId": cas_filesystem_id,
-            "manifestUri": manifest_uri,
-            "storedBytes": stored_bytes,
-            "logicalBytes": logical_bytes,
-            "novelBytesUploaded": novel_bytes_uploaded,
-            "dedupBytesReused": dedup_bytes_reused,
-        },
-    }))
 }
 
 fn rootfs_disk_bytes(disk_mb: Option<u64>, prepared: &PreparedSandboxTemplateBuild) -> Result<u64> {
@@ -3116,7 +2890,7 @@ fn join_posix(base: &str, child: &str) -> String {
     normalize_posix(&format!("{}/{}", base.trim_end_matches('/'), child))
 }
 
-fn collect_dir_files(root: &Path, current: &Path) -> Result<Vec<(PathBuf, String)>> {
+pub(crate) fn collect_dir_files(root: &Path, current: &Path) -> Result<Vec<(PathBuf, String)>> {
     let mut files = Vec::new();
     let dockerignore = dockerignore_matcher(root)?;
     collect_dir_files_filtered(root, current, dockerignore.as_ref(), &mut files)?;
@@ -3444,16 +3218,9 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
         .unwrap();
         let plan = super::plan_image_import("ubuntu:24.04", None).unwrap();
 
-        let spec = super::build_rootfs_spec(
-            &prepared_spec,
-            &prepared,
-            &plan,
-            Some(10240),
-            None,
-            false,
-            false,
-        )
-        .unwrap();
+        let spec =
+            super::build_rootfs_spec(&prepared_spec, &prepared, &plan, Some(10240), None, false)
+                .unwrap();
         assert_eq!(spec["importImageReference"], "ubuntu:24.04");
         assert_eq!(spec["baseImage"], "ubuntu:24.04");
         assert_eq!(spec["dockerfile"], "FROM ubuntu:24.04\n");
@@ -4069,92 +3836,6 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
     }
 
     #[test]
-    fn simulated_cas_sources_use_fake_local_manifests_without_snapshot_ids() {
-        let cas_parent = super::ResolvedTemplateSource {
-            prepare_payload: json!({
-                "templateId": "tmpl-cas-parent",
-                "name": "cas-parent",
-                "reference": "tensorlake/cas-parent",
-                "snapshotId": "snapshot-cas-parent",
-                "public": false,
-            }),
-            snapshot_format_version: Some(super::CAS_SNAPSHOT_FORMAT_VERSION.to_string()),
-            snapshot_uri: Some("s3://production/cas-parent/manifest.json".to_string()),
-            rootfs_disk_bytes: Some(4096),
-        };
-        let durable_additional = super::ResolvedTemplateSource {
-            prepare_payload: json!({
-                "templateId": "tmpl-durable",
-                "name": "durable",
-                "reference": "tensorlake/durable",
-                "snapshotId": "snapshot-durable",
-                "public": false,
-            }),
-            snapshot_format_version: Some("durable_archive_v1".to_string()),
-            snapshot_uri: Some("s3://production/durable.tlsnap".to_string()),
-            rootfs_disk_bytes: Some(8192),
-        };
-        let cas_additional = super::ResolvedTemplateSource {
-            prepare_payload: json!({
-                "templateId": "tmpl-cas-tool",
-                "name": "cas-tool",
-                "reference": "tensorlake/cas-tool",
-                "snapshotId": "snapshot-cas-tool",
-                "public": false,
-            }),
-            snapshot_format_version: Some(super::CAS_SNAPSHOT_FORMAT_VERSION.to_string()),
-            snapshot_uri: Some("s3://production/cas-tool/manifest.json".to_string()),
-            rootfs_disk_bytes: Some(16384),
-        };
-        let mut prepared_spec = json!({
-            "parent": null,
-            "additionalLocalImages": [{
-                "templateId": "tmpl-durable",
-                "name": "durable",
-                "reference": "tensorlake/durable",
-                "snapshotId": "snapshot-durable",
-                "snapshotUri": "s3://prepared/durable.tlsnap"
-            }]
-        });
-
-        super::inject_simulated_cas_sources(
-            &mut prepared_spec,
-            Some(&cas_parent),
-            &[durable_additional, cas_additional],
-        )
-        .unwrap();
-
-        assert_eq!(
-            prepared_spec["parent"]["snapshotFormatVersion"],
-            super::CAS_SNAPSHOT_FORMAT_VERSION
-        );
-        assert_eq!(prepared_spec["parent"]["rootfsDiskBytes"], 4096);
-        assert!(
-            prepared_spec["parent"]["snapshotUri"]
-                .as_str()
-                .unwrap()
-                .starts_with(&format!(
-                    "file://{}/filesystems/",
-                    super::SIMULATED_CAS_BLOB_STORE_ROOT
-                ))
-        );
-        assert!(prepared_spec["parent"].get("snapshotId").is_none());
-        assert_eq!(
-            prepared_spec["additionalLocalImages"][0]["snapshotUri"],
-            "s3://prepared/durable.tlsnap"
-        );
-        assert_eq!(
-            prepared_spec["additionalLocalImages"][1]["snapshotFormatVersion"],
-            super::CAS_SNAPSHOT_FORMAT_VERSION
-        );
-        assert!(
-            prepared_spec["additionalLocalImages"][1]
-                .get("snapshotId")
-                .is_none()
-        );
-    }
-
-    #[test]
     fn template_build_payload_imposes_no_eligibility_policy() {
         // The client owns no node-kind or snapshot-format allowlist: diff
         // templates, cas-streaming templates, and formats this client has
@@ -4244,7 +3925,6 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
             Some(2048),
             Some("{}".to_string()),
             true,
-            false,
         )
         .unwrap();
         assert_eq!(spec["dockerfile"], "FROM alpine\nRUN echo hi\n");
@@ -4273,79 +3953,9 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
             import_image_reference: None,
         };
 
-        let spec =
-            build_rootfs_spec(&prepared_spec, &prepared, &plan, None, None, false, false).unwrap();
+        let spec = build_rootfs_spec(&prepared_spec, &prepared, &plan, None, None, false).unwrap();
         assert_eq!(spec["rootfsDiskBytes"], 20_u64 * 1024 * 1024 * 1024);
         assert!(spec.get("dockerCompat").is_none());
-    }
-
-    #[test]
-    fn build_rootfs_spec_for_simulated_cas_strips_durable_destination_fields() {
-        let prepared_spec = json!({
-            "buildId": "build-1",
-            "snapshotId": "snapshot-1",
-            "snapshotUri": "s3://bucket/snapshot.tlsnap",
-            "snapshotRelPath": "snapshots/snapshot-1.tlsnap",
-            "rootfsNodeKind": "base",
-            "upload": {"kind": "single_put"},
-            "manifestUpload": {"url": "https://example/manifest"},
-            "fileManifestUpload": {"url": "https://example/files"},
-            "builder": {
-                "image": "tensorlake/rootfs-builder",
-                "command": "tl-rootfs-build",
-                "cpus": 2,
-                "memoryMb": 4096,
-                "diskMb": 30720
-            }
-        });
-        let prepared: PreparedSandboxTemplateBuild =
-            serde_json::from_value(prepared_spec.clone()).unwrap();
-        let plan = super::plan_image_import("ubuntu:24.04", Some("ubuntu-cas")).unwrap();
-
-        let spec =
-            build_rootfs_spec(&prepared_spec, &prepared, &plan, None, None, false, true).unwrap();
-
-        assert_eq!(spec["buildId"], "build-1");
-        assert_eq!(spec["rootfsFormat"], "cas-streaming");
-        assert_eq!(spec["rootfsNodeKind"], "base");
-        for key in [
-            "snapshotId",
-            "snapshotUri",
-            "snapshotRelPath",
-            "upload",
-            "manifestUpload",
-            "fileManifestUpload",
-        ] {
-            assert!(spec.get(key).is_none(), "{key} leaked into CAS spec");
-        }
-    }
-
-    #[test]
-    fn simulated_cas_result_returns_full_unregistered_receipt() {
-        let prepared = prepared_build("base");
-        let manifest_uri = "file:///var/lib/tensorlake/rootfs-builder/work/cas-blob-store/filesystems/fs/manifest.json";
-        let metadata = json!({
-            "snapshotUri": manifest_uri,
-            "casFilesystemReceipt": {
-                "casFilesystemId": "fs-1",
-                "manifestUri": manifest_uri,
-                "storedBytes": 120,
-                "logicalBytes": 200,
-                "novelBytesUploaded": 80,
-                "dedupBytesReused": 120
-            }
-        });
-
-        let result =
-            super::simulated_cas_build_result("ubuntu-cas", &prepared, &metadata, 4096).unwrap();
-
-        assert_eq!(result["registered"], false);
-        assert_eq!(result["ephemeral"], true);
-        assert_eq!(result["name"], "ubuntu-cas");
-        assert_eq!(result["snapshotUri"], manifest_uri);
-        assert_eq!(result["snapshotSizeBytes"], 120);
-        assert_eq!(result["rootfsDiskBytes"], 4096);
-        assert_eq!(result["casFilesystemReceipt"]["logicalBytes"], 200);
     }
 
     #[test]

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -214,8 +214,9 @@ pub struct CommonBuildOptions {
     /// through the Image Service build plane instead of the platform-api
     /// rootfs builder. The SDK resolves the Dockerfile plan's references
     /// against the Image Service catalog and submits them with the build;
-    /// the service reconciler drives the builder sandbox. Requires
-    /// `TENSORLAKE_IMAGE_SERVICE_URL`.
+    /// the service reconciler drives the builder sandbox. Routed through the
+    /// API host's `/images/v4` ingress path by default;
+    /// `TENSORLAKE_IMAGE_SERVICE_URL` overrides it for local development.
     pub cas: bool,
     pub user_agent: Option<String>,
     pub docker_compat: bool,

--- a/crates/cloud-sdk/tests/sandbox_templates.rs
+++ b/crates/cloud-sdk/tests/sandbox_templates.rs
@@ -168,6 +168,7 @@ async fn test_create_then_delete_sandbox_image() {
                 dockerfile_path,
                 dockerfile_text: None,
                 context_dir: None,
+                build_args: Vec::new(),
             },
             |_| {},
         )

--- a/crates/rust-cloud-sdk-node/src/lib.rs
+++ b/crates/rust-cloud-sdk-node/src/lib.rs
@@ -49,6 +49,9 @@ pub struct SandboxImageBuildOptionsJs {
     /// Opt into the non-default CAS (content-addressed streaming) image
     /// format.
     pub cas: Option<bool>,
+    /// Dockerfile build args forwarded to BuildKit inside the builder. CAS
+    /// builds only.
+    pub build_args: Option<std::collections::HashMap<String, String>>,
 }
 
 #[napi(object)]
@@ -140,6 +143,14 @@ pub async fn build_sandbox_image(
         dockerfile_path: PathBuf::from(options.dockerfile_path),
         dockerfile_text: options.dockerfile_text,
         context_dir: options.context_dir.map(PathBuf::from),
+        build_args: options
+            .build_args
+            .map(|args| {
+                let mut args: Vec<(String, String)> = args.into_iter().collect();
+                args.sort();
+                args
+            })
+            .unwrap_or_default(),
     };
 
     let result = rust_build_sandbox_image(build_options, move |event| {

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -4001,6 +4001,7 @@ fn create_image_context_file(
     dockerfile_text=None,
     context_dir=None,
     cas=false,
+    build_args=None,
     emit=None,
 ))]
 fn build_sandbox_image(
@@ -4023,6 +4024,7 @@ fn build_sandbox_image(
     dockerfile_text: Option<String>,
     context_dir: Option<String>,
     cas: bool,
+    build_args: Option<std::collections::BTreeMap<String, String>>,
     emit: Option<Py<PyAny>>,
 ) -> PyResult<String> {
     let options = tensorlake::sandbox_images::SandboxImageBuildOptions {
@@ -4046,6 +4048,9 @@ fn build_sandbox_image(
         dockerfile_path: PathBuf::from(dockerfile_path),
         dockerfile_text,
         context_dir: context_dir.map(PathBuf::from),
+        build_args: build_args
+            .map(|args| args.into_iter().collect())
+            .unwrap_or_default(),
     };
 
     let result = py


### PR DESCRIPTION
## Summary

`--cas` builds (CLI, Python, and Node, which all funnel through `build_sandbox_image` / `import_sandbox_image`) now run through the Image Service build plane instead of the builder-local simulation:

1. **The SDK resolves, the service pins** (compute-engine-internal ADR 0023): the existing Dockerfile plan parser is unchanged; its external references (final-stage FROM, earlier-stage FROMs, `COPY --from`, `RUN --mount=from`) are resolved client-side against the Image Service catalog by exact-string name lookup, with `cas-v1:<64hex>` accepted as a direct pin and no ARG substitution. Resolved parents are submitted with the build request as `{reference, image_id}` pairs (capped at 3, the sandbox volume budget beside `/target`); misses stay registry references the guest pulls.
2. **Client flow is create → upload → seal → poll**: plain (uncompressed) context tar honoring `.dockerignore`, uploaded through the sealed capability with a bare HTTP client (presigned-PUT safe), sealed by sha256, then polled to a terminal status; the published image record is returned. The Dockerfile text is injected at `.tensorlake/Dockerfile` when the file lives outside the context directory. The reconciler drives the builder sandbox; the client never talks to it.
3. **Registry credentials forwarded**: the local `docker login` state (the same source the legacy path ships into its builder) is sent write-only as `registry_credentials_json` on build creation; the Image Service stages it outside its catalog and the builder guest fetches it through a short-lived URL for registry pulls.
4. **Simulation deleted**: simulated CAS source injection, the fake local blob store, the unregistered receipt result, and cas-destination spec stripping are gone. A legacy build whose reference resolves to a CAS template fails early with guidance to use `--cas`.

Requires `TENSORLAKE_IMAGE_SERVICE_URL` until the platform gateway routes to the service.

## Testing

`cargo test --workspace` green (5 new unit tests for direct pins, Dockerfile placement, and context tar creation; 59 sandbox_images tests still pass); `cargo clippy --workspace --all-targets` introduces no new warnings; `cargo fmt` clean. Live verification against a running Image Service stack is the next step and will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
