### PR TITLE
Bump Tensorlake packages to 0.5.113

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.112"
+version = "0.5.113"
 dependencies = [
  "anyhow",
  "base64",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.112"
+version = "0.5.113"
 dependencies = [
  "anyhow",
  "base64",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.112"
+version = "0.5.113"
 dependencies = [
  "anyhow",
  "base64",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.112"
+version = "0.5.113"
 dependencies = [
  "anyhow",
  "base64",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.112"
+version = "0.5.113"
 dependencies = [
  "anyhow",
  "napi",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.112"
+version = "0.5.113"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.112"
+version = "0.5.113"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.112"
+version = "0.5.113"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.112"
+version = "0.5.113"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.112"
+version = "0.5.113"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.112",
+  "version": "0.5.113",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.112",
+      "version": "0.5.113",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.112",
+  "version": "0.5.113",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Version bump following the #915 precedent (same 7-file shape; `npm ci` + `typecheck` + `git diff --check` clean). This release carries artifact_storage#239 — the vendor-built CLI stores native records **raw when zstd does not earn its frame (≥3% savings required)**, which makes freshly pushed incompressible content byte-addressable and served via the ADR 0047 presigned object redirects the fleet's dataplane already follows (proof on the #239 thread: read-plan `raw` + a live 307 from prod AS). No wire-format or API changes; existing zstd-stored data keeps streaming exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)