### PR TITLE
Fix sandbox update tests for the new network kwarg

### DIFF
--- a/tests/sandbox/test_sandbox_rust_backend.py
+++ b/tests/sandbox/test_sandbox_rust_backend.py
@@ -410,6 +410,7 @@ class TestSandboxRustBackend(unittest.TestCase):
             name="renamed",
             allow_unauthenticated_access=True,
             exposed_ports=[8080],
+            network=None,
         )
         self.assertEqual(traced.name, "renamed")
         self.assertEqual(sandbox.name, "renamed")
@@ -431,6 +432,7 @@ class TestSandboxRustBackend(unittest.TestCase):
             name="new-name",
             allow_unauthenticated_access=None,
             exposed_ports=None,
+            network=None,
         )
 
     def test_update_raises_without_lifecycle_client(self):
@@ -453,6 +455,7 @@ class TestSandboxRustBackend(unittest.TestCase):
             name="new-env",
             allow_unauthenticated_access=None,
             exposed_ports=None,
+            network=None,
         )
         self.assertEqual(sandbox.name, "new-env")
 

--- a/tests/sandbox/test_sandbox_rust_backend_async.py
+++ b/tests/sandbox/test_sandbox_rust_backend_async.py
@@ -559,6 +559,7 @@ class TestAsyncSandboxRustBackend(unittest.IsolatedAsyncioTestCase):
             name="renamed",
             allow_unauthenticated_access=True,
             exposed_ports=[8080],
+            network=None,
         )
         self.assertEqual(traced.name, "renamed")
 


### PR DESCRIPTION
## Problem

The `Tests` workflow has been failing on `main` since #893.

#893 added a `network` parameter to `Sandbox.update()` / `AsyncSandbox.update()`, which always forwards it to `update_sandbox()`. The four mock assertions pinning that lifecycle-client call were not updated:

```
AssertionError: expected call not found.
Expected: update_sandbox('sbx-1', name='renamed', allow_unauthenticated_access=True, exposed_ports=[8080])
Actual:   update_sandbox('sbx-1', name='renamed', allow_unauthenticated_access=True, exposed_ports=[8080], network=None)
```

## Fix

Add `network=None` to the four expected calls.

## Verification

The full set of modules the `Lint and test` job runs now passes locally — 225 tests, the same count CI ran with 4 failures:

```
Ran 225 tests in 0.953s
OK
```

`black --check` and `isort --check` are clean on both files.

## Note

This does not turn the whole workflow green on its own. The `Rust full-feature workspace tests` job is failing separately on a flaky test in the vendored private sources, fixed by tensorlakeai/artifact_storage#221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)