### PR TITLE
Support TLFS mounts on warm-pool claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ with client.create_and_connect(snapshot_id=snapshot.snapshot_id) as sandbox:
 Pre-warm containers for fast startup:
 
 ```python
-from tensorlake.sandbox import NetworkConfig
+from tensorlake.sandbox import FileSystemMount, NetworkConfig
 
 # Create a pool with warm containers and no internet access
 pool = client.create_pool(
@@ -142,8 +142,17 @@ pool = client.create_pool(
     network=NetworkConfig(allow_internet_access=False),
 )
 
-# Claim a sandbox instantly from the pool
-resp = client.claim(pool.pool_id)
+# Claim a sandbox instantly from the pool. Claim-specific file systems are
+# mounted before the sandbox is reported as running.
+resp = client.claim(
+    pool.pool_id,
+    file_systems=[
+        FileSystemMount(
+            file_system_id="file_system_abc",
+            mount_path="/mnt/skills",
+        )
+    ],
+)
 sandbox = client.connect(resp.sandbox_id)
 
 # Named sandboxes can be reconnected later by name

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -21,8 +21,8 @@ use crate::{
 pub use desktop::SandboxDesktopClient;
 
 use models::{
-    ArchivedSandboxInfo, ArchivedSandboxesPaginationDirection, CopySandboxResponse,
-    CreateSandboxPoolRequest, CreateSandboxPoolResponse, CreateSandboxRequest,
+    ArchivedSandboxInfo, ArchivedSandboxesPaginationDirection, ClaimSandboxRequest,
+    CopySandboxResponse, CreateSandboxPoolRequest, CreateSandboxPoolResponse, CreateSandboxRequest,
     CreateSandboxResponse, CreateSnapshotRequest, CreateSnapshotResponse, DaemonInfo,
     DetachFileSystemRequest, FileSystemMount, GetSandboxLogsRequest, HealthResponse,
     ListArchivedSandboxesParams, ListArchivedSandboxesResponse, ListDirectoryResponse,
@@ -328,6 +328,41 @@ impl SandboxesClient {
         self.client
             .execute_json_allow_status(req, &[StatusCode::GATEWAY_TIMEOUT])
             .await
+    }
+
+    /// Claim a sandbox from a pool and apply sandbox-specific file-system
+    /// mounts before the claimed sandbox becomes ready. Fails closed when the
+    /// server does not acknowledge claim-configuration support and attempts
+    /// to terminate the incorrectly configured sandbox returned by that
+    /// server.
+    pub async fn claim_with_request(
+        &self,
+        pool_id: &str,
+        request: &ClaimSandboxRequest,
+    ) -> Result<Traced<CreateSandboxResponse>, SdkError> {
+        let uri = self.endpoint(&format!("sandbox-pools/{pool_id}/sandboxes"));
+        let req = self
+            .client
+            .build_post_json_request(Method::POST, &uri, request)?;
+        let response: Traced<CreateSandboxResponse> = self
+            .client
+            .execute_json_allow_status(req, &[StatusCode::GATEWAY_TIMEOUT])
+            .await?;
+        if response.claim_configuration_applied != Some(true) {
+            let cleanup = match self.delete(&response.sandbox_id).await {
+                Ok(_) => "the incorrectly configured sandbox was terminated".to_string(),
+                Err(error) => format!(
+                    "cleanup of sandbox {:?} also failed: {error}",
+                    response.sandbox_id
+                ),
+            };
+            return Err(SdkError::ClientError(format!(
+                "server did not acknowledge sandbox pool claim configuration for pool \
+                 {pool_id:?}; upgrade the compute-engine server before requesting claim-time \
+                 file systems; {cleanup}"
+            )));
+        }
+        Ok(response)
     }
 
     pub async fn copy(

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -36,6 +36,18 @@ use models::{
 pub const DEFAULT_SANDBOX_PROXY_URL: &str = "https://sandbox.tensorlake.ai";
 pub const SANDBOX_MANAGEMENT_PORT: u16 = 9501;
 
+/// Wire-only response for claim-time configuration negotiation. Keep the
+/// acknowledgement private so adding the protocol field does not make the
+/// existing public [`CreateSandboxResponse`] source-incompatible for Rust
+/// callers that construct it directly.
+#[derive(Debug, serde::Deserialize)]
+struct ClaimSandboxResponse {
+    #[serde(flatten)]
+    sandbox: CreateSandboxResponse,
+    #[serde(default)]
+    claim_configuration_applied: Option<bool>,
+}
+
 /// A reference to a sandbox process: either its OS **pid** or a managed-process **name**
 /// given at creation. This is the single place the pid/name path segment is built, reused by
 /// the Rust SDK, the Python/Node bindings, and the CLI.
@@ -332,8 +344,8 @@ impl SandboxesClient {
 
     /// Claim a sandbox from a pool and apply sandbox-specific file-system
     /// mounts before the claimed sandbox becomes ready. Fails closed when the
-    /// server does not acknowledge claim-configuration support and attempts
-    /// to terminate the incorrectly configured sandbox returned by that
+    /// server does not acknowledge claim-configuration support and requests
+    /// termination of the incorrectly configured sandbox returned by that
     /// server.
     pub async fn claim_with_request(
         &self,
@@ -344,13 +356,18 @@ impl SandboxesClient {
         let req = self
             .client
             .build_post_json_request(Method::POST, &uri, request)?;
-        let response: Traced<CreateSandboxResponse> = self
+        let response: Traced<ClaimSandboxResponse> = self
             .client
             .execute_json_allow_status(req, &[StatusCode::GATEWAY_TIMEOUT])
             .await?;
-        if response.claim_configuration_applied != Some(true) {
+        let claim_configuration_applied = response.claim_configuration_applied;
+        let response = response.map(|response| response.sandbox);
+        if claim_configuration_applied != Some(true) {
             let cleanup = match self.delete(&response.sandbox_id).await {
-                Ok(_) => "the incorrectly configured sandbox was terminated".to_string(),
+                Ok(_) => format!(
+                    "termination was requested for sandbox {:?}",
+                    response.sandbox_id
+                ),
                 Err(error) => format!(
                     "cleanup of sandbox {:?} also failed: {error}",
                     response.sandbox_id

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -178,6 +178,16 @@ pub struct CreateSandboxRequest {
     pub file_systems: Vec<FileSystemMount>,
 }
 
+/// Sandbox-specific state to apply while claiming a warm pool container.
+///
+/// Pool templates stay storage-neutral; these mounts belong only to the
+/// sandbox created by the claim.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ClaimSandboxRequest {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub file_systems: Vec<FileSystemMount>,
+}
+
 /// Request body for detaching a file system from a running sandbox. The
 /// mount path is sent in the body (rather than the URL) so its slashes don't
 /// need URL-encoding.
@@ -427,6 +437,8 @@ impl<'de> Deserialize<'de> for UpdateSandboxPoolRequest {
 pub struct CreateSandboxResponse {
     pub sandbox_id: String,
     pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claim_configuration_applied: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -438,8 +438,6 @@ pub struct CreateSandboxResponse {
     pub sandbox_id: String,
     pub status: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub claim_configuration_applied: Option<bool>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub routing_hint: Option<String>,

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -181,7 +181,11 @@ async fn pool_claim_with_file_systems_rejects_server_without_acknowledgment() {
         .expect_err("an old server must not silently ignore claim-time mounts");
 
     assert!(error.to_string().contains("did not acknowledge"));
-    assert!(error.to_string().contains("was terminated"));
+    assert!(
+        error
+            .to_string()
+            .contains("termination was requested for sandbox \"sbx-1\"")
+    );
     let (_, cleanup_request) = server.await.expect("server join");
     assert!(
         String::from_utf8_lossy(&cleanup_request)

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -3,8 +3,9 @@ use tensorlake::{
     sandboxes::{
         SandboxProxyClient, SandboxesClient,
         models::{
-            ContainerResourcesInfo, CreateSandboxPoolRequest, NetworkConfig, NetworkPolicyUpdate,
-            SandboxPoolRequest, UpdateSandboxPoolRequest, UpdateSandboxRequest,
+            ClaimSandboxRequest, ContainerResourcesInfo, CreateSandboxPoolRequest, FileSystemMount,
+            NetworkConfig, NetworkPolicyUpdate, SandboxPoolRequest, UpdateSandboxPoolRequest,
+            UpdateSandboxRequest,
         },
     },
 };
@@ -99,6 +100,93 @@ async fn direct_empty_post_helper_sends_content_length_zero() {
     let request_text = String::from_utf8_lossy(&request);
     assert!(request_text.starts_with("POST /sandbox-pools/pool-1/sandboxes HTTP/1.1\r\n"));
     assert!(request_text.contains("\r\ncontent-length: 0\r\n"));
+}
+
+#[tokio::test]
+async fn pool_claim_with_file_systems_sends_json_body() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept request");
+        let request = read_http_request(&mut socket).await;
+        let body =
+            r#"{"sandbox_id":"sbx-1","status":"running","claim_configuration_applied":true}"#;
+        write_json_response(&mut socket, body).await;
+        request
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .build()
+        .expect("build client");
+    let sandboxes = SandboxesClient::new(client, "default", false);
+    sandboxes
+        .claim_with_request(
+            "pool-1",
+            &ClaimSandboxRequest {
+                file_systems: vec![FileSystemMount {
+                    file_system_id: "file_system_abc".to_string(),
+                    mount_path: "/mnt/skills".to_string(),
+                }],
+            },
+        )
+        .await
+        .expect("claim sandbox with file systems");
+
+    let request = server.await.expect("server join");
+    let request_text = String::from_utf8_lossy(&request);
+    assert!(request_text.starts_with("POST /sandbox-pools/pool-1/sandboxes HTTP/1.1\r\n"));
+    assert!(request_text.contains("\r\ncontent-type: application/json\r\n"));
+    assert!(request.ends_with(
+        br#"{"file_systems":[{"file_system_id":"file_system_abc","mount_path":"/mnt/skills"}]}"#
+    ));
+}
+
+#[tokio::test]
+async fn pool_claim_with_file_systems_rejects_server_without_acknowledgment() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept request");
+        let claim_request = read_http_request(&mut socket).await;
+        let body = r#"{"sandbox_id":"sbx-1","status":"running"}"#;
+        write_json_response(&mut socket, body).await;
+
+        let (mut socket, _) = listener.accept().await.expect("accept cleanup request");
+        let cleanup_request = read_http_request(&mut socket).await;
+        write_json_response(&mut socket, "{}").await;
+        (claim_request, cleanup_request)
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .build()
+        .expect("build client");
+    let sandboxes = SandboxesClient::new(client, "default", false);
+    let error = sandboxes
+        .claim_with_request(
+            "pool-1",
+            &ClaimSandboxRequest {
+                file_systems: vec![FileSystemMount {
+                    file_system_id: "file_system_abc".to_string(),
+                    mount_path: "/mnt/skills".to_string(),
+                }],
+            },
+        )
+        .await
+        .expect_err("an old server must not silently ignore claim-time mounts");
+
+    assert!(error.to_string().contains("did not acknowledge"));
+    assert!(error.to_string().contains("was terminated"));
+    let (_, cleanup_request) = server.await.expect("server join");
+    assert!(
+        String::from_utf8_lossy(&cleanup_request)
+            .starts_with("DELETE /sandboxes/sbx-1 HTTP/1.1\r\n")
+    );
 }
 
 #[tokio::test]

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -25,9 +25,9 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use tensorlake::sandboxes::models::{
-    ArchivedSandboxesPaginationDirection, CreateSandboxPoolRequest, CreateSandboxRequest,
-    GetSandboxLogsRequest, ListArchivedSandboxesParams, SnapshotType, UpdateSandboxPoolRequest,
-    UpdateSandboxRequest,
+    ArchivedSandboxesPaginationDirection, ClaimSandboxRequest, CreateSandboxPoolRequest,
+    CreateSandboxRequest, GetSandboxLogsRequest, ListArchivedSandboxesParams, SnapshotType,
+    UpdateSandboxPoolRequest, UpdateSandboxRequest,
 };
 use tensorlake::sandboxes::{
     SandboxProxyClient, SandboxesClient, resolve_sandbox_proxy_target, select_sandbox_proxy_url,
@@ -379,9 +379,21 @@ impl NativeSandboxClient {
     }
 
     #[napi]
-    pub async fn claim_sandbox(&self, pool_id: String) -> napi::Result<TracedJson> {
+    pub async fn claim_sandbox(
+        &self,
+        pool_id: String,
+        request_json: Option<String>,
+    ) -> napi::Result<TracedJson> {
         let client = self.client.clone();
-        let traced = client.claim(&pool_id).await.map_err(into_napi_error)?;
+        let request = request_json
+            .as_deref()
+            .map(parse_json_payload::<ClaimSandboxRequest>)
+            .transpose()?;
+        let traced = match request {
+            Some(request) => client.claim_with_request(&pool_id, &request).await,
+            None => client.claim(&pool_id).await,
+        }
+        .map_err(into_napi_error)?;
         let json =
             serde_json::to_string(&*traced).map_err(|e| into_napi_error(SdkError::from(e)))?;
         Ok(TracedJson {

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -36,9 +36,9 @@ use tensorlake::images::models::{ApplicationBuildContext, CreateApplicationBuild
 use tensorlake::sandbox_images::SandboxImageBuildEvent;
 use tensorlake::sandbox_templates::SandboxTemplatesClient;
 use tensorlake::sandboxes::models::{
-    ArchivedSandboxesPaginationDirection, CreateSandboxPoolRequest, CreateSandboxRequest,
-    GetSandboxLogsRequest, ListArchivedSandboxesParams, SnapshotType, UpdateSandboxPoolRequest,
-    UpdateSandboxRequest,
+    ArchivedSandboxesPaginationDirection, ClaimSandboxRequest, CreateSandboxPoolRequest,
+    CreateSandboxRequest, GetSandboxLogsRequest, ListArchivedSandboxesParams, SnapshotType,
+    UpdateSandboxPoolRequest, UpdateSandboxRequest,
 };
 use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
@@ -1602,11 +1602,23 @@ impl CloudSandboxClient {
             .map_err(into_sandbox_py_error)
     }
 
-    fn claim_sandbox(&self, pool_id: String) -> PyResult<(String, String)> {
+    #[pyo3(signature = (pool_id, request_json=None))]
+    fn claim_sandbox(
+        &self,
+        pool_id: String,
+        request_json: Option<String>,
+    ) -> PyResult<(String, String)> {
+        let request = request_json
+            .as_deref()
+            .map(parse_json_payload::<ClaimSandboxRequest>)
+            .transpose()?;
         let client = self.client.clone();
         shared_runtime()
             .block_on(async move {
-                let traced = client.claim(&pool_id).await?;
+                let traced = match request {
+                    Some(request) => client.claim_with_request(&pool_id, &request).await?,
+                    None => client.claim(&pool_id).await?,
+                };
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
                 Ok((trace_id, json))
@@ -1918,17 +1930,24 @@ impl CloudSandboxClient {
         })
     }
 
+    #[pyo3(signature = (pool_id, request_json=None))]
     fn claim_sandbox_async<'py>(
         &self,
         py: Python<'py>,
         pool_id: String,
+        request_json: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let request = request_json
+            .as_deref()
+            .map(parse_json_payload::<ClaimSandboxRequest>)
+            .transpose()?;
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = client
-                .claim(&pool_id)
-                .await
-                .map_err(into_sandbox_py_error)?;
+            let traced = match request {
+                Some(request) => client.claim_with_request(&pool_id, &request).await,
+                None => client.claim(&pool_id).await,
+            }
+            .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -44,6 +44,7 @@ from .exceptions import (
 from .models import (
     CLEAR_NETWORK_POLICY,
     ArchivedSandboxInfo,
+    ClaimSandboxRequest,
     ClearNetworkPolicy,
     ContainerResourcesInfo,
     CopySandboxResponse,
@@ -281,10 +282,21 @@ class AsyncSandboxClient:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    async def claim(self, pool_id: str) -> Traced[CreateSandboxResponse]:
+    async def claim(
+        self,
+        pool_id: str,
+        *,
+        file_systems: list[FileSystemMount] | None = None,
+    ) -> Traced[CreateSandboxResponse]:
         try:
+            claim_kwargs: dict[str, str] = {"pool_id": pool_id}
+            if file_systems:
+                request = ClaimSandboxRequest(file_systems=file_systems)
+                claim_kwargs["request_json"] = request.model_dump_json(
+                    by_alias=True, exclude_none=True
+                )
             trace_id, response_json = await self._rust_client.claim_sandbox_async(
-                pool_id=pool_id
+                **claim_kwargs
             )
             return Traced(
                 trace_id, CreateSandboxResponse.model_validate_json(response_json)
@@ -956,7 +968,7 @@ class AsyncSandboxClient:
 
         requested_name = None if pool_id is not None else name
         if pool_id is not None:
-            result = await request_client.claim(pool_id)
+            result = await request_client.claim(pool_id, file_systems=file_systems)
         else:
             result = await request_client.create(
                 image=image,

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -23,6 +23,7 @@ from .exceptions import (
 from .models import (
     CLEAR_NETWORK_POLICY,
     ArchivedSandboxInfo,
+    ClaimSandboxRequest,
     ClearNetworkPolicy,
     ContainerResourcesInfo,
     CopySandboxResponse,
@@ -511,7 +512,12 @@ class SandboxClient:
         except Exception as e:
             _raise_as_sandbox_error(e)
 
-    def claim(self, pool_id: str) -> Traced[CreateSandboxResponse]:
+    def claim(
+        self,
+        pool_id: str,
+        *,
+        file_systems: list[FileSystemMount] | None = None,
+    ) -> Traced[CreateSandboxResponse]:
         """Claim a sandbox from a pool.
 
         Claims a warm container from the pool, or creates a new one
@@ -519,6 +525,8 @@ class SandboxClient:
 
         Args:
             pool_id: ID of the pool to claim from
+            file_systems: File systems to mount into the claimed sandbox.
+                The sandbox becomes ready only after these mounts converge.
 
         Returns:
             Traced[CreateSandboxResponse] with sandbox_id, status, and trace_id
@@ -528,7 +536,13 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         try:
-            trace_id, response_json = self._rust_client.claim_sandbox(pool_id=pool_id)
+            claim_kwargs: dict[str, str] = {"pool_id": pool_id}
+            if file_systems:
+                request = ClaimSandboxRequest(file_systems=file_systems)
+                claim_kwargs["request_json"] = request.model_dump_json(
+                    by_alias=True, exclude_none=True
+                )
+            trace_id, response_json = self._rust_client.claim_sandbox(**claim_kwargs)
             return Traced(
                 trace_id, CreateSandboxResponse.model_validate_json(response_json)
             )
@@ -1530,8 +1544,8 @@ class SandboxClient:
             name: Optional name for the sandbox. Named sandboxes support
                 suspend/resume. When absent the sandbox is ephemeral.
             file_systems: File systems to mount into the sandbox
-                at boot, each at its own absolute, unique guest mount path.
-                Ignored when claiming from a pool.
+                at boot or warm-pool claim, each at its own absolute, unique
+                guest mount path.
 
         Returns:
             Connected Sandbox instance (auto-terminates in context manager)
@@ -1555,7 +1569,7 @@ class SandboxClient:
         # may fall back to the requested name when caching info locally.
         requested_name = None if pool_id is not None else name
         if pool_id is not None:
-            result = request_client.claim(pool_id)
+            result = request_client.claim(pool_id, file_systems=file_systems)
         else:
             result = request_client.create(
                 image=image,

--- a/src/tensorlake/sandbox/file_system.py
+++ b/src/tensorlake/sandbox/file_system.py
@@ -7,8 +7,9 @@ images). Register one with :func:`create_file_system`, list them with
 :func:`delete_file_system`.
 
 Once registered, mount a file system into a sandbox at boot via
-``Sandbox.create(file_systems=[...])`` or attach it to a running sandbox
-with :meth:`tensorlake.sandbox.Sandbox.attach_file_system`.
+``Sandbox.create(file_systems=[...])``, include it in a warm-pool claim, or
+attach it to a running sandbox with
+:meth:`tensorlake.sandbox.Sandbox.attach_file_system`.
 """
 
 from __future__ import annotations

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -242,8 +242,8 @@ class FileSystem(BaseModel):
     File systems are project-scoped resources managed through the
     platform API. Register one with
     :func:`tensorlake.create_file_system`, then mount it into a sandbox
-    at boot (``Sandbox.create(file_systems=[...])``) or attach it to a
-    running sandbox (:meth:`Sandbox.attach_file_system`).
+    at boot or warm-pool claim (``Sandbox.create(file_systems=[...])``), or
+    attach it to a running sandbox (:meth:`Sandbox.attach_file_system`).
     """
 
     id: str | None = None
@@ -270,6 +270,14 @@ class CreateSandboxRequest(BaseModel):
     network: NetworkConfig | None = None
     snapshot_id: str | None = None
     name: str | None = None
+    file_systems: list[FileSystemMount] | None = None
+
+    model_config = {"populate_by_name": True}
+
+
+class ClaimSandboxRequest(BaseModel):
+    """Sandbox-specific state applied while claiming from a warm pool."""
+
     file_systems: list[FileSystemMount] | None = None
 
     model_config = {"populate_by_name": True}

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -388,7 +388,8 @@ class Sandbox:
             startup_timeout: Deprecated alias for ``request_timeout``.
             name: Optional name; named sandboxes support suspend/resume.
             file_systems: File systems to mount into the sandbox
-                at boot, each at its own absolute, unique guest mount path.
+                at boot or warm-pool claim, each at its own absolute, unique
+                guest mount path.
             api_key: Tensorlake API key (defaults to TENSORLAKE_API_KEY env var).
             api_url: API server URL (defaults to TENSORLAKE_API_URL env var).
             organization_id: Organization ID for multi-tenant access.

--- a/tests/sandbox/test_file_systems.py
+++ b/tests/sandbox/test_file_systems.py
@@ -19,7 +19,11 @@ from tensorlake.sandbox import (
 from tensorlake.sandbox.async_client import AsyncSandboxClient
 from tensorlake.sandbox.client import SandboxClient
 from tensorlake.sandbox.exceptions import SandboxError
-from tensorlake.sandbox.models import CreateSandboxRequest, CreateSandboxResources
+from tensorlake.sandbox.models import (
+    ClaimSandboxRequest,
+    CreateSandboxRequest,
+    CreateSandboxResources,
+)
 
 
 def _sandbox_info_json(file_systems: list[dict]) -> str:
@@ -39,6 +43,7 @@ class _FakeRustClient:
         self.attach_calls: list[tuple[str, str, str]] = []
         self.detach_calls: list[tuple[str, str]] = []
         self.create_request_json: str | None = None
+        self.claim_calls: list[dict[str, str]] = []
 
     def close(self):
         return None
@@ -60,10 +65,15 @@ class _FakeRustClient:
         self.create_request_json = request_json
         return ("trace-create", '{"sandbox_id":"sbx-1","status":"pending"}')
 
+    def claim_sandbox(self, **kwargs):
+        self.claim_calls.append(kwargs)
+        return ("trace-claim", '{"sandbox_id":"sbx-1","status":"pending"}')
+
 
 class _FakeAsyncRustClient:
     def __init__(self):
         self.attach_calls: list[tuple[str, str, str]] = []
+        self.claim_calls: list[dict[str, str]] = []
 
     def close(self):
         return None
@@ -76,6 +86,10 @@ class _FakeAsyncRustClient:
                 [{"file_system_id": file_system_id, "mount_path": mount_path}]
             ),
         )
+
+    async def claim_sandbox_async(self, **kwargs):
+        self.claim_calls.append(kwargs)
+        return ("trace-claim", '{"sandbox_id":"sbx-1","status":"pending"}')
 
 
 def _sync_client(fake: _FakeRustClient) -> SandboxClient:
@@ -195,6 +209,27 @@ class TestFileSystemModels(unittest.TestCase):
         payload = json.loads(request.model_dump_json(by_alias=True, exclude_none=True))
         self.assertNotIn("file_systems", payload)
 
+    def test_claim_request_serializes_file_systems_to_wire_key(self):
+        request = ClaimSandboxRequest(
+            file_systems=[
+                FileSystemMount(
+                    file_system_id="file_system_abc", mount_path="/mnt/skills"
+                )
+            ]
+        )
+        payload = json.loads(request.model_dump_json(by_alias=True, exclude_none=True))
+        self.assertEqual(
+            payload,
+            {
+                "file_systems": [
+                    {
+                        "file_system_id": "file_system_abc",
+                        "mount_path": "/mnt/skills",
+                    }
+                ]
+            },
+        )
+
 
 class TestSandboxClientFileSystems(unittest.TestCase):
     def test_attach_file_system(self):
@@ -245,6 +280,40 @@ class TestSandboxClientFileSystems(unittest.TestCase):
             [{"file_system_id": "file_system_abc", "mount_path": "/mnt/skills"}],
         )
 
+    def test_claim_threads_file_systems(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        client.claim(
+            "pool-1",
+            file_systems=[
+                FileSystemMount(
+                    file_system_id="file_system_abc", mount_path="/mnt/skills"
+                )
+            ],
+        )
+
+        self.assertEqual(fake.claim_calls[0]["pool_id"], "pool-1")
+        self.assertEqual(
+            json.loads(fake.claim_calls[0]["request_json"]),
+            {
+                "file_systems": [
+                    {
+                        "file_system_id": "file_system_abc",
+                        "mount_path": "/mnt/skills",
+                    }
+                ]
+            },
+        )
+
+    def test_claim_without_file_systems_keeps_bodyless_native_call(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        client.claim("pool-1")
+
+        self.assertEqual(fake.claim_calls, [{"pool_id": "pool-1"}])
+
 
 class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
     async def test_attach_file_system(self):
@@ -266,6 +335,25 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
                     file_system_id="file_system_abc", mount_path="/mnt/skills"
                 )
             ],
+        )
+
+    async def test_claim_threads_file_systems(self):
+        fake = _FakeAsyncRustClient()
+        client = _async_client(fake)
+
+        await client.claim(
+            "pool-1",
+            file_systems=[
+                FileSystemMount(
+                    file_system_id="file_system_abc", mount_path="/mnt/skills"
+                )
+            ],
+        )
+
+        self.assertEqual(fake.claim_calls[0]["pool_id"], "pool-1")
+        self.assertEqual(
+            json.loads(fake.claim_calls[0]["request_json"])["file_systems"],
+            [{"file_system_id": "file_system_abc", "mount_path": "/mnt/skills"}],
         )
 
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -11,6 +11,7 @@ import {
   type ArchivedSandboxInfo,
   type CopySandboxOptions,
   type CopySandboxResponse,
+  type ClaimSandboxOptions,
   type CreateAndConnectOptions,
   type CreatePoolOptions,
   type CreateSandboxOptions,
@@ -522,10 +523,29 @@ export class SandboxClient {
     );
   }
 
-  /** Claim a warm sandbox from a pool, creating one if no warm containers are available. */
-  async claim(poolId: string): Promise<Traced<CreateSandboxResponse>> {
+  /**
+   * Claim a warm sandbox from a pool, creating one if no warm containers are
+   * available. Claim-specific file systems are ready before the sandbox is
+   * reported as running.
+   */
+  async claim(
+    poolId: string,
+    options?: ClaimSandboxOptions,
+  ): Promise<Traced<CreateSandboxResponse>> {
+    const requestJson =
+      options?.fileSystems != null && options.fileSystems.length > 0
+        ? JSON.stringify({
+            file_systems: options.fileSystems.map((fs) => ({
+              file_system_id: fs.fileSystemId,
+              mount_path: fs.mountPath,
+            })),
+          })
+        : undefined;
     return this.tracedJson<CreateSandboxResponse>(
-      () => this.native.claimSandbox(poolId),
+      () =>
+        requestJson == null
+          ? this.native.claimSandbox(poolId)
+          : this.native.claimSandbox(poolId, requestJson),
       "sandboxId",
       { poolId, notFoundKind: "pool" },
     );
@@ -789,7 +809,9 @@ export class SandboxClient {
     const createStart = nowMs();
     const result =
       options?.poolId != null
-        ? await requestClient.claim(options.poolId)
+        ? await requestClient.claim(options.poolId, {
+            fileSystems: options.fileSystems,
+          })
         : await requestClient.create(options);
     logSdkTiming(
       "sandbox.create",

--- a/typescript/src/file-system.ts
+++ b/typescript/src/file-system.ts
@@ -10,7 +10,7 @@ import { buildContextFromEnv } from "./sandbox-image.js";
  * file-system API is organization/project-scoped.
  *
  * To mount a registered file system into a sandbox, pass
- * `fileSystems` to `Sandbox.create()` (mount at boot) or call
+ * `fileSystems` to `Sandbox.create()` (including warm-pool claims) or call
  * `sandbox.attachFileSystem()` / `sandbox.detachFileSystem()` on a
  * running sandbox.
  */

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -153,6 +153,7 @@ export type {
   ContainerResourcesInfo,
   NetworkConfig,
   FileSystemMount,
+  ClaimSandboxOptions,
   CopySandboxOptions,
   CopiedSandboxResponse,
   CopySandboxResponse,

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -102,6 +102,11 @@ export interface FileSystemMount {
   mountPath: string;
 }
 
+export interface ClaimSandboxOptions {
+  /** File systems to mount before the claimed sandbox is reported as running. */
+  fileSystems?: FileSystemMount[];
+}
+
 // --- Sandbox lifecycle ---
 
 export interface CreateSandboxOptions {
@@ -123,7 +128,7 @@ export interface CreateSandboxOptions {
   snapshotId?: string;
   /** Optional name for the sandbox. Named sandboxes support suspend/resume. When absent the sandbox is ephemeral. */
   name?: string;
-  /** File systems to mount into the sandbox at boot, each at its own absolute, unique guest mount path. */
+  /** File systems to mount on fresh creation or warm-pool claim, each at its own absolute, unique guest mount path. */
   fileSystems?: FileSystemMount[];
 }
 

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -81,7 +81,7 @@ export interface NativeSandboxProxyClient {
 
 export interface NativeSandboxClient {
   createSandbox(requestJson: string): Promise<TracedJson>;
-  claimSandbox(poolId: string): Promise<TracedJson>;
+  claimSandbox(poolId: string, requestJson?: string): Promise<TracedJson>;
   copySandbox(sandboxId: string, times: number): Promise<TracedJson>;
   getSandbox(sandboxId: string): Promise<TracedJson>;
   listSandboxes(): Promise<TracedJson>;

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -749,6 +749,35 @@ describe("SandboxClient", () => {
       client.close();
     });
 
+    it("sends claim-specific file systems", async () => {
+      const claimSandbox = vi.fn(async () => ({
+        traceId: "t",
+        json: JSON.stringify({ sandbox_id: "sbx-fs", status: "running" }),
+      }));
+      installNativeStub({ client: { claimSandbox } });
+
+      const client = SandboxClient.forLocalhost();
+      const result = await client.claim("pool-1", {
+        fileSystems: [
+          { fileSystemId: "file_system_abc", mountPath: "/mnt/skills" },
+        ],
+      });
+
+      expect(result.sandboxId).toBe("sbx-fs");
+      expect(claimSandbox).toHaveBeenCalledWith(
+        "pool-1",
+        JSON.stringify({
+          file_systems: [
+            {
+              file_system_id: "file_system_abc",
+              mount_path: "/mnt/skills",
+            },
+          ],
+        }),
+      );
+      client.close();
+    });
+
     it("returns readiness timeout responses without retrying", async () => {
       const claimSandbox = vi.fn(async () => ({
         traceId: "t",
@@ -824,6 +853,33 @@ describe("SandboxClient", () => {
   });
 
   describe("createAndConnect", () => {
+    it("threads file systems through a warm-pool claim", async () => {
+      const claimSandbox = vi.fn(async () => ({
+        traceId: "t",
+        json: JSON.stringify({
+          sandbox_id: "sbx-warm-fs",
+          status: "running",
+          sandbox_url: "https://sbx-warm-fs.sandbox.tensorlake.ai",
+        }),
+      }));
+      installNativeStub({ client: { claimSandbox } });
+
+      const client = SandboxClient.forCloud({ apiKey: "key" });
+      const sandbox = await client.createAndConnect({
+        poolId: "pool-1",
+        fileSystems: [
+          { fileSystemId: "file_system_abc", mountPath: "/mnt/skills" },
+        ],
+      });
+
+      expect(claimSandbox).toHaveBeenCalledWith(
+        "pool-1",
+        expect.stringContaining('"file_system_id":"file_system_abc"'),
+      );
+      sandbox.close();
+      client.close();
+    });
+
     it("uses server sandbox URL from running create response", async () => {
       const stub = installNativeStub({
         client: {


### PR DESCRIPTION
## Depends on

- https://github.com/tensorlakeai/compute-engine-internal/pull/1699
- Merge the CEI PR first. This SDK intentionally requires the server's claim-configuration acknowledgment.

## What changed

- Add `ClaimSandboxRequest` and a request-bearing warm-pool claim path to the Rust SDK while preserving the existing bodyless `claim` call.
- Expose optional claim-time `file_systems` through the Python sync/async clients and TypeScript client.
- Thread file-system mounts through `create_and_connect` / `createAndConnect` when a pool is used.
- Require `claim_configuration_applied: true` for configured claims. If an older server ignores the request body, the SDK deletes the claimed sandbox and returns an upgrade error instead of handing back a mount-free sandbox.
- Keep bodyless wire behavior unchanged when no claim configuration is supplied.
- Document and test the Rust, Python, and TypeScript APIs.

## Why

The SDK previously accepted file-system mounts for fresh sandbox creation but dropped them when the same call selected a warm pool. Sending a body alone is unsafe because an older server may ignore it and still return success. The explicit server acknowledgment and cleanup path make mixed-version behavior fail closed.

## Impact

Users can pass the same TLFS mount list regardless of whether a sandbox is created fresh or claimed from a warm pool. Existing unconfigured pool claims retain their bodyless request shape.

## Validation

- `cargo test -p tensorlake` — 187 passed, 1 ignored, plus integration tests and doctests
- `cargo test -p tensorlake --test sandboxes` — 12 passed after rebasing onto current `main`
- Rust clippy for the cloud SDK, PyO3, and N-API crates with `-D warnings`
- Python file-system tests — 17 passed after rebasing
- Python Black and isort checks
- TypeScript type-check after rebasing
- TypeScript focused Vitest suite — 106 passed
- TypeScript lint
- Cargo formatting and `git diff --check`