### PR TITLE
Mount daemon memory: fuser fork (configurable buffer) + jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4006,6 +4006,7 @@ dependencies = [
  "tempfile",
  "tensorlake",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -4105,6 +4106,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -74,3 +74,6 @@ flate2 = { workspace = true }
 sha1 = { workspace = true }
 ignore = { workspace = true }
 tempfile = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemallocator = "0.6"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,7 @@
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL_ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod auth;
 mod cache;
 mod commands;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,21 @@
 #[global_allocator]
 static GLOBAL_ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+/// Compiled-in jemalloc configuration (the prefixed build reads `_rjem_malloc_conf`).
+/// `dirty_decay_ms:0` returns freed pages to the kernel immediately: measured on the 150k-file
+/// mount-daemon burst harness it cuts peak RSS by ~370 MB (1152 -> 781 MB) with no wall-clock
+/// cost (60 s vs 64 s). The background thread handles any deferred purging. Compiled in rather
+/// than set via environment so deployments cannot drift from the measured configuration.
+#[cfg(target_os = "linux")]
+#[repr(transparent)]
+struct MallocConf(*const u8);
+#[cfg(target_os = "linux")]
+unsafe impl Sync for MallocConf {}
+#[cfg(target_os = "linux")]
+#[unsafe(export_name = "_rjem_malloc_conf")]
+static MALLOC_CONF: MallocConf =
+    MallocConf(c"background_thread:true,dirty_decay_ms:0,muzzy_decay_ms:0".as_ptr().cast());
+
 mod auth;
 mod cache;
 mod commands;


### PR DESCRIPTION
Companion to artifact_storage: "Cut mount-daemon RSS 5.4x". Two tensorlake-side changes that the `tl` mount daemon needs:

1. **Pin the fuser 0.18 fork** (`tensorlakeai/fuser@configurable-buffer-size`, upstreamed as cberner/fuser#338) via `[patch.crates-io]` + bump the gsvc-fs-client placeholder to fuser 0.18. The fork adds `Config::read_buffer_size` so the daemon can bound its per-worker FUSE receive buffers (stock fuser hardcodes them to 16 MiB × workers).

2. **Use jemalloc as the `tl` global allocator on Linux.** Heap profiling showed most of the daemon's ~1.2 GB real-build peak was glibc holding freed memory across per-thread arenas (live heap only ~216 MB). jemalloc returns freed pages promptly. This is the **single biggest contributor** to the measured 1170 MB → 215 MB reduction. Linux-only (FUSE daemon + CI/dataplane target); macOS keeps the system allocator.

Must land with the artifact_storage memory PR (they're built together via `just build-cli-full`).