### PR TITLE
tl git push: fix chunk accounting in the push report

### DIFF
--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -915,7 +915,8 @@ pub async fn push(
             })
         );
     } else {
-        // Small files skip chunk negotiation, so uploads can exceed the negotiated count;
+        // `chunks_total` counts distinct chunks push-wide, but a chunk shared by several
+        // tokened full-stream files uploads once per file, so uploads can still exceed it;
         // saturate instead of panicking on the subtraction.
         let deduped = report.chunks_total.saturating_sub(report.chunks_uploaded);
         println!(

--- a/crates/cloud-sdk/src/artifact_storage/ingest.rs
+++ b/crates/cloud-sdk/src/artifact_storage/ingest.rs
@@ -287,8 +287,13 @@ pub struct PushReport {
     pub created: bool,
     pub files: usize,
     pub bytes_total: u64,
+    /// Distinct chunks across the whole push, small staged files included. The negotiation
+    /// population (non-small files only) is intentionally narrower; this field is the honest
+    /// denominator for `chunks_uploaded`.
     pub chunks_total: usize,
-    /// Chunks the server lacked at first negotiation (uploaded by this push).
+    /// Chunks actually uploaded by this push across every path: tokened full streams,
+    /// small staged entries, and missing-chunk uploads. Can slightly exceed `chunks_total`
+    /// when a shared chunk streams inside more than one tokened file.
     pub chunks_uploaded: usize,
     pub bytes_uploaded: u64,
     /// Client-computed git blob oid per file (`(repo_path, hex oid)`), from the chunk pass.
@@ -1293,6 +1298,18 @@ impl ArtifactStorageClient {
             .collect();
         distinct.sort_unstable();
         distinct.dedup();
+        // The report's `chunks_total` counts distinct chunks across the whole push — small
+        // staged files included — so `chunks_uploaded` stays a subset of it and
+        // `total - uploaded` measures real dedup. `distinct` above remains negotiation-only.
+        let distinct_chunk_count = {
+            let mut all: Vec<[u8; 32]> = chunked
+                .iter()
+                .flat_map(|f| f.chunks.iter().map(|(h, _)| *h))
+                .collect();
+            all.sort_unstable();
+            all.dedup();
+            all.len()
+        };
         let missing = self
             .negotiate_missing(
                 project_id,
@@ -1817,7 +1834,7 @@ impl ArtifactStorageClient {
                     created: false,
                     files: chunked.len(),
                     bytes_total: total_bytes,
-                    chunks_total: distinct.len(),
+                    chunks_total: distinct_chunk_count,
                     chunks_uploaded: uploaded_chunks,
                     bytes_uploaded: uploaded_bytes,
                     file_chunks: if opts.collect_file_chunks {
@@ -1999,7 +2016,7 @@ impl ArtifactStorageClient {
                 created: resp.created,
                 files: chunked.len(),
                 bytes_total: total_bytes,
-                chunks_total: distinct.len(),
+                chunks_total: distinct_chunk_count,
                 chunks_uploaded: uploaded_chunks,
                 bytes_uploaded: uploaded_bytes,
                 file_chunks: if opts.collect_file_chunks {


### PR DESCRIPTION
## Problem

`tl git push` of the linux kernel worktree printed:

```
pushed f9d0b70... -> refs/heads/master (94765 files, 94063 of 194 chunks uploaded, 0 deduplicated, ...)
```

`94063 of 194` is a population mismatch, not a display bug: `chunks_total` was `distinct.len()` — the **negotiation** population, which deliberately excludes small staged files (their chunks are never registered server-side) — while `chunks_uploaded` increments on **all four** upload paths including the ~94k small staged entries. As a consequence the display-side `saturating_sub` also reported **0 deduplicated** for every small-file-heavy push, regardless of actual dedup.

## Fix

- `PushReport.chunks_total` now counts distinct chunks across the whole push (small files included), so `uploaded ⊆ total` and `total − uploaded` measures real dedup.
- Negotiation still uses the narrower non-small population (unchanged wire behavior).
- Field docs updated; the stale "chunks the server lacked at first negotiation" doc on `chunks_uploaded` corrected.

`cargo check -p tensorlake` (cloud-sdk) passes. Display-side change in `git.rs` is comment-only.

Found while benchmarking kernel-scale pushes against artifact storage (linux push session 2026-08-26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)