### PR TITLE
Per-mount read_only and prefetch across SDKs and CLI

### DIFF
--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -87,30 +87,55 @@ pub struct CreateArgs<'a> {
     pub no_internet: bool,
     pub network_allow: &'a [String],
     pub network_deny: &'a [String],
-    /// Boot-time file system mounts, each as `<file_system_id>:<mount_path>`.
+    /// Boot-time file system mounts, each as
+    /// `<file_system_id>:<mount_path>[:<opts>]`.
     pub file_systems: &'a [String],
 }
 
-/// Parse `--filesystem <id>:<path>` flags into the request
-/// `file_systems` array. Splits on the first `:` (file system ids and
-/// absolute mount paths never contain one).
+const FILESYSTEM_FLAG_USAGE: &str = "--filesystem must be <file_system_id>:<mount_path>[:<opts>] where <opts> is a \
+     comma-separated list of `ro` and/or `prefetch`";
+
+/// Parse `--filesystem <id>:<path>[:<opts>]` flags into the request
+/// `file_systems` array. The id ends at the first `:` and the mount path at
+/// the second (file system ids and absolute mount paths never contain one);
+/// the optional trailing segment is a comma-separated option list drawn from
+/// `ro` and `prefetch`. The option keys are added to the wire object only when
+/// set: older servers reject unknown mount fields, so an explicit `false`
+/// must never be sent.
 fn parse_file_system_mounts(raw: &[String]) -> Result<Vec<serde_json::Value>> {
     raw.iter()
         .map(|entry| {
-            let (file_system_id, mount_path) = entry.split_once(':').ok_or_else(|| {
-                CliError::usage(format!(
-                    "--filesystem must be <file_system_id>:<mount_path>, got {entry:?}"
-                ))
+            let (file_system_id, rest) = entry.split_once(':').ok_or_else(|| {
+                CliError::usage(format!("{FILESYSTEM_FLAG_USAGE}, got {entry:?}"))
             })?;
+            let (mount_path, opts) = match rest.split_once(':') {
+                Some((mount_path, opts)) => (mount_path, Some(opts)),
+                None => (rest, None),
+            };
             if file_system_id.is_empty() || mount_path.is_empty() {
                 return Err(CliError::usage(format!(
-                    "--filesystem must be <file_system_id>:<mount_path>, got {entry:?}"
+                    "{FILESYSTEM_FLAG_USAGE}, got {entry:?}"
                 )));
             }
-            Ok(serde_json::json!({
+            let mut mount = serde_json::json!({
                 "file_system_id": file_system_id,
                 "mount_path": mount_path,
-            }))
+            });
+            if let Some(opts) = opts {
+                for opt in opts.split(',') {
+                    match opt {
+                        "ro" => mount["read_only"] = serde_json::Value::Bool(true),
+                        "prefetch" => mount["prefetch"] = serde_json::Value::Bool(true),
+                        _ => {
+                            return Err(CliError::usage(format!(
+                                "unknown --filesystem option {opt:?} in {entry:?}: \
+                                 valid options are `ro` and `prefetch`"
+                            )));
+                        }
+                    }
+                }
+            }
+            Ok(mount)
         })
         .collect()
 }
@@ -402,6 +427,72 @@ mod tests {
     fn parse_file_system_mounts_rejects_empty_sides() {
         assert!(parse_file_system_mounts(&[":/mnt".to_string()]).is_err());
         assert!(parse_file_system_mounts(&["file_system_abc:".to_string()]).is_err());
+    }
+
+    #[test]
+    fn parse_file_system_mounts_without_opts_omits_mount_modes() {
+        let mounts = parse_file_system_mounts(&["skills:/mnt/skills".to_string()]).unwrap();
+        assert_eq!(
+            mounts[0],
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+            })
+        );
+    }
+
+    #[test]
+    fn parse_file_system_mounts_parses_ro_opt() {
+        let mounts = parse_file_system_mounts(&["skills:/mnt/skills:ro".to_string()]).unwrap();
+        assert_eq!(
+            mounts[0],
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+                "read_only": true,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_file_system_mounts_parses_prefetch_opt() {
+        let mounts =
+            parse_file_system_mounts(&["skills:/mnt/skills:prefetch".to_string()]).unwrap();
+        assert_eq!(
+            mounts[0],
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+                "prefetch": true,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_file_system_mounts_parses_combined_opts() {
+        let mounts =
+            parse_file_system_mounts(&["skills:/mnt/skills:ro,prefetch".to_string()]).unwrap();
+        assert_eq!(
+            mounts[0],
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+                "read_only": true,
+                "prefetch": true,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_file_system_mounts_rejects_unknown_opt() {
+        let error = parse_file_system_mounts(&["skills:/mnt/skills:rw".to_string()]).unwrap_err();
+        assert!(error.to_string().contains("unknown --filesystem option"));
+    }
+
+    #[test]
+    fn parse_file_system_mounts_rejects_empty_opt() {
+        assert!(parse_file_system_mounts(&["skills:/mnt/skills:".to_string()]).is_err());
+        assert!(parse_file_system_mounts(&["skills:/mnt/skills:ro,".to_string()]).is_err());
     }
 
     #[test]

--- a/crates/cli/src/commands/sbx/fs.rs
+++ b/crates/cli/src/commands/sbx/fs.rs
@@ -37,29 +37,48 @@ fn print_mounts_table(mounts: &[FileSystemMount]) {
         return;
     }
 
-    let mut table = new_table(&["File System ID", "Mount Path"]);
+    let mut table = new_table(&["File System ID", "Mount Path", "Options"]);
     for mount in mounts {
+        let mut options = Vec::new();
+        if mount.read_only {
+            options.push("ro");
+        }
+        if mount.prefetch {
+            options.push("prefetch");
+        }
         table.add_row(vec![
             Cell::new(mount.file_system_id.as_str()),
             Cell::new(mount.mount_path.as_str()),
+            Cell::new(options.join(",")),
         ]);
     }
     println!("{table}");
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn attach(
     ctx: &CliContext,
     sandbox_id: &str,
     file_system_id: &str,
     mount_path: &str,
+    read_only: bool,
+    prefetch: bool,
     output_json: bool,
 ) -> Result<()> {
     let client = ctx.client()?;
     let url = sandbox_endpoint(ctx, &format!("sandboxes/{sandbox_id}/file_systems"));
-    let body = serde_json::json!({
+    // The option keys are present only when set: older servers deserialize
+    // attach bodies with `deny_unknown_fields` and reject an explicit `false`.
+    let mut body = serde_json::json!({
         "file_system_id": file_system_id,
         "mount_path": mount_path,
     });
+    if read_only {
+        body["read_only"] = serde_json::Value::Bool(true);
+    }
+    if prefetch {
+        body["prefetch"] = serde_json::Value::Bool(true);
+    }
 
     let resp = client
         .post(&url)

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1183,8 +1183,11 @@ enum SbxCommands {
         network_deny: Vec<String>,
 
         /// Mount a registered file system at boot as
-        /// `<file_system_id>:<mount_path>` (can be repeated)
-        #[arg(short = 'f', long = "filesystem", value_name = "ID:PATH")]
+        /// `<file_system_id>:<mount_path>[:<opts>]`, where `<opts>` is a
+        /// comma-separated list of `ro` (read-only) and/or `prefetch`
+        /// (eagerly download contents), e.g. `data:/mnt/data:ro,prefetch`
+        /// (can be repeated)
+        #[arg(short = 'f', long = "filesystem", value_name = "ID:PATH[:OPTS]")]
         file_systems: Vec<String>,
     },
 
@@ -1517,6 +1520,14 @@ enum SbxFsCommands {
         /// Absolute guest mount path (e.g. `/mnt/skills`)
         #[arg(short, long)]
         path: String,
+
+        /// Mount the file system read-only
+        #[arg(long = "read-only")]
+        read_only: bool,
+
+        /// Eagerly download the file system's contents into the sandbox
+        #[arg(long)]
+        prefetch: bool,
 
         /// Print the updated sandbox as JSON
         #[arg(long)]
@@ -2481,6 +2492,8 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             sandbox_id,
                             file_system_id,
                             path,
+                            read_only,
+                            prefetch,
                             json,
                         } => {
                             commands::sbx::fs::attach(
@@ -2488,6 +2501,8 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 &sandbox_id,
                                 &file_system_id,
                                 &path,
+                                read_only,
+                                prefetch,
                                 json,
                             )
                             .await
@@ -2805,9 +2820,7 @@ async fn run_git_mount_command(ctx: &mut CliContext, subcmd: GitCommands) -> err
         // `subject` is either a mount path or a bare repo name. Resolve mount scope only when it
         // names a path (or was omitted for the non-project form), so `tl git log <repo>` works
         // from anywhere, exactly like the pre-logical-v1 surface did.
-        GitCommands::Log { subject, .. } => {
-            git_graph_mount_dir(subject.as_deref(), true)?
-        }
+        GitCommands::Log { subject, .. } => git_graph_mount_dir(subject.as_deref(), true)?,
         GitCommands::Smartlog {
             subject, project, ..
         } => git_graph_mount_dir(subject.as_deref(), !*project)?,
@@ -3891,10 +3904,21 @@ mod tests {
             }
             _ => panic!("expected git mount command"),
         }
-        assert!(Cli::try_parse_from(["tl", "git", "mount", "d", "./w", "--ro", "--publish"]).is_err());
         assert!(
-            Cli::try_parse_from(["tl", "git", "mount", "d", "./w", "--ro", "--workspace", "0a"])
-                .is_err()
+            Cli::try_parse_from(["tl", "git", "mount", "d", "./w", "--ro", "--publish"]).is_err()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "tl",
+                "git",
+                "mount",
+                "d",
+                "./w",
+                "--ro",
+                "--workspace",
+                "0a"
+            ])
+            .is_err()
         );
         match parse_command(["tl", "git", "workspaces", "demo", "--json"]) {
             Commands::Git(GitCommands::Workspaces { repo, json }) => {

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -531,16 +531,24 @@ impl SandboxesClient {
     ///
     /// The mount completes asynchronously on the dataplane; the returned
     /// [`SandboxInfo`] already reflects the new entry in `file_systems`.
+    ///
+    /// `read_only` and `prefetch` select optional mount modes; they are sent
+    /// on the wire only when `true` so older servers (which reject unknown
+    /// fields) keep accepting attach bodies.
     pub async fn attach_file_system(
         &self,
         sandbox_id: &str,
         file_system_id: &str,
         mount_path: &str,
+        read_only: bool,
+        prefetch: bool,
     ) -> Result<Traced<SandboxInfo>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/file_systems"));
         let body = FileSystemMount {
             file_system_id: file_system_id.to_string(),
             mount_path: mount_path.to_string(),
+            read_only,
+            prefetch,
         };
         let req = self
             .client

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -235,13 +235,23 @@ fn default_allow_internet_access() -> bool {
 
 /// One file system mounted into a sandbox at an absolute guest path.
 ///
-/// `file_system_id` is the registered file system's id (e.g.
-/// `file_system_...`) and `mount_path` is an absolute, unique guest path
+/// `file_system_id` is the Artifact Storage file-system name created with
+/// `tl fs create <name>` and `mount_path` is an absolute, unique guest path
 /// (e.g. `/mnt/skills`).
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+///
+/// `read_only` and `prefetch` are optional mount modes. They serialize only
+/// when `true`: older servers deserialize mount bodies with
+/// `deny_unknown_fields` and would reject an explicit `false`.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct FileSystemMount {
     pub file_system_id: String,
     pub mount_path: String,
+    /// Mount the file system read-only inside the guest.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub read_only: bool,
+    /// Eagerly download the complete file system into the guest cache.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub prefetch: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1013,6 +1023,63 @@ mod tests {
                 deny_out: vec![],
             })
         );
+    }
+
+    #[test]
+    fn file_system_mount_omits_false_mount_modes() {
+        let mount = FileSystemMount {
+            file_system_id: "skills".to_string(),
+            mount_path: "/mnt/skills".to_string(),
+            read_only: false,
+            prefetch: false,
+        };
+        assert_eq!(
+            serde_json::to_value(&mount).unwrap(),
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills"
+            })
+        );
+    }
+
+    #[test]
+    fn file_system_mount_serializes_true_mount_modes() {
+        let mount = FileSystemMount {
+            file_system_id: "skills".to_string(),
+            mount_path: "/mnt/skills".to_string(),
+            read_only: true,
+            prefetch: true,
+        };
+        assert_eq!(
+            serde_json::to_value(&mount).unwrap(),
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+                "read_only": true,
+                "prefetch": true
+            })
+        );
+    }
+
+    #[test]
+    fn file_system_mount_deserializes_absent_and_present_mount_modes() {
+        let absent: FileSystemMount = serde_json::from_value(serde_json::json!({
+            "file_system_id": "skills",
+            "mount_path": "/mnt/skills"
+        }))
+        .unwrap();
+        assert!(!absent.read_only);
+        assert!(!absent.prefetch);
+
+        let present: FileSystemMount = serde_json::from_value(serde_json::json!({
+            "file_system_id": "skills",
+            "mount_path": "/mnt/skills",
+            "read_only": true,
+            "prefetch": true
+        }))
+        .unwrap();
+        assert!(present.read_only);
+        assert!(present.prefetch);
     }
 
     #[test]

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -129,6 +129,7 @@ async fn pool_claim_with_file_systems_sends_json_body() {
                 file_systems: vec![FileSystemMount {
                     file_system_id: "file_system_abc".to_string(),
                     mount_path: "/mnt/skills".to_string(),
+                    ..Default::default()
                 }],
             },
         )
@@ -174,6 +175,7 @@ async fn pool_claim_with_file_systems_rejects_server_without_acknowledgment() {
                 file_systems: vec![FileSystemMount {
                     file_system_id: "file_system_abc".to_string(),
                     mount_path: "/mnt/skills".to_string(),
+                    ..Default::default()
                 }],
             },
         )

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -558,14 +558,24 @@ impl NativeSandboxClient {
         sandbox_id: String,
         file_system_id: String,
         mount_path: String,
+        read_only: Option<bool>,
+        prefetch: Option<bool>,
     ) -> napi::Result<TracedJson> {
+        let read_only = read_only.unwrap_or(false);
+        let prefetch = prefetch.unwrap_or(false);
         with_retry(self.client.clone(), 5, move |c| {
             let sandbox_id = sandbox_id.clone();
             let file_system_id = file_system_id.clone();
             let mount_path = mount_path.clone();
             async move {
                 let traced = c
-                    .attach_file_system(&sandbox_id, &file_system_id, &mount_path)
+                    .attach_file_system(
+                        &sandbox_id,
+                        &file_system_id,
+                        &mount_path,
+                        read_only,
+                        prefetch,
+                    )
                     .await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced)?;

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -1755,11 +1755,14 @@ impl CloudSandboxClient {
         })
     }
 
+    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false))]
     fn attach_file_system(
         &self,
         sandbox_id: String,
         file_system_id: String,
         mount_path: String,
+        read_only: bool,
+        prefetch: bool,
     ) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
@@ -1767,7 +1770,13 @@ impl CloudSandboxClient {
             let mount_path = mount_path.clone();
             async move {
                 let traced = client
-                    .attach_file_system(&sandbox_id, &file_system_id, &mount_path)
+                    .attach_file_system(
+                        &sandbox_id,
+                        &file_system_id,
+                        &mount_path,
+                        read_only,
+                        prefetch,
+                    )
                     .await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
@@ -2158,12 +2167,15 @@ impl CloudSandboxClient {
         })
     }
 
+    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false))]
     fn attach_file_system_async<'py>(
         &self,
         py: Python<'py>,
         sandbox_id: String,
         file_system_id: String,
         mount_path: String,
+        read_only: bool,
+        prefetch: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
@@ -2172,8 +2184,14 @@ impl CloudSandboxClient {
                 let file_system_id = file_system_id.clone();
                 let mount_path = mount_path.clone();
                 async move {
-                    c.attach_file_system(&sandbox_id, &file_system_id, &mount_path)
-                        .await
+                    c.attach_file_system(
+                        &sandbox_id,
+                        &file_system_id,
+                        &mount_path,
+                        read_only,
+                        prefetch,
+                    )
+                    .await
                 }
             })
             .await

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -447,18 +447,24 @@ class AsyncSandboxClient:
         sandbox_id: str,
         file_system_id: str,
         mount_path: str,
+        *,
+        read_only: bool = False,
+        prefetch: bool = False,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to a running sandbox.
 
         The returned ``SandboxInfo`` already reflects the new
         ``file_systems`` entry; the mount completes asynchronously on the
-        dataplane.
+        dataplane. ``read_only`` mounts the file system read-only;
+        ``prefetch`` eagerly downloads its contents.
         """
         try:
             trace_id, response_json = await self._rust_client.attach_file_system_async(
                 sandbox_id=sandbox_id,
                 file_system_id=file_system_id,
                 mount_path=mount_path,
+                read_only=read_only,
+                prefetch=prefetch,
             )
             return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -404,19 +404,29 @@ class AsyncSandbox:
         self,
         file_system_id: str,
         mount_path: str,
+        *,
+        read_only: bool = False,
+        prefetch: bool = False,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to this running sandbox.
 
         Args:
-            file_system_id: The registered file system's id.
+            file_system_id: The registered file system's name (created with
+                ``tl fs create <name>``).
             mount_path: Absolute, unique guest mount path (e.g. ``/mnt/skills``).
+            read_only: Mount the file system read-only.
+            prefetch: Eagerly download the file system's contents.
 
         Returns:
             Traced[SandboxInfo] with this sandbox's updated file systems.
         """
         self._require_lifecycle_client("attach_file_system")
         traced = await self._lifecycle_client.attach_file_system(
-            self._lifecycle_identifier(), file_system_id, mount_path
+            self._lifecycle_identifier(),
+            file_system_id,
+            mount_path,
+            read_only=read_only,
+            prefetch=prefetch,
         )
         self._sandbox_id = traced.sandbox_id
         self._cached_info = traced.value

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1006,6 +1006,9 @@ class SandboxClient:
         sandbox_id: str,
         file_system_id: str,
         mount_path: str,
+        *,
+        read_only: bool = False,
+        prefetch: bool = False,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to a running sandbox.
 
@@ -1015,8 +1018,11 @@ class SandboxClient:
 
         Args:
             sandbox_id: ID or name of the running sandbox.
-            file_system_id: The registered file system's id.
+            file_system_id: The registered file system's name (created with
+                ``tl fs create <name>``).
             mount_path: Absolute, unique guest mount path (e.g. ``/mnt/skills``).
+            read_only: Mount the file system read-only.
+            prefetch: Eagerly download the file system's contents.
 
         Returns:
             Traced[SandboxInfo] with the sandbox's updated file systems.
@@ -1031,6 +1037,8 @@ class SandboxClient:
                 sandbox_id=sandbox_id,
                 file_system_id=file_system_id,
                 mount_path=mount_path,
+                read_only=read_only,
+                prefetch=prefetch,
             )
             return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Annotated, Any
 from urllib.parse import urlparse, urlunparse
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_serializer
 
 _SANDBOX_MANAGEMENT_PORT = 9501
 
@@ -242,13 +242,30 @@ class NetworkConfig(BaseModel):
 class FileSystemMount(BaseModel):
     """A file system mounted into a sandbox at a guest path.
 
-    ``file_system_id`` is the registered file system's id (e.g.
-    ``file_system_...``) and ``mount_path`` is an absolute, unique guest path
-    (e.g. ``/mnt/skills``).
+    ``file_system_id`` is the Artifact Storage file-system name created with
+    ``tl fs create <name>`` and ``mount_path`` is an absolute, unique guest
+    path (e.g. ``/mnt/skills``).
+
+    ``read_only`` mounts the file system read-only; ``prefetch`` eagerly
+    downloads its contents. Both serialize onto the wire only when ``True``:
+    older servers reject mount bodies carrying unknown fields, so ``False``
+    is expressed by omission.
     """
 
     file_system_id: str
     mount_path: str
+    read_only: bool = False
+    prefetch: bool = False
+
+    @model_serializer(mode="wrap")
+    def _omit_false_mount_modes(self, handler):
+        data = handler(self)
+        if isinstance(data, dict):
+            if not self.read_only:
+                data.pop("read_only", None)
+            if not self.prefetch:
+                data.pop("prefetch", None)
+        return data
 
 
 class FileSystem(BaseModel):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -696,19 +696,29 @@ class Sandbox:
         self,
         file_system_id: str,
         mount_path: str,
+        *,
+        read_only: bool = False,
+        prefetch: bool = False,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to this running sandbox.
 
         Args:
-            file_system_id: The registered file system's id.
+            file_system_id: The registered file system's name (created with
+                ``tl fs create <name>``).
             mount_path: Absolute, unique guest mount path (e.g. ``/mnt/skills``).
+            read_only: Mount the file system read-only.
+            prefetch: Eagerly download the file system's contents.
 
         Returns:
             Traced[SandboxInfo] with this sandbox's updated file systems.
         """
         self._require_lifecycle_client("attach_file_system")
         traced = self._lifecycle_client.attach_file_system(
-            self._lifecycle_identifier(), file_system_id, mount_path
+            self._lifecycle_identifier(),
+            file_system_id,
+            mount_path,
+            read_only=read_only,
+            prefetch=prefetch,
         )
         self._sandbox_id = traced.sandbox_id
         self._cached_info = traced.value

--- a/tests/sandbox/test_file_systems.py
+++ b/tests/sandbox/test_file_systems.py
@@ -48,14 +48,18 @@ class _FakeRustClient:
     def close(self):
         return None
 
-    def attach_file_system(self, *, sandbox_id, file_system_id, mount_path):
-        self.attach_calls.append((sandbox_id, file_system_id, mount_path))
-        return (
-            "trace-attach",
-            _sandbox_info_json(
-                [{"file_system_id": file_system_id, "mount_path": mount_path}]
-            ),
+    def attach_file_system(
+        self, *, sandbox_id, file_system_id, mount_path, read_only, prefetch
+    ):
+        self.attach_calls.append(
+            (sandbox_id, file_system_id, mount_path, read_only, prefetch)
         )
+        mount = {"file_system_id": file_system_id, "mount_path": mount_path}
+        if read_only:
+            mount["read_only"] = True
+        if prefetch:
+            mount["prefetch"] = True
+        return ("trace-attach", _sandbox_info_json([mount]))
 
     def detach_file_system(self, *, sandbox_id, mount_path):
         self.detach_calls.append((sandbox_id, mount_path))
@@ -78,14 +82,18 @@ class _FakeAsyncRustClient:
     def close(self):
         return None
 
-    async def attach_file_system_async(self, *, sandbox_id, file_system_id, mount_path):
-        self.attach_calls.append((sandbox_id, file_system_id, mount_path))
-        return (
-            "trace-attach",
-            _sandbox_info_json(
-                [{"file_system_id": file_system_id, "mount_path": mount_path}]
-            ),
+    async def attach_file_system_async(
+        self, *, sandbox_id, file_system_id, mount_path, read_only, prefetch
+    ):
+        self.attach_calls.append(
+            (sandbox_id, file_system_id, mount_path, read_only, prefetch)
         )
+        mount = {"file_system_id": file_system_id, "mount_path": mount_path}
+        if read_only:
+            mount["read_only"] = True
+        if prefetch:
+            mount["prefetch"] = True
+        return ("trace-attach", _sandbox_info_json([mount]))
 
     async def claim_sandbox_async(self, **kwargs):
         self.claim_calls.append(kwargs)
@@ -187,6 +195,53 @@ class TestFileSystemModels(unittest.TestCase):
             {"file_system_id": "file_system_abc", "mount_path": "/mnt/skills"},
         )
 
+    def test_file_system_mount_omits_false_mount_modes(self):
+        mount = FileSystemMount(
+            file_system_id="file_system_abc",
+            mount_path="/mnt/skills",
+            read_only=False,
+            prefetch=False,
+        )
+        self.assertEqual(
+            json.loads(mount.model_dump_json()),
+            {"file_system_id": "file_system_abc", "mount_path": "/mnt/skills"},
+        )
+
+    def test_file_system_mount_serializes_true_mount_modes(self):
+        mount = FileSystemMount(
+            file_system_id="file_system_abc",
+            mount_path="/mnt/skills",
+            read_only=True,
+            prefetch=True,
+        )
+        self.assertEqual(
+            json.loads(mount.model_dump_json()),
+            {
+                "file_system_id": "file_system_abc",
+                "mount_path": "/mnt/skills",
+                "read_only": True,
+                "prefetch": True,
+            },
+        )
+
+    def test_file_system_mount_parses_absent_and_present_mount_modes(self):
+        absent = FileSystemMount.model_validate(
+            {"file_system_id": "file_system_abc", "mount_path": "/mnt/skills"}
+        )
+        self.assertFalse(absent.read_only)
+        self.assertFalse(absent.prefetch)
+
+        present = FileSystemMount.model_validate(
+            {
+                "file_system_id": "file_system_abc",
+                "mount_path": "/mnt/skills",
+                "read_only": True,
+                "prefetch": True,
+            }
+        )
+        self.assertTrue(present.read_only)
+        self.assertTrue(present.prefetch)
+
     def test_create_request_serializes_file_systems_to_wire_key(self):
         request = CreateSandboxRequest(
             resources=CreateSandboxResources(cpus=1.0, memory_mb=1024),
@@ -208,6 +263,43 @@ class TestFileSystemModels(unittest.TestCase):
         )
         payload = json.loads(request.model_dump_json(by_alias=True, exclude_none=True))
         self.assertNotIn("file_systems", payload)
+
+    def test_create_request_omits_false_mount_modes_and_keeps_true(self):
+        request = CreateSandboxRequest(
+            resources=CreateSandboxResources(cpus=1.0, memory_mb=1024),
+            file_systems=[
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    read_only=True,
+                ),
+                FileSystemMount(
+                    file_system_id="file_system_def",
+                    mount_path="/mnt/data",
+                    prefetch=True,
+                ),
+                FileSystemMount(
+                    file_system_id="file_system_ghi", mount_path="/mnt/plain"
+                ),
+            ],
+        )
+        payload = json.loads(request.model_dump_json(by_alias=True, exclude_none=True))
+        self.assertEqual(
+            payload["file_systems"],
+            [
+                {
+                    "file_system_id": "file_system_abc",
+                    "mount_path": "/mnt/skills",
+                    "read_only": True,
+                },
+                {
+                    "file_system_id": "file_system_def",
+                    "mount_path": "/mnt/data",
+                    "prefetch": True,
+                },
+                {"file_system_id": "file_system_ghi", "mount_path": "/mnt/plain"},
+            ],
+        )
 
     def test_claim_request_serializes_file_systems_to_wire_key(self):
         request = ClaimSandboxRequest(
@@ -239,7 +331,8 @@ class TestSandboxClientFileSystems(unittest.TestCase):
         traced = client.attach_file_system("sbx-1", "file_system_abc", "/mnt/skills")
 
         self.assertEqual(
-            fake.attach_calls, [("sbx-1", "file_system_abc", "/mnt/skills")]
+            fake.attach_calls,
+            [("sbx-1", "file_system_abc", "/mnt/skills", False, False)],
         )
         self.assertEqual(traced.trace_id, "trace-attach")
         self.assertEqual(
@@ -247,6 +340,34 @@ class TestSandboxClientFileSystems(unittest.TestCase):
             [
                 FileSystemMount(
                     file_system_id="file_system_abc", mount_path="/mnt/skills"
+                )
+            ],
+        )
+
+    def test_attach_file_system_threads_mount_modes(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        traced = client.attach_file_system(
+            "sbx-1",
+            "file_system_abc",
+            "/mnt/skills",
+            read_only=True,
+            prefetch=True,
+        )
+
+        self.assertEqual(
+            fake.attach_calls,
+            [("sbx-1", "file_system_abc", "/mnt/skills", True, True)],
+        )
+        self.assertEqual(
+            traced.value.file_systems,
+            [
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    read_only=True,
+                    prefetch=True,
                 )
             ],
         )
@@ -280,6 +401,39 @@ class TestSandboxClientFileSystems(unittest.TestCase):
             [{"file_system_id": "file_system_abc", "mount_path": "/mnt/skills"}],
         )
 
+    def test_create_body_omits_false_and_includes_true_mount_modes(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        client.create(
+            image="python:3.11",
+            file_systems=[
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    read_only=True,
+                    prefetch=True,
+                ),
+                FileSystemMount(
+                    file_system_id="file_system_def", mount_path="/mnt/data"
+                ),
+            ],
+        )
+
+        payload = json.loads(fake.create_request_json)
+        self.assertEqual(
+            payload["file_systems"],
+            [
+                {
+                    "file_system_id": "file_system_abc",
+                    "mount_path": "/mnt/skills",
+                    "read_only": True,
+                    "prefetch": True,
+                },
+                {"file_system_id": "file_system_def", "mount_path": "/mnt/data"},
+            ],
+        )
+
     def test_claim_threads_file_systems(self):
         fake = _FakeRustClient()
         client = _sync_client(fake)
@@ -306,6 +460,44 @@ class TestSandboxClientFileSystems(unittest.TestCase):
             },
         )
 
+    def test_claim_body_omits_false_and_includes_true_mount_modes(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        client.claim(
+            "pool-1",
+            file_systems=[
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    read_only=True,
+                ),
+                FileSystemMount(
+                    file_system_id="file_system_def",
+                    mount_path="/mnt/data",
+                    prefetch=True,
+                ),
+            ],
+        )
+
+        self.assertEqual(
+            json.loads(fake.claim_calls[0]["request_json"]),
+            {
+                "file_systems": [
+                    {
+                        "file_system_id": "file_system_abc",
+                        "mount_path": "/mnt/skills",
+                        "read_only": True,
+                    },
+                    {
+                        "file_system_id": "file_system_def",
+                        "mount_path": "/mnt/data",
+                        "prefetch": True,
+                    },
+                ]
+            },
+        )
+
     def test_claim_without_file_systems_keeps_bodyless_native_call(self):
         fake = _FakeRustClient()
         client = _sync_client(fake)
@@ -325,7 +517,8 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(
-            fake.attach_calls, [("sbx-1", "file_system_abc", "/mnt/skills")]
+            fake.attach_calls,
+            [("sbx-1", "file_system_abc", "/mnt/skills", False, False)],
         )
         self.assertEqual(traced.trace_id, "trace-attach")
         self.assertEqual(
@@ -333,6 +526,34 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
             [
                 FileSystemMount(
                     file_system_id="file_system_abc", mount_path="/mnt/skills"
+                )
+            ],
+        )
+
+    async def test_attach_file_system_threads_mount_modes(self):
+        fake = _FakeAsyncRustClient()
+        client = _async_client(fake)
+
+        traced = await client.attach_file_system(
+            "sbx-1",
+            "file_system_abc",
+            "/mnt/skills",
+            read_only=True,
+            prefetch=True,
+        )
+
+        self.assertEqual(
+            fake.attach_calls,
+            [("sbx-1", "file_system_abc", "/mnt/skills", True, True)],
+        )
+        self.assertEqual(
+            traced.value.file_systems,
+            [
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    read_only=True,
+                    prefetch=True,
                 )
             ],
         )

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -9,6 +9,7 @@ import {
 } from "./native-sandbox.js";
 import {
   type ArchivedSandboxInfo,
+  type AttachFileSystemOptions,
   type CopySandboxOptions,
   type CopySandboxResponse,
   type ClaimSandboxOptions,
@@ -18,6 +19,7 @@ import {
   type CreateSandboxPoolResponse,
   type CreateSandboxResponse,
   type CreateSnapshotResponse,
+  type FileSystemMount,
   type GetSandboxLogsOptions,
   type GpuRequest,
   type ListArchivedSandboxesOptions,
@@ -52,6 +54,20 @@ const GPU_MODELS = new Set<string>([
   "A6000",
   "A10",
 ]);
+
+/**
+ * Map a `FileSystemMount` to its wire form. `read_only` and `prefetch` are
+ * included only when `true`: older servers deserialize mount bodies with
+ * `deny_unknown_fields` and would reject an explicit `false`.
+ */
+function fileSystemMountToWire(fs: FileSystemMount): Record<string, unknown> {
+  return {
+    file_system_id: fs.fileSystemId,
+    mount_path: fs.mountPath,
+    ...(fs.readOnly === true ? { read_only: true } : {}),
+    ...(fs.prefetch === true ? { prefetch: true } : {}),
+  };
+}
 
 function gpuRequest(
   gpu: GpuRequest | undefined,
@@ -230,10 +246,7 @@ export class SandboxClient {
     if (options?.snapshotId != null) body.snapshot_id = options.snapshotId;
     if (options?.name != null) body.name = options.name;
     if (options?.fileSystems != null && options.fileSystems.length > 0) {
-      body.file_systems = options.fileSystems.map((fs) => ({
-        file_system_id: fs.fileSystemId,
-        mount_path: fs.mountPath,
-      }));
+      body.file_systems = options.fileSystems.map(fileSystemMountToWire);
     }
 
     if (
@@ -520,9 +533,17 @@ export class SandboxClient {
     sandboxId: string,
     fileSystemId: string,
     mountPath: string,
+    options?: AttachFileSystemOptions,
   ): Promise<Traced<SandboxInfo>> {
     return this.tracedJson<SandboxInfo>(
-      () => this.native.attachFileSystem(sandboxId, fileSystemId, mountPath),
+      () =>
+        this.native.attachFileSystem(
+          sandboxId,
+          fileSystemId,
+          mountPath,
+          options?.readOnly === true,
+          options?.prefetch === true,
+        ),
       "sandboxId",
       { sandboxId, notFoundKind: "sandbox" },
     );
@@ -557,10 +578,7 @@ export class SandboxClient {
     const requestJson =
       options?.fileSystems != null && options.fileSystems.length > 0
         ? JSON.stringify({
-            file_systems: options.fileSystems.map((fs) => ({
-              file_system_id: fs.fileSystemId,
-              mount_path: fs.mountPath,
-            })),
+            file_systems: options.fileSystems.map(fileSystemMountToWire),
           })
         : undefined;
     return this.tracedJson<CreateSandboxResponse>(

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -153,6 +153,7 @@ export type {
   ContainerResourcesInfo,
   NetworkConfig,
   FileSystemMount,
+  AttachFileSystemOptions,
   ClaimSandboxOptions,
   CopySandboxOptions,
   CopiedSandboxResponse,

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -108,13 +108,29 @@ export interface NetworkConfig {
 /**
  * One file system mounted into a sandbox at an absolute guest path.
  *
- * `fileSystemId` is the registered file system's id (e.g.
- * `file_system_...`) and `mountPath` is an absolute, unique guest path
+ * `fileSystemId` is the Artifact Storage file-system name created with
+ * `tl fs create <name>` and `mountPath` is an absolute, unique guest path
  * (e.g. `/mnt/skills`).
+ *
+ * `readOnly` and `prefetch` are optional mount modes; they are sent on the
+ * wire only when `true` (older servers reject unknown mount fields, so
+ * `false` is expressed by omission).
  */
 export interface FileSystemMount {
   fileSystemId: string;
   mountPath: string;
+  /** Mount the file system read-only. */
+  readOnly?: boolean;
+  /** Eagerly download the file system's contents. */
+  prefetch?: boolean;
+}
+
+/** Optional mount modes for attaching a file system to a running sandbox. */
+export interface AttachFileSystemOptions {
+  /** Mount the file system read-only. */
+  readOnly?: boolean;
+  /** Eagerly download the file system's contents. */
+  prefetch?: boolean;
 }
 
 export interface ClaimSandboxOptions {

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -101,6 +101,8 @@ export interface NativeSandboxClient {
     sandboxId: string,
     fileSystemId: string,
     mountPath: string,
+    readOnly?: boolean | null,
+    prefetch?: boolean | null,
   ): Promise<TracedJson>;
   detachFileSystem(
     sandboxId: string,

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -38,6 +38,7 @@ import {
   type SandboxProcessLogFiltersResponse,
   type SendSignalResponse,
   type FileSystemMount,
+  type AttachFileSystemOptions,
   type SnapshotInfo,
   type StartProcessOptions,
   SandboxStatus,
@@ -793,12 +794,14 @@ export class Sandbox {
   async attachFileSystem(
     fileSystemId: string,
     mountPath: string,
+    options?: AttachFileSystemOptions,
   ): Promise<Traced<SandboxInfo>> {
     const client = this.requireLifecycleClient("attachFileSystem");
     const info = await client.attachFileSystem(
       this.lifecycleIdentifier,
       fileSystemId,
       mountPath,
+      options,
     );
     this._setLifecycleIdentifier(info.sandboxId);
     this._setName(info.name ?? null);

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -823,6 +823,51 @@ describe("SandboxClient", () => {
       client.close();
     });
 
+    it("includes claim mount modes only when true", async () => {
+      const claimSandbox = vi.fn(async () => ({
+        traceId: "t",
+        json: JSON.stringify({ sandbox_id: "sbx-fs", status: "running" }),
+      }));
+      installNativeStub({ client: { claimSandbox } });
+
+      const client = SandboxClient.forLocalhost();
+      await client.claim("pool-1", {
+        fileSystems: [
+          {
+            fileSystemId: "file_system_abc",
+            mountPath: "/mnt/skills",
+            readOnly: true,
+            prefetch: true,
+          },
+          {
+            fileSystemId: "file_system_def",
+            mountPath: "/mnt/data",
+            readOnly: false,
+            prefetch: false,
+          },
+        ],
+      });
+
+      expect(claimSandbox).toHaveBeenCalledWith(
+        "pool-1",
+        JSON.stringify({
+          file_systems: [
+            {
+              file_system_id: "file_system_abc",
+              mount_path: "/mnt/skills",
+              read_only: true,
+              prefetch: true,
+            },
+            {
+              file_system_id: "file_system_def",
+              mount_path: "/mnt/data",
+            },
+          ],
+        }),
+      );
+      client.close();
+    });
+
     it("returns readiness timeout responses without retrying", async () => {
       const claimSandbox = vi.fn(async () => ({
         traceId: "t",

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -1086,6 +1086,48 @@ describe("Sandbox", () => {
       ]);
     });
 
+    it("create() includes mount modes only when true", async () => {
+      let captured: Record<string, unknown> | undefined;
+      installNativeStub({
+        client: {
+          createSandbox: vi.fn(async (json: string) => {
+            captured = JSON.parse(json);
+            return { traceId: "t", json: fsSandboxInfoBody() };
+          }),
+        },
+      });
+
+      const client = new SandboxClient(
+        { apiUrl: "http://localhost:8900" },
+        /* _internal */ true,
+      );
+      await client.create({
+        fileSystems: [
+          {
+            fileSystemId: "file_system_abc",
+            mountPath: "/mnt/skills",
+            readOnly: true,
+            prefetch: true,
+          },
+          {
+            fileSystemId: "file_system_def",
+            mountPath: "/mnt/data",
+            readOnly: false,
+            prefetch: false,
+          },
+        ],
+      });
+      expect(captured?.file_systems).toEqual([
+        {
+          file_system_id: "file_system_abc",
+          mount_path: "/mnt/skills",
+          read_only: true,
+          prefetch: true,
+        },
+        { file_system_id: "file_system_def", mount_path: "/mnt/data" },
+      ]);
+    });
+
     it("create() omits file_systems when none are provided", async () => {
       let captured: Record<string, unknown> | undefined;
       installNativeStub({
@@ -1138,6 +1180,95 @@ describe("Sandbox", () => {
         { fileSystemId: "file_system_abc", mountPath: "/mnt/skills" },
       ]);
       expect(stub.client.attachFileSystem).toHaveBeenCalledOnce();
+      sbx.close();
+    });
+
+    it("attachFileSystem() threads mount modes and surfaces them in the response", async () => {
+      const stub = installNativeStub({
+        client: {
+          attachFileSystem: vi.fn(
+            async (
+              sandboxId: string,
+              fileSystemId: string,
+              mountPath: string,
+              readOnly?: boolean,
+              prefetch?: boolean,
+            ) => {
+              expect(sandboxId).toBe("sbx-abc");
+              expect(fileSystemId).toBe("file_system_abc");
+              expect(mountPath).toBe("/mnt/skills");
+              expect(readOnly).toBe(true);
+              expect(prefetch).toBe(true);
+              return {
+                traceId: "t",
+                json: fsSandboxInfoBody({
+                  file_systems: [
+                    {
+                      file_system_id: "file_system_abc",
+                      mount_path: "/mnt/skills",
+                      read_only: true,
+                      prefetch: true,
+                    },
+                  ],
+                }),
+              };
+            },
+          ),
+        },
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-abc",
+        apiUrl: "http://localhost:8900",
+      });
+      const info = await sbx.attachFileSystem("file_system_abc", "/mnt/skills", {
+        readOnly: true,
+        prefetch: true,
+      });
+      expect(info.fileSystems).toEqual([
+        {
+          fileSystemId: "file_system_abc",
+          mountPath: "/mnt/skills",
+          readOnly: true,
+          prefetch: true,
+        },
+      ]);
+      expect(stub.client.attachFileSystem).toHaveBeenCalledOnce();
+      sbx.close();
+    });
+
+    it("attachFileSystem() sends false mount modes when no options are given", async () => {
+      const attachFileSystem = vi.fn(
+        async (
+          _sandboxId: string,
+          _fileSystemId: string,
+          _mountPath: string,
+          readOnly?: boolean,
+          prefetch?: boolean,
+        ) => {
+          expect(readOnly).toBe(false);
+          expect(prefetch).toBe(false);
+          return {
+            traceId: "t",
+            json: fsSandboxInfoBody({
+              file_systems: [
+                { file_system_id: "file_system_abc", mount_path: "/mnt/skills" },
+              ],
+            }),
+          };
+        },
+      );
+      installNativeStub({ client: { attachFileSystem } });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-abc",
+        apiUrl: "http://localhost:8900",
+      });
+      const info = await sbx.attachFileSystem("file_system_abc", "/mnt/skills");
+      expect(info.fileSystems).toEqual([
+        { fileSystemId: "file_system_abc", mountPath: "/mnt/skills" },
+      ]);
+      expect(attachFileSystem).toHaveBeenCalledOnce();
       sbx.close();
     });
 


### PR DESCRIPTION
## Summary

- `FileSystemMount` gains `read_only`/`prefetch` in the Python, TypeScript, and Rust SDKs, threaded through sandbox create, warm-pool claim, and runtime attach (including the PyO3/N-API bindings into the shared Rust core).
- CLI: `tl sbx create -f <ID:PATH[:OPTS]>` with OPTS from `ro`,`prefetch` (e.g. `-f data:/mnt/data:ro,prefetch`); `tl sbx fs attach --read-only/--prefetch`; mount tables show an Options column.
- Compat rule enforced in every serializer: both fields are **omitted entirely when false** (old servers are `deny_unknown_fields`), included only when true. Response parsing tolerates absent fields.
- Stale `FileSystemMount` docstring fixed: the id is the Artifact Storage file-system name from `tl fs create <name>`.

Companions: compute-engine-internal#<pending>, artifact_storage#233, platform-api#680.

## Validation

Rust: 203 lib + 12 integration tests green incl. new omit/include/deserialize mode tests; 9 CLI parser tests (ro, prefetch, combined, unknown-opt and empty-opt errors). Python: 25/25 in tests.sandbox.test_file_systems incl. create/claim/attach body-shape tests. TypeScript: typecheck clean, 117/117 in sandbox+client suites incl. wire-shape tests. Pre-existing environment-dependent failures (TS deploy capsule tests, live-cloud lifecycle test) confirmed unrelated on a clean stash. fmt/clippy/eslint/black clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)