### PR TITLE
fix(sdk): drop the now-unused SandboxPoolRequest import from the bridges

### DIFF
--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -26,8 +26,8 @@ use serde_json::Value;
 
 use tensorlake::sandboxes::models::{
     ArchivedSandboxesPaginationDirection, CreateSandboxPoolRequest, CreateSandboxRequest,
-    GetSandboxLogsRequest, ListArchivedSandboxesParams, SandboxPoolRequest, SnapshotType,
-    UpdateSandboxPoolRequest, UpdateSandboxRequest,
+    GetSandboxLogsRequest, ListArchivedSandboxesParams, SnapshotType, UpdateSandboxPoolRequest,
+    UpdateSandboxRequest,
 };
 use tensorlake::sandboxes::{
     SandboxProxyClient, SandboxesClient, resolve_sandbox_proxy_target, select_sandbox_proxy_url,

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -35,8 +35,8 @@ use tensorlake::sandbox_images::SandboxImageBuildEvent;
 use tensorlake::sandbox_templates::SandboxTemplatesClient;
 use tensorlake::sandboxes::models::{
     ArchivedSandboxesPaginationDirection, CreateSandboxPoolRequest, CreateSandboxRequest,
-    GetSandboxLogsRequest, ListArchivedSandboxesParams, SandboxPoolRequest, SnapshotType,
-    UpdateSandboxPoolRequest, UpdateSandboxRequest,
+    GetSandboxLogsRequest, ListArchivedSandboxesParams, SnapshotType, UpdateSandboxPoolRequest,
+    UpdateSandboxRequest,
 };
 use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,


### PR DESCRIPTION
## Problem

#876 retyped the pool-update entry points in the pyo3 and napi bridges to `UpdateSandboxPoolRequest`, which left `SandboxPoolRequest` imported but unused in both crates. Unused imports are warnings, so `cargo check` passed locally, but the `-D warnings` build in CI fails:

```
error: unused import: `SandboxPoolRequest`
  --> crates/rust-cloud-sdk-py/src/lib.rs:38:57
```

This broke **compute-engine-internal main**, whose gVisor acceptance job has a "Build Tensorlake SDK" step that builds this repo: https://github.com/tensorlakeai/compute-engine-internal/actions/runs/30423146675

## Fix

Remove the import from both bridge crates (the napi crate had the identical latent failure) and re-wrap the import lists per rustfmt.

## Validation

This time against the flag CI actually uses, not plain `cargo check`:

- `RUSTFLAGS="-D warnings" cargo check --all-targets` → clean for `tensorlake`, `tensorlake-rust-cloud-sdk-py`, and `tensorlake-rust-cloud-sdk-node`
- `cargo fmt --all -- --check` clean
- `cargo test -p tensorlake --test sandboxes` → 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)