### PR TITLE
feat(sandbox-pools): allow replacing the pool network policy on update, release 0.5.91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "base64",
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "base64",
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "base64",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "napi",
  "napi-build",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.90"
+version = "0.5.91"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -142,10 +142,11 @@ named = client.create(image="tensorlake/ubuntu-minimal", name="stable-name")
 sandbox = client.connect("stable-name")
 ```
 
-Set the pool network policy when you create the pool, or replace it later with
-a pool update: the service recycles the pool's unclaimed warm containers onto
-the new policy, while containers already claimed by sandboxes keep the policy
-they booted with.
+Set the pool network policy when you create the pool, replace it later with a
+pool update, or pass `CLEAR_NETWORK_POLICY` (Python) / `null` (TypeScript) to
+remove it. On a change the service recycles the pool's unclaimed warm
+containers onto the new policy, while containers already claimed by sandboxes
+keep the policy they booted with.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ named = client.create(image="tensorlake/ubuntu-minimal", name="stable-name")
 sandbox = client.connect("stable-name")
 ```
 
-Set the pool network policy when you create the pool. Create a new pool to use a
-different network policy.
+Set the pool network policy when you create the pool, or replace it later with
+a pool update: the service recycles the pool's unclaimed warm containers onto
+the new policy, while containers already claimed by sandboxes keep the policy
+they booted with.
 
 ---
 

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -27,9 +27,10 @@ use models::{
     DetachFileSystemRequest, FileSystemMount, GetSandboxLogsRequest, HealthResponse,
     ListArchivedSandboxesParams, ListArchivedSandboxesResponse, ListDirectoryResponse,
     ListProcessesResponse, ListSandboxPoolsResponse, ListSandboxesResponse, ListSnapshotsResponse,
-    OutputEvent, OutputResponse, ProcessInfo, RunProcessEvent, SandboxInfo, SandboxLogsResponse,
-    SandboxPoolInfo, SandboxPoolRequest, SandboxProcessLogFiltersResponse, SendSignalResponse,
-    SignBlobRequest, SnapshotInfo, SnapshotType, UpdateSandboxRequest,
+    NetworkPolicyUpdate, OutputEvent, OutputResponse, ProcessInfo, RunProcessEvent, SandboxInfo,
+    SandboxLogsResponse, SandboxPoolInfo, SandboxPoolRequest, SandboxProcessLogFiltersResponse,
+    SendSignalResponse, SignBlobRequest, SnapshotInfo, SnapshotType, UpdateSandboxPoolRequest,
+    UpdateSandboxRequest,
 };
 
 pub const DEFAULT_SANDBOX_PROXY_URL: &str = "https://sandbox.tensorlake.ai";
@@ -601,35 +602,36 @@ impl SandboxesClient {
     ) -> Result<Traced<SandboxPoolInfo>, SdkError> {
         self.update_pool_with_network(
             pool_id,
-            &CreateSandboxPoolRequest {
+            &UpdateSandboxPoolRequest {
                 pool: request.clone(),
-                network: None,
+                network: NetworkPolicyUpdate::Keep,
             },
         )
         .await
     }
 
-    /// Replace a pool configuration, optionally replacing its network policy.
+    /// Replace a pool configuration, optionally changing its network policy.
     ///
-    /// `network: None` keeps the pool's current policy. `network: Some(..)`
-    /// replaces it: the service recycles the pool's unclaimed warm containers
-    /// onto the new policy, while containers already claimed by sandboxes keep
-    /// the policy they booted with.
+    /// [`NetworkPolicyUpdate::Keep`] leaves the current policy in place;
+    /// [`NetworkPolicyUpdate::Clear`] removes it; [`NetworkPolicyUpdate::Set`]
+    /// replaces it. On a change the service recycles the pool's unclaimed warm
+    /// containers onto the new policy, while containers already claimed by
+    /// sandboxes keep the policy they booted with.
     pub async fn update_pool_with_network(
         &self,
         pool_id: &str,
-        request: &CreateSandboxPoolRequest,
+        request: &UpdateSandboxPoolRequest,
     ) -> Result<Traced<SandboxPoolInfo>, SdkError> {
-        let network = match &request.network {
-            Some(network) => Some(network.clone()),
-            // The service replaces the pool wholesale, so an absent policy
-            // would clear it; echo the current policy to keep it.
-            None => self.get_pool(pool_id).await?.network_policy.clone(),
-        };
-        let request = CreateSandboxPoolRequest {
-            pool: request.pool.clone(),
-            network,
-        };
+        let mut request = request.clone();
+        // Newer services keep the current policy when the field is absent, but
+        // older ones clear it, so resolve `Keep` into the current policy here.
+        // Sending the unchanged policy is a no-op for the service: the pool's
+        // boot config does not change, so no warm containers are recycled.
+        if request.network.is_keep()
+            && let Some(current) = self.get_pool(pool_id).await?.network_policy.clone()
+        {
+            request.network = NetworkPolicyUpdate::Set(current);
+        }
 
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}"));
         let req = self

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -592,15 +592,43 @@ impl SandboxesClient {
             .map(|r| r.pools))
     }
 
+    /// Replace a pool configuration, keeping its current network policy.
+    /// Use [`Self::update_pool_with_network`] to replace the policy too.
     pub async fn update_pool(
         &self,
         pool_id: &str,
         request: &SandboxPoolRequest,
     ) -> Result<Traced<SandboxPoolInfo>, SdkError> {
-        let current = self.get_pool(pool_id).await?;
+        self.update_pool_with_network(
+            pool_id,
+            &CreateSandboxPoolRequest {
+                pool: request.clone(),
+                network: None,
+            },
+        )
+        .await
+    }
+
+    /// Replace a pool configuration, optionally replacing its network policy.
+    ///
+    /// `network: None` keeps the pool's current policy. `network: Some(..)`
+    /// replaces it: the service recycles the pool's unclaimed warm containers
+    /// onto the new policy, while containers already claimed by sandboxes keep
+    /// the policy they booted with.
+    pub async fn update_pool_with_network(
+        &self,
+        pool_id: &str,
+        request: &CreateSandboxPoolRequest,
+    ) -> Result<Traced<SandboxPoolInfo>, SdkError> {
+        let network = match &request.network {
+            Some(network) => Some(network.clone()),
+            // The service replaces the pool wholesale, so an absent policy
+            // would clear it; echo the current policy to keep it.
+            None => self.get_pool(pool_id).await?.network_policy.clone(),
+        };
         let request = CreateSandboxPoolRequest {
-            pool: request.clone(),
-            network: current.network_policy.clone(),
+            pool: request.pool.clone(),
+            network,
         };
 
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}"));

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -220,6 +220,65 @@ pub struct CreateSandboxPoolRequest {
     pub network: Option<NetworkConfig>,
 }
 
+/// What a pool update should do with the pool's network policy.
+///
+/// A pool update replaces the pool record wholesale, so the three states are
+/// distinct on the wire: the field is omitted to keep the current policy,
+/// sent as `null` to clear it, or sent as an object to replace it.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum NetworkPolicyUpdate {
+    /// Leave the pool's current network policy in place.
+    #[default]
+    Keep,
+    /// Remove the pool's network policy, leaving containers unrestricted.
+    Clear,
+    /// Replace the pool's network policy.
+    Set(NetworkConfig),
+}
+
+impl NetworkPolicyUpdate {
+    pub fn is_keep(&self) -> bool {
+        matches!(self, Self::Keep)
+    }
+}
+
+impl Serialize for NetworkPolicyUpdate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            // `Keep` is normally skipped by `skip_serializing_if`; if a caller
+            // serializes it directly, `null` is the closest wire meaning.
+            Self::Keep | Self::Clear => serializer.serialize_none(),
+            Self::Set(policy) => serializer.serialize_some(policy),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for NetworkPolicyUpdate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Only reached when the key is present, so an absent field falls back
+        // to `Default` (`Keep`) via `serde(default)` on the field.
+        Ok(match Option::<NetworkConfig>::deserialize(deserializer)? {
+            None => Self::Clear,
+            Some(policy) => Self::Set(policy),
+        })
+    }
+}
+
+/// A pool update request carrying a tri-state network policy instruction.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct UpdateSandboxPoolRequest {
+    #[serde(flatten)]
+    pub pool: SandboxPoolRequest,
+    #[serde(default, skip_serializing_if = "NetworkPolicyUpdate::is_keep")]
+    pub network: NetworkPolicyUpdate,
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CreateSandboxResponse {
     pub sandbox_id: String,

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -3,7 +3,8 @@ use tensorlake::{
     sandboxes::{
         SandboxProxyClient, SandboxesClient,
         models::{
-            ContainerResourcesInfo, CreateSandboxPoolRequest, NetworkConfig, SandboxPoolRequest,
+            ContainerResourcesInfo, CreateSandboxPoolRequest, NetworkConfig, NetworkPolicyUpdate,
+            SandboxPoolRequest, UpdateSandboxPoolRequest,
         },
     },
 };
@@ -246,7 +247,7 @@ async fn update_pool_with_network_replaces_policy_without_get() {
     let info = sandboxes
         .update_pool_with_network(
             "pool-1",
-            &CreateSandboxPoolRequest {
+            &UpdateSandboxPoolRequest {
                 pool: SandboxPoolRequest {
                     image: Some("alpine".to_string()),
                     resources: ContainerResourcesInfo {
@@ -259,7 +260,7 @@ async fn update_pool_with_network_replaces_policy_without_get() {
                     max_containers: None,
                     warm_containers: Some(1),
                 },
-                network: Some(NetworkConfig {
+                network: NetworkPolicyUpdate::Set(NetworkConfig {
                     allow_internet_access: true,
                     allow_out: vec![],
                     deny_out: vec!["198.51.100.0/24".to_string()],
@@ -283,6 +284,109 @@ async fn update_pool_with_network_replaces_policy_without_get() {
             deny_out: vec!["198.51.100.0/24".to_string()],
         })
     );
+}
+
+#[tokio::test]
+async fn update_pool_clear_sends_explicit_null_network() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    // One request only: clearing must not read the current policy first.
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept update");
+        let update = read_http_request(&mut socket).await;
+        write_json_response(
+            &mut socket,
+            r#"{
+                "pool_id":"pool-1",
+                "namespace":"default",
+                "image":"alpine",
+                "resources":{"cpus":1.0,"memory_mb":1024,"ephemeral_disk_mb":1024}
+            }"#,
+        )
+        .await;
+        update
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .build()
+        .expect("build client");
+    let sandboxes = SandboxesClient::new(client, "default", false);
+
+    let info = sandboxes
+        .update_pool_with_network(
+            "pool-1",
+            &UpdateSandboxPoolRequest {
+                pool: SandboxPoolRequest {
+                    image: Some("alpine".to_string()),
+                    resources: ContainerResourcesInfo {
+                        cpus: 1.0,
+                        memory_mb: 1024,
+                        ephemeral_disk_mb: 1024,
+                    },
+                    timeout_secs: 0,
+                    entrypoint: None,
+                    max_containers: None,
+                    warm_containers: Some(1),
+                },
+                network: NetworkPolicyUpdate::Clear,
+            },
+        )
+        .await
+        .expect("clear pool network policy");
+
+    let update = server.await.expect("server join");
+    let update_text = String::from_utf8_lossy(&update);
+    assert!(
+        update_text.contains(r#""network":null"#),
+        "clear must send an explicit null so the service removes the policy: {update_text}"
+    );
+    assert_eq!(info.network_policy, None);
+}
+
+#[test]
+fn network_policy_update_wire_shapes() {
+    // Keep is omitted entirely, Clear is an explicit null, Set is an object.
+    let pool = SandboxPoolRequest {
+        image: Some("alpine".to_string()),
+        resources: ContainerResourcesInfo {
+            cpus: 1.0,
+            memory_mb: 1024,
+            ephemeral_disk_mb: 1024,
+        },
+        timeout_secs: 0,
+        entrypoint: None,
+        max_containers: None,
+        warm_containers: None,
+    };
+    let encode = |network| {
+        serde_json::to_string(&UpdateSandboxPoolRequest {
+            pool: pool.clone(),
+            network,
+        })
+        .expect("serialize")
+    };
+
+    assert!(!encode(NetworkPolicyUpdate::Keep).contains("network"));
+    assert!(encode(NetworkPolicyUpdate::Clear).contains(r#""network":null"#));
+    assert!(
+        encode(NetworkPolicyUpdate::Set(NetworkConfig {
+            allow_internet_access: false,
+            allow_out: vec![],
+            deny_out: vec![],
+        }))
+        .contains(r#""network":{"allow_internet_access":false"#)
+    );
+
+    // Round-trip: an absent key must decode back to Keep, null to Clear.
+    let keep: UpdateSandboxPoolRequest =
+        serde_json::from_str(&encode(NetworkPolicyUpdate::Keep)).expect("decode keep");
+    assert_eq!(keep.network, NetworkPolicyUpdate::Keep);
+    let clear: UpdateSandboxPoolRequest =
+        serde_json::from_str(&encode(NetworkPolicyUpdate::Clear)).expect("decode clear");
+    assert_eq!(clear.network, NetworkPolicyUpdate::Clear);
 }
 
 async fn read_http_request(socket: &mut TcpStream) -> Vec<u8> {

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -208,6 +208,83 @@ async fn pool_network_policy_is_sent_and_preserved_on_update() {
     assert!(update_text.contains(r#""network":{"allow_internet_access":false"#));
 }
 
+#[tokio::test]
+async fn update_pool_with_network_replaces_policy_without_get() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    // Exactly one request is served: an explicit replacement policy must be
+    // sent as-is, with no current-policy GET beforehand.
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept update");
+        let update = read_http_request(&mut socket).await;
+        write_json_response(
+            &mut socket,
+            r#"{
+                "pool_id":"pool-1",
+                "namespace":"default",
+                "image":"alpine",
+                "resources":{"cpus":1.0,"memory_mb":1024,"ephemeral_disk_mb":1024},
+                "network_policy":{
+                    "allow_internet_access":true,
+                    "allow_out":[],
+                    "deny_out":["198.51.100.0/24"]
+                }
+            }"#,
+        )
+        .await;
+        update
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .build()
+        .expect("build client");
+    let sandboxes = SandboxesClient::new(client, "default", false);
+
+    let info = sandboxes
+        .update_pool_with_network(
+            "pool-1",
+            &CreateSandboxPoolRequest {
+                pool: SandboxPoolRequest {
+                    image: Some("alpine".to_string()),
+                    resources: ContainerResourcesInfo {
+                        cpus: 1.0,
+                        memory_mb: 1024,
+                        ephemeral_disk_mb: 1024,
+                    },
+                    timeout_secs: 0,
+                    entrypoint: None,
+                    max_containers: None,
+                    warm_containers: Some(1),
+                },
+                network: Some(NetworkConfig {
+                    allow_internet_access: true,
+                    allow_out: vec![],
+                    deny_out: vec!["198.51.100.0/24".to_string()],
+                }),
+            },
+        )
+        .await
+        .expect("update pool with network");
+
+    let update = server.await.expect("server join");
+    let update_text = String::from_utf8_lossy(&update);
+    assert!(update_text.starts_with("PUT /sandbox-pools/pool-1 HTTP/1.1\r\n"));
+    assert!(update_text.contains(
+        r#""network":{"allow_internet_access":true,"allow_out":[],"deny_out":["198.51.100.0/24"]}"#
+    ));
+    assert_eq!(
+        info.network_policy,
+        Some(NetworkConfig {
+            allow_internet_access: true,
+            allow_out: vec![],
+            deny_out: vec!["198.51.100.0/24".to_string()],
+        })
+    );
+}
+
 async fn read_http_request(socket: &mut TcpStream) -> Vec<u8> {
     let mut request = Vec::new();
     let mut buf = [0_u8; 4096];

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.90"
+version = "0.5.91"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -681,12 +681,12 @@ impl NativeSandboxClient {
         pool_id: String,
         request_json: String,
     ) -> napi::Result<TracedJson> {
-        let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
+        let request: CreateSandboxPoolRequest = parse_json_payload(&request_json)?;
         with_retry(self.client.clone(), 5, move |c| {
             let pool_id = pool_id.clone();
             let request = request.clone();
             async move {
-                let traced = c.update_pool(&pool_id, &request).await?;
+                let traced = c.update_pool_with_network(&pool_id, &request).await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced)?;
                 Ok(TracedJson { trace_id, json })

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -27,7 +27,7 @@ use serde_json::Value;
 use tensorlake::sandboxes::models::{
     ArchivedSandboxesPaginationDirection, CreateSandboxPoolRequest, CreateSandboxRequest,
     GetSandboxLogsRequest, ListArchivedSandboxesParams, SandboxPoolRequest, SnapshotType,
-    UpdateSandboxRequest,
+    UpdateSandboxPoolRequest, UpdateSandboxRequest,
 };
 use tensorlake::sandboxes::{
     SandboxProxyClient, SandboxesClient, resolve_sandbox_proxy_target, select_sandbox_proxy_url,
@@ -681,7 +681,7 @@ impl NativeSandboxClient {
         pool_id: String,
         request_json: String,
     ) -> napi::Result<TracedJson> {
-        let request: CreateSandboxPoolRequest = parse_json_payload(&request_json)?;
+        let request: UpdateSandboxPoolRequest = parse_json_payload(&request_json)?;
         with_retry(self.client.clone(), 5, move |c| {
             let pool_id = pool_id.clone();
             let request = request.clone();

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.90"
+version = "0.5.91"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -1876,12 +1876,12 @@ impl CloudSandboxClient {
     }
 
     fn update_pool(&self, pool_id: String, request_json: String) -> PyResult<(String, String)> {
-        let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
+        let request: CreateSandboxPoolRequest = parse_json_payload(&request_json)?;
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
             let request = request.clone();
             async move {
-                let traced = client.update_pool(&pool_id, &request).await?;
+                let traced = client.update_pool_with_network(&pool_id, &request).await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
                 Ok((trace_id, json))
@@ -2323,13 +2323,13 @@ impl CloudSandboxClient {
         pool_id: String,
         request_json: String,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let request: SandboxPoolRequest = parse_json_payload(&request_json)?;
+        let request: CreateSandboxPoolRequest = parse_json_payload(&request_json)?;
         let client = self.client.clone();
         future_into_py(py, async move {
             let traced = retry_async_op(client, 5, move |c| {
                 let pool_id = pool_id.clone();
                 let request = request.clone();
-                async move { c.update_pool(&pool_id, &request).await }
+                async move { c.update_pool_with_network(&pool_id, &request).await }
             })
             .await
             .map_err(into_sandbox_py_error)?;

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -36,7 +36,7 @@ use tensorlake::sandbox_templates::SandboxTemplatesClient;
 use tensorlake::sandboxes::models::{
     ArchivedSandboxesPaginationDirection, CreateSandboxPoolRequest, CreateSandboxRequest,
     GetSandboxLogsRequest, ListArchivedSandboxesParams, SandboxPoolRequest, SnapshotType,
-    UpdateSandboxRequest,
+    UpdateSandboxPoolRequest, UpdateSandboxRequest,
 };
 use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
@@ -1876,7 +1876,7 @@ impl CloudSandboxClient {
     }
 
     fn update_pool(&self, pool_id: String, request_json: String) -> PyResult<(String, String)> {
-        let request: CreateSandboxPoolRequest = parse_json_payload(&request_json)?;
+        let request: UpdateSandboxPoolRequest = parse_json_payload(&request_json)?;
         self.run_with_retry(5, move |client| {
             let pool_id = pool_id.clone();
             let request = request.clone();
@@ -2323,7 +2323,7 @@ impl CloudSandboxClient {
         pool_id: String,
         request_json: String,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let request: CreateSandboxPoolRequest = parse_json_payload(&request_json)?;
+        let request: UpdateSandboxPoolRequest = parse_json_payload(&request_json)?;
         let client = self.client.clone();
         future_into_py(py, async move {
             let traced = retry_async_op(client, 5, move |c| {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.90"
+version = "0.5.91"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/__init__.py
+++ b/src/tensorlake/sandbox/__init__.py
@@ -19,8 +19,10 @@ from .file_system import (
     list_file_systems,
 )
 from .models import (
+    CLEAR_NETWORK_POLICY,
     ArchivedSandboxInfo,
     CheckpointType,
+    ClearNetworkPolicy,
     CommandResult,
     ContainerResourcesInfo,
     CopiedSandboxResponse,
@@ -95,6 +97,8 @@ __all__ = [
     "CreateSandboxPoolResponse",
     "ContainerResourcesInfo",
     "GPUResources",
+    "CLEAR_NETWORK_POLICY",
+    "ClearNetworkPolicy",
     "NetworkConfig",
     "ArchivedSandboxInfo",
     "ListArchivedSandboxesResponse",

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -704,8 +704,8 @@ class AsyncSandboxClient:
     ) -> Traced[CreateSandboxPoolResponse]:
         """Create a sandbox pool.
 
-        Set ``network`` to apply a network policy to each pool container. Create
-        a new pool to use a different network policy.
+        Set ``network`` to apply a network policy to each pool container. The
+        policy can be replaced later with ``update_pool``.
         """
         request_model = SandboxPoolRequest(
             image=image,
@@ -758,8 +758,15 @@ class AsyncSandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
+        network: NetworkConfig | None = None,
     ) -> Traced[SandboxPoolInfo]:
-        """Update a pool and keep its current network policy."""
+        """Update a sandbox pool configuration.
+
+        Omit ``network`` to keep the pool's current network policy. Set it to
+        replace the policy: the service recycles the pool's unclaimed warm
+        containers onto the new policy, while containers already claimed by
+        sandboxes keep the policy they booted with.
+        """
         request_model = SandboxPoolRequest(
             image=image,
             resources=ContainerResourcesInfo(
@@ -769,6 +776,7 @@ class AsyncSandboxClient:
             entrypoint=entrypoint,
             max_containers=max_containers,
             warm_containers=warm_containers,
+            network=network,
         )
         try:
             trace_id, response_json = await self._rust_client.update_pool_async(

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -42,7 +42,9 @@ from .exceptions import (
     SandboxNotFoundError,
 )
 from .models import (
+    CLEAR_NETWORK_POLICY,
     ArchivedSandboxInfo,
+    ClearNetworkPolicy,
     ContainerResourcesInfo,
     CopySandboxResponse,
     CreateSandboxPoolResponse,
@@ -71,6 +73,22 @@ from .models import (
     UpdateSandboxRequest,
     snapshot_satisfies_wait_condition,
 )
+
+
+def _pool_update_request_json(
+    request_model: SandboxPoolRequest,
+    network: NetworkConfig | ClearNetworkPolicy | None,
+) -> str:
+    """Serialize a pool update, preserving the tri-state ``network`` contract.
+
+    ``exclude_none`` drops an unset policy so the service keeps the pool's
+    current one, while :data:`CLEAR_NETWORK_POLICY` has to reach the wire as an
+    explicit JSON ``null`` to remove it.
+    """
+    payload = json.loads(request_model.model_dump_json(exclude_none=True))
+    if network is CLEAR_NETWORK_POLICY:
+        payload["network"] = None
+    return json.dumps(payload)
 
 
 class AsyncSandboxClient:
@@ -758,14 +776,15 @@ class AsyncSandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
-        network: NetworkConfig | None = None,
+        network: NetworkConfig | ClearNetworkPolicy | None = None,
     ) -> Traced[SandboxPoolInfo]:
         """Update a sandbox pool configuration.
 
-        Omit ``network`` to keep the pool's current network policy. Set it to
-        replace the policy: the service recycles the pool's unclaimed warm
-        containers onto the new policy, while containers already claimed by
-        sandboxes keep the policy they booted with.
+        Omit ``network`` to keep the pool's current network policy, set it to
+        replace the policy, or pass :data:`CLEAR_NETWORK_POLICY` to remove the
+        policy entirely. On a change the service recycles the pool's unclaimed
+        warm containers onto the new policy, while containers already claimed
+        by sandboxes keep the policy they booted with.
         """
         request_model = SandboxPoolRequest(
             image=image,
@@ -776,12 +795,12 @@ class AsyncSandboxClient:
             entrypoint=entrypoint,
             max_containers=max_containers,
             warm_containers=warm_containers,
-            network=network,
+            network=None if network is CLEAR_NETWORK_POLICY else network,
         )
         try:
             trace_id, response_json = await self._rust_client.update_pool_async(
                 pool_id=pool_id,
-                request_json=request_model.model_dump_json(exclude_none=True),
+                request_json=_pool_update_request_json(request_model, network),
             )
             return Traced(trace_id, SandboxPoolInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -718,13 +718,19 @@ class AsyncSandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
-        network: NetworkConfig | None = None,
+        network: NetworkConfig | ClearNetworkPolicy | None = None,
     ) -> Traced[CreateSandboxPoolResponse]:
         """Create a sandbox pool.
 
         Set ``network`` to apply a network policy to each pool container. The
         policy can be replaced later with ``update_pool``.
         """
+        if network is CLEAR_NETWORK_POLICY:
+            raise ValueError(
+                "CLEAR_NETWORK_POLICY only applies to update_pool; omit network "
+                "to create a pool without a policy."
+            )
+
         request_model = SandboxPoolRequest(
             image=image,
             resources=ContainerResourcesInfo(

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -21,7 +21,9 @@ from .exceptions import (
     SandboxNotFoundError,
 )
 from .models import (
+    CLEAR_NETWORK_POLICY,
     ArchivedSandboxInfo,
+    ClearNetworkPolicy,
     ContainerResourcesInfo,
     CopySandboxResponse,
     CreateSandboxPoolResponse,
@@ -234,6 +236,22 @@ def _startup_failure_message(
     if termination_reason:
         return f"{prefix}: termination reason: {termination_reason}"
     return prefix
+
+
+def _pool_update_request_json(
+    request_model: SandboxPoolRequest,
+    network: NetworkConfig | ClearNetworkPolicy | None,
+) -> str:
+    """Serialize a pool update, preserving the tri-state ``network`` contract.
+
+    ``exclude_none`` drops an unset policy so the service keeps the pool's
+    current one, while :data:`CLEAR_NETWORK_POLICY` has to reach the wire as an
+    explicit JSON ``null`` to remove it.
+    """
+    payload = json.loads(request_model.model_dump_json(exclude_none=True))
+    if network is CLEAR_NETWORK_POLICY:
+        payload["network"] = None
+    return json.dumps(payload)
 
 
 class SandboxClient:
@@ -1260,14 +1278,15 @@ class SandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
-        network: NetworkConfig | None = None,
+        network: NetworkConfig | ClearNetworkPolicy | None = None,
     ) -> Traced[SandboxPoolInfo]:
         """Update a sandbox pool configuration.
 
-        Omit ``network`` to keep the pool's current network policy. Set it to
-        replace the policy: the service recycles the pool's unclaimed warm
-        containers onto the new policy, while containers already claimed by
-        sandboxes keep the policy they booted with.
+        Omit ``network`` to keep the pool's current network policy, set it to
+        replace the policy, or pass :data:`CLEAR_NETWORK_POLICY` to remove the
+        policy entirely. On a change the service recycles the pool's unclaimed
+        warm containers onto the new policy, while containers already claimed
+        by sandboxes keep the policy they booted with.
 
         Args:
             pool_id: ID of the pool to update
@@ -1281,7 +1300,8 @@ class SandboxClient:
             max_containers: Maximum number of containers in pool
             warm_containers: Number of warm containers to maintain
             network: Replacement network policy for each container in the
-                pool. Omit to keep the current policy.
+                pool. Omit to keep the current policy, or pass
+                ``CLEAR_NETWORK_POLICY`` to remove it.
 
         Returns:
             SandboxPoolInfo with updated pool details
@@ -1300,13 +1320,13 @@ class SandboxClient:
             entrypoint=entrypoint,
             max_containers=max_containers,
             warm_containers=warm_containers,
-            network=network,
+            network=None if network is CLEAR_NETWORK_POLICY else network,
         )
 
         try:
             trace_id, response_json = self._rust_client.update_pool(
                 pool_id=pool_id,
-                request_json=request_model.model_dump_json(exclude_none=True),
+                request_json=_pool_update_request_json(request_model, network),
             )
             return Traced(trace_id, SandboxPoolInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1183,7 +1183,7 @@ class SandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
-        network: NetworkConfig | None = None,
+        network: NetworkConfig | ClearNetworkPolicy | None = None,
     ) -> Traced[CreateSandboxPoolResponse]:
         """Create a new sandbox pool.
 
@@ -1206,6 +1206,12 @@ class SandboxClient:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
+        if network is CLEAR_NETWORK_POLICY:
+            raise ValueError(
+                "CLEAR_NETWORK_POLICY only applies to update_pool; omit network "
+                "to create a pool without a policy."
+            )
+
         request_model = SandboxPoolRequest(
             image=image,
             resources=ContainerResourcesInfo(

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1260,11 +1260,14 @@ class SandboxClient:
         entrypoint: list[str] | None = None,
         max_containers: int | None = None,
         warm_containers: int | None = None,
+        network: NetworkConfig | None = None,
     ) -> Traced[SandboxPoolInfo]:
         """Update a sandbox pool configuration.
 
-        This operation keeps the current network policy. Create a new pool to
-        use a different network policy.
+        Omit ``network`` to keep the pool's current network policy. Set it to
+        replace the policy: the service recycles the pool's unclaimed warm
+        containers onto the new policy, while containers already claimed by
+        sandboxes keep the policy they booted with.
 
         Args:
             pool_id: ID of the pool to update
@@ -1277,6 +1280,8 @@ class SandboxClient:
             entrypoint: Custom entrypoint command (optional)
             max_containers: Maximum number of containers in pool
             warm_containers: Number of warm containers to maintain
+            network: Replacement network policy for each container in the
+                pool. Omit to keep the current policy.
 
         Returns:
             SandboxPoolInfo with updated pool details
@@ -1295,6 +1300,7 @@ class SandboxClient:
             entrypoint=entrypoint,
             max_containers=max_containers,
             warm_containers=warm_containers,
+            network=network,
         )
 
         try:

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -165,6 +165,20 @@ class CreateSandboxResources(BaseModel):
     gpus: list[GPUResources] | None = None
 
 
+class ClearNetworkPolicy(Enum):
+    """Sentinel type for :data:`CLEAR_NETWORK_POLICY`."""
+
+    TOKEN = "clear"
+
+
+CLEAR_NETWORK_POLICY = ClearNetworkPolicy.TOKEN
+"""Pass as ``network`` to ``update_pool`` to remove a pool's network policy.
+
+Omitting ``network`` keeps the pool's current policy, so removing one needs an
+explicit instruction. Containers in the pool become unrestricted.
+"""
+
+
 class NetworkConfig(BaseModel):
     """Network access control policy for sandbox containers.
 

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -1266,6 +1266,14 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         pool = client.get_pool("pool-1")
         self.assertEqual(pool.network_policy, policy)
 
+    def test_clear_sentinel_is_rejected_on_pool_create(self):
+        # Clearing is only meaningful against an existing pool; creating one
+        # without a policy is just omitting the argument.
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        with self.assertRaises(ValueError) as ctx:
+            client.create_pool(image="alpine", network=CLEAR_NETWORK_POLICY)
+        self.assertIn("only applies to update_pool", str(ctx.exception))
+
     def test_pool_network_policy_update_is_sent(self):
         captured: dict[str, str] = {}
 

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from tensorlake.sandbox import (
+    CLEAR_NETWORK_POLICY,
     NetworkConfig,
     PoolInUseError,
     SandboxNotFoundError,
@@ -1314,11 +1315,20 @@ class TestSandboxClientRustBackend(unittest.TestCase):
             },
         )
 
-        # Omitting the policy must omit the key entirely so the Rust layer
-        # keeps the pool's current policy.
+        # Omitting the policy must omit the key entirely so the service keeps
+        # the pool's current policy.
         client.update_pool(pool_id="pool-1", image="alpine")
         request = json.loads(captured["request_json"])
         self.assertNotIn("network", request)
+
+        # CLEAR_NETWORK_POLICY must reach the wire as an explicit null so the
+        # service removes the policy instead of keeping it.
+        client.update_pool(
+            pool_id="pool-1", image="alpine", network=CLEAR_NETWORK_POLICY
+        )
+        request = json.loads(captured["request_json"])
+        self.assertIn("network", request)
+        self.assertIsNone(request["network"])
 
     def test_snapshot_threads_snapshot_type_to_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -1265,6 +1265,61 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         pool = client.get_pool("pool-1")
         self.assertEqual(pool.network_policy, policy)
 
+    def test_pool_network_policy_update_is_sent(self):
+        captured: dict[str, str] = {}
+
+        class _PoolRustClient:
+            def close(self):
+                return None
+
+            def update_pool(self, pool_id, request_json):
+                captured["pool_id"] = pool_id
+                captured["request_json"] = request_json
+                return (
+                    "trace-update",
+                    json.dumps(
+                        {
+                            "pool_id": "pool-1",
+                            "namespace": "default",
+                            "image": "alpine",
+                            "resources": {
+                                "cpus": 1.0,
+                                "memory_mb": 1024,
+                                "ephemeral_disk_mb": 1024,
+                            },
+                        }
+                    ),
+                )
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _PoolRustClient()
+
+        client.update_pool(
+            pool_id="pool-1",
+            image="alpine",
+            network=NetworkConfig(
+                allow_internet_access=False,
+                allow_out=[],
+                deny_out=["192.0.2.0/24"],
+            ),
+        )
+        request = json.loads(captured["request_json"])
+        self.assertEqual(captured["pool_id"], "pool-1")
+        self.assertEqual(
+            request["network"],
+            {
+                "allow_internet_access": False,
+                "allow_out": [],
+                "deny_out": ["192.0.2.0/24"],
+            },
+        )
+
+        # Omitting the policy must omit the key entirely so the Rust layer
+        # keeps the pool's current policy.
+        client.update_pool(pool_id="pool-1", image="alpine")
+        request = json.loads(captured["request_json"])
+        self.assertNotIn("network", request)
+
     def test_snapshot_threads_snapshot_type_to_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         fake = _FakeRustClient()

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch
 
 from tensorlake.sandbox import (
+    CLEAR_NETWORK_POLICY,
     NetworkConfig,
     PoolInUseError,
     SandboxNotFoundError,
@@ -1219,6 +1220,57 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
                 await client.delete_pool("pool-1")
         finally:
             sandbox_client_module.RustCloudSandboxClientError = previous
+
+    async def test_pool_network_policy_update_is_sent(self):
+        captured: dict[str, str] = {}
+
+        class _PoolRustClient:
+            def close(self):
+                return None
+
+            async def update_pool_async(self, pool_id, request_json):
+                captured["pool_id"] = pool_id
+                captured["request_json"] = request_json
+                return (
+                    "trace-update",
+                    json.dumps(
+                        {
+                            "pool_id": "pool-1",
+                            "namespace": "default",
+                            "image": "alpine",
+                            "resources": {
+                                "cpus": 1.0,
+                                "memory_mb": 1024,
+                                "ephemeral_disk_mb": 1024,
+                            },
+                        }
+                    ),
+                )
+
+        client = AsyncSandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _PoolRustClient()
+
+        await client.update_pool(
+            pool_id="pool-1",
+            image="alpine",
+            network=NetworkConfig(
+                allow_internet_access=False, allow_out=[], deny_out=[]
+            ),
+        )
+        request = json.loads(captured["request_json"])
+        self.assertEqual(captured["pool_id"], "pool-1")
+        self.assertEqual(request["network"]["allow_internet_access"], False)
+
+        # Omitted keeps the current policy; the sentinel clears it.
+        await client.update_pool(pool_id="pool-1", image="alpine")
+        self.assertNotIn("network", json.loads(captured["request_json"]))
+
+        await client.update_pool(
+            pool_id="pool-1", image="alpine", network=CLEAR_NETWORK_POLICY
+        )
+        request = json.loads(captured["request_json"])
+        self.assertIn("network", request)
+        self.assertIsNone(request["network"])
 
     async def test_pool_network_policy_is_sent_and_returned(self):
         captured: dict[str, str] = {}

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.90",
+  "version": "0.5.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.90",
+      "version": "0.5.91",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.90",
+  "version": "0.5.91",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -138,7 +138,9 @@ export class SandboxClient {
     // The native client releases its connection pool on GC; nothing to do.
   }
 
-  private withRequestTimeout(requestTimeout: number | undefined): SandboxClient {
+  private withRequestTimeout(
+    requestTimeout: number | undefined,
+  ): SandboxClient {
     if (requestTimeout == null) {
       return this;
     }
@@ -146,14 +148,17 @@ export class SandboxClient {
     if (timeoutMs === this.requestTimeoutMs) {
       return this;
     }
-    return new SandboxClient({
-      apiUrl: this.apiUrl,
-      apiKey: this.apiKey,
-      organizationId: this.organizationId,
-      projectId: this.projectId,
-      namespace: this.namespace,
-      timeoutMs,
-    }, /* _internal */ true);
+    return new SandboxClient(
+      {
+        apiUrl: this.apiUrl,
+        apiKey: this.apiKey,
+        organizationId: this.organizationId,
+        projectId: this.projectId,
+        namespace: this.namespace,
+        timeoutMs,
+      },
+      /* _internal */ true,
+    );
   }
 
   // --- Native marshalling helpers ---
@@ -183,7 +188,9 @@ export class SandboxClient {
   // --- Sandbox CRUD ---
 
   /** Create a new sandbox. Returns immediately; the sandbox may still be starting. Use `createAndConnect()` for a blocking, ready-to-use handle. */
-  async create(options?: CreateSandboxOptions): Promise<Traced<CreateSandboxResponse>> {
+  async create(
+    options?: CreateSandboxOptions,
+  ): Promise<Traced<CreateSandboxResponse>> {
     const gpuResources = gpuRequest(options?.gpus, options?.gpuModel);
     const body: Record<string, unknown> = {
       resources: {
@@ -199,10 +206,7 @@ export class SandboxClient {
     if (options?.entrypoint != null) body.entrypoint = options.entrypoint;
     if (options?.snapshotId != null) body.snapshot_id = options.snapshotId;
     if (options?.name != null) body.name = options.name;
-    if (
-      options?.fileSystems != null &&
-      options.fileSystems.length > 0
-    ) {
+    if (options?.fileSystems != null && options.fileSystems.length > 0) {
       body.file_systems = options.fileSystems.map((fs) => ({
         file_system_id: fs.fileSystemId,
         mount_path: fs.mountPath,
@@ -238,8 +242,12 @@ export class SandboxClient {
 
   /** List all sandboxes in the namespace. */
   async list(): Promise<Traced<SandboxInfo[]>> {
-    const { traceId, json } = await callNative(() => this.native.listSandboxes());
-    const parsed = JSON.parse(json) as { sandboxes?: Record<string, unknown>[] };
+    const { traceId, json } = await callNative(() =>
+      this.native.listSandboxes(),
+    );
+    const parsed = JSON.parse(json) as {
+      sandboxes?: Record<string, unknown>[];
+    };
     const sandboxes = (parsed.sandboxes ?? []).map(
       (s) => fromSnakeKeys(s, "sandboxId") as SandboxInfo,
     );
@@ -322,7 +330,10 @@ export class SandboxClient {
   }
 
   /** Update sandbox properties such as name, exposed ports, and proxy auth settings. */
-  async update(sandboxId: string, options: UpdateSandboxOptions): Promise<Traced<SandboxInfo>> {
+  async update(
+    sandboxId: string,
+    options: UpdateSandboxOptions,
+  ): Promise<Traced<SandboxInfo>> {
     const body: Record<string, unknown> = {};
     if (options.name != null) body.name = options.name;
     if (options.allowUnauthenticatedAccess != null) {
@@ -332,7 +343,9 @@ export class SandboxClient {
       body.exposed_ports = normalizeUserPorts(options.exposedPorts);
     }
     if (Object.keys(body).length === 0) {
-      throw new SandboxError("At least one sandbox update field must be provided.");
+      throw new SandboxError(
+        "At least one sandbox update field must be provided.",
+      );
     }
     return this.tracedJson<SandboxInfo>(
       () => this.native.updateSandbox(sandboxId, JSON.stringify(body)),
@@ -380,7 +393,9 @@ export class SandboxClient {
     const requestedPorts = normalizeUserPorts(ports);
     const current = await this.getPortAccess(sandboxId);
     const toRemove = new Set(requestedPorts);
-    const desiredPorts = current.exposedPorts.filter((port) => !toRemove.has(port));
+    const desiredPorts = current.exposedPorts.filter(
+      (port) => !toRemove.has(port),
+    );
     return this.update(sandboxId, {
       allowUnauthenticatedAccess: desiredPorts.length
         ? current.allowUnauthenticatedAccess
@@ -391,7 +406,10 @@ export class SandboxClient {
 
   /** Terminate and delete a sandbox. */
   async delete(sandboxId: string): Promise<void> {
-    await callNative(() => this.native.deleteSandbox(sandboxId), { sandboxId, notFoundKind: "sandbox" });
+    await callNative(() => this.native.deleteSandbox(sandboxId), {
+      sandboxId,
+      notFoundKind: "sandbox",
+    });
   }
 
   /**
@@ -402,8 +420,14 @@ export class SandboxClient {
    * `{ wait: false }` to return immediately after the request is sent
    * (fire-and-return); the server processes the suspend asynchronously.
    */
-  async suspend(sandboxId: string, options?: SuspendResumeOptions): Promise<void> {
-    await callNative(() => this.native.suspendSandbox(sandboxId), { sandboxId, notFoundKind: "sandbox" });
+  async suspend(
+    sandboxId: string,
+    options?: SuspendResumeOptions,
+  ): Promise<void> {
+    await callNative(() => this.native.suspendSandbox(sandboxId), {
+      sandboxId,
+      notFoundKind: "sandbox",
+    });
     if (options?.wait === false) return;
     const timeout = options?.timeout ?? 300;
     const pollInterval = options?.pollInterval ?? 1;
@@ -412,11 +436,15 @@ export class SandboxClient {
       const info = await this.get(sandboxId);
       if (info.status === SandboxStatus.SUSPENDED) return;
       if (info.status === SandboxStatus.TERMINATED) {
-        throw new SandboxError(`Sandbox ${sandboxId} terminated while waiting for suspend`);
+        throw new SandboxError(
+          `Sandbox ${sandboxId} terminated while waiting for suspend`,
+        );
       }
       await sleep(pollInterval * 1000);
     }
-    throw new SandboxError(`Sandbox ${sandboxId} did not suspend within ${timeout}s`);
+    throw new SandboxError(
+      `Sandbox ${sandboxId} did not suspend within ${timeout}s`,
+    );
   }
 
   /**
@@ -426,8 +454,14 @@ export class SandboxClient {
    * `{ wait: false }` to return immediately after the request is sent
    * (fire-and-return); the server processes the resume asynchronously.
    */
-  async resume(sandboxId: string, options?: SuspendResumeOptions): Promise<void> {
-    await callNative(() => this.native.resumeSandbox(sandboxId), { sandboxId, notFoundKind: "sandbox" });
+  async resume(
+    sandboxId: string,
+    options?: SuspendResumeOptions,
+  ): Promise<void> {
+    await callNative(() => this.native.resumeSandbox(sandboxId), {
+      sandboxId,
+      notFoundKind: "sandbox",
+    });
     if (options?.wait === false) return;
     const timeout = options?.timeout ?? 300;
     const pollInterval = options?.pollInterval ?? 1;
@@ -436,11 +470,15 @@ export class SandboxClient {
       const info = await this.get(sandboxId);
       if (info.status === SandboxStatus.RUNNING) return;
       if (info.status === SandboxStatus.TERMINATED) {
-        throw new SandboxError(`Sandbox ${sandboxId} terminated while waiting for resume`);
+        throw new SandboxError(
+          `Sandbox ${sandboxId} terminated while waiting for resume`,
+        );
       }
       await sleep(pollInterval * 1000);
     }
-    throw new SandboxError(`Sandbox ${sandboxId} did not resume within ${timeout}s`);
+    throw new SandboxError(
+      `Sandbox ${sandboxId} did not resume within ${timeout}s`,
+    );
   }
 
   /**
@@ -455,8 +493,7 @@ export class SandboxClient {
     mountPath: string,
   ): Promise<Traced<SandboxInfo>> {
     return this.tracedJson<SandboxInfo>(
-      () =>
-        this.native.attachFileSystem(sandboxId, fileSystemId, mountPath),
+      () => this.native.attachFileSystem(sandboxId, fileSystemId, mountPath),
       "sandboxId",
       { sandboxId, notFoundKind: "sandbox" },
     );
@@ -526,7 +563,8 @@ export class SandboxClient {
     options?: SnapshotOptions,
   ): Promise<CreateSnapshotResponse> {
     return this.plainJson<CreateSnapshotResponse>(
-      () => this.native.createSnapshot(sandboxId, options?.snapshotType ?? null),
+      () =>
+        this.native.createSnapshot(sandboxId, options?.snapshotType ?? null),
       "snapshotId",
       { sandboxId, notFoundKind: "sandbox" },
     );
@@ -542,8 +580,12 @@ export class SandboxClient {
 
   /** List all snapshots in the namespace. */
   async listSnapshots(): Promise<Traced<SnapshotInfo[]>> {
-    const { traceId, json } = await callNative(() => this.native.listSnapshots());
-    const parsed = JSON.parse(json) as { snapshots?: Record<string, unknown>[] };
+    const { traceId, json } = await callNative(() =>
+      this.native.listSnapshots(),
+    );
+    const parsed = JSON.parse(json) as {
+      snapshots?: Record<string, unknown>[];
+    };
     const snapshots = (parsed.snapshots ?? []).map(
       (s) => fromSnakeKeys(s, "snapshotId") as SnapshotInfo,
     );
@@ -577,7 +619,8 @@ export class SandboxClient {
 
     while (Date.now() < deadline) {
       const info = await this.getSnapshot(result.snapshotId);
-      if (snapshotStatusSatisfiesWaitCondition(info.status, waitUntil)) return info;
+      if (snapshotStatusSatisfiesWaitCondition(info.status, waitUntil))
+        return info;
       if (info.status === SnapshotStatus.FAILED) {
         throw new SandboxError(
           `Snapshot ${result.snapshotId} failed: ${info.error}`,
@@ -594,7 +637,9 @@ export class SandboxClient {
   // --- Pools ---
 
   /** Create a new sandbox pool with warm pre-booted containers. */
-  async createPool(options: CreatePoolOptions): Promise<CreateSandboxPoolResponse> {
+  async createPool(
+    options: CreatePoolOptions,
+  ): Promise<CreateSandboxPoolResponse> {
     const body: Record<string, unknown> = {
       image: options.image,
       resources: {
@@ -606,8 +651,10 @@ export class SandboxClient {
     };
 
     if (options.entrypoint != null) body.entrypoint = options.entrypoint;
-    if (options.maxContainers != null) body.max_containers = options.maxContainers;
-    if (options.warmContainers != null) body.warm_containers = options.warmContainers;
+    if (options.maxContainers != null)
+      body.max_containers = options.maxContainers;
+    if (options.warmContainers != null)
+      body.warm_containers = options.warmContainers;
     if (options.network != null) body.network = toSnakeKeys(options.network);
 
     return this.plainJson<CreateSandboxPoolResponse>(
@@ -635,17 +682,16 @@ export class SandboxClient {
     return Object.assign(pools, { traceId });
   }
 
-  /** Replace a pool configuration and keep its current network policy. */
+  /**
+   * Replace a pool configuration. Omit `network` to keep the pool's current
+   * network policy; set it to replace the policy — the service recycles the
+   * pool's unclaimed warm containers onto the new policy, while containers
+   * already claimed by sandboxes keep the policy they booted with.
+   */
   async updatePool(
     poolId: string,
     options: UpdatePoolOptions,
   ): Promise<SandboxPoolInfo> {
-    if ((options as UpdatePoolOptions & { network?: unknown }).network != null) {
-      throw new SandboxError(
-        "Network policy updates are not supported. Create a new pool to change the network policy.",
-      );
-    }
-
     const body: Record<string, unknown> = {
       image: options.image,
       resources: {
@@ -657,8 +703,11 @@ export class SandboxClient {
     };
 
     if (options.entrypoint != null) body.entrypoint = options.entrypoint;
-    if (options.maxContainers != null) body.max_containers = options.maxContainers;
-    if (options.warmContainers != null) body.warm_containers = options.warmContainers;
+    if (options.maxContainers != null)
+      body.max_containers = options.maxContainers;
+    if (options.warmContainers != null)
+      body.warm_containers = options.warmContainers;
+    if (options.network != null) body.network = toSnakeKeys(options.network);
 
     return this.plainJson<SandboxPoolInfo>(
       () => this.native.updatePool(poolId, JSON.stringify(body)),
@@ -669,7 +718,10 @@ export class SandboxClient {
 
   /** Delete a sandbox pool. Fails if the pool has active containers. */
   async deletePool(poolId: string): Promise<void> {
-    await callNative(() => this.native.deletePool(poolId), { poolId, notFoundKind: "pool" });
+    await callNative(() => this.native.deletePool(poolId), {
+      poolId,
+      notFoundKind: "pool",
+    });
   }
 
   // --- Connect ---
@@ -684,8 +736,8 @@ export class SandboxClient {
   ): Sandbox {
     const explicitProxyUrlProvided = arguments.length >= 5;
     const resolvedExplicitProxyUrl = explicitProxyUrlProvided
-      ? explicitProxyUrl ?? undefined
-      : proxyUrl ?? explicitProxyUrlOverride() ?? undefined;
+      ? (explicitProxyUrl ?? undefined)
+      : (proxyUrl ?? explicitProxyUrlOverride() ?? undefined);
     return new Sandbox({
       sandboxId: identifier,
       proxyUrl,
@@ -694,7 +746,8 @@ export class SandboxClient {
       organizationId: this.organizationId,
       projectId: this.projectId,
       routingHint,
-      resolveProxyInfo: async (currentIdentifier) => this.get(currentIdentifier),
+      resolveProxyInfo: async (currentIdentifier) =>
+        this.get(currentIdentifier),
       requestTimeout,
       nativeClient: this.native,
     });
@@ -706,9 +759,7 @@ export class SandboxClient {
    * Blocks until the sandbox is ready or `requestTimeout` elapses. The returned
    * `Sandbox` auto-terminates when `terminate()` is called.
    */
-  async createAndConnect(
-    options?: CreateAndConnectOptions,
-  ): Promise<Sandbox> {
+  async createAndConnect(options?: CreateAndConnectOptions): Promise<Sandbox> {
     const opStart = nowMs();
     const requestTimeout =
       options?.requestTimeout ??
@@ -724,15 +775,22 @@ export class SandboxClient {
     // claim() never sends options.name to the server, so only create() should fall
     // back to it locally when the server response omits a name.
     const createStart = nowMs();
-    const result = options?.poolId != null
-      ? await requestClient.claim(options.poolId)
-      : await requestClient.create(options);
-    logSdkTiming("sandbox.create", options?.poolId != null ? "claim_response" : "create_response", createStart, {
-      sandbox_id: result.sandboxId,
-      status: result.status,
-      server_trace_id: result.traceId,
-    });
-    const requestedName = options?.poolId != null ? null : options?.name ?? null;
+    const result =
+      options?.poolId != null
+        ? await requestClient.claim(options.poolId)
+        : await requestClient.create(options);
+    logSdkTiming(
+      "sandbox.create",
+      options?.poolId != null ? "claim_response" : "create_response",
+      createStart,
+      {
+        sandbox_id: result.sandboxId,
+        status: result.status,
+        server_trace_id: result.traceId,
+      },
+    );
+    const requestedName =
+      options?.poolId != null ? null : (options?.name ?? null);
 
     const finishConnect = (
       sandboxId: string,
@@ -741,7 +799,8 @@ export class SandboxClient {
       ingressEndpoint: string | undefined,
       sandboxUrl: string | undefined,
     ) => {
-      const explicitProxyUrl = options?.proxyUrl ?? explicitProxyUrlOverride() ?? undefined;
+      const explicitProxyUrl =
+        options?.proxyUrl ?? explicitProxyUrlOverride() ?? undefined;
       const selectedProxyUrl = this.native.selectSandboxProxyUrl(
         sandboxId,
         sandboxUrl ?? null,
@@ -849,9 +908,10 @@ export class SandboxClient {
   }
 }
 
-function resolveRequestTimeoutMs(
-  options?: { requestTimeout?: number; timeoutMs?: number },
-): number {
+function resolveRequestTimeoutMs(options?: {
+  requestTimeout?: number;
+  timeoutMs?: number;
+}): number {
   if (options?.requestTimeout != null) {
     return secondsToMillis(options.requestTimeout);
   }
@@ -864,14 +924,18 @@ function resolveRequestTimeoutMs(
 
 function secondsToMillis(seconds: number): number {
   if (!Number.isFinite(seconds) || seconds <= 0) {
-    throw new SandboxError("requestTimeout must be a positive number of seconds");
+    throw new SandboxError(
+      "requestTimeout must be a positive number of seconds",
+    );
   }
   return Math.ceil(seconds * 1000);
 }
 
 function validateTimeoutMs(timeoutMs: number): void {
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    throw new SandboxError("timeoutMs must be a positive number of milliseconds");
+    throw new SandboxError(
+      "timeoutMs must be a positive number of milliseconds",
+    );
   }
 }
 
@@ -884,7 +948,10 @@ function snapshotStatusSatisfiesWaitCondition(
   waitUntil: SnapshotWaitCondition,
 ): boolean {
   if (waitUntil === "local_ready") {
-    return status === SnapshotStatus.LOCAL_READY || status === SnapshotStatus.COMPLETED;
+    return (
+      status === SnapshotStatus.LOCAL_READY ||
+      status === SnapshotStatus.COMPLETED
+    );
   }
   return status === SnapshotStatus.COMPLETED;
 }
@@ -897,9 +964,10 @@ function formatStartupFailureMessage(
     terminationReason?: string;
   },
 ): string {
-  const prefix = status === SandboxStatus.TERMINATED
-    ? `Sandbox ${sandboxId} terminated during startup`
-    : `Sandbox ${sandboxId} became ${status} during startup`;
+  const prefix =
+    status === SandboxStatus.TERMINATED
+      ? `Sandbox ${sandboxId} terminated during startup`
+      : `Sandbox ${sandboxId} became ${status} during startup`;
   const detail = formatErrorDetails(options.errorDetails);
   if (detail) {
     return `${prefix}: ${detail}`;

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -684,9 +684,10 @@ export class SandboxClient {
 
   /**
    * Replace a pool configuration. Omit `network` to keep the pool's current
-   * network policy; set it to replace the policy — the service recycles the
-   * pool's unclaimed warm containers onto the new policy, while containers
-   * already claimed by sandboxes keep the policy they booted with.
+   * network policy, set it to replace the policy, or pass `null` to remove the
+   * policy entirely. On a change the service recycles the pool's unclaimed
+   * warm containers onto the new policy, while containers already claimed by
+   * sandboxes keep the policy they booted with.
    */
   async updatePool(
     poolId: string,
@@ -707,7 +708,12 @@ export class SandboxClient {
       body.max_containers = options.maxContainers;
     if (options.warmContainers != null)
       body.warm_containers = options.warmContainers;
-    if (options.network != null) body.network = toSnakeKeys(options.network);
+    // Tri-state: omit to keep the current policy, `null` to clear it, an
+    // object to replace it.
+    if (options.network !== undefined) {
+      body.network =
+        options.network === null ? null : toSnakeKeys(options.network);
+    }
 
     return this.plainJson<SandboxPoolInfo>(
       () => this.native.updatePool(poolId, JSON.stringify(body)),

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -259,12 +259,7 @@ export interface SnapshotAndWaitOptions extends SnapshotOptions {
 // --- Persisted sandbox logs ---
 
 export type SandboxLogLevel =
-  | "trace"
-  | "debug"
-  | "info"
-  | "warn"
-  | "error"
-  | "fatal";
+  "trace" | "debug" | "info" | "warn" | "error" | "fatal";
 
 export interface GetSandboxLogsOptions {
   levels?: SandboxLogLevel[];
@@ -322,11 +317,17 @@ export interface CreatePoolOptions {
   entrypoint?: string[];
   maxContainers?: number;
   warmContainers?: number;
-  /** Network policy for each container. Create a new pool to change this policy. */
+  /** Network policy for each container. Can be replaced later via updatePool. */
   network?: NetworkConfig;
 }
 
 export interface UpdatePoolOptions {
+  /**
+   * Network policy for each container. Omit to keep the pool's current
+   * policy; set to replace it (unclaimed warm containers are recycled onto
+   * the new policy).
+   */
+  network?: NetworkConfig;
   /** Sandbox image name, such as `tensorlake/ubuntu-minimal` or a registered Sandbox Image. */
   image: string;
   cpus?: number;
@@ -399,16 +400,10 @@ export interface ProcessHealthCheck {
 }
 
 export type ManagedProcessStatus =
-  | "starting"
-  | "running"
-  | "backing_off"
-  | "stopped";
+  "starting" | "running" | "backing_off" | "stopped";
 
 export type ManagedProcessHealthStatus =
-  | "disabled"
-  | "starting"
-  | "healthy"
-  | "unhealthy";
+  "disabled" | "starting" | "healthy" | "unhealthy";
 
 export interface ManagedProcessExit {
   exitCode?: number;
@@ -676,11 +671,9 @@ export function parseTimestamp(v: unknown): Date | undefined {
  * Recursively convert all object keys from snake_case to camelCase,
  * with special handling for `id` → contextual name and timestamp parsing.
  */
-export function fromSnakeKeys(
-  obj: unknown,
-  idField?: string,
-): unknown {
-  if (Array.isArray(obj)) return obj.map((item) => fromSnakeKeys(item, idField));
+export function fromSnakeKeys(obj: unknown, idField?: string): unknown {
+  if (Array.isArray(obj))
+    return obj.map((item) => fromSnakeKeys(item, idField));
   if (obj !== null && typeof obj === "object" && !(obj instanceof Date)) {
     const result: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -323,11 +323,11 @@ export interface CreatePoolOptions {
 
 export interface UpdatePoolOptions {
   /**
-   * Network policy for each container. Omit to keep the pool's current
-   * policy; set to replace it (unclaimed warm containers are recycled onto
-   * the new policy).
+   * Network policy for each container. Omit to keep the pool's current policy,
+   * set to replace it, or pass `null` to remove it (unclaimed warm containers
+   * are recycled onto the new policy).
    */
-  network?: NetworkConfig;
+  network?: NetworkConfig | null;
   /** Sandbox image name, such as `tensorlake/ubuntu-minimal` or a registered Sandbox Image. */
   image: string;
   cpus?: number;

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -10,9 +10,7 @@ import { clearNativeStub, installNativeStub } from "./native-stub.js";
 
 /** Build the native error a non-2xx HTTP response now surfaces from Rust. */
 function nativeError(status: number, message: string): Error {
-  return new Error(
-    JSON.stringify({ category: "remote_api", status, message }),
-  );
+  return new Error(JSON.stringify({ category: "remote_api", status, message }));
 }
 
 describe("SandboxClient", () => {
@@ -72,7 +70,10 @@ describe("SandboxClient", () => {
             expect(body.resources.gpus).toEqual([{ count: 1, model: "A10" }]);
             return {
               traceId: "t",
-              json: JSON.stringify({ sandbox_id: "sbx-gpu", status: "pending" }),
+              json: JSON.stringify({
+                sandbox_id: "sbx-gpu",
+                status: "pending",
+              }),
             };
           }),
         },
@@ -92,7 +93,10 @@ describe("SandboxClient", () => {
             expect(body.resources.gpus).toBeUndefined();
             return {
               traceId: "t",
-              json: JSON.stringify({ sandbox_id: "sbx-cpu", status: "pending" }),
+              json: JSON.stringify({
+                sandbox_id: "sbx-cpu",
+                status: "pending",
+              }),
             };
           }),
         },
@@ -112,9 +116,9 @@ describe("SandboxClient", () => {
       });
 
       const client = SandboxClient.forLocalhost();
-      await expect(client.create({ gpus: 1, gpuModel: "H100" })).rejects.toThrow(
-        "only A10",
-      );
+      await expect(
+        client.create({ gpus: 1, gpuModel: "H100" }),
+      ).rejects.toThrow("only A10");
       client.close();
     });
 
@@ -162,7 +166,10 @@ describe("SandboxClient", () => {
             expect(body.name).toBe("my-sandbox");
             return {
               traceId: "t",
-              json: JSON.stringify({ sandbox_id: "sbx-named", status: "pending" }),
+              json: JSON.stringify({
+                sandbox_id: "sbx-named",
+                status: "pending",
+              }),
             };
           }),
         },
@@ -219,7 +226,6 @@ describe("SandboxClient", () => {
       expect(createSandbox).toHaveBeenCalledOnce();
       client.close();
     });
-
   });
 
   describe("get", () => {
@@ -293,7 +299,9 @@ describe("SandboxClient", () => {
       const info = await client.get("sbx-ports");
       expect(info.allowUnauthenticatedAccess).toBe(true);
       expect(info.exposedPorts).toEqual([8080, 3000]);
-      expect(info.ingressEndpoint).toBe("https://sandbox.us-east-1.aws.tensorlake.ai");
+      expect(info.ingressEndpoint).toBe(
+        "https://sandbox.us-east-1.aws.tensorlake.ai",
+      );
       expect(info.sandboxUrl).toBe("https://sbx-ports.sandbox.tensorlake.ai");
       client.close();
     });
@@ -332,7 +340,11 @@ describe("SandboxClient", () => {
                   id: "sbx-1",
                   namespace: "default",
                   status: "running",
-                  resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
+                  resources: {
+                    cpus: 1,
+                    memory_mb: 1024,
+                    ephemeral_disk_mb: 1024,
+                  },
                 },
               ],
             }),
@@ -379,7 +391,11 @@ describe("SandboxClient", () => {
                 id: "sbx-1",
                 namespace: "default",
                 status: "running",
-                resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
+                resources: {
+                  cpus: 1,
+                  memory_mb: 1024,
+                  ephemeral_disk_mb: 1024,
+                },
                 name: "my-new-name",
               }),
             };
@@ -409,7 +425,11 @@ describe("SandboxClient", () => {
                 id: "sbx-1",
                 namespace: "default",
                 status: "running",
-                resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
+                resources: {
+                  cpus: 1,
+                  memory_mb: 1024,
+                  ephemeral_disk_mb: 1024,
+                },
                 allow_unauthenticated_access: true,
                 exposed_ports: [8080, 8081],
               }),
@@ -462,7 +482,9 @@ describe("SandboxClient", () => {
       const access = await client.getPortAccess("sbx-1");
       expect(access.allowUnauthenticatedAccess).toBe(false);
       expect(access.exposedPorts).toEqual([8080]);
-      expect(access.ingressEndpoint).toBe("https://sandbox.us-east-1.aws.tensorlake.ai");
+      expect(access.ingressEndpoint).toBe(
+        "https://sandbox.us-east-1.aws.tensorlake.ai",
+      );
       expect(access.sandboxUrl).toBe("https://sbx-1.sandbox.tensorlake.ai");
       client.close();
     });
@@ -491,7 +513,11 @@ describe("SandboxClient", () => {
                 id: "sbx-1",
                 namespace: "default",
                 status: "running",
-                resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
+                resources: {
+                  cpus: 1,
+                  memory_mb: 1024,
+                  ephemeral_disk_mb: 1024,
+                },
                 allow_unauthenticated_access: true,
                 exposed_ports: [8080, 8081],
               }),
@@ -532,7 +558,11 @@ describe("SandboxClient", () => {
                 id: "sbx-1",
                 namespace: "default",
                 status: "running",
-                resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
+                resources: {
+                  cpus: 1,
+                  memory_mb: 1024,
+                  ephemeral_disk_mb: 1024,
+                },
                 allow_unauthenticated_access: false,
                 exposed_ports: [],
               }),
@@ -573,7 +603,9 @@ describe("SandboxClient", () => {
       const stub = installNativeStub();
 
       const client = SandboxClient.forLocalhost();
-      await expect(client.suspend("sbx-1", { wait: false })).resolves.toBeUndefined();
+      await expect(
+        client.suspend("sbx-1", { wait: false }),
+      ).resolves.toBeUndefined();
       expect(stub.client.suspendSandbox).toHaveBeenCalledWith("sbx-1");
       client.close();
     });
@@ -606,7 +638,9 @@ describe("SandboxClient", () => {
       const stub = installNativeStub();
 
       const client = SandboxClient.forLocalhost();
-      await expect(client.resume("sbx-1", { wait: false })).resolves.toBeUndefined();
+      await expect(
+        client.resume("sbx-1", { wait: false }),
+      ).resolves.toBeUndefined();
       expect(stub.client.resumeSandbox).toHaveBeenCalledWith("sbx-1");
       client.close();
     });
@@ -900,7 +934,10 @@ describe("SandboxClient", () => {
         client: {
           createSandbox: vi.fn(async () => ({
             traceId: "t",
-            json: JSON.stringify({ sandbox_id: "sbx-timeout", status: "timeout" }),
+            json: JSON.stringify({
+              sandbox_id: "sbx-timeout",
+              status: "timeout",
+            }),
           })),
           deleteSandbox,
         },
@@ -928,7 +965,9 @@ describe("SandboxClient", () => {
               namespace: "default",
               status: "terminated",
               resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
-              error_details: { message: "failed to pull image tensorlake/missing-image" },
+              error_details: {
+                message: "failed to pull image tensorlake/missing-image",
+              },
             }),
           })),
         },
@@ -950,7 +989,10 @@ describe("SandboxClient", () => {
         client: {
           createSnapshot: vi.fn(async () => ({
             traceId: "t",
-            json: JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
+            json: JSON.stringify({
+              snapshot_id: "snap-1",
+              status: "in_progress",
+            }),
           })),
         },
       });
@@ -1029,7 +1071,10 @@ describe("SandboxClient", () => {
         client: {
           createSnapshot: vi.fn(async () => ({
             traceId: "t",
-            json: JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
+            json: JSON.stringify({
+              snapshot_id: "snap-1",
+              status: "in_progress",
+            }),
           })),
           getSnapshot: vi.fn(async () => ({
             traceId: "t",
@@ -1057,7 +1102,10 @@ describe("SandboxClient", () => {
         client: {
           createSnapshot: vi.fn(async () => ({
             traceId: "t",
-            json: JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
+            json: JSON.stringify({
+              snapshot_id: "snap-1",
+              status: "in_progress",
+            }),
           })),
           getSnapshot: vi.fn(async () => {
             getCalls += 1;
@@ -1192,24 +1240,65 @@ describe("SandboxClient", () => {
       client.close();
     });
 
-    it("rejects a network policy on pool update", async () => {
-      const updatePool = vi.fn();
+    it("sends a replacement network policy on pool update", async () => {
+      const updatePool = vi.fn(async () => ({
+        traceId: "t",
+        json: JSON.stringify({
+          pool_id: "pool-1",
+          namespace: "default",
+          image: "node:20",
+          network_policy: {
+            allow_internet_access: false,
+            allow_out: ["10.0.0.0/8"],
+            deny_out: [],
+          },
+        }),
+      }));
       installNativeStub({ client: { updatePool } });
 
       const client = SandboxClient.forLocalhost();
-      await expect(
-        client.updatePool("pool-1", {
-          image: "node:20",
-          network: {
-            allowInternetAccess: true,
-            allowOut: [],
-            denyOut: [],
-          },
-        } as UpdatePoolOptions & { network: NetworkConfig }),
-      ).rejects.toThrow(
-        "Network policy updates are not supported. Create a new pool to change the network policy.",
-      );
-      expect(updatePool).not.toHaveBeenCalled();
+      const info = await client.updatePool("pool-1", {
+        image: "node:20",
+        network: {
+          allowInternetAccess: false,
+          allowOut: ["10.0.0.0/8"],
+          denyOut: [],
+        },
+      });
+      expect(updatePool).toHaveBeenCalledTimes(1);
+      const [, bodyJson] = updatePool.mock.calls[0] as unknown as [
+        string,
+        string,
+      ];
+      const body = JSON.parse(bodyJson) as Record<string, unknown>;
+      expect(body.network).toEqual({
+        allow_internet_access: false,
+        allow_out: ["10.0.0.0/8"],
+        deny_out: [],
+      });
+      expect(info.networkPolicy).toEqual({
+        allowInternetAccess: false,
+        allowOut: ["10.0.0.0/8"],
+        denyOut: [],
+      });
+      client.close();
+    });
+
+    it("omits network from the update body when not provided", async () => {
+      const updatePool = vi.fn(async () => ({
+        traceId: "t",
+        json: JSON.stringify({ pool_id: "pool-1", namespace: "default" }),
+      }));
+      installNativeStub({ client: { updatePool } });
+
+      const client = SandboxClient.forLocalhost();
+      await client.updatePool("pool-1", { image: "node:20" });
+      const [, bodyJson] = updatePool.mock.calls[0] as unknown as [
+        string,
+        string,
+      ];
+      const body = JSON.parse(bodyJson) as Record<string, unknown>;
+      expect(body).not.toHaveProperty("network");
       client.close();
     });
   });

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SandboxClient } from "../src/client.js";
-import {
-  type NetworkConfig,
-  SandboxStatus,
-  SnapshotStatus,
-  type UpdatePoolOptions,
-} from "../src/models.js";
+import { SandboxStatus, SnapshotStatus } from "../src/models.js";
 import { clearNativeStub, installNativeStub } from "./native-stub.js";
 
 /** Build the native error a non-2xx HTTP response now surfaces from Rust. */
@@ -1281,6 +1276,25 @@ describe("SandboxClient", () => {
         allowOut: ["10.0.0.0/8"],
         denyOut: [],
       });
+      client.close();
+    });
+
+    it("sends an explicit null to clear the network policy on update", async () => {
+      const updatePool = vi.fn(async () => ({
+        traceId: "t",
+        json: JSON.stringify({ pool_id: "pool-1", namespace: "default" }),
+      }));
+      installNativeStub({ client: { updatePool } });
+
+      const client = SandboxClient.forLocalhost();
+      await client.updatePool("pool-1", { image: "node:20", network: null });
+      const [, bodyJson] = updatePool.mock.calls[0] as unknown as [
+        string,
+        string,
+      ];
+      const body = JSON.parse(bodyJson) as Record<string, unknown>;
+      expect(body).toHaveProperty("network");
+      expect(body.network).toBeNull();
       client.close();
     });
 


### PR DESCRIPTION
## Summary

compute-engine-internal#1500 taught the service to recycle a pool's unclaimed warm containers when its network policy changes and to enforce the policy match at claim time. That removes the reason #873 made the policy create-only in the SDKs, so this PR lets users replace a pool's network policy through `update_pool` across all three SDKs.

Semantics are the same everywhere: **omit `network` to keep the pool's current policy, set it to replace the policy, or clear it to remove the policy entirely.** On replacement, the service recycles the pool's unclaimed warm containers onto the new policy, while containers already claimed by sandboxes keep the policy they booted with.

- **Rust**: `update_pool_with_network(pool_id, &UpdateSandboxPoolRequest)` with a `NetworkPolicyUpdate { Keep, Clear, Set(..) }` enum — `Keep` omits the field, `Clear` sends `null`, `Set` sends the object. `update_pool` keeps its keep-current behavior and delegates, staying source-compatible.
- **Python**: `update_pool` gains `network` on both sync and async clients, accepting a `NetworkConfig`, omission, or the new `CLEAR_NETWORK_POLICY` sentinel.
- **TypeScript**: `UpdatePoolOptions.network` accepts `NetworkConfig | null`; the "Network policy updates are not supported" throw is removed.
- Docstrings and the README no longer instruct users to create a new pool to change the policy.

## Validation

- `cargo test -p tensorlake` — includes a wire-shape test pinning Keep/Clear/Set to omitted/`null`/object with round-trip decode, and HTTP tests asserting neither replace nor clear performs a current-policy GET
- `cargo check -p tensorlake-rust-cloud-sdk-py` / `-node`
- `cargo fmt --all`; `cargo clippy -p tensorlake --all-targets` (one pre-existing `type_complexity` warning in `artifact_storage`, same as #873)
- TypeScript: `npm run typecheck`; 60/60 client tests (throw test replaced by replace / omit-keeps / explicit-null-clears tests)
- Python rust-backend tests: 95 passed (update-body coverage for all three modes, on both sync and async clients)
- Live service tests not run (no Tensorlake credentials in this environment)

## Release

Bumps 0.5.90 → 0.5.91 via `python .github/scripts/bump_version.py 0.5.91`; `Cargo.lock` regenerated with `cargo update -w` (workspace entries only); `typescript/package-lock.json` version fields synced via `npm install --package-lock-only`. After merge, dispatch the four release workflows against `main` as usual.

## ⚠️ Deploy ordering

Ship **compute-engine-internal#1500 to production before releasing this SDK version**. Against an older server, a policy update from this SDK changes the pool record without recycling warm containers — the exact hole #1500 closes.

compute-engine-internal#1509 (absent vs null on the update route) is **not** required for this SDK to be correct: `Keep` is still resolved client-side into the current policy, so keep-current works against any server version, and `Clear` sends an explicit `null`, which older servers also treat as a clear. Once #1509 is universally deployed, a later SDK release can drop the resolve-Keep read entirely.

## Post-deploy validation

- Create a pool with `allow_internet_access=True`, then update it to `allow_internet_access=False`.
- Confirm the pool read returns the new policy and warm containers are replaced (pool container list turns over).
- Claim a sandbox and confirm an external HTTP request fails.
- Update the pool again *without* `network` and confirm the policy is unchanged.
- Clear the policy (`CLEAR_NETWORK_POLICY` / `null`) and confirm the pool read returns no policy and external access works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

