### PR TITLE
Use single quotes in sbx CLI example commands so `!` survives copy-paste

### DIFF
--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -197,7 +197,7 @@ fn print_post_create_tip(
     eprintln!();
     eprintln!("Get started:");
     eprintln!("  tl sbx ssh {display_id}");
-    eprintln!("  tl sbx exec {display_id} -- bash -c \"echo Hello, World!\"");
+    eprintln!("  tl sbx exec {display_id} -- bash -c 'echo Hello, World!'");
     if is_ephemeral {
         eprintln!("  tl sbx name {display_id} <name>  # make persistent (enables suspend/resume)");
     }
@@ -236,7 +236,7 @@ fn print_post_create_tip(
         (
             "write files into your sandbox via the HTTP API?",
             format!(
-                "  curl -X PUT \"{proxy_url}/api/v1/files?path=/tmp/hello.txt\"{header_flags} \\\n     -H \"Content-Type: application/octet-stream\" \\\n     -d \"Hello from sandbox!\""
+                "  curl -X PUT \"{proxy_url}/api/v1/files?path=/tmp/hello.txt\"{header_flags} \\\n     -H \"Content-Type: application/octet-stream\" \\\n     -d 'Hello from sandbox!'"
             ),
         ),
         (

--- a/crates/cli/src/commands/sbx/name.rs
+++ b/crates/cli/src/commands/sbx/name.rs
@@ -38,7 +38,7 @@ fn print_post_name_tip(name: &str) {
     eprintln!();
     eprintln!("Since your sandbox has a name, you can access it with commands like:");
     eprintln!("  tl sbx ssh {name}");
-    eprintln!("  tl sbx exec {name} -- bash -c \"echo Hello, World!\"");
+    eprintln!("  tl sbx exec {name} -- bash -c 'echo Hello, World!'");
     eprintln!("  tl sbx cp ./myfile.py {name}:/tmp/myfile.py");
     eprintln!("  tl sbx suspend {name}");
     eprintln!();


### PR DESCRIPTION
Addressed the issue mentioned in the feedback from Jeremy Morrell
https://tensorlakeai.slack.com/archives/C05MCD64DRD/p1786846254166499