### PR TITLE
Fix Windows CLI mount feature gate

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2741,7 +2741,6 @@ async fn run_fs_command(_ctx: &mut CliContext, _subcmd: FsCommands) -> error::Re
     ))
 }
 
-#[cfg(feature = "mount")]
 /// Resolve the mount a `tl git log`/`tl git smartlog` subject refers to, if any.
 ///
 /// The subject is either a mount path or a bare repository name. A repository name frequently also
@@ -2775,6 +2774,7 @@ fn git_graph_mount_dir(
     }
 }
 
+#[cfg(feature = "mount")]
 async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> error::Result<()> {
     let mut subcmd = match subcmd {
         GitCommands::Prefetch { path } => {


### PR DESCRIPTION
## What changed

Move the `mount` feature gate from the already-gated `git_graph_mount_dir` helper back onto `run_git_mount_command`.

## Why

PR #900 inserted a new helper between the feature attribute and `run_git_mount_command`, accidentally leaving the real mount command dispatcher enabled in builds without the `mount` feature. Windows release binaries enable `git-clone` but not `mount`, so both the real dispatcher and its non-mount fallback compiled, while `commands::fs` and other mount-only helpers did not.

This fixes the 25 Rust compiler errors in [Release - CLI Binaries run 31671712799](https://github.com/tensorlakeai/tensorlake/actions/runs/31671712799/job/94357697169).

## Impact

Windows CLI release builds once again compile without the mount backend. Mount-enabled Linux and macOS behavior is unchanged.

## Validation

- `cargo check -p tensorlake-cli --no-default-features`
- `cargo test -p tensorlake-cli --no-default-features tests::logical_git_mount_and_fs_commands_are_surface_centric -- --exact`
- `git diff --check`

The exact Windows `git-clone` build requires the private vendored `gsvc-codec`, so GitHub Actions remains the end-to-end verification.