### PR TITLE
Deploy function applications with immutable runtime images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.104"
+version = "0.5.105"
 dependencies = [
  "anyhow",
  "base64",

--- a/README.md
+++ b/README.md
@@ -288,6 +288,20 @@ tl secrets set OPENAI_API_KEY "your-openai-key"
 tl deploy examples/readme_example/city_guide.py
 ```
 
+`tl deploy` publishes a version-scoped runtime image for every function through
+Image Service and stores the returned immutable `cas-v1:<image_id>` reference
+in the application manifest. The catalog name is only a build handle and may
+move without changing an already-deployed function. The image contains the
+dependencies declared by `Image`, the language runner, and the native
+function-agent core. Application source remains a separate ZIP that is uploaded
+with the manifest; it is not copied into the runtime image. Reusing an
+application version with different code or configuration is rejected; an
+identical redeploy is idempotent.
+Deployments normally route image and application requests through
+`TENSORLAKE_API_URL`. Split local installations can set
+`TENSORLAKE_IMAGE_SERVICE_URL` and `TENSORLAKE_FUNCTION_SERVICE_URL`
+independently.
+
 #### Call via HTTP
 
 ```bash

--- a/crates/cli/src/commands/deploy.rs
+++ b/crates/cli/src/commands/deploy.rs
@@ -6,6 +6,8 @@ use crate::error::{CliError, Result};
 
 mod typescript;
 
+const PYTHON_DEPLOY_PROTOCOL_VERSION: u64 = 1;
+
 #[derive(Debug, PartialEq, Eq)]
 struct TypeScriptDeployArgs {
     entrypoint: PathBuf,
@@ -142,6 +144,7 @@ async fn run_python_deployer(ctx: &CliContext, remaining_args: &[String]) -> Res
     let reader = BufReader::new(stdout);
     let mut lines = reader.lines();
     let mut ctrl_c = Box::pin(tokio::signal::ctrl_c());
+    let mut protocol_verified = false;
 
     loop {
         let maybe_line = tokio::select! {
@@ -164,6 +167,17 @@ async fn run_python_deployer(ctx: &CliContext, remaining_args: &[String]) -> Res
         };
 
         let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+        if !protocol_verified {
+            if !supports_python_deploy_protocol(&event) {
+                terminate_child(&mut child).await?;
+                return Err(CliError::usage(
+                    "The installed Python Tensorlake SDK is incompatible with this CLI. Upgrade both `tl` and `tensorlake` to the same release.",
+                ));
+            }
+            protocol_verified = true;
+            continue;
+        }
 
         match event_type {
             "status" => {
@@ -278,6 +292,11 @@ async fn run_python_deployer(ctx: &CliContext, remaining_args: &[String]) -> Res
     }
 
     let status = child.wait().await.map_err(CliError::Io)?;
+    if !protocol_verified {
+        return Err(CliError::usage(
+            "The installed Python Tensorlake SDK did not provide a deploy protocol handshake. Upgrade both `tl` and `tensorlake` to the same release.",
+        ));
+    }
 
     if !status.success() {
         let code = status.code().unwrap_or(1);
@@ -285,6 +304,12 @@ async fn run_python_deployer(ctx: &CliContext, remaining_args: &[String]) -> Res
     }
 
     Ok(())
+}
+
+fn supports_python_deploy_protocol(event: &serde_json::Value) -> bool {
+    event.get("type").and_then(|value| value.as_str()) == Some("protocol")
+        && event.get("version").and_then(|value| value.as_u64())
+            == Some(PYTHON_DEPLOY_PROTOCOL_VERSION)
 }
 
 async fn terminate_child(child: &mut tokio::process::Child) -> Result<()> {
@@ -300,7 +325,21 @@ async fn terminate_child(child: &mut tokio::process::Child) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{TypeScriptDeployArgs, typescript_deploy_args};
+    use super::{TypeScriptDeployArgs, supports_python_deploy_protocol, typescript_deploy_args};
+    use serde_json::json;
+
+    #[test]
+    fn python_deployer_protocol_fails_closed() {
+        assert!(supports_python_deploy_protocol(
+            &json!({"type": "protocol", "version": 1})
+        ));
+        assert!(!supports_python_deploy_protocol(
+            &json!({"type": "protocol", "version": 2})
+        ));
+        assert!(!supports_python_deploy_protocol(
+            &json!({"type": "status", "version": 1})
+        ));
+    }
 
     #[test]
     fn selects_rust_typescript_deployment_for_esm_entrypoints() {

--- a/crates/cli/src/commands/deploy/typescript.rs
+++ b/crates/cli/src/commands/deploy/typescript.rs
@@ -38,8 +38,11 @@ const RUNTIME_MODULE: &str = "runtime.mjs";
 const CODE_MANIFEST_FILE: &str = ".tensorlake_code_manifest.json";
 const MAX_CODE_SIZE: u64 = 5 * 1024 * 1024;
 const DEFAULT_NODE_IMAGE: &str = "node:24-bookworm-slim";
+const CAS_IMAGE_REF_PREFIX: &str = "cas-v1:";
 const FUNCTION_RUNNER_CAPSULE_CONTEXT_PATH: &str =
     ".tensorlake/typescript-function-runner-runtime.tgz";
+const FUNCTION_RUNNER_LINUX_X64_BINDING: &str =
+    "package/dist/native/linux-x64/tensorlake-node.node";
 const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 const UNAUTHENTICATED_REQUESTS: &str = "unauthenticated_requests";
 const DISCOVERY_SCRIPT: &str = r#"
@@ -250,6 +253,11 @@ pub async fn run(
     entry_file: &Path,
     upgrade_running_requests: bool,
 ) -> Result<()> {
+    if upgrade_running_requests {
+        return Err(CliError::usage(
+            "--upgrade-running-requests is not supported by Function Service; existing requests stay pinned to their deployed application version",
+        ));
+    }
     let entry_file = canonical_entrypoint(entry_file)?;
     eprintln!(
         "⚙️  Bundling TypeScript application {}",
@@ -257,12 +265,19 @@ pub async fn run(
     );
     let bundle = bundle_application(&entry_file).await?;
 
-    build_application_images(ctx, &entry_file, &bundle).await?;
+    let function_images = build_application_images(ctx, &entry_file, &bundle).await?;
     eprintln!("\n✅ All images built successfully");
 
     for application in &bundle.discovery.applications {
-        upsert_application(ctx, application, &bundle.code_zip, upgrade_running_requests).await?;
-        let name = required_string(application, "name", "application")?;
+        let application = application_with_resolved_images(application, &function_images)?;
+        upsert_application(
+            ctx,
+            &application,
+            &bundle.code_zip,
+            upgrade_running_requests,
+        )
+        .await?;
+        let name = required_string(&application, "name", "application")?;
         eprintln!("🚀 Application `{name}` deployed successfully");
         eprintln!(
             "\n💡 To invoke it, you can use the following cURL command:\n\ncurl {}/applications/{} \\\n  -H \"Authorization: Bearer $TENSORLAKE_API_KEY\" \\\n  --json 'null'",
@@ -625,6 +640,14 @@ fn load_function_runner_capsule(
             "Tensorlake TypeScript function runner capsule is empty",
         ));
     }
+    if !manifest
+        .files
+        .contains_key(FUNCTION_RUNNER_LINUX_X64_BINDING)
+    {
+        return Err(CliError::usage(format!(
+            "The Tensorlake TypeScript function runner capsule does not contain the Linux x64 native agent core required by sandbox images ({FUNCTION_RUNNER_LINUX_X64_BINDING}). Reinstall the published package or build the linux-x64 native target before running build:runtime."
+        )));
+    }
 
     let package_directory = capsule_root.join("package");
     let actual_files = collect_capsule_files(&package_directory)?;
@@ -845,15 +868,19 @@ async fn build_application_images(
     ctx: &CliContext,
     entry_file: &Path,
     bundle: &ApplicationBundle,
-) -> Result<()> {
+) -> Result<BTreeMap<(String, String), String>> {
     let discovery = &bundle.discovery;
     let context_directory = entry_file.parent().unwrap_or_else(|| Path::new("."));
     let empty_context_directory = bundle._temp.path().join("image-context");
-    let mut built = BTreeMap::<String, String>::new();
+    let mut built = BTreeMap::<String, (String, String)>::new();
+    let mut function_images = BTreeMap::new();
     for application in &discovery.applications {
         let application_name = required_string(application, "name", "application")?;
         let version = required_string(application, "version", application_name)?;
-        let default_name = format!("applications/{application_name}/versions/{version}/default");
+        let application_component = registered_image_component(application_name);
+        let version_component = registered_image_component(version);
+        let default_name =
+            format!("applications/{application_component}/versions/{version_component}/default");
         let functions = application
             .get("functions")
             .and_then(Value::as_object)
@@ -864,11 +891,16 @@ async fn build_application_images(
             })?;
         for (function_name, function_manifest) in functions {
             let image = discovery.images.get(function_name).and_then(Option::as_ref);
-            let registered_name = function_manifest
-                .get("image")
-                .and_then(Value::as_str)
-                .unwrap_or(&default_name)
-                .to_string();
+            let explicit_name = function_manifest.get("image").and_then(Value::as_str);
+            let registered_name = explicit_name.map_or_else(
+                || default_name.clone(),
+                |image_name| {
+                    let image_component = registered_image_component(image_name);
+                    format!(
+                        "applications/{application_component}/versions/{version_component}/images/{image_component}"
+                    )
+                },
+            );
             let fingerprint = match image {
                 Some(image) => format!(
                     "{}:{}",
@@ -880,15 +912,18 @@ async fn build_application_images(
                     bundle.function_runner_capsule.runtime_id
                 ),
             };
-            if let Some(previous) = built.get(&registered_name) {
+            if let Some((previous, immutable_ref)) = built.get(&registered_name) {
                 if previous != &fingerprint {
                     return Err(CliError::usage(format!(
                         "Different Image definitions use the registered name '{registered_name}'"
                     )));
                 }
+                function_images.insert(
+                    (application_name.to_string(), function_name.to_string()),
+                    immutable_ref.clone(),
+                );
                 continue;
             }
-            built.insert(registered_name.clone(), fingerprint);
             eprintln!("📦 Building `{registered_name}` image...");
             let dockerfile = application_dockerfile(image)?;
             let needs_context = image.is_some_and(|image| {
@@ -905,13 +940,13 @@ async fn build_application_images(
                     organization_id: ctx.effective_organization_id(),
                     project_id: ctx.effective_project_id(),
                     namespace: ctx.namespace.clone(),
-                    registered_name: Some(registered_name),
+                    registered_name: Some(registered_name.clone()),
                     disk_mb: None,
                     builder_disk_mb: None,
                     cpus: None,
                     memory_mb: None,
                     is_public: false,
-                    cas: false,
+                    cas: true,
                     user_agent: Some(format!(
                         "Tensorlake CLI (rust/{})",
                         env!("CARGO_PKG_VERSION")
@@ -933,12 +968,100 @@ async fn build_application_images(
                 build_args: Vec::new(),
             };
             let mut renderer = ImageBuildEventRenderer::new();
-            build_sandbox_image(options, |event| renderer.render(event))
+            let published = build_sandbox_image(options, |event| renderer.render(event))
                 .await
                 .map_err(|error| CliError::Other(error.into()))?;
+            let immutable_ref = published_image_reference(&published)?;
+            built.insert(registered_name, (fingerprint, immutable_ref.clone()));
+            function_images.insert(
+                (application_name.to_string(), function_name.to_string()),
+                immutable_ref,
+            );
         }
     }
-    Ok(())
+    Ok(function_images)
+}
+
+fn published_image_reference(image: &Value) -> Result<String> {
+    let image_id = image
+        .get("image_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CliError::Other(anyhow::anyhow!(
+                "Image Service publication returned no immutable image_id"
+            ))
+        })?;
+    if image_id.len() != 64
+        || !image_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(CliError::Other(anyhow::anyhow!(
+            "Image Service publication returned an invalid immutable image_id"
+        )));
+    }
+    Ok(format!("{CAS_IMAGE_REF_PREFIX}{image_id}"))
+}
+
+fn registered_image_component(value: &str) -> String {
+    if value.len() <= 64 && is_valid_registered_image_component(value) {
+        return value.to_string();
+    }
+    let digest = hex::encode(Sha256::digest(value.as_bytes()));
+    format!("id-{}", &digest[..32])
+}
+
+fn is_valid_registered_image_component(value: &str) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    let mut previous_was_separator = true;
+    for byte in value.bytes() {
+        let is_separator = matches!(byte, b'.' | b'_' | b'-');
+        if is_separator {
+            if previous_was_separator {
+                return false;
+            }
+        } else if !(byte.is_ascii_lowercase() || byte.is_ascii_digit()) {
+            return false;
+        }
+        previous_was_separator = is_separator;
+    }
+    !previous_was_separator
+}
+
+fn application_with_resolved_images(
+    application: &Value,
+    function_images: &BTreeMap<(String, String), String>,
+) -> Result<Value> {
+    let mut application = application.clone();
+    let application_name = required_string(&application, "name", "application")?.to_string();
+    let functions = application
+        .get_mut("functions")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| {
+            CliError::usage(format!(
+                "Application '{application_name}' is missing functions"
+            ))
+        })?;
+    for (function_name, manifest) in functions {
+        let registered_name = function_images
+            .get(&(application_name.clone(), function_name.clone()))
+            .ok_or_else(|| {
+                CliError::usage(format!(
+                    "Runtime image was not prepared for function '{function_name}'"
+                ))
+            })?;
+        manifest
+            .as_object_mut()
+            .ok_or_else(|| {
+                CliError::usage(format!(
+                    "Application '{application_name}' has an invalid manifest for function '{function_name}'"
+                ))
+            })?
+            .insert("image".to_string(), Value::String(registered_name.clone()));
+    }
+    Ok(application)
 }
 
 fn application_dockerfile(image: Option<&SerializedImageDefinition>) -> Result<String> {
@@ -1016,11 +1139,18 @@ async fn upsert_application(
 ) -> Result<()> {
     let client = ctx.client()?;
     let mut application = application.clone();
-    ensure_public_endpoint_id(&ctx.api_url, &ctx.namespace, &client, &mut application).await?;
+    let function_service_url = function_service_url(&ctx.api_url);
+    ensure_public_endpoint_id(
+        &function_service_url,
+        &ctx.namespace,
+        &client,
+        &mut application,
+    )
+    .await?;
     let manifest = serde_json::to_string(&application)?;
     let url = format!(
         "{}/v1/namespaces/{}/applications",
-        ctx.api_url.trim_end_matches('/'),
+        function_service_url.trim_end_matches('/'),
         urlencoding::encode(&ctx.namespace)
     );
     let mut delay = Duration::from_millis(500);
@@ -1059,6 +1189,19 @@ async fn upsert_application(
         delay *= 2;
     }
     unreachable!()
+}
+
+fn function_service_url(api_url: &str) -> String {
+    resolve_function_service_url(
+        api_url,
+        std::env::var("TENSORLAKE_FUNCTION_SERVICE_URL").ok(),
+    )
+}
+
+fn resolve_function_service_url(api_url: &str, override_url: Option<String>) -> String {
+    override_url
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| api_url.to_string())
 }
 
 fn allows_unauthenticated_requests(application: &Value) -> bool {
@@ -1143,9 +1286,11 @@ fn required_string<'a>(value: &'a Value, key: &str, label: &str) -> Result<&'a s
 #[cfg(test)]
 mod tests {
     use super::{
-        SerializedImageOperation, application_dockerfile, bundle_application, canonical_entrypoint,
+        FUNCTION_RUNNER_LINUX_X64_BINDING, SerializedImageOperation, application_dockerfile,
+        application_with_resolved_images, bundle_application, canonical_entrypoint,
         discover_deployment_with_timeout, ensure_public_endpoint_id, load_function_runner_capsule,
-        render_image_operation,
+        published_image_reference, registered_image_component, render_image_operation,
+        resolve_function_service_url,
     };
     use serde_json::json;
     use std::collections::BTreeMap;
@@ -1209,6 +1354,7 @@ mod tests {
         assert!(
             paths.contains(&"package/bin/tensorlake-typescript-function-runner.js".to_string())
         );
+        assert!(paths.contains(&FUNCTION_RUNNER_LINUX_X64_BINDING.to_string()));
     }
 
     #[test]
@@ -1221,6 +1367,68 @@ mod tests {
         assert_eq!(
             render_image_operation(&operation).unwrap(),
             "ENV NAME=\"a value\""
+        );
+    }
+
+    #[test]
+    fn writes_resolved_registered_images_into_application_manifest() {
+        let application = json!({
+            "name": "app",
+            "runtime": "typescript",
+            "functions": {
+                "default_fn": {"name": "default_fn"},
+                "custom_fn": {"name": "custom_fn", "image": "logical-image"}
+            }
+        });
+        let images = BTreeMap::from([
+            (
+                ("app".to_string(), "default_fn".to_string()),
+                format!("cas-v1:{}", "a".repeat(64)),
+            ),
+            (
+                ("app".to_string(), "custom_fn".to_string()),
+                format!("cas-v1:{}", "b".repeat(64)),
+            ),
+        ]);
+
+        let resolved = application_with_resolved_images(&application, &images).unwrap();
+
+        assert_eq!(
+            resolved["functions"]["default_fn"]["image"],
+            format!("cas-v1:{}", "a".repeat(64))
+        );
+        assert_eq!(
+            resolved["functions"]["custom_fn"]["image"],
+            format!("cas-v1:{}", "b".repeat(64))
+        );
+    }
+
+    #[test]
+    fn validates_published_image_ids_and_registered_name_components() {
+        let image_id = "a".repeat(64);
+        assert_eq!(
+            published_image_reference(&json!({ "image_id": image_id })).unwrap(),
+            format!("cas-v1:{}", "a".repeat(64))
+        );
+        assert!(published_image_reference(&json!({ "image_id": "mutable-name" })).is_err());
+        assert_eq!(registered_image_component("app-v1"), "app-v1");
+        let sanitized = registered_image_component("My Application");
+        assert!(sanitized.starts_with("id-"));
+        assert_eq!(sanitized.len(), 35);
+    }
+
+    #[test]
+    fn function_service_url_defaults_to_api_origin() {
+        assert_eq!(
+            resolve_function_service_url("https://api.tensorlake.ai", None),
+            "https://api.tensorlake.ai"
+        );
+        assert_eq!(
+            resolve_function_service_url(
+                "https://api.tensorlake.ai",
+                Some("http://functions.test:8930".to_string())
+            ),
+            "http://functions.test:8930"
         );
     }
 

--- a/crates/cloud-sdk/src/image_service_builds.rs
+++ b/crates/cloud-sdk/src/image_service_builds.rs
@@ -10,7 +10,7 @@
 //! only creates the build, uploads and seals the context, and polls the
 //! build to completion; it never talks to the builder sandbox.
 
-use std::{path::Path, time::Duration};
+use std::{collections::HashSet, path::Path, time::Duration};
 
 use reqwest::{Method, StatusCode, header::CONTENT_LENGTH};
 use serde_json::{Value, json};
@@ -20,7 +20,8 @@ use crate::{
     Client,
     sandbox_images::{
         CommonBuildOptions, DockerfileBuildPlan, SandboxImageBuildError, SandboxImageBuildEvent,
-        client_builder, collect_dir_files, resolve_build_context, resolved_docker_config_json,
+        SandboxImageContextFile, client_builder, collect_dir_files, normalize_context_file_path,
+        resolve_build_context, resolved_docker_config_json,
     },
 };
 
@@ -62,6 +63,7 @@ pub(crate) async fn run_image_service_build<F>(
     plan: DockerfileBuildPlan,
     dockerfile_path: Option<&Path>,
     build_args: Vec<(String, String)>,
+    context_files: Vec<SandboxImageContextFile>,
     options: CommonBuildOptions,
     mut emit: F,
 ) -> Result<Value>
@@ -146,6 +148,7 @@ where
         &upload,
         &plan,
         injected_dockerfile.as_deref(),
+        &context_files,
         &mut emit,
     )
     .await?;
@@ -431,6 +434,7 @@ async fn upload_and_seal_context(
     upload: &Value,
     plan: &DockerfileBuildPlan,
     injected_dockerfile: Option<&str>,
+    context_files: &[SandboxImageContextFile],
     emit: &mut impl FnMut(SandboxImageBuildEvent),
 ) -> Result<()> {
     emit(SandboxImageBuildEvent::Status(
@@ -440,8 +444,12 @@ async fn upload_and_seal_context(
         .prefix("tensorlake-image-context-")
         .suffix(".tar")
         .tempfile()?;
-    let (tar_bytes, digest) =
-        create_context_tar(&plan.context_dir, injected_dockerfile, tar_file.path())?;
+    let (tar_bytes, digest) = create_context_tar(
+        &plan.context_dir,
+        injected_dockerfile,
+        context_files,
+        tar_file.path(),
+    )?;
 
     let max_bytes = upload.get("max_bytes").and_then(Value::as_u64);
     if let Some(max_bytes) = max_bytes
@@ -509,9 +517,11 @@ async fn upload_and_seal_context(
 fn create_context_tar(
     context_dir: &Path,
     injected_dockerfile: Option<&str>,
+    context_files: &[SandboxImageContextFile],
     tar_path: &Path,
 ) -> Result<(u64, String)> {
     let mut tar = tar::Builder::new(std::fs::File::create(tar_path)?);
+    let mut archived_paths = HashSet::new();
     if context_dir.is_dir() {
         for (full_path, relative_path) in collect_dir_files(context_dir, context_dir)? {
             if injected_dockerfile.is_some() && relative_path == INJECTED_DOCKERFILE_PATH {
@@ -522,6 +532,7 @@ fn create_context_tar(
             }
             let mut file = std::fs::File::open(&full_path)?;
             tar.append_file(&relative_path, &mut file)?;
+            archived_paths.insert(relative_path);
         }
     }
     if let Some(dockerfile_text) = injected_dockerfile {
@@ -534,6 +545,33 @@ fn create_context_tar(
             &mut header,
             INJECTED_DOCKERFILE_PATH,
             dockerfile_text.as_bytes(),
+        )?;
+        archived_paths.insert(INJECTED_DOCKERFILE_PATH.to_string());
+    }
+
+    let mut context_files = context_files
+        .iter()
+        .map(|file| Ok((normalize_context_file_path(&file.path)?, file)))
+        .collect::<Result<Vec<_>>>()?;
+    context_files.sort_by(|left, right| left.0.cmp(&right.0));
+    for (relative_path, file) in context_files {
+        if !archived_paths.insert(relative_path.clone()) {
+            return Err(SandboxImageBuildError::usage(format!(
+                "in-memory build context file '{relative_path}' conflicts with another context file"
+            )));
+        }
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_size(file.contents.len() as u64);
+        header.set_mode(file.mode & 0o777);
+        header.set_uid(0);
+        header.set_gid(0);
+        header.set_mtime(0);
+        header.set_cksum();
+        tar.append_data(
+            &mut header,
+            relative_path,
+            std::io::Cursor::new(&file.contents),
         )?;
     }
     tar.finish()?;
@@ -746,7 +784,7 @@ mod tests {
 
         let tar_path = scratch.path().join("out.tar");
         let (bytes, digest) =
-            create_context_tar(dir.path(), Some("FROM scratch\n"), &tar_path).unwrap();
+            create_context_tar(dir.path(), Some("FROM scratch\n"), &[], &tar_path).unwrap();
         assert_eq!(bytes, std::fs::metadata(&tar_path).unwrap().len());
         assert_eq!(digest.len(), 64);
 
@@ -777,12 +815,52 @@ mod tests {
         std::fs::write(dir.path().join(INJECTED_DOCKERFILE_PATH), "FROM x\n").unwrap();
 
         let tar_path = scratch.path().join("out.tar");
-        let error = create_context_tar(dir.path(), Some("FROM scratch\n"), &tar_path)
+        let error = create_context_tar(dir.path(), Some("FROM scratch\n"), &[], &tar_path)
             .expect_err("reserved path must collide");
         assert!(
             error.to_string().contains(".tensorlake/Dockerfile"),
             "{error}"
         );
+    }
+
+    #[test]
+    fn context_tar_carries_validated_in_memory_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        let tar_path = scratch.path().join("out.tar");
+        let files = vec![SandboxImageContextFile {
+            path: ".tensorlake/runtime.tgz".into(),
+            contents: b"runtime".to_vec(),
+            mode: 0o640,
+        }];
+
+        create_context_tar(dir.path(), Some("FROM scratch\n"), &files, &tar_path).unwrap();
+
+        let mut archive = tar::Archive::new(std::fs::File::open(&tar_path).unwrap());
+        let runtime = archive
+            .entries()
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .find(|entry| entry.path().unwrap() == Path::new(".tensorlake/runtime.tgz"))
+            .expect("in-memory runtime file");
+        assert_eq!(runtime.header().mode().unwrap(), 0o640);
+    }
+
+    #[test]
+    fn context_tar_rejects_in_memory_file_collisions() {
+        let dir = tempfile::tempdir().unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("runtime.tgz"), "disk").unwrap();
+        let tar_path = scratch.path().join("out.tar");
+        let files = vec![SandboxImageContextFile {
+            path: "runtime.tgz".into(),
+            contents: b"memory".to_vec(),
+            mode: 0o644,
+        }];
+
+        let error = create_context_tar(dir.path(), None, &files, &tar_path)
+            .expect_err("disk and memory paths must not collide");
+        assert!(error.to_string().contains("conflicts"), "{error}");
     }
 
     fn plan_with_context(context_dir: std::path::PathBuf) -> DockerfileBuildPlan {

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -439,18 +439,15 @@ where
         )?
     };
     if options.common.cas {
-        if !options.context_files.is_empty() {
-            return Err(SandboxImageBuildError::usage(
-                "in-memory context files are not supported by Image Service builds",
-            ));
-        }
         // CAS images build through the Image Service: the SDK resolves the
         // plan's references and submits them; the service reconciler drives
         // the builder sandbox.
+        let dockerfile_path = options.dockerfile_path.clone();
         return crate::image_service_builds::run_image_service_build(
             plan,
-            Some(&options.dockerfile_path),
+            Some(&dockerfile_path),
             options.build_args,
+            options.context_files,
             options.common,
             emit,
         )
@@ -487,6 +484,7 @@ where
         return crate::image_service_builds::run_image_service_build(
             plan,
             None,
+            Vec::new(),
             Vec::new(),
             options.common,
             emit,
@@ -2281,7 +2279,7 @@ fn create_context_archive(
     })
 }
 
-fn normalize_context_file_path(path: &Path) -> Result<String> {
+pub(crate) fn normalize_context_file_path(path: &Path) -> Result<String> {
     let mut components = Vec::new();
     for component in path.components() {
         match component {

--- a/crates/function-agent-core/src/agent.rs
+++ b/crates/function-agent-core/src/agent.rs
@@ -143,7 +143,7 @@ enum AgentMessage {
     AssignmentPrepared {
         attempt_id: String,
         fence_token: u64,
-        result: Result<AgentAssignment, String>,
+        result: Box<Result<AgentAssignment, String>>,
     },
     FunctionCallResultPrepared {
         attempt_id: String,
@@ -428,7 +428,7 @@ impl FunctionAgent {
                 .send(AgentMessage::AssignmentPrepared {
                     attempt_id,
                     fence_token,
-                    result,
+                    result: Box::new(result),
                 })
                 .await;
         });
@@ -663,7 +663,7 @@ impl FunctionAgent {
                 result,
             } => {
                 self.pending_assignments.remove(&attempt_id);
-                match result {
+                match *result {
                     Ok(assignment) => {
                         if let Err(error) = self.start_runtime(assignment).await {
                             error!(%error, %attempt_id, "failed to start assigned function runtime");
@@ -683,7 +683,7 @@ impl FunctionAgent {
                             result: AgentRunResult::Failure {
                                 attempt_id,
                                 fence_token,
-                                reason: FailureReason::InternalError,
+                                reason: FailureReason::RuntimeLost,
                                 message: Some(message),
                             },
                         });
@@ -1347,6 +1347,18 @@ async fn materialize_assignment_inputs(
     client: &Client,
     assignment: &mut AgentAssignment,
 ) -> Result<()> {
+    if let Some(blob) = assignment.application_code_blob.as_ref() {
+        ensure!(
+            assignment.application_code_sha256 == blob.sha256,
+            "application code digest does not match its durable blob reference"
+        );
+        let read = assignment
+            .application_code_read
+            .take()
+            .ok_or_else(|| anyhow!("application code blob has no read capability"))?;
+        let bytes = download_blob(client, blob, read).await?;
+        assignment.application_code_base64 = BASE64.encode(bytes);
+    }
     for input in &mut assignment.inputs {
         let (Some(blob), Some(read)) = (input.blob.as_ref(), input.read.take()) else {
             continue;
@@ -1514,6 +1526,86 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn materializes_and_verifies_application_code_blob() {
+        install_default_crypto_provider();
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("application.zip");
+        tokio::fs::write(&path, b"zip-code").await.unwrap();
+        let uri = Url::from_file_path(&path).unwrap().to_string();
+        let mut assignment = AgentAssignment {
+            attempt_id: "attempt".into(),
+            fence_token: 1,
+            function_run_id: "run".into(),
+            request_id: "request".into(),
+            namespace: "ns".into(),
+            application: "app".into(),
+            application_version: "v1".into(),
+            function: "function".into(),
+            timeout_ms: 1_000,
+            initialization_timeout_ms: 1_000,
+            inputs: Vec::new(),
+            request_headers: Vec::new(),
+            call_metadata_base64: String::new(),
+            application_code_base64: String::new(),
+            application_code_blob: Some(crate::model::BlobReference {
+                uri: uri.clone(),
+                size_bytes: 8,
+                sha256: hex::encode(Sha256::digest(b"zip-code")),
+            }),
+            application_code_read: Some(crate::state_machine::AgentReadPlan {
+                url: uri,
+                method: "GET".into(),
+                headers: Default::default(),
+                expires_at_ms: u64::MAX,
+            }),
+            application_code_sha256: hex::encode(Sha256::digest(b"zip-code")),
+            execution_history: Vec::new(),
+        };
+
+        materialize_assignment_inputs(&Client::new(), &mut assignment)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            assignment.application_code_base64,
+            BASE64.encode(b"zip-code")
+        );
+        assert!(assignment.application_code_read.is_none());
+    }
+
+    #[tokio::test]
+    async fn assignment_materialization_failure_is_infrastructure_failure() {
+        let mut agent = FunctionAgent::new_validated(config()).unwrap();
+        agent.pending_assignments.insert("attempt".into());
+
+        agent
+            .apply_agent_message(AgentMessage::AssignmentPrepared {
+                attempt_id: "attempt".into(),
+                fence_token: 7,
+                result: Box::new(Err("object store unavailable".into())),
+            })
+            .await;
+
+        let event = agent.outbox.front().expect("failure event");
+        let AgentEventPayload::Result {
+            result:
+                AgentRunResult::Failure {
+                    reason,
+                    attempt_id,
+                    fence_token,
+                    ..
+                },
+        } = &event.payload
+        else {
+            panic!("expected assignment failure event")
+        };
+        assert_eq!(attempt_id, "attempt");
+        assert_eq!(*fence_token, 7);
+        assert_eq!(*reason, FailureReason::RuntimeLost);
+        assert!(!reason.counts_against_user_retries());
+    }
+
     #[test]
     fn config_rejects_unbounded_or_ambiguous_values() {
         let mut invalid = config();
@@ -1627,6 +1719,8 @@ mod tests {
             request_headers: Vec::new(),
             call_metadata_base64: String::new(),
             application_code_base64: String::new(),
+            application_code_blob: None,
+            application_code_read: None,
             application_code_sha256: String::new(),
             execution_history: Vec::new(),
         };
@@ -1677,6 +1771,8 @@ mod tests {
             request_headers: Vec::new(),
             call_metadata_base64: String::new(),
             application_code_base64: String::new(),
+            application_code_blob: None,
+            application_code_read: None,
             application_code_sha256: String::new(),
             execution_history: Vec::new(),
         };

--- a/crates/function-agent-core/src/runtime.rs
+++ b/crates/function-agent-core/src/runtime.rs
@@ -722,6 +722,8 @@ mod tests {
             }],
             call_metadata_base64: String::new(),
             application_code_base64: BASE64.encode(b"code"),
+            application_code_blob: None,
+            application_code_read: None,
             application_code_sha256: "digest".into(),
             execution_history: Vec::new(),
         }

--- a/crates/function-agent-core/src/state_machine.rs
+++ b/crates/function-agent-core/src/state_machine.rs
@@ -86,7 +86,12 @@ pub struct AgentAssignment {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub request_headers: Vec<RequestHeader>,
     pub call_metadata_base64: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub application_code_base64: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub application_code_blob: Option<BlobReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub application_code_read: Option<AgentReadPlan>,
     pub application_code_sha256: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub execution_history: Vec<ExecutionHistoryEntry>,

--- a/src/tensorlake/applications/interface/decorators.py
+++ b/src/tensorlake/applications/interface/decorators.py
@@ -77,10 +77,9 @@ class _ApplicationDecorator(_Decorator):
             retries=self._retries,
             region=self._region,
             # Use a unique random version. We don't provide user controlled versioning at the moment.
-            # Use only alphanumeric characters so app version can be used as container tags.
-            version=nanoid(
-                alphabet="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-            ),
+            # Keep the identifier lowercase so it is also a valid Image Service
+            # repository-name component.
+            version=nanoid(alphabet="0123456789abcdefghijklmnopqrstuvwxyz"),
             allow=list(self._allow),
         )
 

--- a/src/tensorlake/applications/remote/code/loader.py
+++ b/src/tensorlake/applications/remote/code/loader.py
@@ -60,6 +60,8 @@ def walk_code(
             for dir_name in dir_names
             if os.path.join(dir_path, dir_name) not in ignored_absolute_paths
         ]
+        dir_names.sort()
+        file_names.sort()
         for file_name in file_names:
             # Only include Python files.
             if not file_name.endswith(".py"):

--- a/src/tensorlake/applications/remote/code/zip.py
+++ b/src/tensorlake/applications/remote/code/zip.py
@@ -1,5 +1,6 @@
 import inspect
 import io
+import json
 import os
 import stat
 import sys
@@ -31,6 +32,16 @@ CODE_ZIP_MANIFEST_FILE_NAME = ".tensorlake_code_manifest.json"
 # If only application Python code is put into the ZIP archive without external dependencies then
 # the code size should be much smaller than 5 MB.
 _MAX_CODE_SIZE_BYTES = 5 * 1024 * 1024
+_CANONICAL_ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+_CANONICAL_MANIFEST_MODE = stat.S_IFREG | 0o644
+
+
+def _canonical_zip_info(file_name: str, mode: int) -> zipfile.ZipInfo:
+    zip_info = zipfile.ZipInfo(file_name, date_time=_CANONICAL_ZIP_TIMESTAMP)
+    zip_info.create_system = 3
+    zip_info.external_attr = (mode & 0xFFFF) << 16
+    zip_info.compress_type = zipfile.ZIP_DEFLATED
+    return zip_info
 
 
 def zip_code(
@@ -79,22 +90,45 @@ def _zip_code(
         allowZip64=False,
         compresslevel=5,
     ) as zipf:
-        zipf.writestr(CODE_ZIP_MANIFEST_FILE_NAME, code_zip_manifest.model_dump_json())
+        manifest_json = json.dumps(
+            code_zip_manifest.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        zipf.writestr(
+            _canonical_zip_info(
+                CODE_ZIP_MANIFEST_FILE_NAME,
+                _CANONICAL_MANIFEST_MODE,
+            ),
+            manifest_json,
+            compress_type=zipfile.ZIP_DEFLATED,
+            compresslevel=5,
+        )
         for file_path in walk_code(code_dir_path, ignored_absolute_paths):
             # The file is added to the ZIP archive with its original rwx/rwx/rwx permissions.
             # When unzipping the files owner and group are set to the current process uid, gid.
             # We need to check that file owner has read access on the file so the unzipping process
             # can load and run them.
-            if not (os.stat(file_path).st_mode & stat.S_IRUSR):
+            file_stat = os.stat(file_path)
+            if not (file_stat.st_mode & stat.S_IRUSR):
                 raise SDKUsageError(
                     f"Application code file {file_path} is not readable by its owner. "
                     "Please change the file permissions."
                 )
 
             file_path_inside_code_dir = os.path.relpath(file_path, code_dir_path)
-            zipf.write(file_path, file_path_inside_code_dir)
+            with open(file_path, "rb") as source_file:
+                zipf.writestr(
+                    _canonical_zip_info(
+                        file_path_inside_code_dir,
+                        file_stat.st_mode,
+                    ),
+                    source_file.read(),
+                    compress_type=zipfile.ZIP_DEFLATED,
+                    compresslevel=5,
+                )
             zip_infos.append(zipf.getinfo(file_path_inside_code_dir))
-            zip_code_size += os.path.getsize(file_path)
+            zip_code_size += file_stat.st_size
             # Check code size after adding each file to the ZIP archive to prevent infinite
             # recursion because we allow soft links in the code directory for users' convenience.
             _check_code_size(zip_code_size, zip_infos)

--- a/src/tensorlake/applications/remote/deploy.py
+++ b/src/tensorlake/applications/remote/deploy.py
@@ -14,6 +14,7 @@ from ..remote.manifests.application import (
 from .code.ignored_code_paths import ignored_code_paths
 from .code.loader import load_code
 from .code.zip import zip_code
+from .images import prepare_application_images
 
 _UNAUTHENTICATED_REQUESTS = "unauthenticated_requests"
 
@@ -55,14 +56,16 @@ def _ensure_public_endpoint_id(
 
 def deploy_applications(
     applications_file_path: str,
-    upgrade_running_requests: bool = True,
+    upgrade_running_requests: bool = False,
     load_source_dir_modules: bool = False,
     api_client=None,
+    function_images: dict[tuple[str, str], str] | None = None,
 ) -> None:
     """Deploys all applications in the supplied .py file so they are runnable in remote mode (i.e. on Tensorlake Cloud).
 
     `application_file_path` is a path to the .py file where the applications are defined.
-    `upgrade_running_requests` indicates whether to update running requests to use the deployed code.
+    `upgrade_running_requests` is retained for call-site compatibility but must be False;
+                               Function Service pins existing requests to their application version.
     `load_source_dir_modules` indicates whether to load the .py file so all applications from it get added to the registry.
                                Should be set to True when called from CLI, False when called programmatically from test code
                                because applications in test code are already loaded into registry.
@@ -71,6 +74,10 @@ def deploy_applications(
     Raises SDKUsageError if the client configuration is not valid for the operation.
     Raises TensorlakeError on other errors.
     """
+    if upgrade_running_requests:
+        raise ValueError(
+            "upgrading running requests is not supported by Function Service"
+        )
     # Work with absolute paths to make sure that the path comparisons work correctly.
     applications_file_path: str = os.path.abspath(applications_file_path)
     applications_dir_path: str = os.path.dirname(applications_file_path)
@@ -81,6 +88,11 @@ def deploy_applications(
 
     # Now the application is fully loaded into memory so we can use the registry.
     functions: List[Function] = get_functions()
+    if function_images is None:
+        function_images = prepare_application_images(
+            functions,
+            context_dir=applications_dir_path,
+        )
     app_code: bytes = zip_code(
         code_dir_path=applications_dir_path,
         ignored_absolute_paths=ignored_absolute_paths,
@@ -101,7 +113,9 @@ def deploy_applications(
     try:
         for application in filter_applications(functions):
             app_manifest: ApplicationManifest = create_application_manifest(
-                application_function=application, all_functions=functions
+                application_function=application,
+                all_functions=functions,
+                function_images=function_images,
             )
             _ensure_public_endpoint_id(api_client, app_manifest)
             api_client.upsert_application(

--- a/src/tensorlake/applications/remote/images.py
+++ b/src/tensorlake/applications/remote/images.py
@@ -1,0 +1,158 @@
+import hashlib
+import re
+from dataclasses import dataclass
+
+from tensorlake.image.sandbox_builder import build_sandbox_application_image
+
+from ..applications import filter_applications, functions_for_application
+from ..image import Image
+from ..interface.exceptions import SDKUsageError
+from ..interface.function import Function
+
+_DEFAULT_APPLICATION_IMAGE_NAME = "default"
+_IMAGE_NAME_COMPONENT = re.compile(r"[a-z0-9]+(?:[._-][a-z0-9]+)*\Z")
+_CAS_IMAGE_ID = re.compile(r"[0-9a-f]{64}\Z")
+
+
+@dataclass(frozen=True)
+class ApplicationImageBuild:
+    image: Image
+    registered_name: str
+    function_keys: tuple[tuple[str, str], ...]
+
+
+def registered_image_component(value: str) -> str:
+    if len(value) <= 64 and _IMAGE_NAME_COMPONENT.fullmatch(value):
+        return value
+    return f"id-{hashlib.sha256(value.encode('utf-8')).hexdigest()[:32]}"
+
+
+def default_application_image_name(
+    application_name: str, application_version: str
+) -> str:
+    return (
+        f"applications/{registered_image_component(application_name)}"
+        f"/versions/{registered_image_component(application_version)}/default"
+    )
+
+
+def explicit_application_image_name(
+    application_name: str, application_version: str, image_name: str
+) -> str:
+    return (
+        f"applications/{registered_image_component(application_name)}"
+        f"/versions/{registered_image_component(application_version)}"
+        f"/images/{registered_image_component(image_name)}"
+    )
+
+
+def immutable_image_reference(published: dict, registered_name: str) -> str:
+    image_id = published.get("image_id")
+    if not isinstance(image_id, str) or not _CAS_IMAGE_ID.fullmatch(image_id):
+        raise SDKUsageError(
+            "Image Service did not return an immutable image ID for "
+            f"'{registered_name}'"
+        )
+    return f"cas-v1:{image_id}"
+
+
+def _append_image_build(
+    image_builds: list[ApplicationImageBuild],
+    seen_builds: set[tuple[str, str]],
+    seen_registered_names: dict[str, str],
+    image: Image,
+    registered_name: str,
+    function_key: tuple[str, str],
+) -> None:
+    previous_image_id = seen_registered_names.get(registered_name)
+    if previous_image_id is not None and previous_image_id != image._id:
+        raise SDKUsageError(
+            f"multiple different Image objects use the name '{registered_name}'. "
+            "Use unique Image(name=...) values so each function resolves "
+            "to the intended sandbox image."
+        )
+    seen_registered_names[registered_name] = image._id
+    build_key = (image._id, registered_name)
+    if build_key in seen_builds:
+        for index, image_build in enumerate(image_builds):
+            if (image_build.image._id, image_build.registered_name) == build_key:
+                image_builds[index] = ApplicationImageBuild(
+                    image=image_build.image,
+                    registered_name=image_build.registered_name,
+                    function_keys=(*image_build.function_keys, function_key),
+                )
+                return
+        raise AssertionError("recorded application image build is missing")
+    seen_builds.add(build_key)
+    image_builds.append(
+        ApplicationImageBuild(
+            image=image,
+            registered_name=registered_name,
+            function_keys=(function_key,),
+        )
+    )
+
+
+def application_image_builds(functions: list[Function]) -> list[ApplicationImageBuild]:
+    image_builds: list[ApplicationImageBuild] = []
+    for application in filter_applications(functions):
+        seen_builds: set[tuple[str, str]] = set()
+        seen_image_names: dict[str, str] = {}
+        application_name = application._function_config.function_name
+        application_version = application._application_config.version
+        default_image: Image | None = None
+        default_registered_name = default_application_image_name(
+            application_name,
+            application_version,
+        )
+        for function in functions_for_application(application, functions):
+            function_key = (
+                application_name,
+                function._function_config.function_name,
+            )
+            image = function._function_config.image
+            if image is None:
+                if default_image is None:
+                    default_image = Image(name=_DEFAULT_APPLICATION_IMAGE_NAME)
+                _append_image_build(
+                    image_builds,
+                    seen_builds,
+                    seen_image_names,
+                    default_image,
+                    default_registered_name,
+                    function_key,
+                )
+                continue
+            _append_image_build(
+                image_builds,
+                seen_builds,
+                seen_image_names,
+                image,
+                explicit_application_image_name(
+                    application_name, application_version, image.name
+                ),
+                function_key,
+            )
+    return image_builds
+
+
+def prepare_application_images(
+    functions: list[Function],
+    *,
+    context_dir: str,
+    build_envs: list[tuple[str, str]] | None = None,
+) -> dict[tuple[str, str], str]:
+    function_images: dict[tuple[str, str], str] = {}
+    for image_build in application_image_builds(functions):
+        published = build_sandbox_application_image(
+            image_build.image,
+            registered_name=image_build.registered_name,
+            build_env_vars=build_envs,
+            context_dir=context_dir,
+        )
+        immutable_ref = immutable_image_reference(
+            published, image_build.registered_name
+        )
+        for function_key in image_build.function_keys:
+            function_images[function_key] = immutable_ref
+    return function_images

--- a/src/tensorlake/applications/remote/manifests/application.py
+++ b/src/tensorlake/applications/remote/manifests/application.py
@@ -1,7 +1,7 @@
 import base64
 import inspect
 import pickle
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Literal
 
 from pydantic import BaseModel, Field
 
@@ -16,6 +16,7 @@ from ...function.user_data_serializer import (
     function_input_serializer,
     function_output_serializer,
 )
+from ...interface.exceptions import TensorlakeError
 from ...interface.function import (
     ApplicationCapability,
     Function,
@@ -54,6 +55,7 @@ class ApplicationManifest(BaseModel):
     allow: List[ApplicationCapability] = Field(default_factory=list)
     public_endpoint_id: str | None = None
     version: str
+    runtime: Literal["python"] = "python"
     functions: Dict[str, FunctionManifest]
     entrypoint: EntryPointManifest
 
@@ -69,7 +71,9 @@ class ApplicationManifest(BaseModel):
 
 
 def create_application_manifest(
-    application_function: Function, all_functions: List[Function]
+    application_function: Function,
+    all_functions: List[Function],
+    function_images: dict[tuple[str, str], str] | None = None,
 ) -> ApplicationManifest:
     """Creates ApplicationManifest for the supplied application function.
 
@@ -84,6 +88,24 @@ def create_application_manifest(
         )
         for fn in all_functions
     }
+    if function_images is not None:
+        application_name = application_function._function_config.function_name
+        for function_name, manifest in function_manifests.items():
+            image = function_images.get((application_name, function_name))
+            if image is None:
+                raise TensorlakeError(
+                    f"runtime image was not prepared for function '{function_name}'"
+                )
+            image_id = image.removeprefix("cas-v1:")
+            if (
+                not image.startswith("cas-v1:")
+                or len(image_id) != 64
+                or any(byte not in "0123456789abcdef" for byte in image_id)
+            ):
+                raise TensorlakeError(
+                    f"runtime image for function '{function_name}' is not immutable"
+                )
+            manifest.image = image
 
     inputs: list[EntryPointInputManifest] = _input_manifests(application_function)
     inputs_base64: str = base64.encodebytes(serialize_input_manifests(inputs)).decode(
@@ -100,6 +122,7 @@ def create_application_manifest(
         tags=app_config.tags,
         allow=app_config.allow,
         version=app_config.version,
+        runtime="python",
         functions=function_manifests,
         entrypoint=EntryPointManifest(
             function_name=application_function._function_config.function_name,

--- a/src/tensorlake/cli/deploy.py
+++ b/src/tensorlake/cli/deploy.py
@@ -4,18 +4,25 @@ import json
 import os
 import sys
 import traceback
-from dataclasses import dataclass
 from pathlib import Path
 
-from tensorlake.applications import Function, Image, SDKUsageError, TensorlakeError
-from tensorlake.applications.applications import (
-    filter_applications,
-    functions_for_application,
-)
+from tensorlake.applications import Function, SDKUsageError, TensorlakeError
+from tensorlake.applications.applications import filter_applications
 from tensorlake.applications.registry import get_functions
 from tensorlake.applications.remote.code.loader import load_code
 from tensorlake.applications.remote.curl_command import example_application_curl_command
 from tensorlake.applications.remote.deploy import deploy_applications
+from tensorlake.applications.remote.images import (
+    ApplicationImageBuild as _ApplicationImageBuild,
+)
+from tensorlake.applications.remote.images import (
+    application_image_builds as _application_images,
+)
+from tensorlake.applications.remote.images import (
+    default_application_image_name,
+    explicit_application_image_name,
+    immutable_image_reference,
+)
 from tensorlake.applications.secrets import list_secret_names
 from tensorlake.applications.validation import (
     ValidationMessage,
@@ -28,14 +35,9 @@ from tensorlake.image.sandbox_builder import (
     SandboxImageBuildError,
     build_sandbox_application_image,
 )
+from tensorlake.image.utils import _SDK_VERSION
 
-_DEFAULT_APPLICATION_IMAGE_NAME = "default"
-
-
-@dataclass(frozen=True)
-class _ApplicationImageBuild:
-    image: Image
-    registered_name: str
+_DEPLOY_PROTOCOL_VERSION = 1
 
 
 def _emit(obj):
@@ -101,6 +103,21 @@ def _build_context_from_env() -> Context:
     )
 
 
+def _function_service_context(auth: Context) -> Context:
+    function_service_url = os.environ.get("TENSORLAKE_FUNCTION_SERVICE_URL", "").strip()
+    if not function_service_url:
+        return auth
+    return Context.default(
+        api_url=function_service_url,
+        api_key=auth.api_key,
+        personal_access_token=auth.personal_access_token,
+        namespace=auth.namespace,
+        organization_id=auth.organization_id,
+        project_id=auth.project_id,
+        debug=auth.debug,
+    )
+
+
 def _warning_missing_secrets(auth: Context, secrets: list[str]) -> list[str]:
     """Check for missing secrets and return their names."""
     try:
@@ -122,21 +139,30 @@ def _parse_build_envs(build_envs: list[str]) -> list[tuple[str, str]]:
     return parsed_build_envs
 
 
-def _onprem_enabled() -> bool:
-    return os.environ.get("TENSORLAKE_ONPREM", "").lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
-
-
 def deploy(
     application_file_path: str,
     upgrade_running_requests: bool,
     build_envs: list[tuple[str, str]] | None = None,
 ):
     """Deploys applications to Tensorlake Cloud, emitting NDJSON events to stdout."""
+    _emit(
+        {
+            "type": "protocol",
+            "version": _DEPLOY_PROTOCOL_VERSION,
+            "sdk_version": _SDK_VERSION,
+        }
+    )
+    if upgrade_running_requests:
+        _emit(
+            {
+                "type": "error",
+                "message": (
+                    "--upgrade-running-requests is not supported by Function Service; "
+                    "existing requests stay pinned to their deployed application version"
+                ),
+            }
+        )
+        sys.exit(1)
     _emit(
         {
             "type": "status",
@@ -184,23 +210,15 @@ def deploy(
 
     functions: list[Function] = get_functions()
 
-    if _onprem_enabled():
-        deploy_applications(
-            applications_file_path=application_file_path,
-            upgrade_running_requests=upgrade_running_requests,
-            load_source_dir_modules=False,
-        )
-        _emit({"type": "done"})
-        return
-
     auth = _build_context_from_env()
+    function_service = _function_service_context(auth)
 
     missing = _warning_missing_secrets(auth, list(list_secret_names()))
     if missing:
         _emit({"type": "missing_secrets", "count": len(missing), "names": missing})
 
     try:
-        asyncio.run(
+        function_images = asyncio.run(
             _prepare_images(
                 functions,
                 context_dir=str(Path(application_file_path).parent),
@@ -215,11 +233,12 @@ def deploy(
         sys.exit(1)
 
     _deploy_applications(
-        api_client=auth.cloud_client,
-        api_url=auth.api_url,
+        api_client=function_service.cloud_client,
+        api_url=function_service.api_url,
         application_file_path=application_file_path,
         upgrade_running_requests=upgrade_running_requests,
         functions=functions,
+        function_images=function_images,
     )
 
 
@@ -227,14 +246,15 @@ async def _prepare_images(
     functions: list[Function],
     context_dir: str,
     build_envs: list[tuple[str, str]] | None = None,
-):
+) -> dict[tuple[str, str], str]:
     image_builds = _application_images(functions)
+    function_images: dict[tuple[str, str], str] = {}
     for image_build in image_builds:
         image = image_build.image
         image_name = image_build.registered_name
         _emit({"type": "build_start", "image": image_name})
         try:
-            await asyncio.to_thread(
+            published = await asyncio.to_thread(
                 build_sandbox_application_image,
                 image,
                 registered_name=image_name,
@@ -254,69 +274,12 @@ async def _prepare_images(
             )
             sys.exit(1)
 
+        immutable_ref = immutable_image_reference(published, image_name)
+        for function_key in image_build.function_keys:
+            function_images[function_key] = immutable_ref
+
     _emit({"type": "build_done"})
-
-
-def default_application_image_name(
-    application_name: str, application_version: str
-) -> str:
-    return f"applications/{application_name}/versions/{application_version}/default"
-
-
-def _append_image_build(
-    image_builds: list[_ApplicationImageBuild],
-    seen_image_ids: set[str],
-    seen_registered_names: dict[str, str],
-    image: Image,
-    registered_name: str,
-) -> None:
-    previous_image_id = seen_registered_names.get(registered_name)
-    if previous_image_id is not None and previous_image_id != image._id:
-        raise SDKUsageError(
-            f"multiple different Image objects use the name '{registered_name}'. "
-            "Use unique Image(name=...) values so each function resolves "
-            "to the intended sandbox image."
-        )
-    seen_registered_names[registered_name] = image._id
-    if image._id in seen_image_ids:
-        return
-    seen_image_ids.add(image._id)
-    image_builds.append(
-        _ApplicationImageBuild(image=image, registered_name=registered_name)
-    )
-
-
-def _application_images(functions: list[Function]) -> list[_ApplicationImageBuild]:
-    image_builds: list[_ApplicationImageBuild] = []
-    seen_image_ids: set[str] = set()
-    seen_image_names: dict[str, str] = {}
-    for application in filter_applications(functions):
-        default_image: Image | None = None
-        default_registered_name = default_application_image_name(
-            application._function_config.function_name,
-            application._application_config.version,
-        )
-        for function in functions_for_application(application, functions):
-            image = function._function_config.image
-            if image is None:
-                if default_image is None:
-                    default_image = Image(name=_DEFAULT_APPLICATION_IMAGE_NAME)
-                _append_image_build(
-                    image_builds,
-                    seen_image_ids,
-                    seen_image_names,
-                    default_image,
-                    default_registered_name,
-                )
-                continue
-            _append_image_build(
-                image_builds,
-                seen_image_ids,
-                seen_image_names,
-                image,
-                image.name,
-            )
-    return image_builds
+    return function_images
 
 
 def _deploy_applications(
@@ -325,6 +288,7 @@ def _deploy_applications(
     application_file_path: str,
     upgrade_running_requests: bool,
     functions: list[Function],
+    function_images: dict[tuple[str, str], str],
 ):
     _emit({"type": "status", "message": "Deploying applications..."})
 
@@ -334,6 +298,7 @@ def _deploy_applications(
             upgrade_running_requests=upgrade_running_requests,
             load_source_dir_modules=False,
             api_client=api_client,
+            function_images=function_images,
         )
 
         for application_function in filter_applications(functions):

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -222,6 +222,7 @@ def _run_rust_image_create(
     builder_disk_mb: int | None,
     is_public: bool,
     docker_compat: bool,
+    cas: bool,
     emit: EmitFn,
 ) -> dict:
     ctx, token = _resolve_build_credentials()
@@ -246,7 +247,7 @@ def _run_rust_image_create(
         docker_compat,
         dockerfile_text,
         context_dir,
-        cas=False,
+        cas=cas,
         emit=_forwarder(emit),
     )
     return _finish_image_registration(result_json, registered_name, emit)
@@ -326,9 +327,9 @@ def _finish_image_registration(
     emit(
         {
             "type": "image_registered",
-            "image_id": result.get("id", ""),
+            "image_id": result.get("image_id") or result.get("id", ""),
             "name": registered_name,
-            "snapshot_id": result.get("snapshot_id", ""),
+            "snapshot_id": result.get("snapshot_id") or result.get("image_id", ""),
         }
     )
     return result
@@ -668,6 +669,7 @@ def build_sandbox_image(
                 builder_disk_mb=builder_disk_mb,
                 is_public=is_public,
                 docker_compat=docker_compat,
+                cas=False,
                 emit=emit,
             )
         except SandboxImageError:
@@ -813,6 +815,7 @@ def build_sandbox_application_image(
             builder_disk_mb=builder_disk_mb,
             is_public=is_public,
             docker_compat=False,
+            cas=True,
             emit=emit,
         )
     except SandboxImageError:

--- a/src/tensorlake/image/utils.py
+++ b/src/tensorlake/image/utils.py
@@ -50,7 +50,8 @@ def dockerfile_content(img: Image, extra_env_vars: List[tuple] | None = None) ->
     dockerfile_lines.append("USER root")
     dockerfile_lines.append(
         f"RUN PIP_USER=false {install_cmd} "
-        "&& test -x /usr/local/bin/function-executor"
+        "&& test -x /usr/local/bin/tensorlake-python-function-runner "
+        "&& python3 -c 'from tensorlake._cloud_sdk import FunctionAgentCore'"
     )
 
     return "\n".join(dockerfile_lines)

--- a/tests/applications/test_application_manifest.py
+++ b/tests/applications/test_application_manifest.py
@@ -3,7 +3,14 @@ import unittest
 
 import validate_all_applications
 
-from tensorlake.applications import Image, Retries, application, cls, function
+from tensorlake.applications import (
+    Image,
+    Retries,
+    TensorlakeError,
+    application,
+    cls,
+    function,
+)
 from tensorlake.applications.registry import get_functions
 from tensorlake.applications.remote.manifests.application import (
     ApplicationManifest,
@@ -284,6 +291,40 @@ def function_with_custom_image(x: int) -> str:
 
 
 class TestFunctionManifestImages(unittest.TestCase):
+    def test_runtime_and_resolved_images_are_serialized_for_deployment(self):
+        app_manifest: ApplicationManifest = create_application_manifest(
+            application_function=default_application_function,
+            all_functions=get_functions(),
+            function_images={
+                (
+                    default_application_function._function_config.function_name,
+                    function._function_config.function_name,
+                ): f"cas-v1:{'a' * 64}"
+                for function in get_functions()
+            },
+        )
+
+        manifest = json.loads(app_manifest.model_dump_json())
+        self.assertEqual(manifest["runtime"], "python")
+        self.assertEqual(
+            manifest["functions"]["function_with_default_image"]["image"],
+            f"cas-v1:{'a' * 64}",
+        )
+
+    def test_resolved_images_must_be_immutable(self):
+        with self.assertRaisesRegex(TensorlakeError, "is not immutable"):
+            create_application_manifest(
+                application_function=default_application_function,
+                all_functions=get_functions(),
+                function_images={
+                    (
+                        default_application_function._function_config.function_name,
+                        function._function_config.function_name,
+                    ): "mutable-image-name"
+                    for function in get_functions()
+                },
+            )
+
     def test_default_function_image_is_omitted(self):
         app_manifest: ApplicationManifest = create_application_manifest(
             application_function=default_application_function,

--- a/tests/applications/test_code_zip.py
+++ b/tests/applications/test_code_zip.py
@@ -1,0 +1,45 @@
+import stat
+import tempfile
+import unittest
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+from tensorlake.applications.remote.code.zip import (
+    CODE_ZIP_MANIFEST_FILE_NAME,
+    zip_code,
+)
+
+
+class TestCodeZip(unittest.TestCase):
+    def test_application_zip_is_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            nested = root / "nested"
+            nested.mkdir()
+            (root / "z.py").write_text("Z = 1\n")
+            (root / "a.py").write_text("A = 1\n")
+            (nested / "m.py").write_text("M = 1\n")
+
+            first = zip_code(str(root), set(), [])
+            second = zip_code(str(root), set(), [])
+
+        self.assertEqual(first, second)
+        with zipfile.ZipFile(BytesIO(first)) as archive:
+            self.assertEqual(
+                archive.namelist(),
+                [
+                    CODE_ZIP_MANIFEST_FILE_NAME,
+                    "a.py",
+                    "z.py",
+                    "nested/m.py",
+                ],
+            )
+            for entry in archive.infolist():
+                self.assertEqual(entry.date_time, (1980, 1, 1, 0, 0, 0))
+                self.assertEqual(entry.create_system, 3)
+                self.assertTrue(stat.S_ISREG(entry.external_attr >> 16))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/applications/test_deploy_public_endpoint.py
+++ b/tests/applications/test_deploy_public_endpoint.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from tensorlake.applications import application, function
 from tensorlake.applications.remote.deploy import deploy_applications
@@ -37,7 +38,21 @@ class FakeDeployClient:
 
 class TestDeployPublicEndpoint(unittest.TestCase):
     def _deployed_manifest(self, client: FakeDeployClient) -> dict:
-        deploy_applications(__file__, api_client=client)
+        image_ref = f"cas-v1:{'a' * 64}"
+        with (
+            patch(
+                "tensorlake.applications.remote.deploy.get_functions",
+                return_value=[public_endpoint_app],
+            ),
+            patch(
+                "tensorlake.applications.remote.deploy.prepare_application_images",
+                return_value={
+                    ("public_endpoint_app", "public_endpoint_app"): image_ref
+                },
+            ) as prepare_images,
+        ):
+            deploy_applications(__file__, api_client=client)
+        prepare_images.assert_called_once()
         return next(
             upsert["manifest"]
             for upsert in client.upserts

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -9,6 +9,9 @@ from tensorlake.applications import Image, application, function
 from tensorlake.applications import registry as registry_module
 from tensorlake.cli import deploy as deploy_module
 
+_IMAGE_ID = "a" * 64
+_IMAGE_REF = f"cas-v1:{_IMAGE_ID}"
+
 
 @contextmanager
 def isolated_registry():
@@ -21,6 +24,22 @@ def isolated_registry():
 
 
 class TestDeployHelpers(unittest.TestCase):
+    def test_application_image_names_sanitize_catalog_components(self):
+        name = deploy_module.explicit_application_image_name(
+            "My Application", "Version 1", "GPU/Image"
+        )
+
+        self.assertRegex(
+            name,
+            r"^applications/id-[0-9a-f]{32}/versions/id-[0-9a-f]{32}/images/id-[0-9a-f]{32}$",
+        )
+
+    def test_immutable_image_reference_rejects_mutable_build_results(self):
+        with self.assertRaisesRegex(deploy_module.SDKUsageError, "immutable image ID"):
+            deploy_module.immutable_image_reference(
+                {"image_id": "mutable-name"}, "application-image"
+            )
+
     def test_format_error_message_does_not_include_exception_payload(self):
         message = deploy_module._format_error_message(
             "build failed", RuntimeError("secret")
@@ -70,6 +89,39 @@ class TestDeployHelpers(unittest.TestCase):
             organization_id="org-1",
             project_id="proj-1",
             debug=False,
+        )
+
+    def test_function_service_context_uses_explicit_service_url(self):
+        auth = SimpleNamespace(
+            api_key="api-key",
+            personal_access_token=None,
+            namespace="ns",
+            organization_id="org-1",
+            project_id="project-1",
+            debug=True,
+        )
+        expected = object()
+        with (
+            patch.dict(
+                os.environ,
+                {"TENSORLAKE_FUNCTION_SERVICE_URL": "http://functions.test:8930"},
+                clear=True,
+            ),
+            patch.object(
+                deploy_module.Context, "default", return_value=expected
+            ) as context_default,
+        ):
+            actual = deploy_module._function_service_context(auth)
+
+        self.assertIs(actual, expected)
+        context_default.assert_called_once_with(
+            api_url="http://functions.test:8930",
+            api_key="api-key",
+            personal_access_token=None,
+            namespace="ns",
+            organization_id="org-1",
+            project_id="project-1",
+            debug=True,
         )
 
     def test_warning_missing_secrets_returns_only_missing(self):
@@ -153,7 +205,7 @@ class TestDeployEntrypoints(unittest.TestCase):
                 )
 
         self.assertEqual(exc.exception.code, 1)
-        self.assertEqual(emit.call_args_list[0].args[0]["type"], "status")
+        self.assertEqual(emit.call_args_list[0].args[0]["type"], "protocol")
         event = emit.call_args_list[-1].args[0]
         self.assertEqual(event["type"], "error")
         self.assertIn(
@@ -161,6 +213,21 @@ class TestDeployEntrypoints(unittest.TestCase):
             event["message"],
         )
         self.assertEqual(event["details"], "ImportError: boom")
+
+    def test_deploy_rejects_upgrading_running_requests_before_building(self):
+        with patch.object(deploy_module, "_emit") as emit:
+            with self.assertRaises(SystemExit) as exc:
+                deploy_module.deploy(
+                    application_file_path="my_app.py",
+                    upgrade_running_requests=True,
+                )
+
+        self.assertEqual(exc.exception.code, 1)
+        self.assertEqual(emit.call_args_list[0].args[0]["type"], "protocol")
+        self.assertIn(
+            "not supported by Function Service",
+            emit.call_args_list[1].args[0]["message"],
+        )
 
     def test_deploy_emits_validation_failed_when_validation_has_errors(self):
         with (
@@ -200,6 +267,7 @@ class TestDeployEntrypoints(unittest.TestCase):
 
     def test_deploy_runs_build_and_deploy_flow(self):
         prepare_images = AsyncMock()
+        prepare_images.return_value = {}
         auth = self._make_auth_context()
         application = SimpleNamespace(_name="app-one")
         with (
@@ -233,7 +301,7 @@ class TestDeployEntrypoints(unittest.TestCase):
         ):
             deploy_module.deploy(
                 application_file_path="my_app.py",
-                upgrade_running_requests=True,
+                upgrade_running_requests=False,
             )
 
         prepare_images.assert_awaited_once_with(
@@ -243,9 +311,10 @@ class TestDeployEntrypoints(unittest.TestCase):
         )
         deploy_apps.assert_called_once_with(
             applications_file_path=os.path.abspath("my_app.py"),
-            upgrade_running_requests=True,
+            upgrade_running_requests=False,
             load_source_dir_modules=False,
             api_client=auth.cloud_client,
+            function_images={},
         )
         deployed_event = next(
             call.args[0]
@@ -353,9 +422,9 @@ class TestDeployEntrypoints(unittest.TestCase):
                 patch.object(
                     deploy_module,
                     "build_sandbox_application_image",
-                    return_value={},
+                    return_value={"image_id": _IMAGE_ID},
                 ) as build_image,
-                patch.object(deploy_module, "_deploy_applications"),
+                patch.object(deploy_module, "_deploy_applications") as deploy_apps,
                 patch.object(deploy_module, "_emit") as emit,
             ):
                 deploy_module.deploy(
@@ -375,20 +444,63 @@ class TestDeployEntrypoints(unittest.TestCase):
             [call.kwargs["registered_name"] for call in build_image.call_args_list],
             [
                 finance_analyzer_default,
-                "parser-image",
-                "agent-image",
-                "code-exec-image",
+                deploy_module.explicit_application_image_name(
+                    finance_analyzer._function_config.function_name,
+                    finance_analyzer._application_config.version,
+                    "parser-image",
+                ),
+                deploy_module.explicit_application_image_name(
+                    finance_analyzer._function_config.function_name,
+                    finance_analyzer._application_config.version,
+                    "agent-image",
+                ),
+                deploy_module.explicit_application_image_name(
+                    finance_analyzer._function_config.function_name,
+                    finance_analyzer._application_config.version,
+                    "code-exec-image",
+                ),
                 finance_query_default,
+                deploy_module.explicit_application_image_name(
+                    finance_query._function_config.function_name,
+                    finance_query._application_config.version,
+                    "parser-image",
+                ),
+                deploy_module.explicit_application_image_name(
+                    finance_query._function_config.function_name,
+                    finance_query._application_config.version,
+                    "agent-image",
+                ),
+                deploy_module.explicit_application_image_name(
+                    finance_query._function_config.function_name,
+                    finance_query._application_config.version,
+                    "code-exec-image",
+                ),
             ],
         )
         self.assertEqual(
             [
                 call.args[0]
                 for call in build_image.call_args_list
-                if call.kwargs["registered_name"]
-                in {"parser-image", "agent-image", "code-exec-image"}
+                if call.args[0] in {parser_image, agent_image, code_exec_image}
             ],
-            [parser_image, agent_image, code_exec_image],
+            [
+                parser_image,
+                agent_image,
+                code_exec_image,
+                parser_image,
+                agent_image,
+                code_exec_image,
+            ],
+        )
+        function_images = deploy_apps.call_args.kwargs["function_images"]
+        self.assertEqual(
+            function_images[
+                (
+                    finance_query._function_config.function_name,
+                    run_query_agent._function_config.function_name,
+                )
+            ],
+            _IMAGE_REF,
         )
         emit.assert_any_call({"type": "build_done"})
 
@@ -413,9 +525,9 @@ class TestDeployEntrypoints(unittest.TestCase):
                 patch.object(
                     deploy_module,
                     "build_sandbox_application_image",
-                    return_value={},
+                    return_value={"image_id": _IMAGE_ID},
                 ) as build_image,
-                patch.object(deploy_module, "_deploy_applications"),
+                patch.object(deploy_module, "_deploy_applications") as deploy_apps,
                 patch.object(deploy_module, "_emit") as emit,
             ):
                 deploy_module.deploy(
@@ -431,6 +543,19 @@ class TestDeployEntrypoints(unittest.TestCase):
         self.assertEqual(build_image.call_args.args[0].name, "default")
         self.assertEqual(
             build_image.call_args.kwargs["registered_name"], registered_name
+        )
+        self.assertEqual(
+            deploy_apps.call_args.kwargs["function_images"],
+            {
+                (
+                    default_image_app._function_config.function_name,
+                    default_image_app._function_config.function_name,
+                ): _IMAGE_REF,
+                (
+                    default_image_app._function_config.function_name,
+                    helper._function_config.function_name,
+                ): _IMAGE_REF,
+            },
         )
         emit.assert_any_call({"type": "build_start", "image": registered_name})
 
@@ -469,7 +594,7 @@ class TestDeployEntrypoints(unittest.TestCase):
             patch.object(
                 deploy_module,
                 "build_sandbox_application_image",
-                return_value={},
+                return_value={"image_id": _IMAGE_ID},
             ) as build_image,
             patch.object(deploy_module, "_deploy_applications") as deploy_apps,
             patch.object(deploy_module, "_emit") as emit,
@@ -482,7 +607,10 @@ class TestDeployEntrypoints(unittest.TestCase):
         build_image.assert_called_once()
         self.assertEqual(build_image.call_args.args[0], shared_image)
         self.assertEqual(
-            build_image.call_args.kwargs["registered_name"], "shared-image"
+            build_image.call_args.kwargs["registered_name"],
+            deploy_module.explicit_application_image_name(
+                "app-one", "v1", "shared-image"
+            ),
         )
         build_start_events = [
             call.args[0]
@@ -491,7 +619,14 @@ class TestDeployEntrypoints(unittest.TestCase):
         ]
         self.assertEqual(
             build_start_events,
-            [{"type": "build_start", "image": "shared-image"}],
+            [
+                {
+                    "type": "build_start",
+                    "image": deploy_module.explicit_application_image_name(
+                        "app-one", "v1", "shared-image"
+                    ),
+                }
+            ],
         )
         deploy_apps.assert_called_once()
 
@@ -547,11 +682,13 @@ class TestDeployEntrypoints(unittest.TestCase):
         )
 
         with (
-            patch.object(
-                deploy_module, "filter_applications", return_value=[application]
+            patch(
+                "tensorlake.applications.remote.images.filter_applications",
+                return_value=[application],
             ),
-            patch.object(
-                deploy_module, "functions_for_application", return_value=[application]
+            patch(
+                "tensorlake.applications.remote.images.functions_for_application",
+                return_value=[application],
             ),
             patch.object(
                 deploy_module,
@@ -574,9 +711,12 @@ class TestDeployEntrypoints(unittest.TestCase):
         emit.assert_any_call(
             {
                 "type": "build_failed",
-                "image": "parser-image",
+                "image": deploy_module.explicit_application_image_name(
+                    "app", "v1", "parser-image"
+                ),
                 "error": (
-                    "image 'parser-image' build failed: rootfs builder failed. "
+                    "image 'applications/app/versions/v1/images/parser-image' "
+                    "build failed: rootfs builder failed. "
                     "check your Image() configuration and try again."
                 ),
             }

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -185,6 +185,7 @@ class TestBuildSandboxImageFromDockerfileOptions(unittest.TestCase):
                 context_dir=None,
                 is_public=False,
                 docker_compat=False,
+                cas=False,
                 emit=emitted.append,
             )
 
@@ -645,6 +646,8 @@ class TestBuildSandboxApplicationImage(unittest.TestCase):
                 memory_mb=BUILD_MEMORY_MB,
             )
 
+        self.assertIs(rust_builder_mock.call_args.kwargs["cas"], True)
+
         dockerfile_text = captured["dockerfile_text"]
         self.assertIsInstance(dockerfile_text, str)
         dockerfile_lines = dockerfile_text.rstrip().splitlines()
@@ -659,7 +662,10 @@ class TestBuildSandboxApplicationImage(unittest.TestCase):
         self.assertNotIn("id -u", install_line)
         self.assertIn("RUN PIP_USER=false python3 -m pip install", install_line)
         self.assertTrue(
-            install_line.endswith("&& test -x /usr/local/bin/function-executor"),
+            install_line.endswith(
+                "&& test -x /usr/local/bin/tensorlake-python-function-runner "
+                "&& python3 -c 'from tensorlake._cloud_sdk import FunctionAgentCore'"
+            ),
             install_line,
         )
 
@@ -682,7 +688,14 @@ class TestApplicationDockerfileContent(unittest.TestCase):
         )
         self.assertNotIn("sudo", dockerfile)
         self.assertNotIn("id -u", dockerfile)
-        self.assertIn("&& test -x /usr/local/bin/function-executor", dockerfile)
+        self.assertIn(
+            "&& test -x /usr/local/bin/tensorlake-python-function-runner",
+            dockerfile,
+        )
+        self.assertIn(
+            "python3 -c 'from tensorlake._cloud_sdk import FunctionAgentCore'",
+            dockerfile,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- build default and explicitly configured Python and TypeScript function images through Image Service
- resolve every function image to an immutable `cas-v1:<sha256>` reference before deployment
- keep application source code in a separate ZIP artifact and make programmatic Python deployment use the same image preparation path as the CLI
- include in-memory build context files in CAS image builds and require the Linux x64 native function-agent core in TypeScript runtime capsules
- classify pre-runtime artifact materialization failures as infrastructure loss in the shared Rust agent core

## Why

Function Service now treats application versions and their runtime image bindings as immutable. The SDK previously sent mutable image names and some deployment entry points could skip application image preparation, so a deployed version could not reliably identify the exact runtime filesystem it should execute against.

This makes image publication and manifest construction one deployment transaction from the SDK's point of view while preserving the existing ZIP-based application-code artifact.

## User impact

Python and TypeScript applications can continue using default or custom `Image` definitions. Deployment now builds and registers those definitions with Image Service and stores only immutable content-addressed references in Function Service manifests. Redeploying the same application version with different content is rejected.

## Validation

- `cargo nextest run -p tensorlake -p tensorlake-cli -p tensorlake-function-agent-core` — 748 passed
- focused Python deployment/image tests — 83 passed
- `npm test` — 437 passed
- `npm run typecheck`
- `npm run lint`
- focused Rust Clippy with `-D warnings`
- Python Black and isort checks
- built and validated a real Linux x64 TypeScript function-runner capsule

Companion Compute Engine PR: https://github.com/tensorlakeai/compute-engine-internal/pull/1665
