### PR TITLE
Add CLI support for sandbox network updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "base64",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "base64",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "base64",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "napi",
  "napi-build",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.103"
+version = "0.5.104"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ tl sbx cp ./my_script.py <sandbox-id>:/tmp/my_script.py
 # Open an interactive terminal
 tl sbx ssh <sandbox-id>
 
+# Block all outbound internet access on a running sandbox
+tl sbx update <sandbox-id> --no-internet
+
+# Allow outbound traffic only to selected destinations
+tl sbx update <sandbox-id> --network-allow api.example.com
+
+# Remove the network policy and restore unrestricted outbound access
+tl sbx update <sandbox-id> --clear-network
+
 # Terminate when done
 tl sbx terminate <sandbox-id>
 ```

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -1,7 +1,7 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
-    DEFAULT_SANDBOX_WAIT_TIMEOUT, apply_proxy_access_settings, sandbox_endpoint,
-    wait_for_sandbox_status,
+    DEFAULT_SANDBOX_WAIT_TIMEOUT, apply_proxy_access_settings, build_network_config,
+    sandbox_endpoint, wait_for_sandbox_status,
 };
 use crate::error::{CliError, Result};
 use serde::Deserialize;
@@ -157,19 +157,8 @@ pub async fn run(ctx: &CliContext, args: CreateArgs<'_>) -> Result<()> {
 
     apply_proxy_access_settings(&mut body, ports, allow_unauthenticated_access);
 
-    let has_network = no_internet || !network_allow.is_empty() || !network_deny.is_empty();
-    if has_network {
-        let mut network = serde_json::json!({});
-        if no_internet {
-            network["allow_internet_access"] = serde_json::Value::Bool(false);
-        }
-        if !network_allow.is_empty() {
-            network["allow_out"] = serde_json::json!(network_allow);
-        }
-        if !network_deny.is_empty() {
-            network["deny_out"] = serde_json::json!(network_deny);
-        }
-        body["network"] = network;
+    if let Some(network) = build_network_config(no_internet, network_allow, network_deny)? {
+        body["network"] = serde_json::to_value(network)?;
     }
 
     let file_system_mounts = parse_file_system_mounts(file_systems)?;

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -20,13 +20,14 @@ pub mod ssh;
 pub mod suspend;
 pub mod terminate;
 pub mod tunnel;
+pub mod update;
 
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
 use chrono::{DateTime, Local, TimeZone, Utc};
 use tensorlake::sandboxes::{
-    resolve_default_sandbox_proxy_url, resolve_sandbox_proxy_target as resolve_core_proxy_target,
-    select_sandbox_proxy_url,
+    models::NetworkConfig, resolve_default_sandbox_proxy_url,
+    resolve_sandbox_proxy_target as resolve_core_proxy_target, select_sandbox_proxy_url,
 };
 use tokio::time::{Duration, Instant};
 
@@ -71,6 +72,34 @@ pub fn apply_proxy_access_settings(
     if allow_unauthenticated_access || !ports.is_empty() {
         body["allow_unauthenticated_access"] = serde_json::Value::Bool(true);
     }
+}
+
+/// Build the CLI's egress policy from its mutually exclusive network modes.
+///
+/// A non-empty `allow_out` is itself a default-drop allowlist in the
+/// dataplane while preserving resolver-scoped DNS. `allow_internet_access`
+/// must therefore remain true for `--network-allow`; false is reserved for
+/// the absolute `--no-internet` mode, which also blocks DNS.
+pub fn build_network_config(
+    no_internet: bool,
+    network_allow: &[String],
+    network_deny: &[String],
+) -> Result<Option<NetworkConfig>> {
+    if no_internet && (!network_allow.is_empty() || !network_deny.is_empty()) {
+        return Err(CliError::usage(
+            "--no-internet cannot be combined with allow or deny rules",
+        ));
+    }
+
+    if !no_internet && network_allow.is_empty() && network_deny.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(NetworkConfig {
+        allow_internet_access: !no_internet,
+        allow_out: network_allow.to_vec(),
+        deny_out: network_deny.to_vec(),
+    }))
 }
 
 /// Image name displayed when a sandbox carries no explicit image (i.e. it
@@ -422,6 +451,53 @@ mod proxy_access_tests {
 
         assert!(body.get("allow_unauthenticated_access").is_none());
         assert!(body.get("exposed_ports").is_none());
+    }
+}
+
+#[cfg(test)]
+mod network_config_tests {
+    use super::build_network_config;
+
+    #[test]
+    fn no_network_flags_omit_the_policy() {
+        assert_eq!(build_network_config(false, &[], &[]).unwrap(), None);
+    }
+
+    #[test]
+    fn allow_rules_keep_dns_enabled_for_dataplane_allowlist_mode() {
+        let allow = vec!["api.example.com".to_string()];
+        let policy = build_network_config(false, &allow, &[]).unwrap().unwrap();
+
+        assert!(policy.allow_internet_access);
+        assert_eq!(policy.allow_out, allow);
+        assert!(policy.deny_out.is_empty());
+    }
+
+    #[test]
+    fn deny_rules_use_default_allow_mode() {
+        let deny = vec!["ads.example.com".to_string()];
+        let policy = build_network_config(false, &[], &deny).unwrap().unwrap();
+
+        assert!(policy.allow_internet_access);
+        assert!(policy.allow_out.is_empty());
+        assert_eq!(policy.deny_out, deny);
+    }
+
+    #[test]
+    fn no_internet_builds_an_absolute_block_policy() {
+        let policy = build_network_config(true, &[], &[]).unwrap().unwrap();
+
+        assert!(!policy.allow_internet_access);
+        assert!(policy.allow_out.is_empty());
+        assert!(policy.deny_out.is_empty());
+    }
+
+    #[test]
+    fn no_internet_rejects_allow_and_deny_rules() {
+        let rule = vec!["example.com".to_string()];
+
+        assert!(build_network_config(true, &rule, &[]).is_err());
+        assert!(build_network_config(true, &[], &rule).is_err());
     }
 }
 

--- a/crates/cli/src/commands/sbx/run.rs
+++ b/crates/cli/src/commands/sbx/run.rs
@@ -1,5 +1,5 @@
 use crate::auth::context::CliContext;
-use crate::commands::sbx::{apply_proxy_access_settings, sandbox_endpoint};
+use crate::commands::sbx::{apply_proxy_access_settings, build_network_config, sandbox_endpoint};
 use crate::error::{CliError, Result};
 
 #[allow(clippy::too_many_arguments)]
@@ -43,19 +43,8 @@ pub async fn run(
         create_body["image"] = serde_json::Value::String(img.to_string());
     }
     apply_proxy_access_settings(&mut create_body, ports, allow_unauthenticated_access);
-    let has_network = no_internet || !network_allow.is_empty() || !network_deny.is_empty();
-    if has_network {
-        let mut network = serde_json::json!({});
-        if no_internet {
-            network["allow_internet_access"] = serde_json::Value::Bool(false);
-        }
-        if !network_allow.is_empty() {
-            network["allow_out"] = serde_json::json!(network_allow);
-        }
-        if !network_deny.is_empty() {
-            network["deny_out"] = serde_json::json!(network_deny);
-        }
-        create_body["network"] = network;
+    if let Some(network) = build_network_config(no_internet, network_allow, network_deny)? {
+        create_body["network"] = serde_json::to_value(network)?;
     }
 
     let create_resp = client

--- a/crates/cli/src/commands/sbx/update.rs
+++ b/crates/cli/src/commands/sbx/update.rs
@@ -1,0 +1,174 @@
+use crate::auth::context::CliContext;
+use crate::commands::sbx::{build_network_config, sandbox_endpoint};
+use crate::error::{CliError, Result};
+use tensorlake::sandboxes::models::{NetworkPolicyUpdate, UpdateSandboxRequest};
+
+#[derive(Clone, Copy)]
+pub struct UpdateNetworkArgs<'a> {
+    pub clear_network: bool,
+    pub no_internet: bool,
+    pub network_allow: &'a [String],
+    pub network_deny: &'a [String],
+}
+
+pub async fn run(ctx: &CliContext, sandbox_id: &str, args: UpdateNetworkArgs<'_>) -> Result<()> {
+    let client = ctx.client()?;
+    let url = sandbox_endpoint(ctx, &format!("sandboxes/{sandbox_id}"));
+    let request = build_update_request(args)?;
+
+    let resp = client
+        .patch(&url)
+        .json(&request)
+        .send()
+        .await
+        .map_err(CliError::Http)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(CliError::Other(anyhow::anyhow!(
+            "failed to update sandbox network configuration (HTTP {}): {}",
+            status,
+            body
+        )));
+    }
+
+    if args.clear_network {
+        println!("Cleared network configuration for sandbox {sandbox_id}");
+    } else {
+        println!("Updated network configuration for sandbox {sandbox_id}");
+    }
+    Ok(())
+}
+
+fn build_update_request(args: UpdateNetworkArgs<'_>) -> Result<UpdateSandboxRequest> {
+    if args.clear_network
+        && (args.no_internet || !args.network_allow.is_empty() || !args.network_deny.is_empty())
+    {
+        return Err(CliError::usage(
+            "--clear-network cannot be combined with replacement network settings",
+        ));
+    }
+
+    let network = if args.clear_network {
+        NetworkPolicyUpdate::Clear
+    } else {
+        let config = build_network_config(args.no_internet, args.network_allow, args.network_deny)?
+            .ok_or_else(|| CliError::usage("provide a network setting or use --clear-network"))?;
+        NetworkPolicyUpdate::Set(config)
+    };
+
+    Ok(UpdateSandboxRequest {
+        name: None,
+        allow_unauthenticated_access: None,
+        exposed_ports: None,
+        network,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UpdateNetworkArgs, build_update_request};
+
+    fn serialize(args: UpdateNetworkArgs<'_>) -> serde_json::Value {
+        serde_json::to_value(build_update_request(args).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn update_request_replaces_the_complete_network_policy() {
+        let allow = vec!["api.example.com".to_string(), "10.0.0.0/8".to_string()];
+        let deny = vec!["10.10.0.0/16".to_string()];
+
+        let request = serialize(UpdateNetworkArgs {
+            clear_network: false,
+            no_internet: false,
+            network_allow: &allow,
+            network_deny: &deny,
+        });
+
+        assert_eq!(request["network"]["allow_internet_access"], true);
+        assert_eq!(request["network"]["allow_out"], serde_json::json!(allow));
+        assert_eq!(request["network"]["deny_out"], serde_json::json!(deny));
+        assert!(request.get("name").is_none());
+    }
+
+    #[test]
+    fn no_internet_blocks_everything() {
+        let request = serialize(UpdateNetworkArgs {
+            clear_network: false,
+            no_internet: true,
+            network_allow: &[],
+            network_deny: &[],
+        });
+
+        assert_eq!(request["network"]["allow_internet_access"], false);
+        assert_eq!(request["network"]["allow_out"], serde_json::json!([]));
+        assert_eq!(request["network"]["deny_out"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn update_request_allows_internet_by_default_when_using_deny_rules() {
+        let deny = vec!["ads.example.com".to_string()];
+
+        let request = serialize(UpdateNetworkArgs {
+            clear_network: false,
+            no_internet: false,
+            network_allow: &[],
+            network_deny: &deny,
+        });
+
+        assert_eq!(request["network"]["allow_internet_access"], true);
+        assert_eq!(request["network"]["allow_out"], serde_json::json!([]));
+        assert_eq!(request["network"]["deny_out"], serde_json::json!(deny));
+    }
+
+    #[test]
+    fn clear_network_sends_an_explicit_null() {
+        let request = serialize(UpdateNetworkArgs {
+            clear_network: true,
+            no_internet: false,
+            network_allow: &[],
+            network_deny: &[],
+        });
+
+        assert_eq!(request["network"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn update_request_rejects_an_empty_update() {
+        let result = build_update_request(UpdateNetworkArgs {
+            clear_network: false,
+            no_internet: false,
+            network_allow: &[],
+            network_deny: &[],
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_request_rejects_clear_with_replacement_settings() {
+        let deny = vec!["example.com".to_string()];
+        let result = build_update_request(UpdateNetworkArgs {
+            clear_network: true,
+            no_internet: false,
+            network_allow: &[],
+            network_deny: &deny,
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn update_request_rejects_no_internet_with_rules() {
+        let allow = vec!["example.com".to_string()];
+        let result = build_update_request(UpdateNetworkArgs {
+            clear_network: false,
+            no_internet: true,
+            network_allow: &allow,
+            network_deny: &[],
+        });
+
+        assert!(result.is_err());
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1096,16 +1096,20 @@ enum SbxCommands {
         #[arg(long, hide = true)]
         allow_unauthenticated_access: bool,
 
-        /// Block all outbound internet access
-        #[arg(short = 'N', long)]
+        /// Block all outbound internet access, including DNS
+        #[arg(
+            short = 'N',
+            long,
+            conflicts_with_all = ["network_allow", "network_deny"]
+        )]
         no_internet: bool,
 
-        /// Allow outbound traffic to this IP or CIDR (can be repeated)
-        #[arg(short = 'A', long = "network-allow")]
+        /// Allow outbound traffic only to this IP, CIDR, or hostname, plus resolver-scoped DNS (can be repeated)
+        #[arg(short = 'A', long = "network-allow", conflicts_with = "no_internet")]
         network_allow: Vec<String>,
 
-        /// Deny outbound traffic to this IP or CIDR (can be repeated)
-        #[arg(short = 'D', long = "network-deny")]
+        /// Deny outbound traffic to this IP, CIDR, or hostname (can be repeated)
+        #[arg(short = 'D', long = "network-deny", conflicts_with = "no_internet")]
         network_deny: Vec<String>,
 
         /// Mount a registered file system at boot as
@@ -1331,16 +1335,20 @@ enum SbxCommands {
         #[arg(long, hide = true)]
         allow_unauthenticated_access: bool,
 
-        /// Block all outbound internet access
-        #[arg(short = 'N', long)]
+        /// Block all outbound internet access, including DNS
+        #[arg(
+            short = 'N',
+            long,
+            conflicts_with_all = ["network_allow", "network_deny"]
+        )]
         no_internet: bool,
 
-        /// Allow outbound traffic to this IP or CIDR (can be repeated)
-        #[arg(short = 'A', long = "network-allow")]
+        /// Allow outbound traffic only to this IP, CIDR, or hostname, plus resolver-scoped DNS (can be repeated)
+        #[arg(short = 'A', long = "network-allow", conflicts_with = "no_internet")]
         network_allow: Vec<String>,
 
-        /// Deny outbound traffic to this IP or CIDR (can be repeated)
-        #[arg(short = 'D', long = "network-deny")]
+        /// Deny outbound traffic to this IP, CIDR, or hostname (can be repeated)
+        #[arg(short = 'D', long = "network-deny", conflicts_with = "no_internet")]
         network_deny: Vec<String>,
     },
 
@@ -1353,6 +1361,46 @@ enum SbxCommands {
         /// letters, digits, and hyphens, not end with a hyphen, max 63 chars. Names that are
         /// exactly 21 lowercase alphanumeric characters are rejected (ambiguous with sandbox IDs).
         new_name: String,
+    },
+
+    /// Update the network configuration of a running sandbox
+    #[command(group(
+        clap::ArgGroup::new("network_update")
+            .required(true)
+            .multiple(true)
+            .args(["no_internet", "network_allow", "network_deny", "clear_network"])
+    ))]
+    Update {
+        /// Sandbox ID or name
+        sandbox_id: String,
+
+        /// Replace the network policy and block all outbound internet access, including DNS
+        #[arg(
+            short = 'N',
+            long,
+            conflicts_with_all = ["network_allow", "network_deny", "clear_network"]
+        )]
+        no_internet: bool,
+
+        /// Allow outbound traffic only to this IP, CIDR, or hostname, plus resolver-scoped DNS (can be repeated)
+        #[arg(
+            short = 'A',
+            long = "network-allow",
+            conflicts_with_all = ["no_internet", "clear_network"]
+        )]
+        network_allow: Vec<String>,
+
+        /// Deny outbound traffic to this IP, CIDR, or hostname (can be repeated)
+        #[arg(
+            short = 'D',
+            long = "network-deny",
+            conflicts_with_all = ["no_internet", "clear_network"]
+        )]
+        network_deny: Vec<String>,
+
+        /// Remove the network policy and restore unrestricted outbound access
+        #[arg(long, conflicts_with_all = ["no_internet", "network_allow", "network_deny"])]
+        clear_network: bool,
     },
 
     /// Interactive shell in a sandbox, or manage native SSH keys
@@ -2031,6 +2079,25 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                         sandbox_id,
                         new_name,
                     } => commands::sbx::name::run(ctx, &sandbox_id, &new_name).await,
+                    SbxCommands::Update {
+                        sandbox_id,
+                        no_internet,
+                        network_allow,
+                        network_deny,
+                        clear_network,
+                    } => {
+                        commands::sbx::update::run(
+                            ctx,
+                            &sandbox_id,
+                            commands::sbx::update::UpdateNetworkArgs {
+                                clear_network,
+                                no_internet,
+                                network_allow: &network_allow,
+                                network_deny: &network_deny,
+                            },
+                        )
+                        .await
+                    }
                     SbxCommands::Suspend {
                         sandbox_id,
                         no_wait,
@@ -4041,6 +4108,190 @@ mod tests {
             }
             _ => panic!("expected sbx create command"),
         }
+    }
+
+    #[test]
+    fn sbx_update_parses_replacement_network_policy() {
+        match parse_command([
+            "tl",
+            "sbx",
+            "update",
+            "sbx-123",
+            "--network-allow",
+            "api.example.com",
+            "--network-deny",
+            "10.10.0.0/16",
+        ]) {
+            Commands::Sbx(SbxCommands::Update {
+                sandbox_id,
+                no_internet,
+                network_allow,
+                network_deny,
+                clear_network,
+            }) => {
+                assert_eq!(sandbox_id, "sbx-123");
+                assert!(!no_internet);
+                assert_eq!(network_allow, vec!["api.example.com"]);
+                assert_eq!(network_deny, vec!["10.10.0.0/16"]);
+                assert!(!clear_network);
+            }
+            _ => panic!("expected sbx update command"),
+        }
+    }
+
+    #[test]
+    fn sbx_update_parses_clear_network() {
+        match parse_command(["tl", "sbx", "update", "stable-name", "--clear-network"]) {
+            Commands::Sbx(SbxCommands::Update {
+                sandbox_id,
+                clear_network,
+                ..
+            }) => {
+                assert_eq!(sandbox_id, "stable-name");
+                assert!(clear_network);
+            }
+            _ => panic!("expected sbx update command"),
+        }
+    }
+
+    #[test]
+    fn sbx_update_parses_no_internet_as_block_all() {
+        match parse_command(["tl", "sbx", "update", "sbx-123", "--no-internet"]) {
+            Commands::Sbx(SbxCommands::Update {
+                no_internet,
+                network_allow,
+                network_deny,
+                ..
+            }) => {
+                assert!(no_internet);
+                assert!(network_allow.is_empty());
+                assert!(network_deny.is_empty());
+            }
+            _ => panic!("expected sbx update command"),
+        }
+    }
+
+    #[test]
+    fn sbx_update_requires_a_network_change() {
+        assert!(Cli::try_parse_from(["tl", "sbx", "update", "sbx-123"]).is_err());
+    }
+
+    #[test]
+    fn sbx_update_rejects_clear_with_replacement_policy() {
+        assert!(
+            Cli::try_parse_from([
+                "tl",
+                "sbx",
+                "update",
+                "sbx-123",
+                "--clear-network",
+                "--network-deny",
+                "example.com",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn sbx_update_rejects_no_internet_with_allow_or_deny_rules() {
+        for rule in ["--network-allow", "--network-deny"] {
+            assert!(
+                Cli::try_parse_from([
+                    "tl",
+                    "sbx",
+                    "update",
+                    "sbx-123",
+                    "--no-internet",
+                    rule,
+                    "example.com",
+                ])
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn sbx_create_and_run_reject_no_internet_with_allow_or_deny_rules() {
+        for args in [
+            vec![
+                "tl",
+                "sbx",
+                "create",
+                "--no-internet",
+                "--network-allow",
+                "example.com",
+            ],
+            vec![
+                "tl",
+                "sbx",
+                "create",
+                "--no-internet",
+                "--network-deny",
+                "example.com",
+            ],
+            vec![
+                "tl",
+                "sbx",
+                "run",
+                "--no-internet",
+                "--network-allow",
+                "example.com",
+                "echo",
+            ],
+            vec![
+                "tl",
+                "sbx",
+                "run",
+                "--no-internet",
+                "--network-deny",
+                "example.com",
+                "echo",
+            ],
+        ] {
+            assert!(Cli::try_parse_from(args).is_err());
+        }
+    }
+
+    #[test]
+    fn sbx_network_allow_and_deny_rules_can_be_combined() {
+        assert!(
+            Cli::try_parse_from([
+                "tl",
+                "sbx",
+                "create",
+                "--network-allow",
+                "10.0.0.0/8",
+                "--network-deny",
+                "10.10.0.0/16",
+            ])
+            .is_ok()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "tl",
+                "sbx",
+                "run",
+                "--network-allow",
+                "10.0.0.0/8",
+                "--network-deny",
+                "10.10.0.0/16",
+                "echo",
+            ])
+            .is_ok()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "tl",
+                "sbx",
+                "update",
+                "sbx-123",
+                "--network-allow",
+                "10.0.0.0/8",
+                "--network-deny",
+                "10.10.0.0/16",
+            ])
+            .is_ok()
+        );
     }
 
     #[test]

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.103"
+version = "0.5.104"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.103"
+version = "0.5.104"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.103"
+version = "0.5.104"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.103",
+  "version": "0.5.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.103",
+      "version": "0.5.104",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.103",
+  "version": "0.5.104",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- add `tl sbx update` for replacing, blocking, or clearing a running sandbox's network policy
- share network-policy construction across `sbx create`, `sbx run`, and `sbx update`
- align CLI validation and help text with dataplane semantics
- bump Tensorlake package metadata from `0.5.103` to `0.5.104`

## Why

The CLI had no live network-update surface and constructed create/run network payloads independently. That made the distinction between block-all mode and dataplane allowlist mode unclear.

A non-empty allowlist uses `allow_internet_access=true`: the dataplane allows the listed destinations and resolver-scoped DNS while default-dropping other egress. `--no-internet` uses `allow_internet_access=false` and blocks all outbound traffic, including DNS.

## Behavior

- `-N` / `--no-internet` conflicts with `-A` and `-D`
- `-A` / `--network-allow` can be repeated and enables allowlist mode with resolver-scoped DNS
- `-D` / `--network-deny` can be repeated; deny rules take precedence when combined with allow rules
- `tl sbx update <id> --clear-network` sends an explicit `null` to restore unrestricted egress
- each update replaces or clears the complete network policy

## Checks

- `cargo test -p tensorlake-cli`
- `cargo clippy -p tensorlake-cli --all-targets -- -D warnings`
- `cargo check -p tensorlake-cli`
- `git diff --check`

## Documentation

- [tensorlakeai/docs#374](https://github.com/tensorlakeai/docs/pull/374)
