### PR TITLE
Bump Tensorlake packages to 0.5.100

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "base64",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "base64",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.99"
+version = "0.5.100"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.99"
+version = "0.5.100"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.99"
+version = "0.5.100"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.99"
+version = "0.5.100"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.99"
+version = "0.5.100"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.99",
+  "version": "0.5.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.99",
+      "version": "0.5.100",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.99",
+  "version": "0.5.100",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the Tensorlake Rust workspace and CLI packages from 0.5.99 to 0.5.100
- bump Python package metadata and the TypeScript package
- update the `gsvc-fs-client` resolution placeholder and both lockfiles

## Why

This prepares the next standalone CLI build to consume the repaired private TLFS client from [artifact_storage#200](https://github.com/tensorlakeai/artifact_storage/pull/200).

The private `gsvc-fs-client` and `gsvc-mount` sources are injected from `artifact_storage` while building an official CLI release. The release should therefore run only after artifact_storage#200 is merged, and it should pin that merge commit or a descendant.

## Impact

All publishable Tensorlake package surfaces now report version `0.5.100`. This PR contains release metadata changes only; the TLFS implementation remains in the private artifact-storage repository and is injected at build time.

## Validation

- `make bump_version VERSION=0.5.100`
- `cargo metadata --locked --no-deps --format-version 1`
- verified the Rust workspace, CLI, Node SDK, Python Rust SDK, and filesystem placeholder resolve to `0.5.100`
- verified the TypeScript package and lockfile versions agree at `0.5.100`
- `git diff --check`
