### PR TITLE
Bump Tensorlake packages to 0.5.96

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "base64",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "base64",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.95"
+version = "0.5.96"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.95"
+version = "0.5.96"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.95"
+version = "0.5.96"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.95"
+version = "0.5.96"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.95"
+version = "0.5.96"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.95",
+  "version": "0.5.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.95",
+      "version": "0.5.96",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.95",
+  "version": "0.5.96",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the Tensorlake Rust workspace and CLI packages from 0.5.95 to 0.5.96
- bump Python package metadata for `tensorlake` and `tensorlake-rust-cloud-sdk`
- bump the TypeScript package and lockfile metadata
- keep the public `gsvc-fs-client` resolution placeholder aligned with the release version
- refresh the affected Cargo lockfile package versions

## Why

Companion release bump for tensorlakeai/artifact_storage#183 (merged): the vendored
`gsvc-fs-client` now raises the mount daemon's open-file ceiling to `min(1,048,576, fs.nr_open)`
when privileged and refuses `tl fs mount` / `tl git mount` on Linux when the achievable ceiling is
below 65,536 — descriptor exhaustion previously surfaced to builds as `EIO` mid-burst
(tensorlakeai/artifact_storage#181, the TLFS-on-FUSE CI cache incident).

## Validation

- `cargo update --workspace` refreshed exactly the five workspace/placeholder package entries
- `npm --prefix typescript install --package-lock-only --ignore-scripts` produced no additional
  lockfile changes
- `cargo check -p tensorlake-cli` (public feature set) passes at 0.5.96
- the full-feature CLI suite ran green against the vendored artifact_storage change pre-merge
  (`just test-cli-full`, 908 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)