### PR TITLE
Bump version to 0.5.106

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "base64",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "base64",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "base64",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "base64",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "anyhow",
  "napi",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.105"
+version = "0.5.106"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.105"
+version = "0.5.106"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.105"
+version = "0.5.106"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.105"
+version = "0.5.106"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.105"
+version = "0.5.106"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.105",
+  "version": "0.5.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.105",
+      "version": "0.5.106",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.105",
+  "version": "0.5.106",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bumps all packages (Python SDK, Rust CLI/crates, npm package) from 0.5.105 to 0.5.106 for a lockstep release, via `.github/scripts/bump_version.py`. Lockfiles refreshed to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)