### PR TITLE
Add application info commands and release 0.5.94

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.93"
+version = "0.5.94"
 dependencies = [
  "anyhow",
  "base64",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.93"
+version = "0.5.94"
 dependencies = [
  "anyhow",
  "base64",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.93"
+version = "0.5.94"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.93"
+version = "0.5.94"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.93"
+version = "0.5.94"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.93"
+version = "0.5.94"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/commands/applications.rs
+++ b/crates/cli/src/commands/applications.rs
@@ -5,6 +5,8 @@ use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
 use crate::output::table::new_table;
 
+const APPLICATION_DETAILS_LABEL_WIDTH: usize = 20;
+
 pub async fn ls(ctx: &CliContext) -> Result<()> {
     let client = ctx.client()?;
     let resp = client
@@ -45,28 +47,19 @@ pub async fn ls(ctx: &CliContext) -> Result<()> {
         return Ok(());
     }
 
-    let mut table = new_table(&["Name", "Description", "Deployed At"]);
+    let mut table = new_table(&["Name", "Description", "Public Endpoint ID", "Deployed At"]);
     for app in &active {
         let name = app.get("name").and_then(|v| v.as_str()).unwrap_or("-");
         let description = app
             .get("description")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        let deployed_at = app
-            .get("created_at")
-            .and_then(|v| v.as_i64())
-            .map(|ts| {
-                // created_at is Unix timestamp in milliseconds
-                Utc.timestamp_millis_opt(ts)
-                    .single()
-                    .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
-                    .unwrap_or_else(|| "-".to_string())
-            })
-            .unwrap_or_else(|| "-".to_string());
+        let deployed_at = format_deployed_at(app.get("created_at"));
 
         table.add_row(vec![
             Cell::new(name),
             Cell::new(description),
+            Cell::new(public_endpoint_id(app)),
             Cell::new(&deployed_at),
         ]);
     }
@@ -90,4 +83,279 @@ pub async fn ls(ctx: &CliContext) -> Result<()> {
     }
 
     Ok(())
+}
+
+pub async fn describe(ctx: &CliContext, application: &str) -> Result<()> {
+    let client = ctx.client()?;
+    let resp = client
+        .get(format!(
+            "{}/v1/namespaces/{}/applications/{}",
+            ctx.api_url,
+            ctx.namespace,
+            urlencoding::encode(application)
+        ))
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "application '{}' not found",
+            application
+        )));
+    }
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to fetch application '{}' (HTTP {}): {}",
+            application,
+            status,
+            body
+        )));
+    }
+
+    let item = resp
+        .json::<serde_json::Value>()
+        .await
+        .map_err(CliError::Http)?;
+    print!("{}", format_application_details(&item, &ctx.namespace));
+    Ok(())
+}
+
+fn format_application_details(item: &serde_json::Value, namespace: &str) -> String {
+    let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("-");
+    let description = item
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let version = item.get("version").and_then(|v| v.as_str()).unwrap_or("-");
+    let state = format_application_state(item.get("state"));
+    let entrypoint = item.get("entrypoint");
+    let entrypoint_function = entrypoint
+        .and_then(|v| v.get("function_name").or_else(|| v.get("functionName")))
+        .and_then(|v| v.as_str())
+        .unwrap_or("-");
+    let input_serializer = entrypoint
+        .and_then(|v| {
+            v.get("input_serializer")
+                .or_else(|| v.get("inputSerializer"))
+        })
+        .and_then(|v| v.as_str())
+        .unwrap_or("-");
+    let output_serializer = entrypoint
+        .and_then(|v| {
+            v.get("output_serializer")
+                .or_else(|| v.get("outputSerializer"))
+        })
+        .and_then(|v| v.as_str())
+        .unwrap_or("-");
+    let functions = format_object_keys(item.get("functions"));
+    let allow = format_string_array(item.get("allow"));
+    let tags = format_tags(item.get("tags"));
+    let deployed_at = format_deployed_at(item.get("created_at"));
+    let tombstoned = item
+        .get("tombstoned")
+        .and_then(|v| v.as_bool())
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".to_string());
+
+    let mut output = String::new();
+    push_detail(&mut output, "Name", name);
+    push_detail(&mut output, "Namespace", namespace);
+    push_detail(&mut output, "Description", description);
+    push_detail(&mut output, "Version", version);
+    push_detail(&mut output, "State", &state);
+    push_detail(&mut output, "Public endpoint ID", public_endpoint_id(item));
+    push_detail(&mut output, "Entrypoint", entrypoint_function);
+    push_detail(&mut output, "Input serializer", input_serializer);
+    push_detail(&mut output, "Output serializer", output_serializer);
+    push_detail(&mut output, "Functions", &functions);
+    push_detail(&mut output, "Allow", &allow);
+    push_detail(&mut output, "Tags", &tags);
+    push_detail(&mut output, "Deployed at", &deployed_at);
+    push_detail(&mut output, "Tombstoned", &tombstoned);
+    output
+}
+
+fn push_detail(output: &mut String, label: &str, value: &str) {
+    output.push_str(&format!(
+        "{:<APPLICATION_DETAILS_LABEL_WIDTH$}{}\n",
+        format!("{label}:"),
+        value
+    ));
+}
+
+fn public_endpoint_id(item: &serde_json::Value) -> &str {
+    item.get("public_endpoint_id")
+        .or_else(|| item.get("publicEndpointId"))
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("-")
+}
+
+fn format_deployed_at(created_at: Option<&serde_json::Value>) -> String {
+    created_at
+        .and_then(|v| v.as_i64())
+        .and_then(|ts| Utc.timestamp_millis_opt(ts).single())
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn format_object_keys(value: Option<&serde_json::Value>) -> String {
+    let mut keys = value
+        .and_then(|v| v.as_object())
+        .map(|object| object.keys().cloned().collect::<Vec<_>>())
+        .unwrap_or_default();
+    keys.sort();
+    if keys.is_empty() {
+        "-".to_string()
+    } else {
+        keys.join(", ")
+    }
+}
+
+fn format_string_array(value: Option<&serde_json::Value>) -> String {
+    let values = value
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if values.is_empty() {
+        "-".to_string()
+    } else {
+        values.join(", ")
+    }
+}
+
+fn format_tags(value: Option<&serde_json::Value>) -> String {
+    let mut tags = value
+        .and_then(|v| v.as_object())
+        .map(|object| {
+            object
+                .iter()
+                .map(|(key, value)| {
+                    let value = value
+                        .as_str()
+                        .map(str::to_string)
+                        .unwrap_or_else(|| value.to_string());
+                    format!("{key}={value}")
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    tags.sort();
+    if tags.is_empty() {
+        "-".to_string()
+    } else {
+        tags.join(", ")
+    }
+}
+
+fn format_application_state(value: Option<&serde_json::Value>) -> String {
+    match value {
+        Some(serde_json::Value::String(state)) => state.clone(),
+        Some(serde_json::Value::Object(state)) => {
+            if let Some(disabled) = state.get("disabled") {
+                let reason = disabled
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if reason.is_empty() {
+                    "disabled".to_string()
+                } else {
+                    format!("disabled ({reason})")
+                }
+            } else {
+                serde_json::Value::Object(state.clone()).to_string()
+            }
+        }
+        Some(value) if !value.is_null() => value.to_string(),
+        _ => "-".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_application_details, public_endpoint_id};
+    use serde_json::json;
+
+    #[test]
+    fn public_endpoint_id_supports_wire_name_and_missing_values() {
+        assert_eq!(
+            public_endpoint_id(&json!({"public_endpoint_id": "endpoint_snake"})),
+            "endpoint_snake"
+        );
+        assert_eq!(
+            public_endpoint_id(&json!({"publicEndpointId": "endpoint_camel"})),
+            "endpoint_camel"
+        );
+        assert_eq!(public_endpoint_id(&json!({})), "-");
+        assert_eq!(public_endpoint_id(&json!({"public_endpoint_id": ""})), "-");
+    }
+
+    #[test]
+    fn application_details_include_deployment_and_public_endpoint_information() {
+        let application = json!({
+            "name": "weather",
+            "description": "Current weather",
+            "version": "v42",
+            "state": "active",
+            "public_endpoint_id": "endpoint_abc123",
+            "entrypoint": {
+                "function_name": "weather_app",
+                "input_serializer": "json",
+                "output_serializer": "pickle"
+            },
+            "functions": {
+                "weather_app": {},
+                "helper": {}
+            },
+            "allow": ["unauthenticated_requests"],
+            "tags": {
+                "team": "agents",
+                "env": "prod"
+            },
+            "created_at": 1700000000000_i64,
+            "tombstoned": false
+        });
+
+        let details = format_application_details(&application, "default");
+
+        assert!(details.contains("Name:               weather\n"));
+        assert!(details.contains("Namespace:          default\n"));
+        assert!(details.contains("Version:            v42\n"));
+        assert!(details.contains("State:              active\n"));
+        assert!(details.contains("Public endpoint ID: endpoint_abc123\n"));
+        assert!(details.contains("Entrypoint:         weather_app\n"));
+        assert!(details.contains("Functions:          helper, weather_app\n"));
+        assert!(details.contains("Allow:              unauthenticated_requests\n"));
+        assert!(details.contains("Tags:               env=prod, team=agents\n"));
+        assert!(details.contains("Deployed at:        2023-11-14 22:13:20\n"));
+        assert!(details.contains("Tombstoned:         false\n"));
+    }
+
+    #[test]
+    fn application_details_render_missing_optional_values_as_dashes() {
+        let details = format_application_details(
+            &json!({
+                "name": "private-app",
+                "entrypoint": {},
+                "functions": {},
+                "tags": {},
+                "allow": []
+            }),
+            "project",
+        );
+
+        assert!(details.contains("Public endpoint ID: -\n"));
+        assert!(details.contains("State:              -\n"));
+        assert!(details.contains("Functions:          -\n"));
+        assert!(details.contains("Deployed at:        -\n"));
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -936,6 +936,13 @@ enum AppCommands {
     #[command(subcommand)]
     Cron(CronCommands),
 
+    /// Show detailed information for an application
+    #[command(alias = "info")]
+    Describe {
+        /// Application name
+        application: String,
+    },
+
     /// List applications
     #[command(name = "ls")]
     Applications(ApplicationsArgs),
@@ -2346,6 +2353,10 @@ async fn run_app_command(ctx: &mut CliContext, subcmd: AppCommands) -> error::Re
         AppCommands::New { name, force } => commands::new::run(&name, force),
         AppCommands::Deploy { args } => run_deploy_command(ctx, &args).await,
         AppCommands::Cron(subcmd) => run_cron_command(ctx, subcmd).await,
+        AppCommands::Describe { application } => {
+            ensure_auth_and_project(ctx).await?;
+            commands::applications::describe(ctx, &application).await
+        }
         AppCommands::Applications(app_args) => run_applications_command(ctx, app_args).await,
     }
 }
@@ -2914,6 +2925,18 @@ mod tests {
         match parse_command(["tl", "app", "ls"]) {
             Commands::App(AppCommands::Applications(ApplicationsArgs { command: None })) => {}
             _ => panic!("expected app ls command"),
+        }
+        match parse_command(["tl", "app", "describe", "hello_world"]) {
+            Commands::App(AppCommands::Describe { application }) => {
+                assert_eq!(application, "hello_world");
+            }
+            _ => panic!("expected app describe command"),
+        }
+        match parse_command(["tl", "app", "info", "hello_world"]) {
+            Commands::App(AppCommands::Describe { application }) => {
+                assert_eq!(application, "hello_world");
+            }
+            _ => panic!("expected app info alias"),
         }
     }
 

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.93"
+version = "0.5.94"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.93"
+version = "0.5.94"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.93"
+version = "0.5.94"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.93",
+  "version": "0.5.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.93",
+      "version": "0.5.94",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.93",
+  "version": "0.5.94",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- add `tl app describe <application>` with `tl app info` as an alias
- render application deployment metadata, including public endpoint ID, entrypoint, functions, access capabilities, tags, and deployment time
- add a `Public Endpoint ID` column to `tl app ls`, using `-` for applications without a public endpoint
- bump the unified SDK and CLI package versions from `0.5.93` to `0.5.94`

## Why

The Rust CLI could list applications but could not inspect a single application the way `tl sbx describe/info` can inspect a sandbox. The list output also omitted the public endpoint identifier, making it harder to discover which deployed applications expose public endpoints.

## Impact

Users can now inspect an application with either `tl app describe` or `tl app info` and can see public endpoint IDs directly in the application list. Existing application commands remain unchanged. Package metadata is prepared for the `0.5.94` SDK and CLI release.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tensorlake-cli --bin tl` — 220 passed
- `cargo test -p tensorlake --lib` — 177 passed, 1 local-service test ignored
- `cargo clippy -p tensorlake-cli --bin tl --no-deps -- -A clippy::question_mark -D warnings`
- `npm test` — 261 passed
