### PR TITLE
Add filesystem mount prefetch flag

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,10 +46,9 @@ jobs:
         with:
           app-id: ${{ secrets.ARTIFACT_STORAGE_APP_ID }}
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
-          # This stacked PR removes redb and the legacy mount sources in artifact_storage#173.
-          # Pin its exact code commit only for this head branch; main and every other PR continue
-          # integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          # Stacked mount PRs pin their exact artifact_storage code commit only on their own head
+          # branch; main and every other PR continue integrating against artifact_storage/main.
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -91,7 +90,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "base64",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "base64",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.92"
+version = "0.5.93"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -229,6 +229,14 @@ pub async fn status(ctx: &CliContext, path: &Path, json: bool) -> Result<()> {
     map(gsvc_fs_client::status(&private_context(ctx), path, json).await)
 }
 
+pub async fn prefetch_filesystem(path: Option<PathBuf>) -> Result<()> {
+    map(gsvc_fs_client::prefetch_filesystem(path).await)
+}
+
+pub async fn prefetch_repository(path: Option<PathBuf>) -> Result<()> {
+    map(gsvc_fs_client::prefetch_repository(path).await)
+}
+
 pub async fn doctor(path: &Path, json: bool) -> Result<()> {
     map(gsvc_fs_client::doctor(path, json).await)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -239,6 +239,10 @@ enum FsCommands {
         /// Mountpoint directory (created; must be empty)
         path: PathBuf,
 
+        /// Download and verify the complete filesystem before this command returns
+        #[arg(long, conflicts_with = "foreground")]
+        prefetch: bool,
+
         /// Run the mount daemon in the foreground (debugging)
         #[arg(long, hide = true)]
         foreground: bool,
@@ -253,6 +257,14 @@ enum FsCommands {
         /// the CLI's `mount timing` phase lines.
         #[arg(long, default_value = "info", hide = true)]
         log_level: String,
+    },
+
+    /// Download and verify every file below a mounted path for network-free reads
+    ///
+    /// Requires enough local disk for the selected working set.
+    Prefetch {
+        /// File or directory inside a mount (default: the current directory)
+        path: Option<PathBuf>,
     },
 
     /// Mint the scoped credential a sandbox needs to attach one filesystem
@@ -608,6 +620,13 @@ enum GitCommands {
         /// Daemon + CLI log level
         #[arg(long, default_value = "info", hide = true)]
         log_level: String,
+    },
+    /// Download and verify every file below a mounted repository path for network-free reads
+    ///
+    /// Requires enough local disk for the selected working set.
+    Prefetch {
+        /// File or directory inside a repository mount (default: the current directory)
+        path: Option<PathBuf>,
     },
     /// Unmount a logical-v1 repository working tree
     Unmount {
@@ -1874,6 +1893,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
             if matches!(
                 subcmd,
                 GitCommands::Mount { .. }
+                    | GitCommands::Prefetch { .. }
                     | GitCommands::Unmount { .. }
                     | GitCommands::Snapshot { .. }
                     | GitCommands::Sync { .. }
@@ -2415,6 +2435,9 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
             return commands::fs::run_macos_kernel_refresh_helper(&state_dir, &through, batch)
                 .await;
         }
+        FsCommands::Prefetch { path } => {
+            return commands::fs::prefetch_filesystem(path).await;
+        }
         other => other,
     };
     // Path-addressed commands default their mounted-directory argument to the mount containing
@@ -2479,6 +2502,7 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
         FsCommands::KernelRefresh { .. } => {
             unreachable!("handled before the auth guard")
         }
+        FsCommands::Prefetch { .. } => unreachable!("handled before the auth guard"),
         FsCommands::Create { name, json } => {
             commands::fs::create_filesystem(ctx, &name, json).await
         }
@@ -2502,12 +2526,18 @@ async fn run_fs_command(ctx: &mut CliContext, subcmd: FsCommands) -> error::Resu
         FsCommands::Mount {
             target,
             path,
+            prefetch,
             foreground,
             trace_ops,
             log_level,
         } => {
             commands::fs::mount_filesystem(ctx, &target, &path, foreground, trace_ops, &log_level)
-                .await
+                .await?;
+            if prefetch {
+                commands::fs::prefetch_filesystem(Some(path)).await
+            } else {
+                Ok(())
+            }
         }
         FsCommands::Daemon {
             state_dir,
@@ -2538,7 +2568,13 @@ async fn run_fs_command(_ctx: &mut CliContext, _subcmd: FsCommands) -> error::Re
 }
 
 #[cfg(feature = "mount")]
-async fn run_git_mount_command(ctx: &mut CliContext, mut subcmd: GitCommands) -> error::Result<()> {
+async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> error::Result<()> {
+    let mut subcmd = match subcmd {
+        GitCommands::Prefetch { path } => {
+            return commands::fs::prefetch_repository(path).await;
+        }
+        other => other,
+    };
     let mount_dir = match &mut subcmd {
         GitCommands::Snapshot { path, .. }
         | GitCommands::Status { path, .. }
@@ -2685,6 +2721,7 @@ async fn run_ssh_keys_command(ctx: &CliContext, subcmd: SshKeysCommands) -> erro
 async fn run_git_command(ctx: &CliContext, subcmd: GitCommands) -> error::Result<()> {
     match subcmd {
         GitCommands::Mount { .. }
+        | GitCommands::Prefetch { .. }
         | GitCommands::Unmount { .. }
         | GitCommands::Snapshot { .. }
         | GitCommands::Sync { .. }
@@ -3149,6 +3186,36 @@ mod tests {
     }
 
     #[test]
+    fn prefetch_mount_flag_parses_and_rejects_foreground_mode() {
+        match parse_command(["tl", "fs", "mount", "scratch", "./w", "--prefetch"]) {
+            Commands::Fs(FsCommands::Mount {
+                target,
+                path,
+                prefetch: true,
+                foreground: false,
+                ..
+            }) => {
+                assert_eq!(target, "scratch");
+                assert_eq!(path, PathBuf::from("./w"));
+            }
+            _ => panic!("expected prefetching fs mount command"),
+        }
+        assert!(
+            Cli::try_parse_from([
+                "tl",
+                "fs",
+                "mount",
+                "scratch",
+                "./w",
+                "--prefetch",
+                "--foreground",
+            ])
+            .is_err(),
+            "foreground mount never returns to run the post-mount prefetch"
+        );
+    }
+
+    #[test]
     fn logical_git_mount_and_fs_commands_are_surface_centric() {
         assert!(Cli::try_parse_from(["tl", "fs", "converge"]).is_err());
 
@@ -3180,17 +3247,23 @@ mod tests {
             Commands::Fs(FsCommands::Mount {
                 target,
                 path,
+                prefetch,
                 foreground,
                 trace_ops,
                 log_level,
             }) => {
                 assert_eq!(target, "scratch");
                 assert_eq!(path, PathBuf::from("./w"));
+                assert!(!prefetch);
                 assert!(!foreground);
                 assert!(!trace_ops);
                 assert_eq!(log_level, "info");
             }
             _ => panic!("expected fs mount command"),
+        }
+        match parse_command(["tl", "fs", "mount", "scratch", "./w", "--prefetch"]) {
+            Commands::Fs(FsCommands::Mount { prefetch: true, .. }) => {}
+            _ => panic!("expected prefetching fs mount command"),
         }
         // The pre-split flags are gone, not hidden.
         for legacy in [
@@ -3336,6 +3409,16 @@ mod tests {
             }) => {}
             _ => panic!("expected fs snapshot command"),
         }
+        match parse_command(["tl", "fs", "prefetch", "./w/DerivedData"]) {
+            Commands::Fs(FsCommands::Prefetch { path }) => {
+                assert_eq!(path, Some(PathBuf::from("./w/DerivedData")));
+            }
+            _ => panic!("expected fs prefetch command"),
+        }
+        match parse_command(["tl", "fs", "prefetch"]) {
+            Commands::Fs(FsCommands::Prefetch { path: None }) => {}
+            _ => panic!("expected cwd-defaulting fs prefetch command"),
+        }
 
         match parse_command(["tl", "fs", "snapshot", "./w", "-m", "wip"]) {
             Commands::Fs(FsCommands::Snapshot { path, message }) => {
@@ -3401,6 +3484,12 @@ mod tests {
                 assert_eq!(log_level, "info");
             }
             _ => panic!("expected logical-v1 git mount command"),
+        }
+        match parse_command(["tl", "git", "prefetch", "./w/build"]) {
+            Commands::Git(GitCommands::Prefetch { path }) => {
+                assert_eq!(path, Some(PathBuf::from("./w/build")));
+            }
+            _ => panic!("expected git prefetch command"),
         }
         match parse_command(["tl", "git", "mount", "demo:main", "./w", "--publish"]) {
             Commands::Git(GitCommands::Mount { publish: true, .. }) => {}

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.92"
+version = "0.5.93"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.92"
+version = "0.5.93"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.92"
+version = "0.5.93"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.92",
+  "version": "0.5.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.92",
+      "version": "0.5.93",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.92",
+  "version": "0.5.93",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- add `tl fs mount <filesystem> <path> --prefetch`
- wait for the detached mount to become available, then eagerly hydrate and verify the mounted filesystem before returning
- retain `tl fs prefetch [PATH]` and `tl git prefetch [PATH]` as retry and subtree-refresh commands for existing mounts
- stream daemon progress and preserve raw path components through the local control protocol
- reject the incompatible `--foreground --prefetch` combination at argument parsing

## Behavior

A prefetch failure does not unmount the filesystem or discard completed cache entries. The user can continue using the mount and retry incrementally with `tl fs prefetch`.

This is a client-only command surface for the logical-v1 cache implemented by tensorlakeai/artifact_storage#176.

## Validation

- `make CLIENT_REPO=../tensorlake-prefetch test-logical-v1-prefetch` in the companion artifact-storage checkout
- parser regression for `--prefetch` and its `--foreground` conflict
- verified `tl fs mount --help`
- `cargo fmt --all -- --check`
- `git diff --check`

Depends on tensorlakeai/artifact_storage#176.
