### PR TITLE
Bump Tensorlake packages to 0.5.101

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "base64",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "base64",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.100"
+version = "0.5.101"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.100"
+version = "0.5.101"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.100"
+version = "0.5.101"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.100"
+version = "0.5.101"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.100"
+version = "0.5.101"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.100",
+  "version": "0.5.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.100",
+      "version": "0.5.101",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.100",
+  "version": "0.5.101",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Release metadata only — `make bump_version VERSION=0.5.101` plus lockfile regeneration (`cargo update --workspace`, `npm install --package-lock-only`). All publishable surfaces report `0.5.101`.

Prepares the standalone CLI release that vendors the TLFS prefetch throughput stack from artifact_storage main (#199 + #206 merged as `ed030e2`, manifest subtree prefix #209 as `0739b89`): cold CI-cache warmup **936 s → 98 s** measured on the reference set. Implementation stays in the private repo and is injected at build time; this release must run against artifact_storage main at or after `ed030e2`, which is its current tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)