### PR TITLE
Bump Tensorlake packages to 0.5.98

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "base64",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "base64",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.97"
+version = "0.5.98"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.97"
+version = "0.5.98"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.97"
+version = "0.5.98"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.97"
+version = "0.5.98"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.97"
+version = "0.5.98"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.97",
+  "version": "0.5.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.97",
+      "version": "0.5.98",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.97",
+  "version": "0.5.98",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the Tensorlake Rust workspace and CLI packages from 0.5.97 to 0.5.98
- bump Python package metadata, the TypeScript package, the `gsvc-fs-client` placeholder, and both lockfiles
- prepare the next standalone CLI build to inject the private filesystem client from `artifact_storage` main

## Why

Companion release bump for tensorlakeai/artifact_storage#188, which merged after CLI v0.5.97 was built. The private `gsvc-fs-client` and `gsvc-mount` sources are injected only while building an official CLI release, so installed v0.5.97 binaries cannot receive the new typed conflict handling, scoped-credential renewal, bulk snapshot-manifest seeding, or whole-segment fetch path without a new binary release.

The artifact-storage server should be deployed before publishing the CLI. The CLI release workflow must pin artifact_storage merge commit `28efdf71ab36d96baebd87acbabcf3f48d7e2869` or a descendant.

No separate PyPI or npm release is required for artifact_storage#188: the published SDKs do not include the private native-filesystem crates. Their metadata moves with the repository's standard shared version bump.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- TypeScript package and lockfile versions agree at `0.5.98`
- `git diff --check`
