### PR TITLE
Avoid API key introspection in CLI and SDK clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.110"
+version = "0.5.112"
 dependencies = [
  "anyhow",
  "base64",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.110"
+version = "0.5.112"
 dependencies = [
  "anyhow",
  "base64",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.110"
+version = "0.5.112"
 dependencies = [
  "anyhow",
  "base64",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.110"
+version = "0.5.112"
 dependencies = [
  "anyhow",
  "base64",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.110"
+version = "0.5.112"
 dependencies = [
  "anyhow",
  "napi",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.110"
+version = "0.5.112"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.111"
+version = "0.5.112"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/cli/src/auth/guard.rs
+++ b/crates/cli/src/auth/guard.rs
@@ -41,6 +41,17 @@ pub async fn ensure_auth(ctx: &mut CliContext) -> Result<()> {
     Ok(())
 }
 
+/// Ensure credentials are available for a Platform API route that derives
+/// project scope directly from an API key. PAT callers still need explicit
+/// organization/project context.
+pub async fn ensure_auth_for_api_key_scoped_project(ctx: &mut CliContext) -> Result<()> {
+    ensure_auth(ctx).await?;
+    if ctx.api_key.is_some() {
+        return Ok(());
+    }
+    ensure_auth_and_project(ctx).await
+}
+
 /// Ensure authentication and org/project are available.
 /// Triggers login and/or init flows as needed.
 pub async fn ensure_auth_and_project(ctx: &mut CliContext) -> Result<()> {
@@ -137,4 +148,29 @@ pub async fn ensure_auth_and_project(ctx: &mut CliContext) -> Result<()> {
     *ctx = CliContext::from_resolved(resolved);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_auth_for_api_key_scoped_project;
+    use crate::auth::context::CliContext;
+    use crate::config::resolver::ResolvedConfig;
+
+    #[tokio::test]
+    async fn api_key_scoped_guard_does_not_require_introspection_or_local_scope() {
+        let mut ctx = CliContext::from_resolved(ResolvedConfig {
+            api_url: "http://127.0.0.1:1".to_string(),
+            cloud_url: "https://cloud.tensorlake.ai".to_string(),
+            namespace: "default".to_string(),
+            api_key: Some("tl_apiKey_test".to_string()),
+            personal_access_token: None,
+            organization_id: None,
+            project_id: None,
+            debug: false,
+        });
+
+        ensure_auth_for_api_key_scoped_project(&mut ctx)
+            .await
+            .expect("API-key-scoped routes do not need introspection");
+    }
 }

--- a/crates/cli/src/commands/sbx/image/describe.rs
+++ b/crates/cli/src/commands/sbx/image/describe.rs
@@ -2,7 +2,7 @@ use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
 
 pub async fn run(ctx: &CliContext, name_or_id: &str) -> Result<()> {
-    let (base_url, _, _) = super::templates_base_url(ctx)?;
+    let base_url = super::templates_base_url(ctx)?;
     let client = ctx.client()?;
     let direct_url = format!("{}/{}", base_url, name_or_id);
 

--- a/crates/cli/src/commands/sbx/image/ls.rs
+++ b/crates/cli/src/commands/sbx/image/ls.rs
@@ -5,7 +5,7 @@ use crate::error::Result;
 use crate::output::table::new_table;
 
 pub async fn run(ctx: &CliContext, output_json: bool) -> Result<()> {
-    let (base_url, _, _) = super::templates_base_url(ctx)?;
+    let base_url = super::templates_base_url(ctx)?;
     let client = ctx.client()?;
 
     let items = super::list_all_images(ctx, &client, &base_url).await?;

--- a/crates/cli/src/commands/sbx/image/mod.rs
+++ b/crates/cli/src/commands/sbx/image/mod.rs
@@ -72,8 +72,15 @@ fn is_progress_status(message: &str) -> bool {
         || message.starts_with(UPLOAD_CONTEXT_PROGRESS_PREFIX)
 }
 
-/// Build the sandbox-templates API base URL for the current org/project.
-pub fn templates_base_url(ctx: &CliContext) -> Result<(String, String, String)> {
+/// Build the sandbox-templates API base URL. API keys use the token-scoped
+/// root route; PATs keep the explicitly addressed compatibility route.
+pub fn templates_base_url(ctx: &CliContext) -> Result<String> {
+    if ctx.api_key.is_some() {
+        return Ok(format!(
+            "{}/platform/v1/sandbox-templates",
+            ctx.api_url.trim_end_matches('/')
+        ));
+    }
     let org_id = ctx
         .effective_organization_id()
         .ok_or_else(|| CliError::auth("Organization ID is required for --image"))?;
@@ -86,7 +93,7 @@ pub fn templates_base_url(ctx: &CliContext) -> Result<(String, String, String)> 
         org_id,
         proj_id
     );
-    Ok((base, org_id, proj_id))
+    Ok(base)
 }
 
 pub fn org_and_project(ctx: &CliContext) -> Result<(String, String)> {
@@ -101,6 +108,9 @@ pub fn org_and_project(ctx: &CliContext) -> Result<(String, String)> {
 
 pub fn sandbox_templates_client(ctx: &CliContext) -> Result<SandboxTemplatesClient> {
     let client = ctx.scoped_cloud_client()?;
+    if ctx.api_key.is_some() {
+        return Ok(SandboxTemplatesClient::new_api_key_scoped(client));
+    }
     let (org_id, proj_id) = org_and_project(ctx)?;
     Ok(SandboxTemplatesClient::new(client, org_id, proj_id))
 }
@@ -227,8 +237,41 @@ pub fn absolute_api_url(api_url: &str, next: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{absolute_api_url, item_matches_image_ref};
+    use super::{absolute_api_url, item_matches_image_ref, templates_base_url};
+    use crate::auth::context::CliContext;
+    use crate::config::resolver::ResolvedConfig;
     use serde_json::json;
+
+    fn test_context(api_key: Option<&str>, personal_access_token: Option<&str>) -> CliContext {
+        CliContext::from_resolved(ResolvedConfig {
+            api_url: "https://api.tensorlake.ai/".to_string(),
+            cloud_url: "https://cloud.tensorlake.ai".to_string(),
+            namespace: "default".to_string(),
+            api_key: api_key.map(str::to_string),
+            personal_access_token: personal_access_token.map(str::to_string),
+            organization_id: Some("org-1".to_string()),
+            project_id: Some("proj-1".to_string()),
+            debug: false,
+        })
+    }
+
+    #[test]
+    fn api_key_templates_url_uses_token_scoped_root_route() {
+        let ctx = test_context(Some("tl_apiKey_test"), Some("tl_pat_test"));
+        assert_eq!(
+            templates_base_url(&ctx).unwrap(),
+            "https://api.tensorlake.ai/platform/v1/sandbox-templates"
+        );
+    }
+
+    #[test]
+    fn pat_templates_url_keeps_explicit_project_route() {
+        let ctx = test_context(None, Some("tl_pat_test"));
+        assert_eq!(
+            templates_base_url(&ctx).unwrap(),
+            "https://api.tensorlake.ai/platform/v1/organizations/org-1/projects/proj-1/sandbox-templates"
+        );
+    }
 
     #[test]
     fn item_matches_image_ref_matches_name_or_id() {

--- a/crates/cli/src/commands/sbx/image/rm.rs
+++ b/crates/cli/src/commands/sbx/image/rm.rs
@@ -20,7 +20,7 @@ pub async fn run(ctx: &CliContext, name_or_id: &str) -> Result<()> {
 }
 
 async fn delete_resolved_image(ctx: &CliContext, name_or_id: &str) -> Result<()> {
-    let (base_url, _, _) = super::templates_base_url(ctx)?;
+    let base_url = super::templates_base_url(ctx)?;
     let client = ctx.client()?;
     let item = super::find_image_item_in_paginated_list(ctx, &client, &base_url, name_or_id)
         .await?

--- a/crates/cli/src/commands/secrets.rs
+++ b/crates/cli/src/commands/secrets.rs
@@ -379,6 +379,22 @@ mod tests {
     }
 
     #[test]
+    fn secrets_client_prefers_api_key_over_pat_without_scope_headers() {
+        let raw_request = execute_and_capture_request(test_ctx(
+            "http://unused",
+            Some("tl_apiKey_test"),
+            Some("tl_pat_test"),
+            Some("org-stale"),
+            Some("project-stale"),
+        ));
+
+        assert!(raw_request.contains("authorization: bearer tl_apikey_test"));
+        assert!(!raw_request.contains("authorization: bearer tl_pat_test"));
+        assert!(!raw_request.contains("x-forwarded-organization-id:"));
+        assert!(!raw_request.contains("x-forwarded-project-id:"));
+    }
+
+    #[test]
     fn read_env_file_returns_secret_pairs() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(".env");

--- a/crates/cli/src/commands/secrets.rs
+++ b/crates/cli/src/commands/secrets.rs
@@ -53,18 +53,23 @@ pub async fn set(ctx: &CliContext, env_file: Option<&Path>, pairs: &[String]) ->
 
     let upsert_secrets = parse_secret_pairs(&entries)?;
 
-    let (organization_id, project_id) = org_and_project(ctx)?;
-    let request = UpsertSecretRequest::builder()
-        .organization_id(organization_id)
-        .project_id(project_id)
-        .secrets(UpsertSecret::Multiple(upsert_secrets.clone()))
-        .build()
-        .map_err(|e| CliError::usage(e.to_string()))?;
-
-    secrets_client(ctx)?
-        .upsert(request)
-        .await
-        .map_err(map_set_sdk_error)?;
+    let client = secrets_client(ctx)?;
+    let secrets = UpsertSecret::Multiple(upsert_secrets.clone());
+    if ctx.api_key.is_some() {
+        client
+            .upsert_api_key_scoped(secrets)
+            .await
+            .map_err(map_set_sdk_error)?;
+    } else {
+        let (organization_id, project_id) = org_and_project(ctx)?;
+        let request = UpsertSecretRequest::builder()
+            .organization_id(organization_id)
+            .project_id(project_id)
+            .secrets(secrets)
+            .build()
+            .map_err(|e| CliError::usage(e.to_string()))?;
+        client.upsert(request).await.map_err(map_set_sdk_error)?;
+    }
 
     let count = upsert_secrets.len();
     if count == 1 {
@@ -130,21 +135,32 @@ pub async fn unset(ctx: &CliContext, names: &[String]) -> Result<()> {
         .filter_map(|s| s.get("name").and_then(|n| n.as_str()).map(|name| (name, s)))
         .collect();
 
-    let (organization_id, project_id) = org_and_project(ctx)?;
     let client = secrets_client(ctx)?;
+    let explicit_scope = if ctx.api_key.is_some() {
+        None
+    } else {
+        Some(org_and_project(ctx)?)
+    };
     let mut num = 0;
 
     for name in names {
         if let Some(secret) = secrets_map.get(name.as_str())
             && let Some(id) = secret.get("id").and_then(|v| v.as_str())
         {
-            let request = DeleteSecretRequest::builder()
-                .organization_id(organization_id.clone())
-                .project_id(project_id.clone())
-                .secret_id(id)
-                .build()
-                .map_err(|e| CliError::usage(e.to_string()))?;
-            client.delete(&request).await.map_err(map_unset_sdk_error)?;
+            if let Some((organization_id, project_id)) = &explicit_scope {
+                let request = DeleteSecretRequest::builder()
+                    .organization_id(organization_id)
+                    .project_id(project_id)
+                    .secret_id(id)
+                    .build()
+                    .map_err(|e| CliError::usage(e.to_string()))?;
+                client.delete(&request).await.map_err(map_unset_sdk_error)?;
+            } else {
+                client
+                    .delete_api_key_scoped(id)
+                    .await
+                    .map_err(map_unset_sdk_error)?;
+            }
             num += 1;
         }
     }
@@ -158,17 +174,20 @@ pub async fn unset(ctx: &CliContext, names: &[String]) -> Result<()> {
 }
 
 async fn get_all_secrets(ctx: &CliContext) -> Result<Vec<serde_json::Value>> {
-    let (organization_id, project_id) = org_and_project(ctx)?;
-    let request = ListSecretsRequest::builder()
-        .organization_id(organization_id)
-        .project_id(project_id)
-        .page_size(100)
-        .build()
-        .map_err(|e| CliError::usage(e.to_string()))?;
-    let resp = secrets_client(ctx)?
-        .list(&request)
-        .await
-        .map_err(map_list_sdk_error)?;
+    let client = secrets_client(ctx)?;
+    let resp = if ctx.api_key.is_some() {
+        client.list_api_key_scoped(Some(100)).await
+    } else {
+        let (organization_id, project_id) = org_and_project(ctx)?;
+        let request = ListSecretsRequest::builder()
+            .organization_id(organization_id)
+            .project_id(project_id)
+            .page_size(100)
+            .build()
+            .map_err(|e| CliError::usage(e.to_string()))?;
+        client.list(&request).await
+    }
+    .map_err(map_list_sdk_error)?;
 
     Ok(resp
         .items

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -34,7 +34,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::num::NonZeroUsize;
 
 use auth::context::CliContext;
-use auth::guard::{ensure_auth, ensure_auth_and_project};
+use auth::guard::{ensure_auth, ensure_auth_and_project, ensure_auth_for_api_key_scoped_project};
 use config::resolver;
 use error::CliError;
 
@@ -2044,7 +2044,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
         Commands::App(subcmd) => run_app_command(ctx, subcmd).await,
         Commands::Cron(subcmd) => run_cron_command(ctx, subcmd).await,
         Commands::Secrets(subcmd) => {
-            ensure_auth_and_project(ctx).await?;
+            ensure_auth_for_api_key_scoped_project(ctx).await?;
             match subcmd {
                 SecretsCommands::Ls => commands::secrets::list(ctx).await,
                 SecretsCommands::Set { env_file, secrets } => {
@@ -2098,7 +2098,11 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                 }
             }
             other => {
-                ensure_auth_and_project(ctx).await?;
+                if matches!(&other, SbxCommands::Image(_)) {
+                    ensure_auth_for_api_key_scoped_project(ctx).await?;
+                } else {
+                    ensure_auth_and_project(ctx).await?;
+                }
                 match other {
                     SbxCommands::Ls {
                         all,

--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -566,7 +566,14 @@ fn new_base_client(
 
 #[cfg(test)]
 mod tests {
-    use super::ensure_rustls_provider;
+    use super::{ClientBuilder, ensure_rustls_provider};
+    use reqwest::Method;
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        sync::mpsc,
+        thread,
+    };
 
     #[test]
     fn installs_rustls_provider() {
@@ -575,5 +582,45 @@ mod tests {
             rustls::crypto::CryptoProvider::get_default().is_some(),
             "rustls crypto provider should be installed"
         );
+    }
+
+    #[test]
+    fn api_key_bearer_is_preserved_for_proxy_without_implicit_scope_headers() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("listener address");
+        let (tx, rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("connection");
+            let mut buffer = [0_u8; 4096];
+            let bytes_read = stream.read(&mut buffer).expect("request");
+            tx.send(String::from_utf8_lossy(&buffer[..bytes_read]).to_string())
+                .expect("captured request");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .expect("response");
+        });
+
+        let api_url = format!("http://{address}");
+        let client = ClientBuilder::new(&api_url)
+            .bearer_token("tl_apiKey_test")
+            .build()
+            .expect("client");
+        let proxy_client = client
+            .with_base_url_without_timeout(&api_url)
+            .expect("proxy client");
+        let request = proxy_client
+            .request(Method::POST, "/sandbox-proxy/processes")
+            .build()
+            .expect("request");
+        tokio::runtime::Runtime::new()
+            .expect("runtime")
+            .block_on(proxy_client.execute_raw(request))
+            .expect("response");
+        let raw_request = rx.recv().expect("captured request").to_lowercase();
+        server.join().expect("server");
+
+        assert!(raw_request.contains("authorization: bearer tl_apikey_test"));
+        assert!(!raw_request.contains("x-forwarded-organization-id:"));
+        assert!(!raw_request.contains("x-forwarded-project-id:"));
     }
 }

--- a/crates/cloud-sdk/src/image_service_builds.rs
+++ b/crates/cloud-sdk/src/image_service_builds.rs
@@ -32,7 +32,7 @@ use crate::{
     sandbox_images::{
         CommonBuildOptions, DockerfileBuildPlan, SandboxImageBuildError, SandboxImageBuildEvent,
         SandboxImageContextFile, client_builder, collect_dir_files, follow_started_process_output,
-        is_localhost, normalize_context_file_path, resolve_build_context,
+        is_localhost, normalize_context_file_path, resolve_image_service_build_context,
         resolved_docker_config_json, sandbox_lifecycle_client, sandbox_proxy_client,
     },
     sandboxes::{SandboxesClient, models::ProcessInfo},
@@ -101,14 +101,17 @@ where
             "Forwarding local registry credentials to the build".to_string(),
         ));
     }
-    let ctx = resolve_build_context(options).await?;
-    let project = ctx.project_id.clone();
+    let ctx = resolve_image_service_build_context(options).await?;
+    let project = ctx
+        .project_id
+        .clone()
+        .expect("Image Service context always resolves a project");
     let image_service_url = image_service_url(&ctx.api_url);
     let client = client_builder(
         &image_service_url,
         &ctx.bearer_token,
         ctx.use_scope_headers,
-        Some(&ctx.organization_id),
+        ctx.organization_id.as_deref(),
         Some(&project),
         ctx.user_agent.as_deref(),
     )
@@ -1513,8 +1516,8 @@ mod tests {
             api_url: api_url.to_string(),
             bearer_token: "token".to_string(),
             use_scope_headers: false,
-            organization_id: "organization-1".to_string(),
-            project_id: "project-1".to_string(),
+            organization_id: Some("organization-1".to_string()),
+            project_id: Some("project-1".to_string()),
             namespace: "default".to_string(),
             user_agent: None,
         }

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -305,6 +305,14 @@ impl Sdk {
         )
     }
 
+    /// Get a sandbox-template client scoped by the authenticated API key.
+    ///
+    /// Unlike [`Sdk::sandbox_templates`], this client uses the token-scoped
+    /// Platform API routes and does not need organization/project discovery.
+    pub fn sandbox_templates_for_api_key(&self) -> SandboxTemplatesClient {
+        SandboxTemplatesClient::new_api_key_scoped(self.client.clone())
+    }
+
     /// Get a client for managing the project-scoped file-system registry.
     pub fn file_systems(&self, organization_id: &str, project_id: &str) -> FileSystemsClient {
         FileSystemsClient::new(
@@ -352,18 +360,14 @@ impl Sdk {
     /// # Example
     ///
     /// ```rust,no_run
-    /// use tensorlake::{Sdk, secrets::models::ListSecretsRequest};
+    /// use tensorlake::Sdk;
     ///
     /// async fn example() -> Result<(), Box<dyn std::error::Error>> {
     ///     let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key")?;
     ///     let secrets_client = sdk.secrets();
     ///
-    ///     // Use the secrets client
-    ///     let request = ListSecretsRequest::builder()
-    ///         .organization_id("org-id".to_string())
-    ///         .project_id("project-id".to_string())
-    ///         .build()?;
-    ///     secrets_client.list(&request).await?;
+    ///     // API keys use the token-scoped route directly.
+    ///     secrets_client.list_api_key_scoped(Some(100)).await?;
     ///     Ok(())
     /// }
     /// ```

--- a/crates/cloud-sdk/src/sandbox_images.rs
+++ b/crates/cloud-sdk/src/sandbox_images.rs
@@ -279,8 +279,8 @@ pub(crate) struct ResolvedBuildContext {
     pub(crate) api_url: String,
     pub(crate) bearer_token: String,
     pub(crate) use_scope_headers: bool,
-    pub(crate) organization_id: String,
-    pub(crate) project_id: String,
+    pub(crate) organization_id: Option<String>,
+    pub(crate) project_id: Option<String>,
     pub(crate) namespace: String,
     pub(crate) user_agent: Option<String>,
 }
@@ -544,7 +544,7 @@ where
         ));
     }
 
-    let ctx = resolve_build_context(options.clone()).await?;
+    let ctx = resolve_build_context(options.clone())?;
 
     emit(SandboxImageBuildEvent::Status(
         "Preparing rootfs build...".to_string(),
@@ -766,13 +766,10 @@ where
     })
 }
 
-pub(crate) async fn resolve_build_context(
-    options: CommonBuildOptions,
-) -> Result<ResolvedBuildContext> {
-    let client = unscoped_client(&options)?;
+pub(crate) fn resolve_build_context(options: CommonBuildOptions) -> Result<ResolvedBuildContext> {
     let (organization_id, project_id) = if options.use_scope_headers {
         match (options.organization_id.clone(), options.project_id.clone()) {
-            (Some(organization_id), Some(project_id)) => (organization_id, project_id),
+            (Some(organization_id), Some(project_id)) => (Some(organization_id), Some(project_id)),
             _ => {
                 return Err(SandboxImageBuildError::auth(
                     "Organization ID and project ID are required for sandbox image builds with PAT authentication",
@@ -780,8 +777,10 @@ pub(crate) async fn resolve_build_context(
             }
         }
     } else {
-        let scope = introspect_scope(&client).await?;
-        (scope.organization_id, scope.project_id)
+        // API keys are self-scoping. Platform template/build routes derive the
+        // exact project from the bearer credential, so no introspection or
+        // local organization/project value is needed.
+        (None, None)
     };
 
     Ok(ResolvedBuildContext {
@@ -790,6 +789,30 @@ pub(crate) async fn resolve_build_context(
         use_scope_headers: options.use_scope_headers,
         organization_id,
         project_id,
+        namespace: options.namespace,
+        user_agent: options.user_agent,
+    })
+}
+
+/// Resolve an explicit project for the CAS Image Service, whose current API
+/// still carries the project identifier in request bodies and query strings.
+/// The token-scoped Platform API path above intentionally avoids this lookup;
+/// this compatibility resolver is only used by CAS builds.
+pub(crate) async fn resolve_image_service_build_context(
+    options: CommonBuildOptions,
+) -> Result<ResolvedBuildContext> {
+    if options.use_scope_headers {
+        return resolve_build_context(options);
+    }
+
+    let client = unscoped_client(&options)?;
+    let scope = introspect_scope(&client).await?;
+    Ok(ResolvedBuildContext {
+        api_url: options.api_url,
+        bearer_token: options.bearer_token,
+        use_scope_headers: false,
+        organization_id: Some(scope.organization_id),
+        project_id: Some(scope.project_id),
         namespace: options.namespace,
         user_agent: options.user_agent,
     })
@@ -834,8 +857,8 @@ fn platform_client(ctx: &ResolvedBuildContext) -> Result<Client> {
         &ctx.api_url,
         &ctx.bearer_token,
         ctx.use_scope_headers,
-        Some(&ctx.organization_id),
-        Some(&ctx.project_id),
+        ctx.organization_id.as_deref(),
+        ctx.project_id.as_deref(),
         ctx.user_agent.as_deref(),
     )
     .build()
@@ -848,8 +871,8 @@ pub(crate) fn sandbox_lifecycle_client(ctx: &ResolvedBuildContext) -> Result<Cli
         &lifecycle_url,
         &ctx.bearer_token,
         ctx.use_scope_headers,
-        Some(&ctx.organization_id),
-        Some(&ctx.project_id),
+        ctx.organization_id.as_deref(),
+        ctx.project_id.as_deref(),
         ctx.user_agent.as_deref(),
     )
     .build()
@@ -992,11 +1015,23 @@ async fn prepare_rootfs_build(
     // registry. The final-stage FROM is treated separately so its resolution
     // becomes the lineage parent; the additional references (earlier stages,
     // COPY --from, RUN --mount=,from) become preload-only local images.
-    let templates = crate::sandbox_templates::SandboxTemplatesClient::new(
-        client.clone(),
-        ctx.organization_id.clone(),
-        ctx.project_id.clone(),
-    );
+    let templates = match (&ctx.organization_id, &ctx.project_id) {
+        (Some(organization_id), Some(project_id)) => {
+            crate::sandbox_templates::SandboxTemplatesClient::new(
+                client.clone(),
+                organization_id.clone(),
+                project_id.clone(),
+            )
+        }
+        (None, None) => {
+            crate::sandbox_templates::SandboxTemplatesClient::new_api_key_scoped(client.clone())
+        }
+        _ => {
+            return Err(SandboxImageBuildError::auth(
+                "Sandbox image build scope is incomplete",
+            ));
+        }
+    };
 
     // Skip the lookup when the final-stage FROM is `FROM <stage-alias>` —
     // the value is an internal reference to an earlier-defined stage, not
@@ -1130,10 +1165,13 @@ async fn complete_rootfs_build(
 }
 
 fn sandbox_template_builds_path(ctx: &ResolvedBuildContext) -> String {
-    format!(
-        "/platform/v1/organizations/{}/projects/{}/sandbox-template-builds",
-        ctx.organization_id, ctx.project_id
-    )
+    match (&ctx.organization_id, &ctx.project_id) {
+        (Some(organization_id), Some(project_id)) => format!(
+            "/platform/v1/organizations/{organization_id}/projects/{project_id}/sandbox-template-builds"
+        ),
+        (None, None) => "/platform/v1/sandbox-template-builds".to_string(),
+        _ => unreachable!("resolved build context validates scope pairs"),
+    }
 }
 
 fn sandbox_proxy_base(
@@ -3108,15 +3146,16 @@ mod tests {
         assert!(message.contains("rootfs builder exited with status 1"));
     }
     use super::{
-        BuilderFailureDiagnostics, CompleteSandboxTemplateBuildRequest, PreparedRootfsBuilder,
-        PreparedRootfsParent, PreparedSandboxTemplateBuild, SandboxImageBuildError,
-        SandboxImageBuildEvent, SandboxImageContextFile, build_rootfs_spec, collect_dir_files,
-        complete_request_from_metadata, contains_disk_space_evidence, contains_oom_killer_evidence,
-        create_context_archive, default_registered_name, load_dockerfile_plan,
-        load_dockerfile_text_plan, logical_dockerfile_lines, normalize_posix,
+        BuilderFailureDiagnostics, CommonBuildOptions, CompleteSandboxTemplateBuildRequest,
+        PreparedRootfsBuilder, PreparedRootfsParent, PreparedSandboxTemplateBuild,
+        SandboxImageBuildError, SandboxImageBuildEvent, SandboxImageContextFile, build_rootfs_spec,
+        collect_dir_files, complete_request_from_metadata, contains_disk_space_evidence,
+        contains_oom_killer_evidence, create_context_archive, default_registered_name,
+        load_dockerfile_plan, load_dockerfile_text_plan, logical_dockerfile_lines, normalize_posix,
         parse_df_line_usage_percent, parse_df_max_usage_percent, prepare_request_body,
-        process_terminal_status, rootfs_builder_env, rootfs_builder_executable, rootfs_disk_bytes,
-        rootfs_disk_bytes_to_mb, sandbox_proxy_base_with_explicit, splice_signed_upload,
+        process_terminal_status, resolve_build_context, rootfs_builder_env,
+        rootfs_builder_executable, rootfs_disk_bytes, rootfs_disk_bytes_to_mb,
+        sandbox_proxy_base_with_explicit, sandbox_template_builds_path, splice_signed_upload,
         streaming_process_payload, template_build_payload, upload_percent,
     };
     use crate::sandboxes::models::ProcessInfo;
@@ -3124,6 +3163,48 @@ mod tests {
     use std::fs::File;
     use std::io::{Read, Write};
     use std::path::PathBuf;
+
+    fn common_build_options(use_scope_headers: bool) -> CommonBuildOptions {
+        CommonBuildOptions {
+            api_url: "https://api.tensorlake.ai".to_string(),
+            bearer_token: "token".to_string(),
+            use_scope_headers,
+            organization_id: Some("org-1".to_string()),
+            project_id: Some("proj-1".to_string()),
+            namespace: "default".to_string(),
+            registered_name: Some("image".to_string()),
+            disk_mb: None,
+            builder_disk_mb: None,
+            cpus: None,
+            memory_mb: None,
+            is_public: false,
+            cas: false,
+            user_agent: None,
+            docker_compat: false,
+        }
+    }
+
+    #[test]
+    fn api_key_build_context_uses_token_scoped_route_without_local_scope() {
+        let context = resolve_build_context(common_build_options(false)).unwrap();
+        assert_eq!(context.organization_id, None);
+        assert_eq!(context.project_id, None);
+        assert_eq!(
+            sandbox_template_builds_path(&context),
+            "/platform/v1/sandbox-template-builds"
+        );
+    }
+
+    #[test]
+    fn pat_build_context_keeps_explicit_project_route() {
+        let context = resolve_build_context(common_build_options(true)).unwrap();
+        assert_eq!(context.organization_id.as_deref(), Some("org-1"));
+        assert_eq!(context.project_id.as_deref(), Some("proj-1"));
+        assert_eq!(
+            sandbox_template_builds_path(&context),
+            "/platform/v1/organizations/org-1/projects/proj-1/sandbox-template-builds"
+        );
+    }
 
     #[test]
     fn oom_dmesg_parser_detects_kernel_oom_entries() {

--- a/crates/cloud-sdk/src/sandbox_templates/mod.rs
+++ b/crates/cloud-sdk/src/sandbox_templates/mod.rs
@@ -47,8 +47,7 @@ fn next_request_path(next: &str) -> String {
 #[derive(Clone)]
 pub struct SandboxTemplatesClient {
     client: Client,
-    organization_id: String,
-    project_id: String,
+    scope: Option<(String, String)>,
 }
 
 impl SandboxTemplatesClient {
@@ -59,16 +58,27 @@ impl SandboxTemplatesClient {
     ) -> Self {
         Self {
             client,
-            organization_id: organization_id.into(),
-            project_id: project_id.into(),
+            scope: Some((organization_id.into(), project_id.into())),
+        }
+    }
+
+    /// Create a client whose project scope is derived from the authenticated
+    /// API key. This uses the token-scoped Platform API routes and avoids a
+    /// separate key-introspection request.
+    pub fn new_api_key_scoped(client: Client) -> Self {
+        Self {
+            client,
+            scope: None,
         }
     }
 
     fn endpoint(&self) -> String {
-        format!(
-            "/platform/v1/organizations/{}/projects/{}/sandbox-templates",
-            self.organization_id, self.project_id
-        )
+        match &self.scope {
+            Some((organization_id, project_id)) => format!(
+                "/platform/v1/organizations/{organization_id}/projects/{project_id}/sandbox-templates"
+            ),
+            None => "/platform/v1/sandbox-templates".to_string(),
+        }
     }
 
     pub async fn create(
@@ -144,7 +154,18 @@ impl SandboxTemplatesClient {
 
 #[cfg(test)]
 mod tests {
-    use super::next_request_path;
+    use super::{SandboxTemplatesClient, next_request_path};
+    use crate::ClientBuilder;
+
+    #[test]
+    fn api_key_scoped_client_uses_root_endpoint() {
+        let client = ClientBuilder::new("https://api.tensorlake.ai")
+            .bearer_token("tl_apiKey_test")
+            .build()
+            .unwrap();
+        let templates = SandboxTemplatesClient::new_api_key_scoped(client);
+        assert_eq!(templates.endpoint(), "/platform/v1/sandbox-templates");
+    }
 
     #[test]
     fn next_request_path_keeps_absolute_path_and_query() {

--- a/crates/cloud-sdk/src/secrets/mod.rs
+++ b/crates/cloud-sdk/src/secrets/mod.rs
@@ -5,26 +5,18 @@
 //! ## Usage
 //!
 //! ```rust
-//! use tensorlake::{Sdk, secrets::models::{UpsertSecretRequest, ListSecretsRequest}};
+//! use tensorlake::{Sdk, secrets::models::UpsertSecret};
 //!
 //! async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //!     let sdk = Sdk::new("https://api.tensorlake.ai", "your-api-key")?;
 //!     let secrets_client = sdk.secrets();
 //!
-//!     // Create a secret
-//!     let create_req = UpsertSecretRequest::builder()
-//!         .organization_id("org-id")
-//!         .project_id("project-id")
-//!         .secrets(("my-secret", "secret-value"))
-//!         .build()?;
-//!     secrets_client.upsert(create_req).await?;
-//!
-//!     // List secrets
-//!     let list_req = ListSecretsRequest::builder()
-//!         .organization_id("org-id")
-//!         .project_id("project-id")
-//!         .build()?;
-//!     secrets_client.list(&list_req).await?;
+//!     // API keys derive the project from the bearer credential, so no
+//!     // introspection or local org/project IDs are needed.
+//!     secrets_client
+//!         .upsert_api_key_scoped(UpsertSecret::from(("my-secret", "secret-value")))
+//!         .await?;
+//!     secrets_client.list_api_key_scoped(Some(100)).await?;
 //!     Ok(())
 //! }
 //! ```
@@ -75,13 +67,29 @@ impl SecretsClient {
         &self,
         request: UpsertSecretRequest,
     ) -> Result<Traced<UpsertSecretResponse>, SdkError> {
-        let uri_str = format!(
+        let path = format!(
             "/platform/v1/organizations/{}/projects/{}/secrets",
             request.organization_id, request.project_id
         );
+        self.upsert_at(&path, request.secrets).await
+    }
+
+    /// Upsert secrets in the project bound to the authenticated API key.
+    pub async fn upsert_api_key_scoped(
+        &self,
+        secrets: UpsertSecret,
+    ) -> Result<Traced<UpsertSecretResponse>, SdkError> {
+        self.upsert_at("/platform/v1/secrets", secrets).await
+    }
+
+    async fn upsert_at(
+        &self,
+        path: &str,
+        secrets: UpsertSecret,
+    ) -> Result<Traced<UpsertSecretResponse>, SdkError> {
         let req = self
             .client
-            .build_post_json_request(Method::PUT, &uri_str, &request.secrets)?;
+            .build_post_json_request(Method::PUT, path, &secrets)?;
         self.client.execute_json(req).await
     }
 
@@ -90,20 +98,44 @@ impl SecretsClient {
         &self,
         request: &models::ListSecretsRequest,
     ) -> Result<Traced<SecretsList>, SdkError> {
-        let uri_str = format!(
+        let path = format!(
             "/platform/v1/organizations/{}/projects/{}/secrets",
             request.organization_id, request.project_id
         );
+        self.list_at(
+            &path,
+            request.next.as_deref(),
+            request.prev.as_deref(),
+            request.page_size,
+        )
+        .await
+    }
 
-        let mut req_builder = self.client.request(Method::GET, &uri_str);
+    /// List secrets in the project bound to the authenticated API key.
+    pub async fn list_api_key_scoped(
+        &self,
+        page_size: Option<i32>,
+    ) -> Result<Traced<SecretsList>, SdkError> {
+        self.list_at("/platform/v1/secrets", None, None, page_size)
+            .await
+    }
 
-        if let Some(param_value) = &request.next {
+    async fn list_at(
+        &self,
+        path: &str,
+        next: Option<&str>,
+        prev: Option<&str>,
+        page_size: Option<i32>,
+    ) -> Result<Traced<SecretsList>, SdkError> {
+        let mut req_builder = self.client.request(Method::GET, path);
+
+        if let Some(param_value) = next {
             req_builder = req_builder.query(&[("next", param_value)]);
         }
-        if let Some(param_value) = &request.prev {
+        if let Some(param_value) = prev {
             req_builder = req_builder.query(&[("prev", param_value)]);
         }
-        if let Some(param_value) = request.page_size {
+        if let Some(param_value) = page_size {
             req_builder = req_builder.query(&[("pageSize", param_value)]);
         }
 
@@ -124,6 +156,13 @@ impl SecretsClient {
         self.client.execute_json(req).await
     }
 
+    /// Get a secret in the project bound to the authenticated API key.
+    pub async fn get_api_key_scoped(&self, secret_id: &str) -> Result<Traced<Secret>, SdkError> {
+        let path = format!("/platform/v1/secrets/{}", urlencoding::encode(secret_id));
+        let req = self.client.request(Method::GET, &path).build()?;
+        self.client.execute_json(req).await
+    }
+
     /// Delete a secret.
     pub async fn delete(
         &self,
@@ -137,6 +176,13 @@ impl SecretsClient {
             .client
             .request(reqwest::Method::DELETE, &uri_str)
             .build()?;
+        Ok(self.client.execute_traced(req).await?.map(|_| ()))
+    }
+
+    /// Delete a secret in the project bound to the authenticated API key.
+    pub async fn delete_api_key_scoped(&self, secret_id: &str) -> Result<Traced<()>, SdkError> {
+        let path = format!("/platform/v1/secrets/{}", urlencoding::encode(secret_id));
+        let req = self.client.request(Method::DELETE, &path).build()?;
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 }

--- a/crates/cloud-sdk/tests/secrets.rs
+++ b/crates/cloud-sdk/tests/secrets.rs
@@ -1,8 +1,83 @@
 use tensorlake::secrets::models::*;
+use tensorlake::{ClientBuilder, secrets::SecretsClient};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
 
 use crate::common::random_string;
 
 mod common;
+
+#[tokio::test]
+async fn api_key_scoped_secrets_use_root_routes_without_introspection() {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let address = listener.local_addr().expect("listener address");
+
+    let server = tokio::spawn(async move {
+        let mut requests = Vec::new();
+
+        let (mut socket, _) = listener.accept().await.expect("accept list request");
+        requests.push(read_http_request(&mut socket).await);
+        write_json_response(
+            &mut socket,
+            r#"{"items":[],"pagination":{"next":null,"prev":null,"total":0}}"#,
+        )
+        .await;
+
+        let (mut socket, _) = listener.accept().await.expect("accept upsert request");
+        requests.push(read_http_request(&mut socket).await);
+        write_json_response(
+            &mut socket,
+            r#"{"id":"secret/1","name":"TOKEN","createdAt":"2026-08-20T00:00:00Z"}"#,
+        )
+        .await;
+
+        let (mut socket, _) = listener.accept().await.expect("accept delete request");
+        requests.push(read_http_request(&mut socket).await);
+        socket
+            .write_all(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
+            .await
+            .expect("write delete response");
+
+        requests
+    });
+
+    let client = ClientBuilder::new(&format!("http://{address}"))
+        .bearer_token("tl_apiKey_test")
+        .build()
+        .expect("build client");
+    let secrets = SecretsClient::new(client);
+
+    secrets
+        .list_api_key_scoped(Some(100))
+        .await
+        .expect("list secrets");
+    secrets
+        .upsert_api_key_scoped(UpsertSecret::from(("TOKEN", "value")))
+        .await
+        .expect("upsert secret");
+    secrets
+        .delete_api_key_scoped("secret/1")
+        .await
+        .expect("delete secret");
+
+    let requests = server.await.expect("server join");
+    let requests: Vec<String> = requests
+        .iter()
+        .map(|request| String::from_utf8_lossy(request).to_string())
+        .collect();
+    assert!(requests[0].starts_with("GET /platform/v1/secrets?pageSize=100 HTTP/1.1\r\n"));
+    assert!(requests[1].starts_with("PUT /platform/v1/secrets HTTP/1.1\r\n"));
+    assert!(requests[2].starts_with("DELETE /platform/v1/secrets/secret%2F1 HTTP/1.1\r\n"));
+    for request in requests {
+        let request = request.to_lowercase();
+        assert!(request.contains("authorization: bearer tl_apikey_test"));
+        assert!(!request.contains("/platform/v1/keys/introspect"));
+        assert!(!request.contains("x-forwarded-organization-id:"));
+        assert!(!request.contains("x-forwarded-project-id:"));
+    }
+}
 
 #[tokio::test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
@@ -187,4 +262,34 @@ async fn test_secrets_operations() {
     if let Err(err) = result {
         panic!("{err}");
     }
+}
+
+async fn write_json_response(socket: &mut tokio::net::TcpStream, body: &str) {
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    socket
+        .write_all(response.as_bytes())
+        .await
+        .expect("write response");
+}
+
+async fn read_http_request(socket: &mut tokio::net::TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut buf = [0_u8; 4096];
+
+    loop {
+        let read = socket.read(&mut buf).await.expect("read request");
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&buf[..read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    request
 }

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.111"
+version = "0.5.112"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.111"
+version = "0.5.112"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -189,20 +189,33 @@ impl CloudApiClient {
     /// Look up a registered sandbox image (template) by name.
     ///
     /// Returns the template JSON, or `None` when no image with that name
-    /// exists. Routed through the platform sandbox-templates API, which
-    /// requires the organization/project scope passed here.
+    /// exists. When organization/project are both omitted, the authenticated
+    /// API key supplies the scope through the token-scoped Platform API route.
     fn find_sandbox_image_by_name(
         &self,
-        organization_id: String,
-        project_id: String,
+        organization_id: Option<String>,
+        project_id: Option<String>,
         image_name: String,
     ) -> PyResult<Option<String>> {
+        let scope = match (organization_id, project_id) {
+            (Some(organization_id), Some(project_id)) => Some((organization_id, project_id)),
+            (None, None) => None,
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "organization_id and project_id must be provided together",
+                ));
+            }
+        };
         self.run_with_retry(5, move |client| {
-            let organization_id = organization_id.clone();
-            let project_id = project_id.clone();
+            let scope = scope.clone();
             let image_name = image_name.clone();
             async move {
-                let templates = SandboxTemplatesClient::new(client, organization_id, project_id);
+                let templates = match scope {
+                    Some((organization_id, project_id)) => {
+                        SandboxTemplatesClient::new(client, organization_id, project_id)
+                    }
+                    None => SandboxTemplatesClient::new_api_key_scoped(client),
+                };
                 match templates.find_by_name(&image_name).await? {
                     Some(traced) => {
                         let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
@@ -216,14 +229,31 @@ impl CloudApiClient {
 
     /// List all registered sandbox images (templates) for the given scope.
     ///
-    /// Returns a JSON array of templates. Routed through the platform
-    /// sandbox-templates API, which requires the organization/project scope.
-    fn list_sandbox_images(&self, organization_id: String, project_id: String) -> PyResult<String> {
+    /// Returns a JSON array of templates. When organization/project are both
+    /// omitted, the authenticated API key supplies the scope.
+    fn list_sandbox_images(
+        &self,
+        organization_id: Option<String>,
+        project_id: Option<String>,
+    ) -> PyResult<String> {
+        let scope = match (organization_id, project_id) {
+            (Some(organization_id), Some(project_id)) => Some((organization_id, project_id)),
+            (None, None) => None,
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "organization_id and project_id must be provided together",
+                ));
+            }
+        };
         self.run_with_retry(5, move |client| {
-            let organization_id = organization_id.clone();
-            let project_id = project_id.clone();
+            let scope = scope.clone();
             async move {
-                let templates = SandboxTemplatesClient::new(client, organization_id, project_id);
+                let templates = match scope {
+                    Some((organization_id, project_id)) => {
+                        SandboxTemplatesClient::new(client, organization_id, project_id)
+                    }
+                    None => SandboxTemplatesClient::new_api_key_scoped(client),
+                };
                 let traced = templates.list().await?;
                 serde_json::to_string(&*traced).map_err(SdkError::from)
             }
@@ -1280,17 +1310,26 @@ impl CloudApiClient {
         })
     }
 
-    #[pyo3(signature = (organization_id, project_id, page_size=100))]
+    #[pyo3(signature = (organization_id=None, project_id=None, page_size=100))]
     fn list_secrets_json(
         &self,
-        organization_id: String,
-        project_id: String,
+        organization_id: Option<String>,
+        project_id: Option<String>,
         page_size: i32,
     ) -> PyResult<String> {
-        self.run_with_retry(5, move |client| {
-            let path = format!(
+        let path = match (organization_id, project_id) {
+            (Some(organization_id), Some(project_id)) => format!(
                 "/platform/v1/organizations/{organization_id}/projects/{project_id}/secrets"
-            );
+            ),
+            (None, None) => "/platform/v1/secrets".to_string(),
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "organization_id and project_id must be provided together",
+                ));
+            }
+        };
+        self.run_with_retry(5, move |client| {
+            let path = path.clone();
             async move {
                 let request = client
                     .request(Method::GET, &path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.111"
+version = "0.5.112"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/cli/_common.py
+++ b/src/tensorlake/cli/_common.py
@@ -75,9 +75,10 @@ class Context:
         return self.organization_id_value
 
     def list_secret_names(self, page_size: int = 100) -> list[str]:
-        org_id = self.organization_id
-        project_id = self.project_id
-        if org_id is None or project_id is None:
+        api_key_scoped = self.api_key is not None
+        org_id = None if api_key_scoped else self.organization_id
+        project_id = None if api_key_scoped else self.project_id
+        if not api_key_scoped and (org_id is None or project_id is None):
             return []
 
         try:

--- a/src/tensorlake/cloud_client.py
+++ b/src/tensorlake/cloud_client.py
@@ -248,8 +248,8 @@ class CloudClient:
 
     def list_secrets_json(
         self,
-        organization_id: str,
-        project_id: str,
+        organization_id: str | None = None,
+        project_id: str | None = None,
         page_size: int = 100,
     ) -> str:
         try:

--- a/src/tensorlake/image/sandbox_builder.py
+++ b/src/tensorlake/image/sandbox_builder.py
@@ -159,8 +159,8 @@ def _rust_find_sandbox_image_by_name(
     api_url: str,
     token: str,
     image_name: str,
-    organization_id: str,
-    project_id: str,
+    organization_id: str | None,
+    project_id: str | None,
     namespace: str | None,
 ) -> str | None:
     try:
@@ -187,8 +187,8 @@ def _rust_find_sandbox_image_by_name(
 def _rust_list_sandbox_images(
     api_url: str,
     token: str,
-    organization_id: str,
-    project_id: str,
+    organization_id: str | None,
+    project_id: str | None,
     namespace: str | None,
 ) -> str:
     try:
@@ -354,13 +354,14 @@ def delete_sandbox_image(image_name: str) -> None:
             "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
         )
 
+    use_explicit_scope = ctx.personal_access_token is not None and ctx.api_key is None
     try:
         _rust_delete_sandbox_image(
             ctx.api_url,
             token,
             image_name,
-            ctx.organization_id,
-            ctx.project_id,
+            ctx.organization_id if use_explicit_scope else None,
+            ctx.project_id if use_explicit_scope else None,
             ctx.namespace,
         )
     except SandboxImageError:
@@ -399,9 +400,9 @@ def find_sandbox_image_by_name(image_name: str) -> dict | None:
 
     Returns the registered sandbox template as a dict, or ``None`` if no image
     with that name exists. Uses the same environment-based Tensorlake auth as
-    :func:`build_sandbox_image`, and requires organization/project context
-    (``TENSORLAKE_ORGANIZATION_ID`` and ``TENSORLAKE_PROJECT_ID``) since the
-    lookup is routed through the platform sandbox-templates API.
+    :func:`build_sandbox_image`. API keys derive project scope from the bearer
+    token; PAT callers still require ``TENSORLAKE_ORGANIZATION_ID`` and
+    ``TENSORLAKE_PROJECT_ID``.
 
     Raises:
         TypeError: ``image_name`` is not a non-empty string.
@@ -417,7 +418,8 @@ def find_sandbox_image_by_name(image_name: str) -> dict | None:
         raise SandboxImageLookupError(
             "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
         )
-    if not ctx.organization_id or not ctx.project_id:
+    use_explicit_scope = ctx.personal_access_token is not None and ctx.api_key is None
+    if use_explicit_scope and (not ctx.organization_id or not ctx.project_id):
         raise SandboxImageLookupError(
             "Looking up a sandbox image by name requires organization and "
             "project context (TENSORLAKE_ORGANIZATION_ID and "
@@ -429,8 +431,8 @@ def find_sandbox_image_by_name(image_name: str) -> dict | None:
             ctx.api_url,
             token,
             image_name,
-            ctx.organization_id,
-            ctx.project_id,
+            ctx.organization_id if use_explicit_scope else None,
+            ctx.project_id if use_explicit_scope else None,
             ctx.namespace,
         )
     except SandboxImageError:
@@ -453,10 +455,9 @@ def list_sandbox_images() -> list[dict]:
 
     Returns the registered sandbox templates as a list of dicts (each with
     ``id``, ``name``, ``snapshot_id``, ``public``, etc.). Uses the same
-    environment-based Tensorlake auth as :func:`build_sandbox_image`, and
-    requires organization/project context (``TENSORLAKE_ORGANIZATION_ID`` and
-    ``TENSORLAKE_PROJECT_ID``) since the listing is routed through the platform
-    sandbox-templates API.
+    environment-based Tensorlake auth as :func:`build_sandbox_image`. API keys
+    derive project scope from the bearer token; PAT callers still require
+    ``TENSORLAKE_ORGANIZATION_ID`` and ``TENSORLAKE_PROJECT_ID``.
 
     Raises:
         SandboxImageLookupError: Credentials or project context are missing, or
@@ -468,7 +469,8 @@ def list_sandbox_images() -> list[dict]:
         raise SandboxImageLookupError(
             "Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials."
         )
-    if not ctx.organization_id or not ctx.project_id:
+    use_explicit_scope = ctx.personal_access_token is not None and ctx.api_key is None
+    if use_explicit_scope and (not ctx.organization_id or not ctx.project_id):
         raise SandboxImageLookupError(
             "Listing sandbox images requires organization and project context "
             "(TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID)."
@@ -478,8 +480,8 @@ def list_sandbox_images() -> list[dict]:
         result_json = _rust_list_sandbox_images(
             ctx.api_url,
             token,
-            ctx.organization_id,
-            ctx.project_id,
+            ctx.organization_id if use_explicit_scope else None,
+            ctx.project_id if use_explicit_scope else None,
             ctx.namespace,
         )
     except SandboxImageError:

--- a/tests/cli/test_common.py
+++ b/tests/cli/test_common.py
@@ -9,11 +9,10 @@ from tensorlake.cli._common import Context
 class _FakeCloudClient:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
+        self.list_secrets_calls = []
 
     def list_secrets_json(self, organization_id, project_id, page_size):
-        assert organization_id == "org-1"
-        assert project_id == "proj-1"
-        assert page_size == 100
+        self.list_secrets_calls.append((organization_id, project_id, page_size))
         return json.dumps(
             {
                 "items": [
@@ -107,8 +106,11 @@ class TestContext(unittest.TestCase):
             )
             secret_names = context.list_secret_names(page_size=100)
             self.assertEqual(secret_names, ["SECRET_A", "SECRET_B"])
+            self.assertEqual(
+                context.cloud_client.list_secrets_calls, [(None, None, 100)]
+            )
 
-    def test_list_secret_names_uses_provided_org_project_without_introspection(self):
+    def test_list_secret_names_api_key_ignores_stale_scope_without_introspection(self):
         with patch.object(common_module, "CloudClient", _FailIntrospectCloudClient):
             context = Context.default(
                 api_key="api-key",
@@ -118,11 +120,37 @@ class TestContext(unittest.TestCase):
             secret_names = context.list_secret_names(page_size=100)
 
             self.assertEqual(secret_names, ["SECRET_A", "SECRET_B"])
+            self.assertEqual(
+                context.cloud_client.list_secrets_calls, [(None, None, 100)]
+            )
 
-    def test_list_secret_names_without_org_or_project_returns_empty(self):
+    def test_list_secret_names_api_key_does_not_require_local_scope(self):
         with patch.object(common_module, "CloudClient", _FakeCloudClient):
             context = Context.default(api_key="api-key")
-            self.assertEqual(context.list_secret_names(page_size=100), [])
+            self.assertEqual(
+                context.list_secret_names(page_size=100),
+                ["SECRET_A", "SECRET_B"],
+            )
+            self.assertEqual(
+                context.cloud_client.list_secrets_calls, [(None, None, 100)]
+            )
+
+    def test_list_secret_names_pat_keeps_explicit_scope(self):
+        with patch.object(common_module, "CloudClient", _FakeCloudClient):
+            context = Context.default(
+                personal_access_token="pat-token",
+                organization_id="org-1",
+                project_id="proj-1",
+            )
+
+            self.assertEqual(
+                context.list_secret_names(page_size=100),
+                ["SECRET_A", "SECRET_B"],
+            )
+            self.assertEqual(
+                context.cloud_client.list_secrets_calls,
+                [("org-1", "proj-1", 100)],
+            )
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_common.py
+++ b/tests/cli/test_common.py
@@ -79,6 +79,20 @@ class TestContext(unittest.TestCase):
             self.assertIsNone(client.kwargs["organization_id"])
             self.assertIsNone(client.kwargs["project_id"])
 
+    def test_rust_cloud_client_prefers_api_key_over_pat_without_forwarding_scope(self):
+        with patch.object(common_module, "CloudClient", _FakeCloudClient):
+            context = Context.default(
+                api_key="tl_apiKey_test",
+                personal_access_token="tl_pat_test",
+                organization_id="org-stale",
+                project_id="project-stale",
+            )
+            client = context.rust_cloud_client
+
+            self.assertEqual(client.kwargs["api_key"], "tl_apiKey_test")
+            self.assertIsNone(client.kwargs["organization_id"])
+            self.assertIsNone(client.kwargs["project_id"])
+
     def test_rust_cloud_client_requires_authentication(self):
         context = Context.default()
         with self.assertRaises(SystemExit):

--- a/tests/image/test_sandbox_builder.py
+++ b/tests/image/test_sandbox_builder.py
@@ -210,8 +210,8 @@ class TestDeleteSandboxImage(unittest.TestCase):
             "https://api.tensorlake.test",
             "tl_apiKey_abc",
             "tensorlake/test:1",
-            "org_1",
-            "proj_1",
+            None,
+            None,
             "default",
         )
 
@@ -256,8 +256,8 @@ class TestFindSandboxImageByName(unittest.TestCase):
             "https://api.tensorlake.test",
             "tl_apiKey_abc",
             "tensorlake/test:1",
-            "org_1",
-            "proj_1",
+            None,
+            None,
             "default",
         )
 
@@ -277,12 +277,57 @@ class TestFindSandboxImageByName(unittest.TestCase):
             with self.assertRaises(sbm.SandboxImageLookupError):
                 sbm.find_sandbox_image_by_name("image")
 
-    def test_requires_org_and_project_context(self):
+    def test_api_key_does_not_require_or_forward_local_scope(self):
         ctx = _make_ctx(organization_id=None, project_id=None)
+
+        with (
+            patch.object(sbm, "_build_context_from_env", return_value=ctx),
+            patch.object(
+                sbm, "_rust_find_sandbox_image_by_name", return_value=None
+            ) as rust_find,
+        ):
+            self.assertIsNone(sbm.find_sandbox_image_by_name("image"))
+
+        rust_find.assert_called_once_with(
+            "https://api.tensorlake.test",
+            "tl_apiKey_abc",
+            "image",
+            None,
+            None,
+            "default",
+        )
+
+    def test_pat_requires_org_and_project_context(self):
+        ctx = _make_ctx(
+            api_key=None,
+            personal_access_token="tl_pat_test",
+            organization_id=None,
+            project_id=None,
+        )
 
         with patch.object(sbm, "_build_context_from_env", return_value=ctx):
             with self.assertRaises(sbm.SandboxImageLookupError):
                 sbm.find_sandbox_image_by_name("image")
+
+    def test_pat_keeps_explicit_scope(self):
+        ctx = _make_ctx(api_key=None, personal_access_token="tl_pat_test")
+
+        with (
+            patch.object(sbm, "_build_context_from_env", return_value=ctx),
+            patch.object(
+                sbm, "_rust_find_sandbox_image_by_name", return_value=None
+            ) as rust_find,
+        ):
+            self.assertIsNone(sbm.find_sandbox_image_by_name("image"))
+
+        rust_find.assert_called_once_with(
+            "https://api.tensorlake.test",
+            "tl_pat_test",
+            "image",
+            "org_1",
+            "proj_1",
+            "default",
+        )
 
     def test_empty_name_raises_type_error(self):
         with self.assertRaises(TypeError):
@@ -317,8 +362,8 @@ class TestListSandboxImages(unittest.TestCase):
         rust_list.assert_called_once_with(
             "https://api.tensorlake.test",
             "tl_apiKey_abc",
-            "org_1",
-            "proj_1",
+            None,
+            None,
             "default",
         )
 
@@ -338,12 +383,55 @@ class TestListSandboxImages(unittest.TestCase):
             with self.assertRaises(sbm.SandboxImageLookupError):
                 sbm.list_sandbox_images()
 
-    def test_requires_org_and_project_context(self):
+    def test_api_key_does_not_require_or_forward_local_scope(self):
         ctx = _make_ctx(organization_id=None, project_id=None)
+
+        with (
+            patch.object(sbm, "_build_context_from_env", return_value=ctx),
+            patch.object(
+                sbm, "_rust_list_sandbox_images", return_value="[]"
+            ) as rust_list,
+        ):
+            self.assertEqual(sbm.list_sandbox_images(), [])
+
+        rust_list.assert_called_once_with(
+            "https://api.tensorlake.test",
+            "tl_apiKey_abc",
+            None,
+            None,
+            "default",
+        )
+
+    def test_pat_requires_org_and_project_context(self):
+        ctx = _make_ctx(
+            api_key=None,
+            personal_access_token="tl_pat_test",
+            organization_id=None,
+            project_id=None,
+        )
 
         with patch.object(sbm, "_build_context_from_env", return_value=ctx):
             with self.assertRaises(sbm.SandboxImageLookupError):
                 sbm.list_sandbox_images()
+
+    def test_pat_keeps_explicit_scope(self):
+        ctx = _make_ctx(api_key=None, personal_access_token="tl_pat_test")
+
+        with (
+            patch.object(sbm, "_build_context_from_env", return_value=ctx),
+            patch.object(
+                sbm, "_rust_list_sandbox_images", return_value="[]"
+            ) as rust_list,
+        ):
+            self.assertEqual(sbm.list_sandbox_images(), [])
+
+        rust_list.assert_called_once_with(
+            "https://api.tensorlake.test",
+            "tl_pat_test",
+            "org_1",
+            "proj_1",
+            "default",
+        )
 
 
 class TestImportSandboxImage(unittest.TestCase):

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.110",
+  "version": "0.5.112",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.110",
+      "version": "0.5.112",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.111",
+  "version": "0.5.112",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/cloud-client.ts
+++ b/typescript/src/cloud-client.ts
@@ -114,17 +114,22 @@ export class CloudClient {
    * Look up a registered sandbox image (template) by its registered name.
    *
    * Returns the template, or `null` when no image with that name exists.
-   * Routed through the platform sandbox-templates API, which requires the
-   * organization/project scope (from the client or the `options` override).
+   * API-key clients may omit organization/project IDs and use the
+   * token-scoped Platform API route directly. Explicit scope remains
+   * available for PAT callers.
    */
   async findSandboxImageByName(
     imageName: string,
     options?: { organizationId?: string; projectId?: string },
   ): Promise<SandboxTemplate | null> {
-    const scope = this.resolveScope(options?.organizationId, options?.projectId);
+    const base = this.platformProjectPath(
+      "sandbox-templates",
+      options?.organizationId,
+      options?.projectId,
+    );
     const response = await this.http.requestResponse(
       "GET",
-      `/platform/v1/organizations/${encodeURIComponent(scope.organizationId)}/projects/${encodeURIComponent(scope.projectId)}/sandbox-templates/by-name/${encodeURIComponent(imageName)}`,
+      `${base}/by-name/${encodeURIComponent(imageName)}`,
       { allowedErrorStatusCodes: new Set([404]) },
     );
     if (response.status === 404) {
@@ -136,14 +141,17 @@ export class CloudClient {
 
   /**
    * List all registered sandbox images (templates), following pagination to
-   * the end. Routed through the platform sandbox-templates API, which requires
-   * the organization/project scope (from the client or the `options` override).
+   * the end. API-key clients may omit organization/project IDs and use the
+   * token-scoped Platform API route directly.
    */
   async listSandboxImages(
     options?: { organizationId?: string; projectId?: string },
   ): Promise<SandboxTemplate[]> {
-    const scope = this.resolveScope(options?.organizationId, options?.projectId);
-    const base = `/platform/v1/organizations/${encodeURIComponent(scope.organizationId)}/projects/${encodeURIComponent(scope.projectId)}/sandbox-templates`;
+    const base = this.platformProjectPath(
+      "sandbox-templates",
+      options?.organizationId,
+      options?.projectId,
+    );
     let path: string | null = `${base}?pageSize=100`;
     const templates: SandboxTemplate[] = [];
     while (path !== null) {
@@ -336,10 +344,14 @@ export class CloudClient {
     projectId?: string;
     pageSize?: number;
   }): Promise<SecretsList> {
-    const scope = this.resolveScope(options?.organizationId, options?.projectId);
+    const base = this.platformProjectPath(
+      "secrets",
+      options?.organizationId,
+      options?.projectId,
+    );
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
-      `/platform/v1/organizations/${encodeURIComponent(scope.organizationId)}/projects/${encodeURIComponent(scope.projectId)}/secrets?pageSize=${options?.pageSize ?? 100}`,
+      `${base}?pageSize=${options?.pageSize ?? 100}`,
     );
     return fromSnakeKeys(raw) as SecretsList;
   }
@@ -348,10 +360,14 @@ export class CloudClient {
     secretId: string,
     options?: { organizationId?: string; projectId?: string },
   ): Promise<Secret> {
-    const scope = this.resolveScope(options?.organizationId, options?.projectId);
+    const base = this.platformProjectPath(
+      "secrets",
+      options?.organizationId,
+      options?.projectId,
+    );
     const raw = await this.http.requestJson<Record<string, unknown>>(
       "GET",
-      `/platform/v1/organizations/${encodeURIComponent(scope.organizationId)}/projects/${encodeURIComponent(scope.projectId)}/secrets/${encodeURIComponent(secretId)}`,
+      `${base}/${encodeURIComponent(secretId)}`,
     );
     return fromSnakeKeys(raw) as Secret;
   }
@@ -360,10 +376,14 @@ export class CloudClient {
     secrets: NewSecret | NewSecret[],
     options?: { organizationId?: string; projectId?: string },
   ): Promise<UpsertSecretResponse> {
-    const scope = this.resolveScope(options?.organizationId, options?.projectId);
+    const base = this.platformProjectPath(
+      "secrets",
+      options?.organizationId,
+      options?.projectId,
+    );
     const raw = await this.http.requestJson<Record<string, unknown> | Record<string, unknown>[]>(
       "PUT",
-      `/platform/v1/organizations/${encodeURIComponent(scope.organizationId)}/projects/${encodeURIComponent(scope.projectId)}/secrets`,
+      base,
       { body: secrets },
     );
     if (Array.isArray(raw)) {
@@ -376,10 +396,14 @@ export class CloudClient {
     secretId: string,
     options?: { organizationId?: string; projectId?: string },
   ): Promise<void> {
-    const scope = this.resolveScope(options?.organizationId, options?.projectId);
+    const base = this.platformProjectPath(
+      "secrets",
+      options?.organizationId,
+      options?.projectId,
+    );
     await this.http.requestResponse(
       "DELETE",
-      `/platform/v1/organizations/${encodeURIComponent(scope.organizationId)}/projects/${encodeURIComponent(scope.projectId)}/secrets/${encodeURIComponent(secretId)}`,
+      `${base}/${encodeURIComponent(secretId)}`,
     );
   }
 
@@ -532,6 +556,24 @@ export class CloudClient {
       organizationId: resolvedOrganizationId,
       projectId: resolvedProjectId,
     };
+  }
+
+  private platformProjectPath(
+    resource: "sandbox-templates" | "secrets",
+    organizationId?: string,
+    projectId?: string,
+  ): string {
+    const resolvedOrganizationId = organizationId ?? this.organizationId;
+    const resolvedProjectId = projectId ?? this.projectId;
+    if (!resolvedOrganizationId && !resolvedProjectId) {
+      return `/platform/v1/${resource}`;
+    }
+    if (!resolvedOrganizationId || !resolvedProjectId) {
+      throw new Error(
+        "organizationId and projectId must be provided together",
+      );
+    }
+    return `/platform/v1/organizations/${encodeURIComponent(resolvedOrganizationId)}/projects/${encodeURIComponent(resolvedProjectId)}/${resource}`;
   }
 }
 

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -546,11 +546,13 @@ export async function deleteSandboxImage(imageName: string): Promise<void> {
     throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.");
   }
 
+  const useScopeHeaders =
+    context.personalAccessToken != null && context.apiKey == null;
   const client = new CloudClient({
     apiUrl: context.apiUrl,
     apiKey: bearerToken,
-    organizationId: context.organizationId,
-    projectId: context.projectId,
+    organizationId: useScopeHeaders ? context.organizationId : undefined,
+    projectId: useScopeHeaders ? context.projectId : undefined,
     namespace: context.namespace,
   });
   try {
@@ -565,9 +567,8 @@ export async function deleteSandboxImage(imageName: string): Promise<void> {
  *
  * Returns the registered sandbox template, or `null` if no image with that
  * name exists. Uses the same environment-based Tensorlake auth as
- * `createSandboxImage`, and requires organization/project context
- * (`TENSORLAKE_ORGANIZATION_ID` and `TENSORLAKE_PROJECT_ID`) since the lookup
- * is routed through the platform sandbox-templates API.
+ * `createSandboxImage`. API keys derive project scope from the bearer token;
+ * PAT callers still require organization/project context.
  */
 export async function findSandboxImageByName(
   imageName: string,
@@ -581,7 +582,9 @@ export async function findSandboxImageByName(
   if (!bearerToken) {
     throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.");
   }
-  if (!context.organizationId || !context.projectId) {
+  const useScopeHeaders =
+    context.personalAccessToken != null && context.apiKey == null;
+  if (useScopeHeaders && (!context.organizationId || !context.projectId)) {
     throw new Error(
       "Looking up a sandbox image by name requires organization and project " +
         "context (TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID).",
@@ -591,8 +594,8 @@ export async function findSandboxImageByName(
   const client = new CloudClient({
     apiUrl: context.apiUrl,
     apiKey: bearerToken,
-    organizationId: context.organizationId,
-    projectId: context.projectId,
+    organizationId: useScopeHeaders ? context.organizationId : undefined,
+    projectId: useScopeHeaders ? context.projectId : undefined,
     namespace: context.namespace,
   });
   try {
@@ -607,9 +610,8 @@ export async function findSandboxImageByName(
  *
  * Returns the registered sandbox templates (each with `id`, `name`,
  * `snapshotId`, `public`, etc.). Uses the same environment-based Tensorlake
- * auth as `createSandboxImage`, and requires organization/project context
- * (`TENSORLAKE_ORGANIZATION_ID` and `TENSORLAKE_PROJECT_ID`) since the listing
- * is routed through the platform sandbox-templates API.
+ * auth as `createSandboxImage`. API keys derive project scope from the bearer
+ * token; PAT callers still require organization/project context.
  */
 export async function listSandboxImages(): Promise<SandboxTemplate[]> {
   const context = buildContextFromEnv();
@@ -617,7 +619,9 @@ export async function listSandboxImages(): Promise<SandboxTemplate[]> {
   if (!bearerToken) {
     throw new Error("Missing TENSORLAKE_API_KEY or TENSORLAKE_PAT credentials.");
   }
-  if (!context.organizationId || !context.projectId) {
+  const useScopeHeaders =
+    context.personalAccessToken != null && context.apiKey == null;
+  if (useScopeHeaders && (!context.organizationId || !context.projectId)) {
     throw new Error(
       "Listing sandbox images requires organization and project context " +
         "(TENSORLAKE_ORGANIZATION_ID and TENSORLAKE_PROJECT_ID).",
@@ -627,8 +631,8 @@ export async function listSandboxImages(): Promise<SandboxTemplate[]> {
   const client = new CloudClient({
     apiUrl: context.apiUrl,
     apiKey: bearerToken,
-    organizationId: context.organizationId,
-    projectId: context.projectId,
+    organizationId: useScopeHeaders ? context.organizationId : undefined,
+    projectId: useScopeHeaders ? context.projectId : undefined,
     namespace: context.namespace,
   });
   try {

--- a/typescript/tests/cloud-client.test.ts
+++ b/typescript/tests/cloud-client.test.ts
@@ -444,6 +444,36 @@ describe("CloudClient", () => {
     client.close();
   });
 
+  it("uses the API-key-scoped sandbox templates route when scope is omitted", async () => {
+    mockFetch((url, init) => {
+      expect(url).toBe(
+        "http://localhost:8900/platform/v1/sandbox-templates/by-name/tensorlake%2Ftest%3A1",
+      );
+      expect(init?.method).toBe("GET");
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer tl_apiKey_test");
+      expect(headers).not.toHaveProperty("X-Forwarded-Organization-Id");
+      expect(headers).not.toHaveProperty("X-Forwarded-Project-Id");
+      return new Response(
+        JSON.stringify({
+          id: "tpl-1",
+          name: "tensorlake/test:1",
+          snapshot_id: "snap-1",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const client = new CloudClient({
+      apiUrl: "http://localhost:8900",
+      apiKey: "tl_apiKey_test",
+    });
+    const template = await client.findSandboxImageByName("tensorlake/test:1");
+
+    expect(template?.snapshotId).toBe("snap-1");
+    client.close();
+  });
+
   it("returns null when a sandbox image is not found", async () => {
     mockFetch(
       () => new Response(JSON.stringify({ message: "not found" }), { status: 404 }),
@@ -509,6 +539,59 @@ describe("CloudClient", () => {
       `${base}?pageSize=100`,
       `${base}?pageSize=100&cursor=abc`,
     ]);
+    client.close();
+  });
+
+  it("uses API-key-scoped secrets routes when scope is omitted", async () => {
+    const requested: Array<{ url: string; method: string | undefined }> = [];
+    mockFetch((url, init) => {
+      requested.push({ url, method: init?.method });
+      const headers = init?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer tl_apiKey_test");
+      expect(headers).not.toHaveProperty("X-Forwarded-Organization-Id");
+      expect(headers).not.toHaveProperty("X-Forwarded-Project-Id");
+
+      if (init?.method === "GET" && url.endsWith("?pageSize=25")) {
+        return new Response(
+          JSON.stringify({
+            items: [],
+            pagination: { next: null, prev: null, total: 0 },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (init?.method === "PUT") {
+        return new Response(
+          JSON.stringify({ id: "secret/1", name: "TOKEN", created_at: "now" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    });
+
+    const client = new CloudClient({
+      apiUrl: "http://localhost:8900",
+      apiKey: "tl_apiKey_test",
+    });
+    await client.listSecrets({ pageSize: 25 });
+    await client.upsertSecrets({ name: "TOKEN", value: "value" });
+    await client.deleteSecret("secret/1");
+
+    expect(requested).toEqual([
+      {
+        url: "http://localhost:8900/platform/v1/secrets?pageSize=25",
+        method: "GET",
+      },
+      {
+        url: "http://localhost:8900/platform/v1/secrets",
+        method: "PUT",
+      },
+      {
+        url: "http://localhost:8900/platform/v1/secrets/secret%2F1",
+        method: "DELETE",
+      },
+    ]);
+    expect(requested.every(({ url }) => !url.includes("/keys/introspect"))).toBe(true);
     client.close();
   });
 

--- a/typescript/tests/sandbox-image.test.ts
+++ b/typescript/tests/sandbox-image.test.ts
@@ -443,6 +443,25 @@ describe("createSandboxImage", () => {
     expect(captured.options.projectId).toBe("proj_1");
   });
 
+  it("prefers API key auth without PAT scope headers when both are set", async () => {
+    vi.stubEnv("TENSORLAKE_API_KEY", "tl_apiKey_test");
+    vi.stubEnv("TENSORLAKE_PAT", "tl_pat_test");
+    vi.stubEnv("TENSORLAKE_ORGANIZATION_ID", "org_stale");
+    vi.stubEnv("TENSORLAKE_PROJECT_ID", "project_stale");
+
+    const tempDir = await mkdir(
+      path.join(os.tmpdir(), `tensorlake-images-${Date.now()}-api-key-precedence`),
+      { recursive: true },
+    );
+    const dockerfilePath = path.join(tempDir, "Dockerfile");
+    await writeFile(dockerfilePath, "FROM python:3.12-slim\n", "utf8");
+
+    const { captured } = makeFakeBinding();
+    await createSandboxImage(dockerfilePath);
+    expect(captured.options.bearerToken).toBe("tl_apiKey_test");
+    expect(captured.options.useScopeHeaders).toBe(false);
+  });
+
   it("rejects an unknown source type", async () => {
     makeFakeBinding();
     await expect(


### PR DESCRIPTION
## Summary

- route API-key-authenticated secrets and sandbox template/image requests through the token-scoped Platform API endpoints
- keep PAT requests on explicit organization/project routes
- avoid forwarding stale organization or project scope when a real API key is selected
- add wire-level regressions across the Rust CLI/SDK, Python bridge, and TypeScript clients
- bump the lockstep CLI and SDK package version to 0.5.112

## Compatibility and rollout

This depends on tensorlakeai/platform-api#679 being deployed before these client changes are released. Existing clients remain compatible because the explicit organization/project routes stay supported.

Introspection is intentionally retained for repository, filesystem, whoami, and CAS Image Service paths whose current contracts still require an explicit project identifier.

## Validation

- `just build-cli` after rebasing onto current `origin/main` and after the 0.5.112 bump
- `cargo test -p tensorlake`
- focused Rust CLI auth, secrets, and sandbox image tests
- `cargo clippy -p tensorlake --all-targets -- -D warnings`
- Python CLI/image tests: 55 passed
- TypeScript test suite: 453 passed
- TypeScript typecheck, lint, and SDK build