### PR TITLE
Bump Tensorlake packages to 0.5.105

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.104"
+version = "0.5.105"
 dependencies = [
  "anyhow",
  "base64",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.104"
+version = "0.5.105"
 dependencies = [
  "anyhow",
  "base64",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.104"
+version = "0.5.105"
 dependencies = [
  "anyhow",
  "base64",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.104"
+version = "0.5.105"
 dependencies = [
  "napi",
  "napi-build",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.104"
+version = "0.5.105"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.104"
+version = "0.5.105"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.104"
+version = "0.5.105"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.104"
+version = "0.5.105"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.104"
+version = "0.5.105"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.104",
+  "version": "0.5.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.104",
+      "version": "0.5.105",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "3.3.11",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.104",
+  "version": "0.5.105",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Version bump to release the tl fs two-writable-sessions wedge fix (tensorlakeai/artifact_storage#224, merged to main).

## What 0.5.105 ships

Stock 0.5.104 wedges a macOS mount into **permanent ENOENT** within seconds when two sessions write the same file (the local-edit + sandbox-build workflow): stat/open fail while readdir lists the name, the kernel-refresh worker retry-loops forever, and only a remount recovers. Three stacked defects, fixed in artifact_storage#224:

1. Remote-rebase eviction deleted inodes the kernel still addressed → retained-item getattr NotFound → FSKit poisons the dentry.
2. `close()` orphan reclaim recreated the poison against the detach fix.
3. Clean file replacements never converged — FSKit has no name-invalidation channel, so they now update the inode **in place** (content-version bump), the same treatment directories already had.

## Verification on this exact branch

- `just build-cli-full` + `just build-tlfs-app` against **merged artifact_storage main** (what `publish_cli` will vendor with its default `source-ref`).
- The wedge reproducer, hardened into a convergence check — two mounts alternately rewriting one ~150KB file, 30 rounds: **zero failed operations, both sessions converge to the last writer's exact content.** Same run on 0.5.104 wedges by round 3.
- Full vendored SDK/CLI suite green on artifact_storage main.
- Bump shape matches 0.5.104's exactly (same 7 files, `cargo update --workspace` lockfile).

## Release notes (for the tag)

- **Fixed:** two mounts of the same drive writing the same paths could permanently wedge one session (ENOENT on paths that `ls` still listed) until remount; remotely replaced files could serve stale content indefinitely on macOS.
- **Changed:** a file replaced by another session now keeps its inode and updates in place when clean and unopened; files held open keep their read view until closed (unchanged guarantee).

⚠️ Release ordering note: `publish_cli` must run **after** this merges, with the default artifact_storage `source-ref: main`; the notarized `TLFS-0.5.105.app.zip` asset must be attached to the same `cli-v0.5.105` release since 0.5.104-app + 0.5.105-CLI refuse to mount together (version lockstep is enforced at mount preflight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)