### PR TITLE
tl git setup: opt clones into packfile-uris

### DIFF
--- a/crates/cli/src/commands/git/setup.rs
+++ b/crates/cli/src/commands/git/setup.rs
@@ -148,6 +148,15 @@ pub(crate) fn configure_credential_helper(
         Some(root),
         &["config", "--local", "--add", &helper_key, &helper_value],
     )?;
+    // Opt this checkout into `packfile-uris`: the server then answers a full clone/fetch with
+    // a direct (presigned object-store) URL for the stored base pack plus a small inline
+    // delta, instead of streaming every pack byte through the service. Stock git only sends
+    // the capability when fetch.uriProtocols is configured, so without this line the fastest
+    // serving path is unreachable from plain git.
+    git_ok(
+        Some(root),
+        &["config", "--local", "fetch.uriProtocols", "https"],
+    )?;
     println!("registered credential helper for {git_base_url} (repo-local git config)");
     Ok(())
 }


### PR DESCRIPTION
Stock git only sends the `packfile-uris` capability when `fetch.uriProtocols` is configured — so plain-git clones of `tl git setup` checkouts never reach the server's strongest serving path (a direct/presigned object-store URL for the stored base pack plus a small inline delta; since artifact_storage#259 the base's extracted-blob complement rides that inline delta, so it covers blob-carrying repos too).

One repo-local config line next to the credential-helper registration: `fetch.uriProtocols=https`. Clones/fetches through such checkouts stop streaming pack bytes through the service pod entirely.

`cargo check -p tensorlake-cli` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)