### PR TITLE
Add standalone TLFS mount daemon

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           # Stacked mount PRs pin their exact artifact_storage code commit only on their own head
           # branch; main and every other PR continue integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && 'b23e6939acfbe7910f45f0f46a16711478b4dac0' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -90,7 +90,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && 'b23e6939acfbe7910f45f0f46a16711478b4dac0' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           # Stacked mount PRs pin their exact artifact_storage code commit only on their own head
           # branch; main and every other PR continue integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && 'b23e6939acfbe7910f45f0f46a16711478b4dac0' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -90,7 +90,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && 'b23e6939acfbe7910f45f0f46a16711478b4dac0' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,7 +1445,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha1 0.11.0",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -1459,7 +1469,7 @@ dependencies = [
  "flate2",
  "fuser",
  "futures",
- "gethostname",
+ "gethostname 1.1.0",
  "gsvc-mount",
  "hex",
  "ignore",
@@ -1472,7 +1482,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1 0.11.0",
- "sha2",
+ "sha2 0.11.0",
  "shlex",
  "tempfile",
  "tensorlake",
@@ -1501,7 +1511,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2662,7 +2672,7 @@ dependencies = [
  "digest 0.10.7",
  "hmac",
  "password-hash",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3695,6 +3705,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3949,7 +3970,7 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "sha1 0.11.0",
- "sha2",
+ "sha2 0.10.9",
  "shlex",
  "tar",
  "tempfile",
@@ -3986,7 +4007,7 @@ dependencies = [
  "eventsource-stream",
  "flate2",
  "futures",
- "gethostname",
+ "gethostname 0.5.0",
  "gsvc-codec",
  "gsvc-fs-client",
  "hex",
@@ -4002,7 +4023,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1 0.11.0",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tensorlake",
  "thiserror 2.0.18",

--- a/crates/cli/src/commands/fs.rs
+++ b/crates/cli/src/commands/fs.rs
@@ -48,6 +48,8 @@ fn private_context(ctx: &CliContext) -> gsvc_fs_client::CliContext {
         project_id: ctx.project_id.clone(),
         debug: ctx.debug,
         trace_id: ctx.trace_id.clone(),
+        system_storage_socket: None,
+        preprovisioned_git_credential: None,
     }
 }
 

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -1,6 +1,8 @@
 use reqwest::{Method, StatusCode};
 use serde::de::DeserializeOwned;
 use std::collections::{HashMap, HashSet};
+#[cfg(unix)]
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::{
@@ -60,6 +62,26 @@ impl ArtifactStorageClient {
             api_client,
             git_client: reqwest::Client::builder()
                 .user_agent(concat!("tensorlake-rust-sdk/", env!("CARGO_PKG_VERSION")))
+                .build()?,
+            git_base_url: trim_base_url(git_base_url.into()),
+            git_credentials: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        })
+    }
+
+    /// Build an Artifact Storage client whose data-plane HTTP connections use
+    /// a local Unix socket. Sandbox TLFS uses this for its root-owned relay to
+    /// the authenticated dataplane-host system-storage proxy.
+    #[cfg(unix)]
+    pub fn new_with_unix_socket(
+        api_client: Client,
+        git_base_url: impl Into<String>,
+        socket_path: &Path,
+    ) -> Result<Self, SdkError> {
+        Ok(Self {
+            api_client,
+            git_client: reqwest::Client::builder()
+                .user_agent(concat!("tensorlake-rust-sdk/", env!("CARGO_PKG_VERSION")))
+                .unix_socket(socket_path)
                 .build()?,
             git_base_url: trim_base_url(git_base_url.into()),
             git_credentials: Arc::new(tokio::sync::Mutex::new(HashMap::new())),

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -281,6 +281,17 @@ impl Sdk {
         ArtifactStorageClient::new(self.client.clone(), git_base_url)
     }
 
+    /// Get an Artifact Storage client whose data-plane requests use a local
+    /// Unix socket instead of guest networking.
+    #[cfg(unix)]
+    pub fn artifact_storage_with_unix_socket(
+        &self,
+        git_base_url: &str,
+        socket_path: &std::path::Path,
+    ) -> Result<ArtifactStorageClient, error::SdkError> {
+        ArtifactStorageClient::new_with_unix_socket(self.client.clone(), git_base_url, socket_path)
+    }
+
     /// Get a client for managing snapshot-backed sandbox image registrations.
     pub fn sandbox_templates(
         &self,

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -13,6 +13,10 @@ publish = false
 [lib]
 path = "src/lib.rs"
 
+[[bin]]
+name = "tlfs-mount-daemon"
+path = "src/tlfs_mount_daemon.rs"
+
 [dependencies]
 tensorlake = { path = "../cloud-sdk" }
 gsvc-mount = { path = "../gsvc-mount" }
@@ -29,7 +33,7 @@ filetime = "0.2"
 fjall = { version = "3.1.8", default-features = false }
 flate2 = { version = "1", features = ["zlib-rs"] }
 futures = "0.3"
-gethostname = "0.5"
+gethostname = "1"
 hex = "0.4"
 ignore = "0.4"
 indicatif = "0.18"
@@ -41,7 +45,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha1 = "0.11"
-sha2 = "0.10"
+sha2 = "0.11"
 shlex = "1"
 tempfile = "3"
 thiserror = "2"

--- a/crates/gsvc-fs-client/src/tlfs_mount_daemon.rs
+++ b/crates/gsvc-fs-client/src/tlfs_mount_daemon.rs
@@ -1,0 +1,6 @@
+compile_error!(
+    "tlfs-mount-daemon requires the private Artifact Storage source; build it with `just \
+     build-tlfs-mount-daemon`"
+);
+
+fn main() {}

--- a/crates/gsvc-mount/Cargo.toml
+++ b/crates/gsvc-mount/Cargo.toml
@@ -38,7 +38,7 @@ bytes = "1"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/justfile
+++ b/justfile
@@ -98,6 +98,34 @@ build-cli-full *ARGS:
 # Back-compat alias for the old recipe name.
 build-cli-mount *ARGS: (build-cli-full ARGS)
 
+# Build only the headless Linux mount daemon used in Tensorlake sandbox images.
+# The private source is staged exactly like the full CLI build, but the output
+# links no CLI command surface.
+build-tlfs-mount-daemon *ARGS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    artifact_storage="{{ARTIFACT_STORAGE_DIR}}"
+    for crate in gsvc-mount gsvc-fs-client; do
+        if [ ! -d "$artifact_storage/crates/$crate/src" ]; then
+            echo "error: $artifact_storage/crates/$crate/src not found." >&2
+            exit 1
+        fi
+    done
+    restore() {
+        for crate in gsvc-mount gsvc-fs-client; do
+            git checkout -q -- "crates/$crate/src" 2>/dev/null || true
+            git clean -fdq "crates/$crate/src" 2>/dev/null || true
+        done
+        rm -f crates/gsvc-fs-client/Cargo.lock
+    }
+    trap restore EXIT
+    for crate in gsvc-mount gsvc-fs-client; do
+        rm -f "crates/$crate/src"/*.rs
+        cp "$artifact_storage/crates/$crate/src"/*.rs "crates/$crate/src"/
+    done
+    cargo build --manifest-path crates/gsvc-fs-client/Cargo.toml \
+        --bin tlfs-mount-daemon {{ARGS}}
+
 # Build the macOS TLFS.app from the private artifact_storage checkout (see its
 # platform/macos/tlfs/README.md). Flags pass through, e.g. `just build-tlfs-app --release`.
 build-tlfs-app *ARGS:


### PR DESCRIPTION
## Summary

- add the Unix-socket Artifact Storage transport needed by sandbox TLFS
- expose a headless `tlfs-mount-daemon` binary outside container-daemon
- accept a preprovisioned exact-repository channel capability without guest-side token mint or renewal
- add the private-engine source-swap build target used by the release image builder
- update the public workspace to the current 0.5.104 dependency line

## Security properties

The daemon receives no Platform API token and never calls `api.tensorlake.dev`. It talks only through the root-owned Unix socket supplied by container-daemon. The host proxy replaces the opaque mount capability with a short-lived exact-filesystem credential.

## Companion drafts

- Artifact Storage transport: https://github.com/tensorlakeai/artifact_storage/pull/222
- Platform token broker: https://github.com/tensorlakeai/platform-api/pull/665
- CEI/dataplane integration: https://github.com/tensorlakeai/compute-engine-internal/pull/1650
- Provisioner packaging: https://github.com/tensorlakeai/provisioner/pull/1243
- Provisioner fleet enablement: https://github.com/tensorlakeai/provisioner/pull/1268
- ZeroFS infrastructure teardown: https://github.com/tensorlakeai/indexify-deployment/pull/830

## Validation

- private Artifact Storage source-swap daemon tests passed
- private source-swap `tlfs-mount-daemon` release build passed
- workflow validation, formatting, and diff checks passed
- Linux and macOS source-swap CI are pinned on this head branch to merged Artifact Storage commit `92131d3795026c33cd2edaa01fa918360bf8e94d` from #222

## Dependency

Artifact Storage #222 is merged. This PR remains draft until CEI #1650 is ready so CEI's image build can compose the merged TensorLake and Artifact Storage source trees and record both revisions.
