### PR TITLE
Snapshot-pinned mounts across SDKs and CLI

### DIFF
--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -88,26 +88,43 @@ pub struct CreateArgs<'a> {
     pub network_allow: &'a [String],
     pub network_deny: &'a [String],
     /// Boot-time file system mounts, each as
-    /// `<file_system_id>:<mount_path>[:<opts>]`.
+    /// `<name>[@<snapshot_id>]:<mount_path>[:<opts>]`.
     pub file_systems: &'a [String],
 }
 
-const FILESYSTEM_FLAG_USAGE: &str = "--filesystem must be <file_system_id>:<mount_path>[:<opts>] where <opts> is a \
-     comma-separated list of `ro` and/or `prefetch`";
+const FILESYSTEM_FLAG_USAGE: &str = "--filesystem must be <name>[@<snapshot_id>]:<mount_path>[:<opts>] where <opts> \
+     is a comma-separated list of `ro` and/or `prefetch`, and a `@<snapshot_id>` pin requires \
+     `ro`";
 
-/// Parse `--filesystem <id>:<path>[:<opts>]` flags into the request
-/// `file_systems` array. The id ends at the first `:` and the mount path at
-/// the second (file system ids and absolute mount paths never contain one);
-/// the optional trailing segment is a comma-separated option list drawn from
-/// `ro` and `prefetch`. The option keys are added to the wire object only when
-/// set: older servers reject unknown mount fields, so an explicit `false`
-/// must never be sent.
+/// Parse `--filesystem <name>[@<snapshot>]:<path>[:<opts>]` flags into the
+/// request `file_systems` array. Everything before the first `:` names the
+/// file system, optionally pinned to a snapshot after `@` (`@` cannot appear
+/// in file system names and snapshot ids are hex-ish, so the split is
+/// unambiguous); the mount path ends at the next `:` (file system names and
+/// absolute mount paths never contain one); the optional trailing segment is
+/// a comma-separated option list drawn from `ro` and `prefetch`. A snapshot
+/// pin requires `ro`: pinned mounts are read-only, and rejecting the combo
+/// here mirrors the server's 400 so users fail fast offline. The option and
+/// pin keys are added to the wire object only when set: older servers reject
+/// unknown mount fields, so an explicit `false` (or a null pin) must never
+/// be sent.
 fn parse_file_system_mounts(raw: &[String]) -> Result<Vec<serde_json::Value>> {
     raw.iter()
         .map(|entry| {
-            let (file_system_id, rest) = entry.split_once(':').ok_or_else(|| {
+            let (mount_source, rest) = entry.split_once(':').ok_or_else(|| {
                 CliError::usage(format!("{FILESYSTEM_FLAG_USAGE}, got {entry:?}"))
             })?;
+            let (file_system_id, snapshot_id) = match mount_source.split_once('@') {
+                Some((name, snapshot)) => {
+                    if name.is_empty() || snapshot.is_empty() || snapshot.contains('@') {
+                        return Err(CliError::usage(format!(
+                            "{FILESYSTEM_FLAG_USAGE}, got {entry:?}"
+                        )));
+                    }
+                    (name, Some(snapshot))
+                }
+                None => (mount_source, None),
+            };
             let (mount_path, opts) = match rest.split_once(':') {
                 Some((mount_path, opts)) => (mount_path, Some(opts)),
                 None => (rest, None),
@@ -121,10 +138,14 @@ fn parse_file_system_mounts(raw: &[String]) -> Result<Vec<serde_json::Value>> {
                 "file_system_id": file_system_id,
                 "mount_path": mount_path,
             });
+            let mut read_only = false;
             if let Some(opts) = opts {
                 for opt in opts.split(',') {
                     match opt {
-                        "ro" => mount["read_only"] = serde_json::Value::Bool(true),
+                        "ro" => {
+                            read_only = true;
+                            mount["read_only"] = serde_json::Value::Bool(true);
+                        }
                         "prefetch" => mount["prefetch"] = serde_json::Value::Bool(true),
                         _ => {
                             return Err(CliError::usage(format!(
@@ -134,6 +155,15 @@ fn parse_file_system_mounts(raw: &[String]) -> Result<Vec<serde_json::Value>> {
                         }
                     }
                 }
+            }
+            if let Some(snapshot_id) = snapshot_id {
+                if !read_only {
+                    return Err(CliError::usage(format!(
+                        "snapshot pin @{snapshot_id} in {entry:?} requires `ro`: \
+                         snapshot-pinned mounts are read-only"
+                    )));
+                }
+                mount["snapshot_id"] = serde_json::Value::String(snapshot_id.to_string());
             }
             Ok(mount)
         })
@@ -493,6 +523,69 @@ mod tests {
     fn parse_file_system_mounts_rejects_empty_opt() {
         assert!(parse_file_system_mounts(&["skills:/mnt/skills:".to_string()]).is_err());
         assert!(parse_file_system_mounts(&["skills:/mnt/skills:ro,".to_string()]).is_err());
+    }
+
+    #[test]
+    fn parse_file_system_mounts_parses_snapshot_pin_with_ro() {
+        let mounts =
+            parse_file_system_mounts(&["skills@0abc123def:/mnt/skills:ro".to_string()]).unwrap();
+        assert_eq!(
+            mounts[0],
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+                "read_only": true,
+                "snapshot_id": "0abc123def",
+            })
+        );
+    }
+
+    #[test]
+    fn parse_file_system_mounts_parses_snapshot_pin_with_combined_opts() {
+        let mounts =
+            parse_file_system_mounts(&["skills@0abc123def:/mnt/skills:ro,prefetch".to_string()])
+                .unwrap();
+        assert_eq!(
+            mounts[0],
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+                "read_only": true,
+                "prefetch": true,
+                "snapshot_id": "0abc123def",
+            })
+        );
+    }
+
+    #[test]
+    fn parse_file_system_mounts_rejects_snapshot_pin_without_ro() {
+        let error =
+            parse_file_system_mounts(&["skills@0abc123def:/mnt/skills".to_string()]).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("snapshot-pinned mounts are read-only"),
+            "unexpected error: {error}"
+        );
+        let error =
+            parse_file_system_mounts(&["skills@0abc123def:/mnt/skills:prefetch".to_string()])
+                .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("snapshot-pinned mounts are read-only"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_file_system_mounts_rejects_malformed_snapshot_pin() {
+        // A bare or one-sided `@` never names a valid mount source.
+        assert!(parse_file_system_mounts(&["@:/mnt/skills:ro".to_string()]).is_err());
+        assert!(parse_file_system_mounts(&["@0abc123def:/mnt/skills:ro".to_string()]).is_err());
+        assert!(parse_file_system_mounts(&["skills@:/mnt/skills:ro".to_string()]).is_err());
+        // `@` cannot appear in file system names or snapshot ids.
+        assert!(parse_file_system_mounts(&["skills@0abc@def:/mnt/skills:ro".to_string()]).is_err());
     }
 
     #[test]

--- a/crates/cli/src/commands/sbx/fs.rs
+++ b/crates/cli/src/commands/sbx/fs.rs
@@ -30,7 +30,9 @@ async fn parse_sandbox_response(resp: Response, action: &str) -> Result<SandboxI
     resp.json().await.map_err(CliError::Http)
 }
 
-/// Render a sandbox's currently-mounted file systems as a table.
+/// Render a sandbox's currently-mounted file systems as a table. A
+/// snapshot-pinned mount shows its pin as `<name>@<snapshot_id>`, mirroring
+/// the `--filesystem <name>[@<snapshot_id>]:<path>[:<opts>]` input syntax.
 fn print_mounts_table(mounts: &[FileSystemMount]) {
     if mounts.is_empty() {
         println!("No file systems mounted.");
@@ -46,8 +48,12 @@ fn print_mounts_table(mounts: &[FileSystemMount]) {
         if mount.prefetch {
             options.push("prefetch");
         }
+        let source = match &mount.snapshot_id {
+            Some(snapshot_id) => format!("{}@{snapshot_id}", mount.file_system_id),
+            None => mount.file_system_id.clone(),
+        };
         table.add_row(vec![
-            Cell::new(mount.file_system_id.as_str()),
+            Cell::new(source),
             Cell::new(mount.mount_path.as_str()),
             Cell::new(options.join(",")),
         ]);
@@ -55,20 +61,23 @@ fn print_mounts_table(mounts: &[FileSystemMount]) {
     println!("{table}");
 }
 
-#[allow(clippy::too_many_arguments)]
-pub async fn attach(
-    ctx: &CliContext,
-    sandbox_id: &str,
+/// Build the attach request body. The option keys are present only when set:
+/// older servers deserialize attach bodies with `deny_unknown_fields` and
+/// reject an explicit `false` (or an unknown pin field). A snapshot pin
+/// without `--read-only` is rejected here, mirroring the server's 400 so
+/// users fail fast offline.
+fn build_attach_body(
     file_system_id: &str,
     mount_path: &str,
     read_only: bool,
     prefetch: bool,
-    output_json: bool,
-) -> Result<()> {
-    let client = ctx.client()?;
-    let url = sandbox_endpoint(ctx, &format!("sandboxes/{sandbox_id}/file_systems"));
-    // The option keys are present only when set: older servers deserialize
-    // attach bodies with `deny_unknown_fields` and reject an explicit `false`.
+    snapshot_id: Option<&str>,
+) -> Result<serde_json::Value> {
+    if snapshot_id.is_some() && !read_only {
+        return Err(CliError::usage(
+            "--snapshot requires --read-only: snapshot-pinned mounts are read-only".to_string(),
+        ));
+    }
     let mut body = serde_json::json!({
         "file_system_id": file_system_id,
         "mount_path": mount_path,
@@ -79,6 +88,26 @@ pub async fn attach(
     if prefetch {
         body["prefetch"] = serde_json::Value::Bool(true);
     }
+    if let Some(snapshot_id) = snapshot_id {
+        body["snapshot_id"] = serde_json::Value::String(snapshot_id.to_string());
+    }
+    Ok(body)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn attach(
+    ctx: &CliContext,
+    sandbox_id: &str,
+    file_system_id: &str,
+    mount_path: &str,
+    read_only: bool,
+    prefetch: bool,
+    snapshot_id: Option<&str>,
+    output_json: bool,
+) -> Result<()> {
+    let client = ctx.client()?;
+    let url = sandbox_endpoint(ctx, &format!("sandboxes/{sandbox_id}/file_systems"));
+    let body = build_attach_body(file_system_id, mount_path, read_only, prefetch, snapshot_id)?;
 
     let resp = client
         .post(&url)
@@ -146,4 +175,48 @@ pub async fn list(ctx: &CliContext, sandbox_id: &str, output_json: bool) -> Resu
 
     print_mounts_table(&info.file_systems);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attach_body_omits_unset_mount_modes() {
+        let body = build_attach_body("skills", "/mnt/skills", false, false, None).unwrap();
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+            })
+        );
+    }
+
+    #[test]
+    fn attach_body_includes_snapshot_pin_with_read_only() {
+        let body =
+            build_attach_body("skills", "/mnt/skills", true, false, Some("0abc123def")).unwrap();
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+                "read_only": true,
+                "snapshot_id": "0abc123def",
+            })
+        );
+    }
+
+    #[test]
+    fn attach_body_rejects_snapshot_pin_without_read_only() {
+        let error = build_attach_body("skills", "/mnt/skills", false, true, Some("0abc123def"))
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("snapshot-pinned mounts are read-only"),
+            "unexpected error: {error}"
+        );
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1183,11 +1183,18 @@ enum SbxCommands {
         network_deny: Vec<String>,
 
         /// Mount a registered file system at boot as
-        /// `<file_system_id>:<mount_path>[:<opts>]`, where `<opts>` is a
-        /// comma-separated list of `ro` (read-only) and/or `prefetch`
-        /// (eagerly download contents), e.g. `data:/mnt/data:ro,prefetch`
-        /// (can be repeated)
-        #[arg(short = 'f', long = "filesystem", value_name = "ID:PATH[:OPTS]")]
+        /// `<name>[@<snapshot_id>]:<mount_path>[:<opts>]`, where `<opts>` is
+        /// a comma-separated list of `ro` (read-only) and/or `prefetch`
+        /// (eagerly download contents), e.g. `data:/mnt/data:ro,prefetch`.
+        /// `@<snapshot_id>` pins the mount to a filesystem snapshot and
+        /// requires `ro` (pinned mounts are read-only), e.g.
+        /// `data@0abc123:/mnt/data:ro`; `@` cannot appear in file system
+        /// names, so everything after it is the snapshot id (can be repeated)
+        #[arg(
+            short = 'f',
+            long = "filesystem",
+            value_name = "NAME[@SNAPSHOT]:PATH[:OPTS]"
+        )]
         file_systems: Vec<String>,
     },
 
@@ -1528,6 +1535,11 @@ enum SbxFsCommands {
         /// Eagerly download the file system's contents into the sandbox
         #[arg(long)]
         prefetch: bool,
+
+        /// Pin the mount to a filesystem snapshot id; requires --read-only
+        /// (snapshot-pinned mounts are read-only)
+        #[arg(long = "snapshot", value_name = "SNAPSHOT_ID")]
+        snapshot_id: Option<String>,
 
         /// Print the updated sandbox as JSON
         #[arg(long)]
@@ -2494,6 +2506,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             path,
                             read_only,
                             prefetch,
+                            snapshot_id,
                             json,
                         } => {
                             commands::sbx::fs::attach(
@@ -2503,6 +2516,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 &path,
                                 read_only,
                                 prefetch,
+                                snapshot_id.as_deref(),
                                 json,
                             )
                             .await

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -48,6 +48,22 @@ struct ClaimSandboxResponse {
     claim_configuration_applied: Option<bool>,
 }
 
+/// Client-side mirror of the server's HTTP 400 for invalid snapshot pins:
+/// a mount that pins `snapshot_id` must also be `read_only`, so callers fail
+/// fast (and offline) instead of round-tripping to the server.
+fn validate_mount_snapshot_pins(mounts: &[FileSystemMount]) -> Result<(), SdkError> {
+    for mount in mounts {
+        if mount.snapshot_id.is_some() && !mount.read_only {
+            return Err(SdkError::ClientError(format!(
+                "file system mount {:?} at {:?} sets snapshot_id without read_only: \
+                 snapshot-pinned mounts are read-only",
+                mount.file_system_id, mount.mount_path
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// A reference to a sandbox process: either its OS **pid** or a managed-process **name**
 /// given at creation. This is the single place the pid/name path segment is built, reused by
 /// the Rust SDK, the Python/Node bindings, and the CLI.
@@ -325,6 +341,7 @@ impl SandboxesClient {
         &self,
         request: &CreateSandboxRequest,
     ) -> Result<Traced<CreateSandboxResponse>, SdkError> {
+        validate_mount_snapshot_pins(&request.file_systems)?;
         let uri = self.endpoint("sandboxes");
         let req = self
             .client
@@ -352,6 +369,7 @@ impl SandboxesClient {
         pool_id: &str,
         request: &ClaimSandboxRequest,
     ) -> Result<Traced<CreateSandboxResponse>, SdkError> {
+        validate_mount_snapshot_pins(&request.file_systems)?;
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}/sandboxes"));
         let req = self
             .client
@@ -535,6 +553,10 @@ impl SandboxesClient {
     /// `read_only` and `prefetch` select optional mount modes; they are sent
     /// on the wire only when `true` so older servers (which reject unknown
     /// fields) keep accepting attach bodies.
+    ///
+    /// `snapshot_id` pins the mount to a specific filesystem snapshot and
+    /// requires `read_only`; it is sent only when set for the same
+    /// compatibility reason.
     pub async fn attach_file_system(
         &self,
         sandbox_id: &str,
@@ -542,6 +564,7 @@ impl SandboxesClient {
         mount_path: &str,
         read_only: bool,
         prefetch: bool,
+        snapshot_id: Option<&str>,
     ) -> Result<Traced<SandboxInfo>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/file_systems"));
         let body = FileSystemMount {
@@ -549,7 +572,9 @@ impl SandboxesClient {
             mount_path: mount_path.to_string(),
             read_only,
             prefetch,
+            snapshot_id: snapshot_id.map(str::to_string),
         };
+        validate_mount_snapshot_pins(std::slice::from_ref(&body))?;
         let req = self
             .client
             .build_post_json_request(Method::POST, &uri, &body)?;
@@ -1190,8 +1215,9 @@ impl SandboxProxyClient {
 #[cfg(test)]
 mod process_ref_tests {
     use super::{
-        ProcessRef, resolve_sandbox_proxy_target, sandbox_proxy_hostname,
+        FileSystemMount, ProcessRef, resolve_sandbox_proxy_target, sandbox_proxy_hostname,
         sandbox_url_from_ingress_endpoint, select_sandbox_proxy_url, validate_managed_name,
+        validate_mount_snapshot_pins,
     };
 
     #[test]
@@ -1321,5 +1347,35 @@ mod process_ref_tests {
             sandbox_proxy_hostname("https://sbx-1.sandbox.gcp-use4.tensorlake.ai").unwrap();
 
         assert_eq!(hostname, "sbx-1.sandbox.gcp-use4.tensorlake.ai");
+    }
+
+    #[test]
+    fn snapshot_pin_without_read_only_is_a_client_error() {
+        let pinned_writable = FileSystemMount {
+            file_system_id: "skills".to_string(),
+            mount_path: "/mnt/skills".to_string(),
+            read_only: false,
+            prefetch: false,
+            snapshot_id: Some("0abc123def".to_string()),
+        };
+        let error = validate_mount_snapshot_pins(std::slice::from_ref(&pinned_writable))
+            .expect_err("a writable snapshot pin must be rejected client-side");
+        assert!(
+            error
+                .to_string()
+                .contains("snapshot-pinned mounts are read-only"),
+            "unexpected error: {error}"
+        );
+
+        let pinned_read_only = FileSystemMount {
+            read_only: true,
+            ..pinned_writable.clone()
+        };
+        let unpinned = FileSystemMount {
+            snapshot_id: None,
+            ..pinned_writable
+        };
+        validate_mount_snapshot_pins(&[pinned_read_only, unpinned])
+            .expect("read-only pins and unpinned mounts are valid");
     }
 }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -242,6 +242,12 @@ fn default_allow_internet_access() -> bool {
 /// `read_only` and `prefetch` are optional mount modes. They serialize only
 /// when `true`: older servers deserialize mount bodies with
 /// `deny_unknown_fields` and would reject an explicit `false`.
+///
+/// `snapshot_id` optionally pins the mount to a specific filesystem
+/// snapshot. A pinned mount must also be `read_only` (the server rejects a
+/// writable pin with HTTP 400). The field serializes only when set: older
+/// servers reject mount bodies carrying unknown fields, so "unpinned" is
+/// expressed by omission.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct FileSystemMount {
     pub file_system_id: String,
@@ -252,6 +258,10 @@ pub struct FileSystemMount {
     /// Eagerly download the complete file system into the guest cache.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub prefetch: bool,
+    /// Pin the mount to a specific filesystem snapshot (requires
+    /// `read_only`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_id: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1032,6 +1042,7 @@ mod tests {
             mount_path: "/mnt/skills".to_string(),
             read_only: false,
             prefetch: false,
+            snapshot_id: None,
         };
         assert_eq!(
             serde_json::to_value(&mount).unwrap(),
@@ -1049,6 +1060,7 @@ mod tests {
             mount_path: "/mnt/skills".to_string(),
             read_only: true,
             prefetch: true,
+            snapshot_id: None,
         };
         assert_eq!(
             serde_json::to_value(&mount).unwrap(),
@@ -1062,6 +1074,26 @@ mod tests {
     }
 
     #[test]
+    fn file_system_mount_serializes_snapshot_pin_only_when_set() {
+        let pinned = FileSystemMount {
+            file_system_id: "skills".to_string(),
+            mount_path: "/mnt/skills".to_string(),
+            read_only: true,
+            prefetch: false,
+            snapshot_id: Some("0abc123def".to_string()),
+        };
+        assert_eq!(
+            serde_json::to_value(&pinned).unwrap(),
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+                "read_only": true,
+                "snapshot_id": "0abc123def"
+            })
+        );
+    }
+
+    #[test]
     fn file_system_mount_deserializes_absent_and_present_mount_modes() {
         let absent: FileSystemMount = serde_json::from_value(serde_json::json!({
             "file_system_id": "skills",
@@ -1070,16 +1102,19 @@ mod tests {
         .unwrap();
         assert!(!absent.read_only);
         assert!(!absent.prefetch);
+        assert_eq!(absent.snapshot_id, None);
 
         let present: FileSystemMount = serde_json::from_value(serde_json::json!({
             "file_system_id": "skills",
             "mount_path": "/mnt/skills",
             "read_only": true,
-            "prefetch": true
+            "prefetch": true,
+            "snapshot_id": "0abc123def"
         }))
         .unwrap();
         assert!(present.read_only);
         assert!(present.prefetch);
+        assert_eq!(present.snapshot_id.as_deref(), Some("0abc123def"));
     }
 
     #[test]

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -560,6 +560,7 @@ impl NativeSandboxClient {
         mount_path: String,
         read_only: Option<bool>,
         prefetch: Option<bool>,
+        snapshot_id: Option<String>,
     ) -> napi::Result<TracedJson> {
         let read_only = read_only.unwrap_or(false);
         let prefetch = prefetch.unwrap_or(false);
@@ -567,6 +568,7 @@ impl NativeSandboxClient {
             let sandbox_id = sandbox_id.clone();
             let file_system_id = file_system_id.clone();
             let mount_path = mount_path.clone();
+            let snapshot_id = snapshot_id.clone();
             async move {
                 let traced = c
                     .attach_file_system(
@@ -575,6 +577,7 @@ impl NativeSandboxClient {
                         &mount_path,
                         read_only,
                         prefetch,
+                        snapshot_id.as_deref(),
                     )
                     .await?;
                 let trace_id = traced.trace_id.clone();

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -1755,7 +1755,7 @@ impl CloudSandboxClient {
         })
     }
 
-    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false))]
+    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false, snapshot_id=None))]
     fn attach_file_system(
         &self,
         sandbox_id: String,
@@ -1763,11 +1763,13 @@ impl CloudSandboxClient {
         mount_path: String,
         read_only: bool,
         prefetch: bool,
+        snapshot_id: Option<String>,
     ) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
             let file_system_id = file_system_id.clone();
             let mount_path = mount_path.clone();
+            let snapshot_id = snapshot_id.clone();
             async move {
                 let traced = client
                     .attach_file_system(
@@ -1776,6 +1778,7 @@ impl CloudSandboxClient {
                         &mount_path,
                         read_only,
                         prefetch,
+                        snapshot_id.as_deref(),
                     )
                     .await?;
                 let trace_id = traced.trace_id.clone();
@@ -2167,7 +2170,7 @@ impl CloudSandboxClient {
         })
     }
 
-    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false))]
+    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false, snapshot_id=None))]
     fn attach_file_system_async<'py>(
         &self,
         py: Python<'py>,
@@ -2176,6 +2179,7 @@ impl CloudSandboxClient {
         mount_path: String,
         read_only: bool,
         prefetch: bool,
+        snapshot_id: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
@@ -2183,6 +2187,7 @@ impl CloudSandboxClient {
                 let sandbox_id = sandbox_id.clone();
                 let file_system_id = file_system_id.clone();
                 let mount_path = mount_path.clone();
+                let snapshot_id = snapshot_id.clone();
                 async move {
                     c.attach_file_system(
                         &sandbox_id,
@@ -2190,6 +2195,7 @@ impl CloudSandboxClient {
                         &mount_path,
                         read_only,
                         prefetch,
+                        snapshot_id.as_deref(),
                     )
                     .await
                 }

--- a/src/tensorlake/filesystem/__init__.py
+++ b/src/tensorlake/filesystem/__init__.py
@@ -14,6 +14,7 @@ from .exceptions import (
     FilesystemException,
     FilesystemNotFoundError,
     MountError,
+    ReadOnlyMountNotSupportedError,
 )
 from .models import (
     FileEntry,
@@ -43,4 +44,5 @@ __all__ = [
     "FilesystemAPIError",
     "MountError",
     "CliNotFoundError",
+    "ReadOnlyMountNotSupportedError",
 ]

--- a/src/tensorlake/filesystem/_cli.py
+++ b/src/tensorlake/filesystem/_cli.py
@@ -16,7 +16,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .exceptions import CliNotFoundError, MountError
+from .exceptions import CliNotFoundError, MountError, ReadOnlyMountNotSupportedError
 
 _DEFAULT_INSTALL_PATH = Path.home() / ".tensorlake" / "bin" / "tl"
 
@@ -107,10 +107,11 @@ class FsCli:
     # names/paths can never be parsed as CLI flags (e.g. a path literally
     # named "--discard" must stay a path, not become the destructive flag).
     def mount(self, filesystem: str, local_path: str, readonly: bool) -> None:
-        args = ["mount"]
         if readonly:
-            args.append("--ro")
-        args += ["--", filesystem, local_path]
+            # `tl fs mount` has no --ro flag; shelling it out anyway would
+            # surface an opaque CLI parse error. Fail honestly instead.
+            raise ReadOnlyMountNotSupportedError()
+        args = ["mount", "--", filesystem, local_path]
         self._run(args)
 
     def unmount(self, local_path: str, discard: bool = False) -> None:

--- a/src/tensorlake/filesystem/client.py
+++ b/src/tensorlake/filesystem/client.py
@@ -155,7 +155,13 @@ class FilesystemClient:
     # -- local mounts ----------------------------------------------------------
 
     def mount(self, name: str, local_path: str, readonly: bool = False) -> "Mount":
-        """Mount a filesystem to a local path (requires the ``tl`` CLI)."""
+        """Mount a filesystem to a local path (requires the ``tl`` CLI).
+
+        ``readonly=True`` is not supported for local mounts and raises
+        :class:`~tensorlake.filesystem.ReadOnlyMountNotSupportedError`; use a
+        sandbox read-only mount (``read_only=True``) or ``tl git mount --ro``
+        instead.
+        """
         self._cli.mount(name, local_path, readonly)
         return Mount(self, name, local_path, readonly)
 
@@ -439,7 +445,13 @@ class Filesystem:
     # -- mounts ---------------------------------------------------------------------
 
     def mount(self, local_path: str, readonly: bool = False) -> "Mount":
-        """Mount this filesystem to a local path (requires the ``tl`` CLI)."""
+        """Mount this filesystem to a local path (requires the ``tl`` CLI).
+
+        ``readonly=True`` is not supported for local mounts and raises
+        :class:`~tensorlake.filesystem.ReadOnlyMountNotSupportedError`; use a
+        sandbox read-only mount (``read_only=True``) or ``tl git mount --ro``
+        instead.
+        """
         return self._client.mount(self._name, local_path, readonly)
 
 

--- a/src/tensorlake/filesystem/exceptions.py
+++ b/src/tensorlake/filesystem/exceptions.py
@@ -65,6 +65,24 @@ class MountError(FilesystemError):
     pass
 
 
+class ReadOnlyMountNotSupportedError(MountError):
+    """Raised when a read-only local mount is requested.
+
+    ``tl fs mount`` has no read-only mode. Read-only views exist elsewhere:
+    mount the filesystem into a sandbox with ``read_only=True`` (e.g.
+    ``tl sbx create -f NAME:PATH:ro``), or use ``tl git mount --ro`` for
+    repositories.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "read-only local mounts are not supported: `tl fs mount` has no "
+            "--ro mode. Mount the filesystem into a sandbox read-only instead "
+            "(read_only=True / `tl sbx create -f NAME:PATH:ro`), or use "
+            "`tl git mount --ro` for repositories."
+        )
+
+
 class CliNotFoundError(MountError):
     """Raised when the `tl` CLI required for mount operations is unavailable."""
 

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -74,6 +74,7 @@ from .models import (
     SnapshotType,
     SnapshotWaitCondition,
     UpdateSandboxRequest,
+    _validate_mount_snapshot_pins,
     snapshot_satisfies_wait_condition,
 )
 
@@ -251,6 +252,7 @@ class AsyncSandboxClient:
         file_systems: list[FileSystemMount] | None = None,
         gpu: GpuRequest | None = None,
     ) -> Traced[CreateSandboxResponse]:
+        _validate_mount_snapshot_pins(file_systems)
         network = None
         if not allow_internet_access or allow_out is not None or deny_out is not None:
             network = NetworkConfig(
@@ -291,6 +293,7 @@ class AsyncSandboxClient:
         *,
         file_systems: list[FileSystemMount] | None = None,
     ) -> Traced[CreateSandboxResponse]:
+        _validate_mount_snapshot_pins(file_systems)
         try:
             claim_kwargs: dict[str, str] = {"pool_id": pool_id}
             if file_systems:
@@ -450,14 +453,28 @@ class AsyncSandboxClient:
         *,
         read_only: bool = False,
         prefetch: bool = False,
+        snapshot_id: str | None = None,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to a running sandbox.
 
         The returned ``SandboxInfo`` already reflects the new
         ``file_systems`` entry; the mount completes asynchronously on the
         dataplane. ``read_only`` mounts the file system read-only;
-        ``prefetch`` eagerly downloads its contents.
+        ``prefetch`` eagerly downloads its contents; ``snapshot_id`` pins
+        the mount to a specific filesystem snapshot and requires
+        ``read_only=True``.
         """
+        _validate_mount_snapshot_pins(
+            [
+                FileSystemMount(
+                    file_system_id=file_system_id,
+                    mount_path=mount_path,
+                    read_only=read_only,
+                    prefetch=prefetch,
+                    snapshot_id=snapshot_id,
+                )
+            ]
+        )
         try:
             trace_id, response_json = await self._rust_client.attach_file_system_async(
                 sandbox_id=sandbox_id,
@@ -465,6 +482,7 @@ class AsyncSandboxClient:
                 mount_path=mount_path,
                 read_only=read_only,
                 prefetch=prefetch,
+                snapshot_id=snapshot_id,
             )
             return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -407,6 +407,7 @@ class AsyncSandbox:
         *,
         read_only: bool = False,
         prefetch: bool = False,
+        snapshot_id: str | None = None,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to this running sandbox.
 
@@ -416,6 +417,8 @@ class AsyncSandbox:
             mount_path: Absolute, unique guest mount path (e.g. ``/mnt/skills``).
             read_only: Mount the file system read-only.
             prefetch: Eagerly download the file system's contents.
+            snapshot_id: Pin the mount to a specific filesystem snapshot.
+                Requires ``read_only=True``.
 
         Returns:
             Traced[SandboxInfo] with this sandbox's updated file systems.
@@ -427,6 +430,7 @@ class AsyncSandbox:
             mount_path,
             read_only=read_only,
             prefetch=prefetch,
+            snapshot_id=snapshot_id,
         )
         self._sandbox_id = traced.sandbox_id
         self._cached_info = traced.value

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -53,6 +53,7 @@ from .models import (
     SnapshotType,
     SnapshotWaitCondition,
     UpdateSandboxRequest,
+    _validate_mount_snapshot_pins,
     snapshot_satisfies_wait_condition,
 )
 
@@ -493,9 +494,12 @@ class SandboxClient:
             Traced[CreateSandboxResponse] with sandbox_id, status, and trace_id
 
         Raises:
+            ValueError: If a file system mount pins ``snapshot_id`` without
+                ``read_only=True``
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
+        _validate_mount_snapshot_pins(file_systems)
         network = None
         if not allow_internet_access or allow_out is not None or deny_out is not None:
             network = NetworkConfig(
@@ -552,9 +556,12 @@ class SandboxClient:
             Traced[CreateSandboxResponse] with sandbox_id, status, and trace_id
 
         Raises:
+            ValueError: If a file system mount pins ``snapshot_id`` without
+                ``read_only=True``
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
+        _validate_mount_snapshot_pins(file_systems)
         try:
             claim_kwargs: dict[str, str] = {"pool_id": pool_id}
             if file_systems:
@@ -1015,6 +1022,7 @@ class SandboxClient:
         *,
         read_only: bool = False,
         prefetch: bool = False,
+        snapshot_id: str | None = None,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to a running sandbox.
 
@@ -1029,15 +1037,29 @@ class SandboxClient:
             mount_path: Absolute, unique guest mount path (e.g. ``/mnt/skills``).
             read_only: Mount the file system read-only.
             prefetch: Eagerly download the file system's contents.
+            snapshot_id: Pin the mount to a specific filesystem snapshot.
+                Requires ``read_only=True``.
 
         Returns:
             Traced[SandboxInfo] with the sandbox's updated file systems.
 
         Raises:
+            ValueError: If ``snapshot_id`` is set without ``read_only=True``
             SandboxNotFoundError: If the sandbox doesn't exist
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
+        _validate_mount_snapshot_pins(
+            [
+                FileSystemMount(
+                    file_system_id=file_system_id,
+                    mount_path=mount_path,
+                    read_only=read_only,
+                    prefetch=prefetch,
+                    snapshot_id=snapshot_id,
+                )
+            ]
+        )
         try:
             trace_id, response_json = self._rust_client.attach_file_system(
                 sandbox_id=sandbox_id,
@@ -1045,6 +1067,7 @@ class SandboxClient:
                 mount_path=mount_path,
                 read_only=read_only,
                 prefetch=prefetch,
+                snapshot_id=snapshot_id,
             )
             return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -256,22 +256,46 @@ class FileSystemMount(BaseModel):
     downloads its contents. Both serialize onto the wire only when ``True``:
     older servers reject mount bodies carrying unknown fields, so ``False``
     is expressed by omission.
+
+    ``snapshot_id`` pins the mount to a specific filesystem snapshot. A
+    pinned mount must also set ``read_only=True`` (the server rejects a
+    writable pin with HTTP 400). It serializes only when set, for the same
+    compatibility reason as the mount modes.
     """
 
     file_system_id: str
     mount_path: str
     read_only: bool = False
     prefetch: bool = False
+    snapshot_id: str | None = None
 
     @model_serializer(mode="wrap")
-    def _omit_false_mount_modes(self, handler):
+    def _omit_unset_mount_modes(self, handler):
         data = handler(self)
         if isinstance(data, dict):
             if not self.read_only:
                 data.pop("read_only", None)
             if not self.prefetch:
                 data.pop("prefetch", None)
+            if self.snapshot_id is None:
+                data.pop("snapshot_id", None)
         return data
+
+
+def _validate_mount_snapshot_pins(mounts: "list[FileSystemMount] | None") -> None:
+    """Client-side mirror of the server's HTTP 400 for invalid snapshot pins.
+
+    A mount that pins ``snapshot_id`` must also be ``read_only``; raising here
+    lets callers fail fast (and offline) instead of round-tripping to the
+    server.
+    """
+    for mount in mounts or []:
+        if mount.snapshot_id is not None and not mount.read_only:
+            raise ValueError(
+                f"file system mount {mount.file_system_id!r} at "
+                f"{mount.mount_path!r} sets snapshot_id without read_only=True: "
+                "snapshot-pinned mounts are read-only"
+            )
 
 
 class FileSystem(BaseModel):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -705,6 +705,7 @@ class Sandbox:
         *,
         read_only: bool = False,
         prefetch: bool = False,
+        snapshot_id: str | None = None,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to this running sandbox.
 
@@ -714,6 +715,8 @@ class Sandbox:
             mount_path: Absolute, unique guest mount path (e.g. ``/mnt/skills``).
             read_only: Mount the file system read-only.
             prefetch: Eagerly download the file system's contents.
+            snapshot_id: Pin the mount to a specific filesystem snapshot.
+                Requires ``read_only=True``.
 
         Returns:
             Traced[SandboxInfo] with this sandbox's updated file systems.
@@ -725,6 +728,7 @@ class Sandbox:
             mount_path,
             read_only=read_only,
             prefetch=prefetch,
+            snapshot_id=snapshot_id,
         )
         self._sandbox_id = traced.sandbox_id
         self._cached_info = traced.value

--- a/tests/filesystem/test_filesystem_unit.py
+++ b/tests/filesystem/test_filesystem_unit.py
@@ -25,7 +25,9 @@ from tensorlake.filesystem import (
     FilesystemInfo,
     FilesystemNotFoundError,
     FilesystemVersion,
+    ReadOnlyMountNotSupportedError,
 )
+from tensorlake.filesystem._cli import FsCli
 from tensorlake.filesystem.client import mount_status_from_raw
 
 _PROJECT = "proj_test"
@@ -522,6 +524,22 @@ class TestFilesystemClient(unittest.TestCase):
             fs.write_file("a.txt", b"x")
         self.assertNotIsInstance(caught.exception, FilesystemAPIError)
         self.assertIn("commit job failed", str(caught.exception))
+
+
+class TestReadOnlyLocalMount(unittest.TestCase):
+    """`tl fs mount` has no --ro; readonly requests must fail honestly."""
+
+    def test_fs_cli_mount_readonly_raises_not_supported(self):
+        with self.assertRaises(ReadOnlyMountNotSupportedError) as caught:
+            FsCli().mount("my-fs", "/tmp/mnt", readonly=True)
+        # The error must point at the supported read-only alternatives.
+        self.assertIn("read_only=True", str(caught.exception))
+        self.assertIn("tl git mount --ro", str(caught.exception))
+
+    def test_client_mount_readonly_raises_not_supported(self):
+        client = _client_with_stub(_StubNative())
+        with self.assertRaises(ReadOnlyMountNotSupportedError):
+            client.mount("my-fs", "/tmp/mnt", readonly=True)
 
 
 if __name__ == "__main__":

--- a/tests/sandbox/test_file_systems.py
+++ b/tests/sandbox/test_file_systems.py
@@ -49,16 +49,25 @@ class _FakeRustClient:
         return None
 
     def attach_file_system(
-        self, *, sandbox_id, file_system_id, mount_path, read_only, prefetch
+        self,
+        *,
+        sandbox_id,
+        file_system_id,
+        mount_path,
+        read_only,
+        prefetch,
+        snapshot_id,
     ):
         self.attach_calls.append(
-            (sandbox_id, file_system_id, mount_path, read_only, prefetch)
+            (sandbox_id, file_system_id, mount_path, read_only, prefetch, snapshot_id)
         )
         mount = {"file_system_id": file_system_id, "mount_path": mount_path}
         if read_only:
             mount["read_only"] = True
         if prefetch:
             mount["prefetch"] = True
+        if snapshot_id is not None:
+            mount["snapshot_id"] = snapshot_id
         return ("trace-attach", _sandbox_info_json([mount]))
 
     def detach_file_system(self, *, sandbox_id, mount_path):
@@ -83,16 +92,25 @@ class _FakeAsyncRustClient:
         return None
 
     async def attach_file_system_async(
-        self, *, sandbox_id, file_system_id, mount_path, read_only, prefetch
+        self,
+        *,
+        sandbox_id,
+        file_system_id,
+        mount_path,
+        read_only,
+        prefetch,
+        snapshot_id,
     ):
         self.attach_calls.append(
-            (sandbox_id, file_system_id, mount_path, read_only, prefetch)
+            (sandbox_id, file_system_id, mount_path, read_only, prefetch, snapshot_id)
         )
         mount = {"file_system_id": file_system_id, "mount_path": mount_path}
         if read_only:
             mount["read_only"] = True
         if prefetch:
             mount["prefetch"] = True
+        if snapshot_id is not None:
+            mount["snapshot_id"] = snapshot_id
         return ("trace-attach", _sandbox_info_json([mount]))
 
     async def claim_sandbox_async(self, **kwargs):
@@ -242,6 +260,46 @@ class TestFileSystemModels(unittest.TestCase):
         self.assertTrue(present.read_only)
         self.assertTrue(present.prefetch)
 
+    def test_file_system_mount_serializes_snapshot_pin_only_when_set(self):
+        unpinned = FileSystemMount(
+            file_system_id="file_system_abc",
+            mount_path="/mnt/skills",
+            read_only=True,
+        )
+        self.assertNotIn("snapshot_id", json.loads(unpinned.model_dump_json()))
+
+        pinned = FileSystemMount(
+            file_system_id="file_system_abc",
+            mount_path="/mnt/skills",
+            read_only=True,
+            snapshot_id="0abc123def",
+        )
+        self.assertEqual(
+            json.loads(pinned.model_dump_json()),
+            {
+                "file_system_id": "file_system_abc",
+                "mount_path": "/mnt/skills",
+                "read_only": True,
+                "snapshot_id": "0abc123def",
+            },
+        )
+
+    def test_file_system_mount_parses_absent_and_present_snapshot_pin(self):
+        absent = FileSystemMount.model_validate(
+            {"file_system_id": "file_system_abc", "mount_path": "/mnt/skills"}
+        )
+        self.assertIsNone(absent.snapshot_id)
+
+        present = FileSystemMount.model_validate(
+            {
+                "file_system_id": "file_system_abc",
+                "mount_path": "/mnt/skills",
+                "read_only": True,
+                "snapshot_id": "0abc123def",
+            }
+        )
+        self.assertEqual(present.snapshot_id, "0abc123def")
+
     def test_create_request_serializes_file_systems_to_wire_key(self):
         request = CreateSandboxRequest(
             resources=CreateSandboxResources(cpus=1.0, memory_mb=1024),
@@ -332,7 +390,7 @@ class TestSandboxClientFileSystems(unittest.TestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", False, False)],
+            [("sbx-1", "file_system_abc", "/mnt/skills", False, False, None)],
         )
         self.assertEqual(traced.trace_id, "trace-attach")
         self.assertEqual(
@@ -358,7 +416,7 @@ class TestSandboxClientFileSystems(unittest.TestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", True, True)],
+            [("sbx-1", "file_system_abc", "/mnt/skills", True, True, None)],
         )
         self.assertEqual(
             traced.value.file_systems,
@@ -371,6 +429,47 @@ class TestSandboxClientFileSystems(unittest.TestCase):
                 )
             ],
         )
+
+    def test_attach_file_system_threads_snapshot_pin(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        traced = client.attach_file_system(
+            "sbx-1",
+            "file_system_abc",
+            "/mnt/skills",
+            read_only=True,
+            snapshot_id="0abc123def",
+        )
+
+        self.assertEqual(
+            fake.attach_calls,
+            [("sbx-1", "file_system_abc", "/mnt/skills", True, False, "0abc123def")],
+        )
+        self.assertEqual(
+            traced.value.file_systems,
+            [
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    read_only=True,
+                    snapshot_id="0abc123def",
+                )
+            ],
+        )
+
+    def test_attach_file_system_rejects_snapshot_pin_without_read_only(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        with self.assertRaisesRegex(ValueError, "snapshot-pinned mounts are read-only"):
+            client.attach_file_system(
+                "sbx-1",
+                "file_system_abc",
+                "/mnt/skills",
+                snapshot_id="0abc123def",
+            )
+        self.assertEqual(fake.attach_calls, [])
 
     def test_detach_file_system(self):
         fake = _FakeRustClient()
@@ -433,6 +532,46 @@ class TestSandboxClientFileSystems(unittest.TestCase):
                 {"file_system_id": "file_system_def", "mount_path": "/mnt/data"},
             ],
         )
+
+    def test_create_body_includes_snapshot_pin_and_rejects_writable_pin(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        client.create(
+            image="python:3.11",
+            file_systems=[
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    read_only=True,
+                    snapshot_id="0abc123def",
+                ),
+            ],
+        )
+        payload = json.loads(fake.create_request_json)
+        self.assertEqual(
+            payload["file_systems"],
+            [
+                {
+                    "file_system_id": "file_system_abc",
+                    "mount_path": "/mnt/skills",
+                    "read_only": True,
+                    "snapshot_id": "0abc123def",
+                }
+            ],
+        )
+
+        with self.assertRaisesRegex(ValueError, "snapshot-pinned mounts are read-only"):
+            client.create(
+                image="python:3.11",
+                file_systems=[
+                    FileSystemMount(
+                        file_system_id="file_system_abc",
+                        mount_path="/mnt/skills",
+                        snapshot_id="0abc123def",
+                    ),
+                ],
+            )
 
     def test_claim_threads_file_systems(self):
         fake = _FakeRustClient()
@@ -498,6 +637,48 @@ class TestSandboxClientFileSystems(unittest.TestCase):
             },
         )
 
+    def test_claim_body_includes_snapshot_pin_and_rejects_writable_pin(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        client.claim(
+            "pool-1",
+            file_systems=[
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    read_only=True,
+                    snapshot_id="0abc123def",
+                ),
+            ],
+        )
+        self.assertEqual(
+            json.loads(fake.claim_calls[0]["request_json"]),
+            {
+                "file_systems": [
+                    {
+                        "file_system_id": "file_system_abc",
+                        "mount_path": "/mnt/skills",
+                        "read_only": True,
+                        "snapshot_id": "0abc123def",
+                    }
+                ]
+            },
+        )
+
+        with self.assertRaisesRegex(ValueError, "snapshot-pinned mounts are read-only"):
+            client.claim(
+                "pool-1",
+                file_systems=[
+                    FileSystemMount(
+                        file_system_id="file_system_abc",
+                        mount_path="/mnt/skills",
+                        snapshot_id="0abc123def",
+                    ),
+                ],
+            )
+        self.assertEqual(len(fake.claim_calls), 1)
+
     def test_claim_without_file_systems_keeps_bodyless_native_call(self):
         fake = _FakeRustClient()
         client = _sync_client(fake)
@@ -518,7 +699,7 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", False, False)],
+            [("sbx-1", "file_system_abc", "/mnt/skills", False, False, None)],
         )
         self.assertEqual(traced.trace_id, "trace-attach")
         self.assertEqual(
@@ -544,7 +725,7 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", True, True)],
+            [("sbx-1", "file_system_abc", "/mnt/skills", True, True, None)],
         )
         self.assertEqual(
             traced.value.file_systems,
@@ -557,6 +738,47 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
                 )
             ],
         )
+
+    async def test_attach_file_system_threads_snapshot_pin(self):
+        fake = _FakeAsyncRustClient()
+        client = _async_client(fake)
+
+        traced = await client.attach_file_system(
+            "sbx-1",
+            "file_system_abc",
+            "/mnt/skills",
+            read_only=True,
+            snapshot_id="0abc123def",
+        )
+
+        self.assertEqual(
+            fake.attach_calls,
+            [("sbx-1", "file_system_abc", "/mnt/skills", True, False, "0abc123def")],
+        )
+        self.assertEqual(
+            traced.value.file_systems,
+            [
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    read_only=True,
+                    snapshot_id="0abc123def",
+                )
+            ],
+        )
+
+    async def test_attach_file_system_rejects_snapshot_pin_without_read_only(self):
+        fake = _FakeAsyncRustClient()
+        client = _async_client(fake)
+
+        with self.assertRaisesRegex(ValueError, "snapshot-pinned mounts are read-only"):
+            await client.attach_file_system(
+                "sbx-1",
+                "file_system_abc",
+                "/mnt/skills",
+                snapshot_id="0abc123def",
+            )
+        self.assertEqual(fake.attach_calls, [])
 
     async def test_claim_threads_file_systems(self):
         fake = _FakeAsyncRustClient()
@@ -576,6 +798,23 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
             json.loads(fake.claim_calls[0]["request_json"])["file_systems"],
             [{"file_system_id": "file_system_abc", "mount_path": "/mnt/skills"}],
         )
+
+    async def test_claim_rejects_writable_snapshot_pin(self):
+        fake = _FakeAsyncRustClient()
+        client = _async_client(fake)
+
+        with self.assertRaisesRegex(ValueError, "snapshot-pinned mounts are read-only"):
+            await client.claim(
+                "pool-1",
+                file_systems=[
+                    FileSystemMount(
+                        file_system_id="file_system_abc",
+                        mount_path="/mnt/skills",
+                        snapshot_id="0abc123def",
+                    ),
+                ],
+            )
+        self.assertEqual(fake.claim_calls, [])
 
 
 class TestFileSystemRegistry(unittest.TestCase):

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -56,16 +56,38 @@ const GPU_MODELS = new Set<string>([
 ]);
 
 /**
+ * Client-side mirror of the server's HTTP 400 for invalid snapshot pins: a
+ * mount that pins `snapshotId` must also be `readOnly`, so callers fail fast
+ * (and offline) instead of round-tripping to the server.
+ */
+function requireReadOnlySnapshotPin(
+  fileSystemId: string,
+  mountPath: string,
+  readOnly: boolean | undefined,
+  snapshotId: string | undefined,
+): void {
+  if (snapshotId != null && readOnly !== true) {
+    throw new SandboxError(
+      `file system mount '${fileSystemId}' at '${mountPath}' sets snapshotId ` +
+        "without readOnly: snapshot-pinned mounts are read-only",
+    );
+  }
+}
+
+/**
  * Map a `FileSystemMount` to its wire form. `read_only` and `prefetch` are
- * included only when `true`: older servers deserialize mount bodies with
- * `deny_unknown_fields` and would reject an explicit `false`.
+ * included only when `true`, and `snapshot_id` only when set: older servers
+ * deserialize mount bodies with `deny_unknown_fields` and would reject an
+ * explicit `false` (or an unknown pin field).
  */
 function fileSystemMountToWire(fs: FileSystemMount): Record<string, unknown> {
+  requireReadOnlySnapshotPin(fs.fileSystemId, fs.mountPath, fs.readOnly, fs.snapshotId);
   return {
     file_system_id: fs.fileSystemId,
     mount_path: fs.mountPath,
     ...(fs.readOnly === true ? { read_only: true } : {}),
     ...(fs.prefetch === true ? { prefetch: true } : {}),
+    ...(fs.snapshotId != null ? { snapshot_id: fs.snapshotId } : {}),
   };
 }
 
@@ -528,6 +550,9 @@ export class SandboxClient {
    *
    * The mount completes asynchronously on the dataplane; the returned
    * `SandboxInfo` already reflects the new entry in `fileSystems`.
+   *
+   * `options.snapshotId` pins the mount to a specific filesystem snapshot
+   * and requires `options.readOnly: true`.
    */
   async attachFileSystem(
     sandboxId: string,
@@ -535,6 +560,12 @@ export class SandboxClient {
     mountPath: string,
     options?: AttachFileSystemOptions,
   ): Promise<Traced<SandboxInfo>> {
+    requireReadOnlySnapshotPin(
+      fileSystemId,
+      mountPath,
+      options?.readOnly,
+      options?.snapshotId,
+    );
     return this.tracedJson<SandboxInfo>(
       () =>
         this.native.attachFileSystem(
@@ -543,6 +574,7 @@ export class SandboxClient {
           mountPath,
           options?.readOnly === true,
           options?.prefetch === true,
+          options?.snapshotId ?? null,
         ),
       "sandboxId",
       { sandboxId, notFoundKind: "sandbox" },

--- a/typescript/src/filesystem-models.ts
+++ b/typescript/src/filesystem-models.ts
@@ -201,6 +201,18 @@ export class MountError extends FilesystemError {
   }
 }
 
+export class ReadOnlyMountNotSupportedError extends MountError {
+  constructor() {
+    super(
+      "read-only local mounts are not supported: `tl fs mount` has no --ro " +
+        "mode. Mount the filesystem into a sandbox read-only instead " +
+        "(readOnly: true / `tl sbx create -f NAME:PATH:ro`), or use " +
+        "`tl git mount --ro` for repositories.",
+    );
+    this.name = "ReadOnlyMountNotSupportedError";
+  }
+}
+
 export class CliNotFoundError extends MountError {
   constructor(detail: string) {
     super(

--- a/typescript/src/filesystem.ts
+++ b/typescript/src/filesystem.ts
@@ -37,6 +37,7 @@ import {
   FilesystemError,
   FilesystemNotFoundError,
   MountError,
+  ReadOnlyMountNotSupportedError,
   fileEntryFromWire,
   mountStatusFromRaw,
   trimSlashes,
@@ -191,10 +192,12 @@ class FsCli {
   // names/paths can never be parsed as CLI flags (e.g. a path literally
   // named "--discard" must stay a path, not become the destructive flag).
   async mount(filesystem: string, localPath: string, readonly: boolean): Promise<void> {
-    const args = ["mount"];
-    if (readonly) args.push("--ro");
-    args.push("--", filesystem, localPath);
-    await this.run(args);
+    if (readonly) {
+      // `tl fs mount` has no --ro flag; shelling it out anyway would surface
+      // an opaque CLI parse error. Fail honestly instead.
+      throw new ReadOnlyMountNotSupportedError();
+    }
+    await this.run(["mount", "--", filesystem, localPath]);
   }
 
   async unmount(localPath: string, discard: boolean): Promise<void> {
@@ -384,7 +387,13 @@ export class FilesystemClient {
 
   // -- local mounts -------------------------------------------------------------
 
-  /** Mount a filesystem to a local path (requires the `tl` CLI). */
+  /**
+   * Mount a filesystem to a local path (requires the `tl` CLI).
+   *
+   * `readonly: true` is not supported for local mounts and throws
+   * {@link ReadOnlyMountNotSupportedError}; use a sandbox read-only mount
+   * (`readOnly: true`) or `tl git mount --ro` instead.
+   */
   async mount(
     name: string,
     localPath: string,
@@ -825,7 +834,13 @@ export class Filesystem {
 
   // -- mounts -------------------------------------------------------------------
 
-  /** Mount this filesystem to a local path (requires the `tl` CLI). */
+  /**
+   * Mount this filesystem to a local path (requires the `tl` CLI).
+   *
+   * `readonly: true` is not supported for local mounts and throws
+   * {@link ReadOnlyMountNotSupportedError}; use a sandbox read-only mount
+   * (`readOnly: true`) or `tl git mount --ro` instead.
+   */
   async mount(localPath: string, readonly = false): Promise<FilesystemMount> {
     return await this.client.mount(this.name, localPath, readonly);
   }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -32,6 +32,7 @@ export {
   FilesystemAPIError,
   MountError,
   CliNotFoundError,
+  ReadOnlyMountNotSupportedError,
 } from "./filesystem-models.js";
 export type {
   FilesystemInfo,

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -115,6 +115,11 @@ export interface NetworkConfig {
  * `readOnly` and `prefetch` are optional mount modes; they are sent on the
  * wire only when `true` (older servers reject unknown mount fields, so
  * `false` is expressed by omission).
+ *
+ * `snapshotId` pins the mount to a specific filesystem snapshot. A pinned
+ * mount must also set `readOnly: true` (the server rejects a writable pin
+ * with HTTP 400). It is sent only when set, for the same compatibility
+ * reason as the mount modes.
  */
 export interface FileSystemMount {
   fileSystemId: string;
@@ -123,6 +128,8 @@ export interface FileSystemMount {
   readOnly?: boolean;
   /** Eagerly download the file system's contents. */
   prefetch?: boolean;
+  /** Pin the mount to a specific filesystem snapshot (requires `readOnly`). */
+  snapshotId?: string;
 }
 
 /** Optional mount modes for attaching a file system to a running sandbox. */
@@ -131,6 +138,8 @@ export interface AttachFileSystemOptions {
   readOnly?: boolean;
   /** Eagerly download the file system's contents. */
   prefetch?: boolean;
+  /** Pin the mount to a specific filesystem snapshot (requires `readOnly`). */
+  snapshotId?: string;
 }
 
 export interface ClaimSandboxOptions {

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -103,6 +103,7 @@ export interface NativeSandboxClient {
     mountPath: string,
     readOnly?: boolean | null,
     prefetch?: boolean | null,
+    snapshotId?: string | null,
   ): Promise<TracedJson>;
   detachFileSystem(
     sandboxId: string,

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -789,7 +789,8 @@ export class Sandbox {
    * Attach a registered file system to this running sandbox at `mountPath`.
    *
    * Returns the updated sandbox info; the new mount appears in
-   * `fileSystems`.
+   * `fileSystems`. `options.snapshotId` pins the mount to a specific
+   * filesystem snapshot and requires `options.readOnly: true`.
    */
   async attachFileSystem(
     fileSystemId: string,

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -868,6 +868,69 @@ describe("SandboxClient", () => {
       client.close();
     });
 
+    it("includes the claim snapshot pin only when set", async () => {
+      const claimSandbox = vi.fn(async () => ({
+        traceId: "t",
+        json: JSON.stringify({ sandbox_id: "sbx-fs", status: "running" }),
+      }));
+      installNativeStub({ client: { claimSandbox } });
+
+      const client = SandboxClient.forLocalhost();
+      await client.claim("pool-1", {
+        fileSystems: [
+          {
+            fileSystemId: "file_system_abc",
+            mountPath: "/mnt/skills",
+            readOnly: true,
+            snapshotId: "0abc123def",
+          },
+          {
+            fileSystemId: "file_system_def",
+            mountPath: "/mnt/data",
+          },
+        ],
+      });
+
+      expect(claimSandbox).toHaveBeenCalledWith(
+        "pool-1",
+        JSON.stringify({
+          file_systems: [
+            {
+              file_system_id: "file_system_abc",
+              mount_path: "/mnt/skills",
+              read_only: true,
+              snapshot_id: "0abc123def",
+            },
+            {
+              file_system_id: "file_system_def",
+              mount_path: "/mnt/data",
+            },
+          ],
+        }),
+      );
+      client.close();
+    });
+
+    it("rejects a claim snapshot pin without readOnly before calling native", async () => {
+      const claimSandbox = vi.fn();
+      installNativeStub({ client: { claimSandbox } });
+
+      const client = SandboxClient.forLocalhost();
+      await expect(
+        client.claim("pool-1", {
+          fileSystems: [
+            {
+              fileSystemId: "file_system_abc",
+              mountPath: "/mnt/skills",
+              snapshotId: "0abc123def",
+            },
+          ],
+        }),
+      ).rejects.toThrow(/snapshot-pinned mounts are read-only/);
+      expect(claimSandbox).not.toHaveBeenCalled();
+      client.close();
+    });
+
     it("returns readiness timeout responses without retrying", async () => {
       const claimSandbox = vi.fn(async () => ({
         traceId: "t",

--- a/typescript/tests/filesystem.test.ts
+++ b/typescript/tests/filesystem.test.ts
@@ -15,6 +15,7 @@ import {
   FilesystemAPIError,
   FilesystemError,
   FilesystemNotFoundError,
+  ReadOnlyMountNotSupportedError,
   fileEntryFromWire,
   mountStatusFromRaw,
   trimSlashes,
@@ -667,5 +668,18 @@ describe("FilesystemClient", () => {
     expect(failure).toBeInstanceOf(FilesystemError);
     expect(failure).not.toBeInstanceOf(FilesystemAPIError);
     expect(String(failure.message)).toContain("commit job failed");
+  });
+
+  // `tl fs mount` has no --ro; readonly requests must fail honestly (before
+  // shelling out) instead of surfacing an opaque CLI parse error.
+  it("mount(readonly: true) throws ReadOnlyMountNotSupportedError", async () => {
+    const client = clientWith(new StubNative());
+    const failure = await client
+      .mount("my-fs", "/tmp/mnt", true)
+      .catch((e) => e);
+    expect(failure).toBeInstanceOf(ReadOnlyMountNotSupportedError);
+    // The error must point at the supported read-only alternatives.
+    expect(String(failure.message)).toContain("readOnly: true");
+    expect(String(failure.message)).toContain("tl git mount --ro");
   });
 });

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -1128,6 +1128,68 @@ describe("Sandbox", () => {
       ]);
     });
 
+    it("create() includes the snapshot pin only when set", async () => {
+      let captured: Record<string, unknown> | undefined;
+      installNativeStub({
+        client: {
+          createSandbox: vi.fn(async (json: string) => {
+            captured = JSON.parse(json);
+            return { traceId: "t", json: fsSandboxInfoBody() };
+          }),
+        },
+      });
+
+      const client = new SandboxClient(
+        { apiUrl: "http://localhost:8900" },
+        /* _internal */ true,
+      );
+      await client.create({
+        fileSystems: [
+          {
+            fileSystemId: "file_system_abc",
+            mountPath: "/mnt/skills",
+            readOnly: true,
+            snapshotId: "0abc123def",
+          },
+          {
+            fileSystemId: "file_system_def",
+            mountPath: "/mnt/data",
+          },
+        ],
+      });
+      expect(captured?.file_systems).toEqual([
+        {
+          file_system_id: "file_system_abc",
+          mount_path: "/mnt/skills",
+          read_only: true,
+          snapshot_id: "0abc123def",
+        },
+        { file_system_id: "file_system_def", mount_path: "/mnt/data" },
+      ]);
+    });
+
+    it("create() rejects a snapshot pin without readOnly before calling native", async () => {
+      const createSandbox = vi.fn();
+      installNativeStub({ client: { createSandbox } });
+
+      const client = new SandboxClient(
+        { apiUrl: "http://localhost:8900" },
+        /* _internal */ true,
+      );
+      await expect(
+        client.create({
+          fileSystems: [
+            {
+              fileSystemId: "file_system_abc",
+              mountPath: "/mnt/skills",
+              snapshotId: "0abc123def",
+            },
+          ],
+        }),
+      ).rejects.toThrow(/snapshot-pinned mounts are read-only/);
+      expect(createSandbox).not.toHaveBeenCalled();
+    });
+
     it("create() omits file_systems when none are provided", async () => {
       let captured: Record<string, unknown> | undefined;
       installNativeStub({
@@ -1269,6 +1331,79 @@ describe("Sandbox", () => {
         { fileSystemId: "file_system_abc", mountPath: "/mnt/skills" },
       ]);
       expect(attachFileSystem).toHaveBeenCalledOnce();
+      sbx.close();
+    });
+
+    it("attachFileSystem() threads the snapshot pin and surfaces it in the response", async () => {
+      const stub = installNativeStub({
+        client: {
+          attachFileSystem: vi.fn(
+            async (
+              sandboxId: string,
+              fileSystemId: string,
+              mountPath: string,
+              readOnly?: boolean,
+              prefetch?: boolean,
+              snapshotId?: string | null,
+            ) => {
+              expect(sandboxId).toBe("sbx-abc");
+              expect(fileSystemId).toBe("file_system_abc");
+              expect(mountPath).toBe("/mnt/skills");
+              expect(readOnly).toBe(true);
+              expect(prefetch).toBe(false);
+              expect(snapshotId).toBe("0abc123def");
+              return {
+                traceId: "t",
+                json: fsSandboxInfoBody({
+                  file_systems: [
+                    {
+                      file_system_id: "file_system_abc",
+                      mount_path: "/mnt/skills",
+                      read_only: true,
+                      snapshot_id: "0abc123def",
+                    },
+                  ],
+                }),
+              };
+            },
+          ),
+        },
+      });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-abc",
+        apiUrl: "http://localhost:8900",
+      });
+      const info = await sbx.attachFileSystem("file_system_abc", "/mnt/skills", {
+        readOnly: true,
+        snapshotId: "0abc123def",
+      });
+      expect(info.fileSystems).toEqual([
+        {
+          fileSystemId: "file_system_abc",
+          mountPath: "/mnt/skills",
+          readOnly: true,
+          snapshotId: "0abc123def",
+        },
+      ]);
+      expect(stub.client.attachFileSystem).toHaveBeenCalledOnce();
+      sbx.close();
+    });
+
+    it("attachFileSystem() rejects a snapshot pin without readOnly before calling native", async () => {
+      const attachFileSystem = vi.fn();
+      installNativeStub({ client: { attachFileSystem } });
+
+      const sbx = await Sandbox.connect({
+        sandboxId: "sbx-abc",
+        apiUrl: "http://localhost:8900",
+      });
+      await expect(
+        sbx.attachFileSystem("file_system_abc", "/mnt/skills", {
+          snapshotId: "0abc123def",
+        }),
+      ).rejects.toThrow(/snapshot-pinned mounts are read-only/);
+      expect(attachFileSystem).not.toHaveBeenCalled();
       sbx.close();
     });
 


### PR DESCRIPTION
## Summary

- `FileSystemMount` gains optional `snapshot_id` (Python/TS/Rust + both native bindings), omitted from wire bodies when unset (old servers are deny_unknown_fields).
- Pins require read-only, validated offline in every language at every entry point (create, warm-pool claim, runtime attach) so users fail fast without a round trip, mirroring the server's 400.
- CLI: `tl sbx create -f 'NAME[@SNAPSHOT]:PATH[:OPTS]'` (`@SNAPSHOT` requires `ro`); `tl sbx fs attach --snapshot <id> --read-only`; mount tables render pinned mounts as `name@snapshot`.
- Honesty fix while touching: the workstation `readonly=True` mount kwargs (Python `FsCli.mount`, TS `FilesystemClient`) previously shelled out to the rejected `tl fs mount --ro` and died on an opaque parse error; they now raise/throw a clear NotSupported pointing at sandbox `read_only` mounts and `tl git mount --ro`.

Companions: compute-engine-internal ADR 0047 PR, artifact_storage#236.

## Validation

Rust 205+12 (+ CLI 275 incl. new parser/body tests), Python 34+22, TypeScript 149, typecheck/eslint/clippy/fmt clean on touched surfaces; pre-existing environment failures verified identical on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)