### PR TITLE
sandbox: dynamic egress network-policy updates

### DIFF
--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -194,6 +194,12 @@ pub struct UpdateSandboxRequest {
     pub allow_unauthenticated_access: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exposed_ports: Option<Vec<u16>>,
+    /// Tri-state update of the running sandbox's egress network policy: omitted
+    /// leaves it unchanged, `null` clears it to unrestricted egress, an object
+    /// replaces the whole policy. The dataplane re-renders the live VM's
+    /// firewall in one atomic swap with no enforcement gap.
+    #[serde(default, skip_serializing_if = "NetworkPolicyUpdate::is_keep")]
+    pub network: NetworkPolicyUpdate,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -220,19 +226,19 @@ pub struct CreateSandboxPoolRequest {
     pub network: Option<NetworkConfig>,
 }
 
-/// What a pool update should do with the pool's network policy.
+/// What an update should do with a pool's or sandbox's network policy.
 ///
-/// A pool update replaces the pool record wholesale, so the three states are
-/// distinct on the wire: the field is omitted to keep the current policy,
-/// sent as `null` to clear it, or sent as an object to replace it.
+/// The three states are distinct on the wire: the field is omitted to keep the
+/// current policy, sent as `null` to clear it, or sent as an object to replace
+/// it. Shared by [`UpdateSandboxPoolRequest`] and [`UpdateSandboxRequest`].
 #[derive(Clone, Debug, Default, PartialEq)]
 pub enum NetworkPolicyUpdate {
-    /// Leave the pool's current network policy in place.
+    /// Leave the current network policy in place.
     #[default]
     Keep,
-    /// Remove the pool's network policy, leaving containers unrestricted.
+    /// Remove the network policy, leaving egress unrestricted.
     Clear,
-    /// Replace the pool's network policy.
+    /// Replace the network policy.
     Set(NetworkConfig),
 }
 

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -4,7 +4,7 @@ use tensorlake::{
         SandboxProxyClient, SandboxesClient,
         models::{
             ContainerResourcesInfo, CreateSandboxPoolRequest, NetworkConfig, NetworkPolicyUpdate,
-            SandboxPoolRequest, UpdateSandboxPoolRequest,
+            SandboxPoolRequest, UpdateSandboxPoolRequest, UpdateSandboxRequest,
         },
     },
 };
@@ -385,6 +385,139 @@ fn network_policy_update_wire_shapes() {
         serde_json::from_str(&encode(NetworkPolicyUpdate::Keep)).expect("decode keep");
     assert_eq!(keep.network, NetworkPolicyUpdate::Keep);
     let clear: UpdateSandboxPoolRequest =
+        serde_json::from_str(&encode(NetworkPolicyUpdate::Clear)).expect("decode clear");
+    assert_eq!(clear.network, NetworkPolicyUpdate::Clear);
+}
+
+const SANDBOX_INFO_JSON: &str = r#"{
+    "sandbox_id":"sb-1",
+    "namespace":"default",
+    "status":"running",
+    "resources":{"cpus":1.0,"memory_mb":1024,"ephemeral_disk_mb":1024}
+}"#;
+
+#[tokio::test]
+async fn update_sandbox_replaces_network_policy() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept update");
+        let update = read_http_request(&mut socket).await;
+        write_json_response(&mut socket, SANDBOX_INFO_JSON).await;
+        update
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .build()
+        .expect("build client");
+    let sandboxes = SandboxesClient::new(client, "default", false);
+
+    sandboxes
+        .update(
+            "sb-1",
+            &UpdateSandboxRequest {
+                name: None,
+                allow_unauthenticated_access: None,
+                exposed_ports: None,
+                network: NetworkPolicyUpdate::Set(NetworkConfig {
+                    allow_internet_access: true,
+                    allow_out: vec!["example.com".to_string()],
+                    deny_out: vec![],
+                }),
+            },
+        )
+        .await
+        .expect("update sandbox network policy");
+
+    let update = server.await.expect("server join");
+    let update_text = String::from_utf8_lossy(&update);
+    assert!(
+        update_text.starts_with("PATCH "),
+        "sandbox network updates must use PATCH: {update_text}"
+    );
+    assert!(
+        update_text.contains(r#""network":{"allow_internet_access":true"#),
+        "the replacement policy must be sent as an object: {update_text}"
+    );
+    assert!(
+        update_text.contains(r#""allow_out":["example.com"]"#),
+        "allow_out entries must be sent: {update_text}"
+    );
+}
+
+#[tokio::test]
+async fn update_sandbox_clear_sends_explicit_null_network() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept update");
+        let update = read_http_request(&mut socket).await;
+        write_json_response(&mut socket, SANDBOX_INFO_JSON).await;
+        update
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .build()
+        .expect("build client");
+    let sandboxes = SandboxesClient::new(client, "default", false);
+
+    sandboxes
+        .update(
+            "sb-1",
+            &UpdateSandboxRequest {
+                name: None,
+                allow_unauthenticated_access: None,
+                exposed_ports: None,
+                network: NetworkPolicyUpdate::Clear,
+            },
+        )
+        .await
+        .expect("clear sandbox network policy");
+
+    let update = server.await.expect("server join");
+    let update_text = String::from_utf8_lossy(&update);
+    assert!(
+        update_text.contains(r#""network":null"#),
+        "clear must send an explicit null so the service removes the policy: {update_text}"
+    );
+}
+
+#[test]
+fn sandbox_network_policy_update_wire_shapes() {
+    // Keep is omitted entirely, Clear is an explicit null, Set is an object —
+    // the tri-state PATCH semantics the running-sandbox update relies on.
+    let encode = |network| {
+        serde_json::to_string(&UpdateSandboxRequest {
+            name: None,
+            allow_unauthenticated_access: None,
+            exposed_ports: None,
+            network,
+        })
+        .expect("serialize")
+    };
+
+    assert!(!encode(NetworkPolicyUpdate::Keep).contains("network"));
+    assert!(encode(NetworkPolicyUpdate::Clear).contains(r#""network":null"#));
+    assert!(
+        encode(NetworkPolicyUpdate::Set(NetworkConfig {
+            allow_internet_access: false,
+            allow_out: vec![],
+            deny_out: vec![],
+        }))
+        .contains(r#""network":{"allow_internet_access":false"#)
+    );
+
+    // Round-trip: an absent key decodes back to Keep, null to Clear.
+    let keep: UpdateSandboxRequest =
+        serde_json::from_str(&encode(NetworkPolicyUpdate::Keep)).expect("decode keep");
+    assert_eq!(keep.network, NetworkPolicyUpdate::Keep);
+    let clear: UpdateSandboxRequest =
         serde_json::from_str(&encode(NetworkPolicyUpdate::Clear)).expect("decode clear");
     assert_eq!(clear.network, NetworkPolicyUpdate::Clear);
 }

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -390,25 +390,36 @@ class AsyncSandboxClient:
         *,
         allow_unauthenticated_access: bool | None = None,
         exposed_ports: list[int] | None = None,
+        network: NetworkConfig | ClearNetworkPolicy | None = None,
     ) -> Traced[SandboxInfo]:
         normalized_ports = (
             _normalize_user_ports(exposed_ports) if exposed_ports is not None else None
         )
+        clearing_network = network is CLEAR_NETWORK_POLICY
+        network_config = network if isinstance(network, NetworkConfig) else None
         if (
             name is None
             and allow_unauthenticated_access is None
             and normalized_ports is None
+            and network_config is None
+            and not clearing_network
         ):
             raise SandboxError("At least one sandbox update field must be provided.")
         request = UpdateSandboxRequest(
             name=name,
             allow_unauthenticated_access=allow_unauthenticated_access,
             exposed_ports=normalized_ports,
+            network=network_config,
         )
+        # exclude_none omits an unset policy (keep); CLEAR must reach the wire
+        # as an explicit null so the service clears it.
+        payload = json.loads(request.model_dump_json(exclude_none=True))
+        if clearing_network:
+            payload["network"] = None
         try:
             trace_id, response_json = await self._rust_client.update_sandbox_async(
                 sandbox_id=sandbox_id,
-                request_json=request.model_dump_json(exclude_none=True),
+                request_json=json.dumps(payload),
             )
             return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -22,6 +22,7 @@ from . import _defaults
 from .exceptions import RemoteAPIError, SandboxConnectionError, SandboxError
 from .models import (
     CheckpointType,
+    ClearNetworkPolicy,
     CommandResult,
     CopySandboxResponse,
     DaemonInfo,
@@ -29,6 +30,7 @@ from .models import (
     HealthResponse,
     ListDirectoryResponse,
     ListProcessesResponse,
+    NetworkConfig,
     OutputEvent,
     OutputMode,
     OutputResponse,
@@ -573,6 +575,7 @@ class AsyncSandbox:
         *,
         allow_unauthenticated_access: bool | None = None,
         exposed_ports: list[int] | None = None,
+        network: NetworkConfig | ClearNetworkPolicy | None = None,
     ) -> Traced[SandboxInfo]:
         self._require_lifecycle_client("update")
         traced = await self._lifecycle_client.update_sandbox(
@@ -580,6 +583,7 @@ class AsyncSandbox:
             name=name,
             allow_unauthenticated_access=allow_unauthenticated_access,
             exposed_ports=exposed_ports,
+            network=network,
         )
         self._sandbox_id = traced.sandbox_id
         self._cached_info = traced.value

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -693,10 +693,12 @@ class SandboxClient:
         *,
         allow_unauthenticated_access: bool | None = None,
         exposed_ports: list[int] | None = None,
+        network: NetworkConfig | ClearNetworkPolicy | None = None,
     ) -> Traced[SandboxInfo]:
-        """Update a sandbox's properties.
+        """Update a running sandbox's properties.
 
-        Supports updating the sandbox name and sandbox proxy access settings.
+        Supports updating the sandbox name, sandbox proxy access settings, and
+        the egress network policy.
 
         Args:
             sandbox_id: ID or name of the sandbox to update
@@ -707,6 +709,12 @@ class SandboxClient:
             exposed_ports: User ports that should be routable through the sandbox
                 proxy. Port ``9501`` is reserved for sandbox management and cannot
                 be configured here.
+            network: Egress network policy update, applied to the running VM's
+                firewall in one atomic swap. Omit (the default) to leave the
+                current policy unchanged, pass a :class:`NetworkConfig` to
+                replace it, or pass :data:`CLEAR_NETWORK_POLICY` to clear it to
+                unrestricted egress. A destination that fails to resolve rejects
+                the update and the previous policy stays enforced.
 
         Returns:
             SandboxInfo with updated sandbox details
@@ -719,10 +727,14 @@ class SandboxClient:
         normalized_ports = (
             _normalize_user_ports(exposed_ports) if exposed_ports is not None else None
         )
+        clearing_network = network is CLEAR_NETWORK_POLICY
+        network_config = network if isinstance(network, NetworkConfig) else None
         if (
             name is None
             and allow_unauthenticated_access is None
             and normalized_ports is None
+            and network_config is None
+            and not clearing_network
         ):
             raise SandboxError("At least one sandbox update field must be provided.")
 
@@ -730,11 +742,18 @@ class SandboxClient:
             name=name,
             allow_unauthenticated_access=allow_unauthenticated_access,
             exposed_ports=normalized_ports,
+            network=network_config,
         )
+        # exclude_none omits an unset policy (keep); CLEAR must reach the wire
+        # as an explicit null so the service clears it. Mirrors the pool
+        # tri-state contract in _pool_update_request_json.
+        payload = json.loads(request.model_dump_json(exclude_none=True))
+        if clearing_network:
+            payload["network"] = None
         try:
             trace_id, response_json = self._rust_client.update_sandbox(
                 sandbox_id=sandbox_id,
-                request_json=request.model_dump_json(exclude_none=True),
+                request_json=json.dumps(payload),
             )
             return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -180,37 +180,43 @@ explicit instruction. Containers in the pool become unrestricted.
 
 
 class NetworkConfig(BaseModel):
-    """Network access control policy for sandbox containers.
+    """Egress network access control policy for a sandbox.
 
-    Rules are enforced via host-level iptables on the DOCKER-USER chain.
-    Each container gets its own chain with rules applied before any user
-    code runs.
+    Enforced host-side per sandbox. ``deny_out`` takes precedence over
+    ``allow_out``: a destination matched by both is blocked. Established and
+    related connections are always permitted (stateful firewall).
 
-    ``allow_out`` rules are evaluated before ``deny_out`` rules, so allow
-    takes precedence over deny.  Established/related connections are always
-    permitted (stateful firewall).
+    When ``allow_internet_access`` is ``True`` (the default), outbound traffic
+    is allowed unless matched by ``deny_out``. When ``False``, outbound is
+    blocked unless matched by ``allow_out`` (and not by ``deny_out``).
 
-    When ``allow_internet_access`` is ``True`` (the default), all outbound
-    traffic is allowed unless explicitly denied by ``deny_out``.  When
-    ``False``, all outbound traffic is blocked unless explicitly allowed by
-    ``allow_out``.
+    Entries may be IPv4 addresses, CIDR ranges, or DNS hostnames (an optional
+    ``:port`` suffix is accepted but does not make the rule port-specific).
+    Hostname rules are followed across DNS changes, so a CDN-backed name keeps
+    working as its addresses rotate. Deny-precedence applies to the sandbox's
+    own DNS resolver too: a ``deny_out`` covering the resolver disables DNS
+    even if ``allow_out`` also covers it.
+
+    The policy can be changed on a running sandbox with
+    :meth:`Sandbox.update` (pass ``network=...`` or
+    :data:`CLEAR_NETWORK_POLICY`).
     """
 
     allow_internet_access: bool = True
     allow_out: list[str] = Field(
         default_factory=list,
         description=(
-            "Destination IPs or CIDRs to allow "
-            '(e.g. ["8.8.8.8", "10.0.0.0/8"]). '
-            "Evaluated before deny_out; takes precedence."
+            "Destinations to allow: IPv4 addresses, CIDRs, or hostnames "
+            '(e.g. ["8.8.8.8", "10.0.0.0/8", "api.example.com"]). '
+            "Overridden by any matching deny_out entry."
         ),
     )
     deny_out: list[str] = Field(
         default_factory=list,
         description=(
-            "Destination IPs or CIDRs to deny "
-            '(e.g. ["192.168.1.0/24"]). '
-            "Evaluated after allow_out."
+            "Destinations to deny: IPv4 addresses, CIDRs, or hostnames "
+            '(e.g. ["192.168.1.0/24", "ads.example.com"]). '
+            "Takes precedence over allow_out."
         ),
     )
 
@@ -270,11 +276,18 @@ class CreateSandboxRequest(BaseModel):
 
 
 class UpdateSandboxRequest(BaseModel):
-    """Request payload for updating a sandbox."""
+    """Request payload for updating a sandbox.
+
+    ``network`` carries only the "set" case here (a policy object). The
+    "keep" and "clear" cases are expressed on the wire by omitting the field
+    or sending an explicit ``null``; the client builds those from the
+    :data:`CLEAR_NETWORK_POLICY` sentinel rather than this model.
+    """
 
     name: str | None = None
     allow_unauthenticated_access: bool | None = None
     exposed_ports: list[int] | None = None
+    network: NetworkConfig | None = None
 
 
 class SandboxPoolRequest(BaseModel):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -22,6 +22,7 @@ from .exceptions import (
 )
 from .models import (
     CheckpointType,
+    ClearNetworkPolicy,
     CommandResult,
     CopySandboxResponse,
     DaemonInfo,
@@ -29,6 +30,7 @@ from .models import (
     HealthResponse,
     ListDirectoryResponse,
     ListProcessesResponse,
+    NetworkConfig,
     OutputEvent,
     OutputMode,
     OutputResponse,
@@ -922,12 +924,13 @@ class Sandbox:
         *,
         allow_unauthenticated_access: bool | None = None,
         exposed_ports: list[int] | None = None,
+        network: NetworkConfig | ClearNetworkPolicy | None = None,
     ) -> Traced[SandboxInfo]:
         """Update this sandbox's properties.
 
-        Supports updating the sandbox name and sandbox proxy access settings.
-        Naming an ephemeral sandbox makes it non-ephemeral and enables
-        suspend/resume.
+        Supports updating the sandbox name, sandbox proxy access settings, and
+        the egress network policy. Naming an ephemeral sandbox makes it
+        non-ephemeral and enables suspend/resume.
 
         Args:
             name: New name for the sandbox.
@@ -935,6 +938,9 @@ class Sandbox:
                 reachable without TensorLake auth.
             exposed_ports: User ports that should be routable through the
                 sandbox proxy. Port ``9501`` is reserved.
+            network: Egress network policy update. Omit to leave it unchanged,
+                pass a :class:`NetworkConfig` to replace it, or pass
+                :data:`CLEAR_NETWORK_POLICY` to clear it to unrestricted egress.
 
         Returns:
             Traced[SandboxInfo] with the updated sandbox details.
@@ -945,6 +951,7 @@ class Sandbox:
             name=name,
             allow_unauthenticated_access=allow_unauthenticated_access,
             exposed_ports=exposed_ports,
+            network=network,
         )
         self._sandbox_id = traced.sandbox_id
         self._cached_info = traced.value

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -884,6 +884,56 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertTrue(info.allow_unauthenticated_access)
         self.assertEqual(info.exposed_ports, [8080, 8081])
 
+    def test_update_sandbox_sets_network_policy(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        client.update_sandbox(
+            "sbx-1",
+            network=NetworkConfig(
+                allow_internet_access=True, allow_out=["example.com"]
+            ),
+        )
+
+        request_json = json.loads(fake.update_request_json)
+        self.assertEqual(
+            request_json["network"],
+            {
+                "allow_internet_access": True,
+                "allow_out": ["example.com"],
+                "deny_out": [],
+            },
+        )
+
+    def test_update_sandbox_clears_network_policy_with_explicit_null(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        client.update_sandbox("sbx-1", network=CLEAR_NETWORK_POLICY)
+
+        request_json = json.loads(fake.update_request_json)
+        self.assertIn("network", request_json)
+        self.assertIsNone(request_json["network"])
+
+    def test_update_sandbox_omits_network_when_unset(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        fake = _FakeRustClient()
+        client._rust_client = fake
+
+        client.update_sandbox("sbx-1", name="renamed")
+
+        request_json = json.loads(fake.update_request_json)
+        self.assertNotIn("network", request_json)
+
+    def test_update_sandbox_requires_at_least_one_field(self):
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = _FakeRustClient()
+
+        with self.assertRaises(SandboxError):
+            client.update_sandbox("sbx-1")
+
     def test_get_port_access_reads_current_settings(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         client._rust_client = _FakeRustClient()

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -871,6 +871,52 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(info.allow_unauthenticated_access)
         self.assertEqual(info.exposed_ports, [8080, 8081])
 
+    async def test_update_sandbox_sets_network_policy(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        await client.update_sandbox(
+            "sbx-1",
+            network=NetworkConfig(
+                allow_internet_access=True, allow_out=["example.com"]
+            ),
+        )
+
+        request_json = json.loads(fake.update_request_json)
+        self.assertEqual(
+            request_json["network"],
+            {
+                "allow_internet_access": True,
+                "allow_out": ["example.com"],
+                "deny_out": [],
+            },
+        )
+
+    async def test_update_sandbox_clears_network_policy_with_explicit_null(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        await client.update_sandbox("sbx-1", network=CLEAR_NETWORK_POLICY)
+
+        request_json = json.loads(fake.update_request_json)
+        self.assertIn("network", request_json)
+        self.assertIsNone(request_json["network"])
+
+    async def test_update_sandbox_omits_network_when_unset(self):
+        fake = _FakeAsyncRustClient()
+        client = _make_client(fake)
+
+        await client.update_sandbox("sbx-1", name="renamed")
+
+        request_json = json.loads(fake.update_request_json)
+        self.assertNotIn("network", request_json)
+
+    async def test_update_sandbox_requires_at_least_one_field(self):
+        client = _make_client(_FakeAsyncRustClient())
+
+        with self.assertRaises(SandboxError):
+            await client.update_sandbox("sbx-1")
+
     async def test_get_port_access_reads_current_settings(self):
         client = _make_client()
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -342,6 +342,12 @@ export class SandboxClient {
     if (options.exposedPorts != null) {
       body.exposed_ports = normalizeUserPorts(options.exposedPorts);
     }
+    // Tri-state network policy: omit to keep the current policy, `null` to
+    // clear it to unrestricted egress, an object to replace it.
+    if (options.network !== undefined) {
+      body.network =
+        options.network === null ? null : toSnakeKeys(options.network);
+    }
     if (Object.keys(body).length === 0) {
       throw new SandboxError(
         "At least one sandbox update field must be provided.",

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -76,6 +76,14 @@ export interface GPUResources {
   model: string;
 }
 
+/**
+ * Egress network access control policy for a sandbox.
+ *
+ * `denyOut` takes precedence over `allowOut`: a destination matched by both is
+ * blocked. Entries may be IPv4 addresses, CIDR ranges, or DNS hostnames;
+ * hostname rules are followed across DNS changes. The policy can be changed on
+ * a running sandbox via `Sandbox.update({ network })` (pass `null` to clear).
+ */
 export interface NetworkConfig {
   allowInternetAccess: boolean;
   allowOut: string[];
@@ -126,6 +134,12 @@ export interface UpdateSandboxOptions {
   allowUnauthenticatedAccess?: boolean;
   /** User ports that should be routable through the sandbox proxy. Port 9501 is reserved. */
   exposedPorts?: number[];
+  /**
+   * Egress network policy for the running sandbox, applied to the live VM's
+   * firewall in one atomic swap. Omit to keep the current policy, set to
+   * replace it, or pass `null` to clear it to unrestricted egress.
+   */
+  network?: NetworkConfig | null;
 }
 
 export interface CreateSandboxResponse {

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -708,10 +708,12 @@ export class Sandbox {
   }
 
   /**
-   * Update this sandbox's properties (name, exposed ports, proxy auth).
+   * Update this sandbox's properties (name, exposed ports, proxy auth, and
+   * egress network policy).
    *
    * Naming an ephemeral sandbox makes it non-ephemeral and enables
-   * suspend/resume.
+   * suspend/resume. For `network`, omit to keep the current policy, pass an
+   * object to replace it, or pass `null` to clear it to unrestricted egress.
    */
   async update(options: UpdateSandboxOptions): Promise<Traced<SandboxInfo>> {
     const client = this.requireLifecycleClient("update");

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -443,6 +443,74 @@ describe("SandboxClient", () => {
       client.close();
     });
 
+    const sandboxInfoJson = JSON.stringify({
+      id: "sbx-1",
+      namespace: "default",
+      status: "running",
+      resources: { cpus: 1, memory_mb: 1024, ephemeral_disk_mb: 1024 },
+    });
+
+    it("replaces the network policy with a snake-cased object", async () => {
+      const stub = installNativeStub({
+        client: {
+          updateSandbox: vi.fn(async (id: string, json: string) => {
+            expect(id).toBe("sbx-1");
+            const body = JSON.parse(json);
+            expect(body.network).toEqual({
+              allow_internet_access: true,
+              allow_out: ["example.com"],
+              deny_out: [],
+            });
+            return { traceId: "t", json: sandboxInfoJson };
+          }),
+        },
+      });
+
+      const client = SandboxClient.forLocalhost();
+      await client.update("sbx-1", {
+        network: {
+          allowInternetAccess: true,
+          allowOut: ["example.com"],
+          denyOut: [],
+        },
+      });
+      expect(stub.client.updateSandbox).toHaveBeenCalledOnce();
+      client.close();
+    });
+
+    it("clears the network policy with an explicit null", async () => {
+      installNativeStub({
+        client: {
+          updateSandbox: vi.fn(async (_id: string, json: string) => {
+            const body = JSON.parse(json);
+            expect("network" in body).toBe(true);
+            expect(body.network).toBeNull();
+            return { traceId: "t", json: sandboxInfoJson };
+          }),
+        },
+      });
+
+      const client = SandboxClient.forLocalhost();
+      await client.update("sbx-1", { network: null });
+      client.close();
+    });
+
+    it("omits network when it is not provided", async () => {
+      installNativeStub({
+        client: {
+          updateSandbox: vi.fn(async (_id: string, json: string) => {
+            const body = JSON.parse(json);
+            expect("network" in body).toBe(false);
+            return { traceId: "t", json: sandboxInfoJson };
+          }),
+        },
+      });
+
+      const client = SandboxClient.forLocalhost();
+      await client.update("sbx-1", { name: "renamed" });
+      client.close();
+    });
+
     it("rejects empty sandbox updates", async () => {
       installNativeStub();
       const client = SandboxClient.forLocalhost();


### PR DESCRIPTION
## What

Adds the ability to change a **running sandbox's egress network policy** without recreating or suspending it. This mirrors the tri-state `network` update contract the pool-update path already uses.

The `network` argument on an update is tri-state:

- **omit** → leave the current policy unchanged
- **pass a policy** → replace the whole policy
- **clear** (`CLEAR_NETWORK_POLICY` in Python, `null` in TS/JSON) → return to unrestricted egress

The change is applied to the live sandbox firewall as one atomic swap (no enforcement gap); established connections aren't cut; and if a hostname in the new policy fails to resolve, the update is rejected and the previous policy stays enforced.

## Changes

- **Rust (`cloud-sdk`)**: `UpdateSandboxRequest` gains `network: NetworkPolicyUpdate` (the existing shared enum) with `skip_serializing_if = "is_keep"`, so keep=omitted, clear=`null`, replace=object. The existing `update` PATCH carries it; bindings are JSON-passthrough, so no PyO3/napi changes are needed.
- **Python**: `Sandbox.update` / `AsyncSandbox.update` / `update_sandbox` accept `network: NetworkConfig | ClearNetworkPolicy | None`, serialized with the same `CLEAR_NETWORK_POLICY`→explicit-null logic as pools.
- **TypeScript**: `UpdateSandboxOptions.network?: NetworkConfig | null` with the `undefined`/`null`/object block in `client.update`.
- Corrected the `NetworkConfig` docstrings to **deny-first** precedence (a destination matched by both `allow_out` and `deny_out` is blocked) and the host-side / hostname-across-DNS behavior, replacing the stale iptables/DOCKER-USER, allow-first description.

## Tests

- Rust wire-shape tests (keep omitted / clear `null` / replace object) in `crates/cloud-sdk/tests/sandboxes.rs`.
- Python stub tests (set / clear / keep / empty-guard) on both sync and async paths.
- TypeScript native-stub tests (replace / clear-null / omit).

All green: `cargo test -p tensorlake --test sandboxes` (9), 104 Python sandbox tests, 264 TS tests; `cargo fmt`/clippy, `make fmt`, and `tsc --noEmit` clean.

## Notes

- Depends on the server-side dynamic-policy support in compute-engine-internal #1626 (the PATCH `network` endpoint); the SDK contract matches that PR.
- Precedence is **deny-first** by decision; the server API doc comment in #1626 should be updated to match.
- Version not bumped — let me know the target version and I'll run `bump_version.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)