### PR TITLE
Bump Tensorlake packages to 0.5.97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "base64",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "base64",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.96"
+version = "0.5.97"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.96"
+version = "0.5.97"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.96"
+version = "0.5.97"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.96"
+version = "0.5.97"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.96"
+version = "0.5.97"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.96",
+  "version": "0.5.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.96",
+      "version": "0.5.97",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.96",
+  "version": "0.5.97",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the Tensorlake Rust workspace and CLI packages from 0.5.96 to 0.5.97
- bump Python package metadata, the TypeScript package, the `gsvc-fs-client` placeholder, and both lockfiles

## Why

Companion release bump for tensorlakeai/artifact_storage#182 (merged): logical-v1 lookups and paged directory enumeration fence cache installs against the exact snapshot used for the remote request and retry against the new authority after autosave publication, instead of turning stale-but-valid responses into `EIO`. This is the read-side race behind the dataplane CI unpack failures (tensorlakeai/artifact_storage#181; latest occurrence compute-engine-internal run 30662781388).

## Validation

- clean-tree bump (placeholders verified restored before staging; files staged explicitly)
- `cargo update --workspace` refreshed exactly the five workspace/placeholder package entries; the TypeScript lockfile refresh produced no additional changes
- this PR's Tests workflow exercises artifact_storage main (with #182) through the full vendored Linux pipeline pre-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)