### PR TITLE
 Fix sandbox networking docstrings to match verified egress behavior

### DIFF
--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -466,12 +466,13 @@ class SandboxClient:
                 ``gpus`` or ``gpu_model``.
             timeout_secs: Timeout in seconds (optional)
             entrypoint: Custom entrypoint command (optional)
-            allow_internet_access: If True (default), all outbound traffic
-                is allowed unless denied — but only while *allow_out* is
-                empty. A non-empty *allow_out* is default-deny in both
-                modes; the flag then only controls whether the sandbox's
-                DNS resolver is implicitly allowed (True) or must itself be
-                listed in *allow_out* (False).
+            allow_internet_access: A simple switch while *allow_out* is
+                empty: True (the default) allows all outbound traffic
+                except *deny_out* matches; False blocks all egress,
+                including DNS. A non-empty *allow_out* is default-deny in
+                both modes; the flag then only controls whether the
+                sandbox's DNS resolver is implicitly allowed (True) or
+                must itself be listed in *allow_out* (False).
             allow_out: Destinations to allow: IPs, CIDRs, or hostnames
                 (e.g. ``["8.8.8.8", "10.0.0.0/8", "api.example.com"]``).
                 When non-empty, all unlisted destinations are blocked.
@@ -1548,12 +1549,13 @@ class SandboxClient:
                 ``gpus`` or ``gpu_model``.
             timeout_secs: Timeout in seconds (optional)
             entrypoint: Custom entrypoint command (optional)
-            allow_internet_access: If True (default), all outbound traffic
-                is allowed unless denied — but only while *allow_out* is
-                empty. A non-empty *allow_out* is default-deny in both
-                modes; the flag then only controls whether the sandbox's
-                DNS resolver is implicitly allowed (True) or must itself be
-                listed in *allow_out* (False).
+            allow_internet_access: A simple switch while *allow_out* is
+                empty: True (the default) allows all outbound traffic
+                except *deny_out* matches; False blocks all egress,
+                including DNS. A non-empty *allow_out* is default-deny in
+                both modes; the flag then only controls whether the
+                sandbox's DNS resolver is implicitly allowed (True) or
+                must itself be listed in *allow_out* (False).
             allow_out: Destinations to allow: IPs, CIDRs, or hostnames
                 (e.g. ``["8.8.8.8", "10.0.0.0/8", "api.example.com"]``).
                 When non-empty, all unlisted destinations are blocked.

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -466,14 +466,19 @@ class SandboxClient:
                 ``gpus`` or ``gpu_model``.
             timeout_secs: Timeout in seconds (optional)
             entrypoint: Custom entrypoint command (optional)
-            allow_internet_access: If True (default), outbound traffic is
-                allowed unless denied. If False, all outbound traffic is
-                blocked unless explicitly allowed.
-            allow_out: Destination IPs/CIDRs to allow
-                (e.g. ``["8.8.8.8", "10.0.0.0/8"]``). Takes precedence
-                over *deny_out*.
-            deny_out: Destination IPs/CIDRs to deny
-                (e.g. ``["192.168.1.0/24"]``).
+            allow_internet_access: If True (default), all outbound traffic
+                is allowed unless denied — but only while *allow_out* is
+                empty. A non-empty *allow_out* is default-deny in both
+                modes; the flag then only controls whether the sandbox's
+                DNS resolver is implicitly allowed (True) or must itself be
+                listed in *allow_out* (False).
+            allow_out: Destinations to allow: IPs, CIDRs, or hostnames
+                (e.g. ``["8.8.8.8", "10.0.0.0/8", "api.example.com"]``).
+                When non-empty, all unlisted destinations are blocked.
+                Overridden by any matching *deny_out* entry.
+            deny_out: Destinations to deny: IPs, CIDRs, or hostnames
+                (e.g. ``["192.168.1.0/24"]``). Takes precedence over
+                *allow_out*.
             snapshot_id: ID of a completed snapshot to restore from.
                 When set, image, resources, and entrypoint are
                 inherited from the snapshot unless explicitly
@@ -1543,14 +1548,19 @@ class SandboxClient:
                 ``gpus`` or ``gpu_model``.
             timeout_secs: Timeout in seconds (optional)
             entrypoint: Custom entrypoint command (optional)
-            allow_internet_access: If True (default), outbound traffic is
-                allowed unless denied. If False, all outbound traffic is
-                blocked unless explicitly allowed.
-            allow_out: Destination IPs/CIDRs to allow
-                (e.g. ``["8.8.8.8", "10.0.0.0/8"]``). Takes precedence
-                over *deny_out*.
-            deny_out: Destination IPs/CIDRs to deny
-                (e.g. ``["192.168.1.0/24"]``).
+            allow_internet_access: If True (default), all outbound traffic
+                is allowed unless denied — but only while *allow_out* is
+                empty. A non-empty *allow_out* is default-deny in both
+                modes; the flag then only controls whether the sandbox's
+                DNS resolver is implicitly allowed (True) or must itself be
+                listed in *allow_out* (False).
+            allow_out: Destinations to allow: IPs, CIDRs, or hostnames
+                (e.g. ``["8.8.8.8", "10.0.0.0/8", "api.example.com"]``).
+                When non-empty, all unlisted destinations are blocked.
+                Overridden by any matching *deny_out* entry.
+            deny_out: Destinations to deny: IPs, CIDRs, or hostnames
+                (e.g. ``["192.168.1.0/24"]``). Takes precedence over
+                *allow_out*.
             pool_id: Pool ID to use for warm containers (optional)
             snapshot_id: ID of a completed snapshot to restore from
             proxy_url: Explicit sandbox proxy URL override. When omitted,

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -201,9 +201,15 @@ class NetworkConfig(BaseModel):
     ``allow_out``: a destination matched by both is blocked. Established and
     related connections are always permitted (stateful firewall).
 
-    When ``allow_internet_access`` is ``True`` (the default), outbound traffic
-    is allowed unless matched by ``deny_out``. When ``False``, outbound is
-    blocked unless matched by ``allow_out`` (and not by ``deny_out``).
+    When ``allow_out`` is empty, ``allow_internet_access`` is a simple switch:
+    ``True`` (the default) allows all outbound traffic except ``deny_out``
+    matches; ``False`` blocks all egress, including DNS. A non-empty
+    ``allow_out`` makes the sandbox default-deny in both modes: only the
+    listed destinations are reachable. ``allow_internet_access`` then only
+    controls DNS: ``True`` implicitly allows the sandbox's resolver, so
+    hostname entries work; ``False`` blocks DNS unless the resolver's IP is
+    itself listed in ``allow_out``, so hostname entries need the resolver IP
+    alongside them (or use IP/CIDR entries only).
 
     Entries may be IPv4 addresses, CIDR ranges, or DNS hostnames (an optional
     ``:port`` suffix is accepted but does not make the rule port-specific).

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -383,10 +383,12 @@ class Sandbox:
                 ``gpus`` or ``gpu_model``.
             timeout_secs: Sandbox timeout in seconds.
             entrypoint: Custom entrypoint command.
-            allow_internet_access: If True (default), outbound traffic is
-                allowed while ``allow_out`` is empty. A non-empty
-                ``allow_out`` is default-deny in both modes; the flag then
-                only controls implicit access to the DNS resolver.
+            allow_internet_access: While ``allow_out`` is empty: True (the
+                default) allows all outbound traffic except ``deny_out``
+                matches; False blocks all egress, including DNS. A
+                non-empty ``allow_out`` is default-deny in both modes; the
+                flag then only controls implicit access to the DNS
+                resolver.
             allow_out: Destinations to allow (IPs, CIDRs, or hostnames).
                 When non-empty, all unlisted destinations are blocked.
             deny_out: Destinations to deny; takes precedence over allow_out.

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -383,9 +383,13 @@ class Sandbox:
                 ``gpus`` or ``gpu_model``.
             timeout_secs: Sandbox timeout in seconds.
             entrypoint: Custom entrypoint command.
-            allow_internet_access: If True (default), outbound traffic is allowed.
-            allow_out: Destination IPs/CIDRs to allow.
-            deny_out: Destination IPs/CIDRs to deny.
+            allow_internet_access: If True (default), outbound traffic is
+                allowed while ``allow_out`` is empty. A non-empty
+                ``allow_out`` is default-deny in both modes; the flag then
+                only controls implicit access to the DNS resolver.
+            allow_out: Destinations to allow (IPs, CIDRs, or hostnames).
+                When non-empty, all unlisted destinations are blocked.
+            deny_out: Destinations to deny; takes precedence over allow_out.
             pool_id: Pool ID to claim a warm container from.
             snapshot_id: Restore from this snapshot ID.
             proxy_url: Override the sandbox proxy URL.


### PR DESCRIPTION
Docs-only. Corrects the allow_internet_access / allow_out / deny_out docstrings to match verified behavior: a non-empty allow_out is default-deny in both modes, and the flag then only controls implicit DNS resolver access. Also covers the previously undocumented case where allow_internet_access=False with an empty allow_out blocks all egress, including DNS.