### PR TITLE
Unbreak CLI release: pin the fuser fork (fuser pins only, no jemalloc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,9 +1235,8 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuser"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a5eca878900c2e39e9e52fd797954b7fc39eeefc8558257114bfea6a698fcf"
+version = "0.18.0"
+source = "git+https://github.com/tensorlakeai/fuser?branch=configurable-buffer-size#2565863131bb3865b068228a715b1efd9a7bfcb3"
 dependencies = [
  "bitflags",
  "libc",
@@ -2487,9 +2486,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,3 +131,8 @@ napi-build = "2"
 codegen-units = 1
 strip = true
 lto = true
+
+[patch.crates-io]
+# Fork of fuser 0.18.0 adding Config::read_buffer_size; consumed by the vendored
+# gsvc-fs-client mount client. See tensorlakeai/fuser and cberner/fuser#338.
+fuser = { git = "https://github.com/tensorlakeai/fuser", branch = "configurable-buffer-size" }

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -58,7 +58,7 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 zstd = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-fuser = { version = "0.17", default-features = false }
+fuser = { version = "0.18", default-features = false }
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -68,3 +68,11 @@ large_enum_variant = "allow"
 result_large_err = "allow"
 too_many_arguments = "allow"
 type_complexity = "allow"
+
+# The mount client uses `Config::read_buffer_size`, which exists only on the tensorlakeai fork of
+# fuser (upstream PR cberner/fuser#338). This manifest is its own workspace root (see the
+# `[workspace]` marker above), so the patch must live here: root-workspace `[patch.crates-io]`
+# sections do not apply to standalone --manifest-path builds like the fuse cross-check and the
+# vendored full-feature CI step.
+[patch.crates-io]
+fuser = { git = "https://github.com/tensorlakeai/fuser", branch = "configurable-buffer-size" }


### PR DESCRIPTION
Unbreaks the `Release - CLI Binaries` workflow on main (run 30967995676: both Linux zigbuild jobs fail with `E0609: no field read_buffer_size on fuser::Config`) and the vendored full-feature CI step (run 30957400238).

artifact_storage#191 merged using `fuser::Config::read_buffer_size`, which exists only on the tensorlakeai/fuser fork (upstream PR cberner/fuser#338). This PR is the minimal companion: the three fuser commits cherry-picked from #887 —

1. placeholder `fuser` 0.17→0.18 mirror + root `[patch.crates-io]` fork pin,
2. the same pin **inside the standalone gsvc-fs-client manifest** (it declares `[workspace]`, so consuming-repo root patches never apply to `--manifest-path` builds — this is why #887's own CI was red until yesterday),
3. a refreshed `Cargo.lock` (the stale lock still resolved crates.io fuser 0.17).

**Deliberately excludes #887's jemalloc commits.** The release workflow cross-compiles linux-aarch64 with `cargo-zigbuild` from an x86 runner, and `tikv-jemalloc-sys` does not link under zigbuild cross-compilation (`_rjem_*` undefined symbols — reproduced repeatedly while building test binaries this week). Landing jemalloc through the release pipeline needs either native arm runners for the aarch64 CLI build (the wheel jobs already use `ubuntu-24.04-arm`) or a zigbuild-compatible jemalloc story; that stays on #887.

After this merges, #887 rebases to just the jemalloc + compiled-in decay-config commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)