### PR TITLE
feat(sandbox-images): sign additional local image downloads via the dataplane, release 0.5.92

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "base64",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "base64",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.91"
+version = "0.5.92"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.91"
+version = "0.5.92"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -669,6 +669,7 @@ where
                 // object operations with the Platform build capability.
                 if prepared.snapshot_rel_path.is_some() {
                     sign_prepared_parent_download(&proxy, &prepared, &mut prepared_spec).await?;
+                    sign_prepared_local_image_downloads(&proxy, &mut prepared_spec).await?;
                 }
                 None
             } else if let Some(rel_path) = prepared.snapshot_rel_path.clone() {
@@ -692,6 +693,7 @@ where
                 let snapshot_uri = splice_signed_upload(&mut prepared_spec, signed)?;
 
                 sign_prepared_parent_download(&proxy, &prepared, &mut prepared_spec).await?;
+                sign_prepared_local_image_downloads(&proxy, &mut prepared_spec).await?;
 
                 Some(snapshot_uri)
             } else {
@@ -1488,6 +1490,67 @@ async fn sign_prepared_parent_download(
         .and_then(Value::as_object_mut)
         .ok_or_else(|| SandboxImageBuildError::other("prepared parent is not a JSON object"))?
         .insert("download".to_string(), signed);
+    Ok(())
+}
+
+/// Entries in `additionalLocalImages` that need a signed download URL, as
+/// `(index, snapshot_uri)`.
+///
+/// CAS entries are builder-local `file://` paths the in-sandbox builder reads
+/// directly, so they are skipped; anything already carrying a `download` block
+/// is left alone.
+fn local_image_sign_targets(prepared_spec: &Value) -> Vec<(usize, String)> {
+    prepared_spec
+        .get("additionalLocalImages")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, entry)| {
+                    if entry.get("download").is_some() {
+                        return None;
+                    }
+                    let uri = entry.get("snapshotUri")?.as_str()?;
+                    (!uri.starts_with("file://")).then(|| (idx, uri.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Sign a read-only download URL for every durable additional local image
+/// (`COPY --from=<registered image>`).
+///
+/// platform-api no longer presigns these — it never could for non-S3 stores —
+/// so the CLI mints them through the dataplane exactly as it does the parent
+/// manifest. Without this, a multi-stage build referencing a `gs://`-backed
+/// image has no way to fetch its bytes.
+async fn sign_prepared_local_image_downloads(
+    proxy: &SandboxProxyClient,
+    prepared_spec: &mut Value,
+) -> Result<()> {
+    for (idx, uri) in local_image_sign_targets(prepared_spec) {
+        let signed = proxy
+            .sign_blob(&SignBlobRequest {
+                target: SignBlobTarget::Blob { uri },
+                op: SignBlobOp::GetBlob,
+            })
+            .await
+            .map_err(SandboxImageBuildError::Sdk)?
+            .into_inner();
+        prepared_spec
+            .get_mut("additionalLocalImages")
+            .and_then(Value::as_array_mut)
+            .and_then(|entries| entries.get_mut(idx))
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| {
+                SandboxImageBuildError::other(
+                    "prepared additionalLocalImages entry is not a JSON object",
+                )
+            })?
+            .insert("download".to_string(), signed);
+    }
     Ok(())
 }
 
@@ -3707,6 +3770,49 @@ Filesystem 1024-blocks Used Available Capacity Mounted on
     fn rootfs_disk_bytes_to_mb_rounds_up() {
         assert_eq!(rootfs_disk_bytes_to_mb(1024 * 1024).unwrap(), 1);
         assert_eq!(rootfs_disk_bytes_to_mb((1024 * 1024) + 1).unwrap(), 2);
+    }
+
+    #[test]
+    fn local_image_sign_targets_selects_durable_remote_entries() {
+        let spec = json!({
+            "additionalLocalImages": [
+                {"reference": "a", "snapshotUri": "gs://bucket/a.tlsnap"},
+                {"reference": "b", "snapshotUri": "s3://bucket/b.tlsnap"},
+            ]
+        });
+        assert_eq!(
+            super::local_image_sign_targets(&spec),
+            vec![
+                (0, "gs://bucket/a.tlsnap".to_string()),
+                (1, "s3://bucket/b.tlsnap".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn local_image_sign_targets_skips_cas_and_already_signed_entries() {
+        let spec = json!({
+            "additionalLocalImages": [
+                // CAS simulation: builder-local path, nothing to sign.
+                {"reference": "cas", "snapshotUri": "file:///var/lib/builder/cas.tlsnap"},
+                // Already carries a download block.
+                {"reference": "signed", "snapshotUri": "gs://bucket/s.tlsnap",
+                 "download": {"kind": "single_get"}},
+                // No identity to sign against.
+                {"reference": "bare"},
+                {"reference": "durable", "snapshotUri": "gs://bucket/d.tlsnap"},
+            ]
+        });
+        assert_eq!(
+            super::local_image_sign_targets(&spec),
+            vec![(3, "gs://bucket/d.tlsnap".to_string())]
+        );
+    }
+
+    #[test]
+    fn local_image_sign_targets_tolerates_missing_or_empty_list() {
+        assert!(super::local_image_sign_targets(&json!({})).is_empty());
+        assert!(super::local_image_sign_targets(&json!({"additionalLocalImages": []})).is_empty());
     }
 
     #[test]

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.91"
+version = "0.5.92"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.91"
+version = "0.5.92"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.91"
+version = "0.5.92"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.91",
+  "version": "0.5.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.91",
+      "version": "0.5.92",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.91",
+  "version": "0.5.92",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Why

Multi-stage builds reference registered images with `COPY --from=<image>`; those arrive in the prepare response as `additionalLocalImages`. The CLI already signs the snapshot upload and the parent manifest against the dataplane, but it consumed these entries **as-is**, so their download URLs still had to come from platform-api's S3-only presign. Two consequences:

1. `COPY --from=<gs:// registered image>` was impossible on GCS BYOC.
2. It was the last thing keeping platform-api in the signing path — tensorlakeai/platform-api#643 removes that presign, so without this change multi-stage builds would arrive with no download URL at all.

## What changed

Sign each durable `additionalLocalImages` entry with the same provider-neutral `GetBlob` call already used for the parent manifest. Skipped:

- **CAS entries** — builder-local `file://` paths the in-sandbox builder reads directly.
- **Entries that already carry a `download` block** — so this is a no-op against a service that still presigns, which keeps the rollout order flexible.

Selection logic is factored into `local_image_sign_targets` so it's unit-testable without a proxy mock.

## ⚠️ Ship this with platform-api#643

The two changes are coupled, and the coupling is tighter than #643's description implied:

- **Single-stage `FROM <base>`** — a **0.5.91** CLI already works after #643 deploys. `splice_signed_upload` and the parent signer both *insert* rather than require pre-existing keys, so the removed blocks don't break them. The customer's `FROM <registered base>` + `RUN` case needs no CLI upgrade.
- **Multi-stage `COPY --from=<registered image>`** — regresses on **any CLI before 0.5.92** once #643 deploys, because nobody signs those entries. Previously platform-api did (S3 only).

Recommended order: **publish 0.5.92 first, then deploy #643.** A CLI upgrade can't be forced, so there's an unavoidable window where an un-upgraded user doing multi-stage builds is broken; if that window is unacceptable, hold #643 until adoption looks fine, or re-add the additional-image presign there for one release.

## Validation

- `cargo test -p tensorlake` — 177 lib + 6 integration tests, including 3 new `local_image_sign_targets` cases (durable remote selection, CAS/already-signed/no-URI skipping, missing/empty list).
- `RUSTFLAGS="-D warnings" cargo check --all-targets` clean for `tensorlake`, `tensorlake-rust-cloud-sdk-py`, `tensorlake-rust-cloud-sdk-node` (the flag CI uses — the gap that caused #877).
- `cargo fmt --all -- --check` clean; TypeScript 261 tests; Python rust-backend 96 tests.
- Live service tests not run (no credentials in this environment).

## Release

0.5.91 → 0.5.92 via `bump_version.py`; `cargo update -w` touched only the five workspace entries; `typescript/package-lock.json` synced. Dispatch the four release workflows against `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)