### PR TITLE
Use IPv4 loopback for request context and release 0.5.95

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "base64",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "base64",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.94"
+version = "0.5.95"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.94"
+version = "0.5.95"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.94"
+version = "0.5.95"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.94"
+version = "0.5.95"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.94"
+version = "0.5.95"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/applications/request_context/http_server/server.py
+++ b/src/tensorlake/applications/request_context/http_server/server.py
@@ -2,14 +2,16 @@ import http.server
 
 from .router import Router
 
+_IPV4_LOOPBACK_ADDRESS = "127.0.0.1"
+
 
 class RequestContextHTTPServer:
-    """HTTP server for handling request context operations."""
+    """HTTP server for handling request context operations over IPv4 loopback."""
 
     def __init__(self, server_router_class: type[Router]):
-        """Initializes the HTTP server to listen on localhost."""
+        """Initializes the HTTP server to listen on IPv4 loopback."""
         self._httpd: http.server.ThreadingHTTPServer = http.server.ThreadingHTTPServer(
-            ("localhost", 0), server_router_class
+            (_IPV4_LOOPBACK_ADDRESS, 0), server_router_class
         )
         self._running: bool = False
 
@@ -17,7 +19,7 @@ class RequestContextHTTPServer:
     def base_url(self) -> str:
         """Returns the base URL of the server."""
         port: int = self._httpd.server_address[1]
-        return f"http://localhost:{port}"
+        return f"http://{_IPV4_LOOPBACK_ADDRESS}:{port}"
 
     def start(self):
         """Starts the HTTP server in the current thread.

--- a/tests/applications/request_context/test_http_server.py
+++ b/tests/applications/request_context/test_http_server.py
@@ -1,0 +1,33 @@
+import http.server
+import socket
+import unittest
+from unittest.mock import patch
+
+from tensorlake.applications.request_context.http_server.server import (
+    RequestContextHTTPServer,
+)
+
+
+class TestRequestContextHTTPServer(unittest.TestCase):
+    def test_uses_ipv4_loopback_without_resolving_localhost(self):
+        original_getaddrinfo = socket.getaddrinfo
+
+        def reject_localhost(host, *args, **kwargs):
+            self.assertNotEqual(host, "localhost")
+            return original_getaddrinfo(host, *args, **kwargs)
+
+        with patch("socket.getaddrinfo", side_effect=reject_localhost):
+            server = RequestContextHTTPServer(http.server.BaseHTTPRequestHandler)
+
+        try:
+            self.assertEqual(server._httpd.server_address[0], "127.0.0.1")
+            self.assertEqual(
+                server.base_url,
+                f"http://127.0.0.1:{server._httpd.server_address[1]}",
+            )
+        finally:
+            server.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.94",
+  "version": "0.5.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.94",
+      "version": "0.5.95",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.94",
+  "version": "0.5.95",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bind the function executor's internal request-context HTTP server to `127.0.0.1`
- use the same IPv4 loopback literal in its client base URL
- add regression coverage that constructs the server while `localhost` resolution is rejected
- bump all lockstep Python SDK, Rust SDK/CLI, PyO3, and TypeScript packages from `0.5.94` to `0.5.95`

## Root cause

Function-executor initialization used the hostname `localhost` for this internal server. User images are materialized directly from OCI layers, while `/etc/hosts` is normally runtime-generated by Docker/containerd and is not reliably present in those layers. Tensorlake's synthetic guest overlay injects its init/runtime files but does not currently synthesize `/etc/hosts`.

The previous guest resolver apparently masked that missing local mapping. Once the dataplane switched guests to the deterministic public resolver `8.8.8.8`, `localhost` returned NXDOMAIN and function-executor initialization failed with `getaddrinfo`/`EAI_NONAME`. Using the loopback literal removes DNS and NSS from this internal control path.

## Impact

Function executors can initialize their internal request-context server even when the guest image has no usable local `localhost` mapping. Version `0.5.95` is ready for the lockstep SDK and CLI release workflows after merge.

## Validation

- `make check`
- `poetry run python tests/applications/request_context/test_http_server.py`
- `poetry run python tests/applications/test_request_context_headers.py`
- all 15 `tests/function_executor/test_*.py` files
- `cargo check --workspace --all-targets`
- TypeScript typecheck and 261 unit tests
- built the `tensorlake-0.5.95` release wheel and verified its native/Python imports and expected entry points in an isolated Python 3.11 environment
- verified all release manifests and workspace packages resolve to `0.5.95`
- `git diff --check`
