### PR TITLE
Fix MountStatus.filesystem parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.110"
+version = "0.5.111"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.110"
+version = "0.5.111"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.110"
+version = "0.5.111"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.110"
+version = "0.5.111"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/filesystem/client.py
+++ b/src/tensorlake/filesystem/client.py
@@ -66,7 +66,10 @@ def mount_status_from_raw(raw: dict, local_path: Optional[str] = None) -> MountS
     """
     return MountStatus(
         path=str(raw.get("path") or raw.get("mount_path") or local_path or ""),
-        filesystem=raw.get("filesystem") or raw.get("file_system") or None,
+        filesystem=raw.get("filesystem")
+        or raw.get("file_system")
+        or raw.get("repository")
+        or None,
         mounted=bool(raw.get("mounted", raw.get("active", True))),
         raw=raw,
     )

--- a/tests/filesystem/test_filesystem_unit.py
+++ b/tests/filesystem/test_filesystem_unit.py
@@ -512,6 +512,12 @@ class TestFilesystemClient(unittest.TestCase):
         self.assertEqual(defaulted.path, "/mnt/y")
         self.assertTrue(defaulted.mounted)
 
+        # Live `tl fs status --json` reports the name under "repository".
+        from_cli = mount_status_from_raw(
+            {"path": "/mnt/z", "repository": "my-fs", "mounted": True}
+        )
+        self.assertEqual(from_cli.filesystem, "my-fs")
+
     def test_error_translation_without_status(self):
         stub = _StubNative(
             errors={"push_filesystem_files": ("internal", None, "commit job failed")}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.110",
+  "version": "0.5.111",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/filesystem-models.ts
+++ b/typescript/src/filesystem-models.ts
@@ -152,9 +152,10 @@ export function mountStatusFromRaw(
         ? Boolean(raw.active)
         : true;
   const path = String(raw.path || raw.mount_path || localPath || "");
-  const filesystem = (raw.filesystem || raw.file_system || null) as
-    | string
-    | null;
+  const filesystem = (raw.filesystem ||
+    raw.file_system ||
+    raw.repository ||
+    null) as string | null;
   return { path, filesystem, mounted, raw };
 }
 

--- a/typescript/tests/filesystem.test.ts
+++ b/typescript/tests/filesystem.test.ts
@@ -306,6 +306,14 @@ describe("filesystem models", () => {
     const defaulted = mountStatusFromRaw({}, "/mnt/y");
     expect(defaulted.path).toBe("/mnt/y");
     expect(defaulted.mounted).toBe(true);
+
+    // Live `tl fs status --json` reports the name under "repository".
+    const fromCli = mountStatusFromRaw({
+      path: "/mnt/z",
+      repository: "my-fs",
+      mounted: true,
+    });
+    expect(fromCli.filesystem).toBe("my-fs");
   });
 });
 


### PR DESCRIPTION
## Changes

- `mount_status_from_raw` / `mountStatusFromRaw` now read the `repository` key.
  Live `tl fs status --json` reports the name there, so `MountStatus.filesystem`
  was always `None`. `filesystem`/`file_system` are still tried first.