### PR TITLE
tl git push: repo-name guard at the SDK boundary; no silent repo auto-create

### DIFF
--- a/crates/cli/src/commands/git.rs
+++ b/crates/cli/src/commands/git.rs
@@ -863,6 +863,7 @@ pub async fn push(
     branch: &str,
     message: &str,
     expect_oid: Option<String>,
+    create: bool,
     output_json: bool,
 ) -> Result<()> {
     use tensorlake::artifact_storage::ingest::PushOptions;
@@ -874,6 +875,48 @@ pub async fn push(
         .git_credential_for_repo(&project_id, repo)
         .await
         .map_err(map_sdk_error)?;
+
+    // The server creates repos lazily on ingest, which turns an argument mixup into data
+    // silently landing in a phantom repo (`tl git push main` created and pushed to a repo
+    // named "main" in prod, 2026-08-27 — tensorlakeai/tensorlake#931). Gate on existence:
+    // pushing to a missing repo is an error unless --create says otherwise.
+    let exists = match client
+        .repo_meta_with_credential(
+            &project_id,
+            repo,
+            &credential.git_username,
+            &credential.token,
+        )
+        .await
+    {
+        Ok(_) => true,
+        Err(tensorlake::error::SdkError::ServerError { status, .. })
+            if status == reqwest::StatusCode::NOT_FOUND =>
+        {
+            false
+        }
+        Err(err) => return Err(map_sdk_error(err)),
+    };
+    if !exists {
+        if !create {
+            return Err(CliError::usage(format!(
+                "repo '{repo}' does not exist in this project.\n\
+                 note: the first argument of `tl git push` is the REPO, not the branch \
+                 (`tl git push <repo> <branch>`).\n\
+                 To create '{repo}' and push in one step, re-run with --create, or create it \
+                 first with `tl git repo create {repo}`."
+            )));
+        }
+        client
+            .create_repo(&project_id, repo, Some(branch))
+            .await
+            .map_err(map_sdk_error)?;
+        println!(
+            "{} repo {} (did not exist)",
+            console::style("created").yellow().bold(),
+            console::style(repo).cyan()
+        );
+    }
 
     let bar = indicatif::ProgressBar::new_spinner();
     bar.enable_steady_tick(std::time::Duration::from_millis(120));

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -505,7 +505,7 @@ enum GitCommands {
     },
     /// Push the current Git worktree to a repo as one commit (resumable chunk upload)
     Push {
-        /// Repo name
+        /// Repo name (NOT the branch — `tl git push <repo> <branch>`)
         repo: String,
         /// Target branch
         #[arg(default_value = "main")]
@@ -516,6 +516,10 @@ enum GitCommands {
         /// Force-with-lease: require the branch to currently equal this commit oid
         #[arg(long)]
         expect_oid: Option<String>,
+        /// Create the repo if it does not exist (without this, pushing to a missing repo is
+        /// an error rather than a silent repo creation)
+        #[arg(long)]
+        create: bool,
         /// Output JSON
         #[arg(long)]
         json: bool,
@@ -3057,8 +3061,9 @@ async fn run_git_command(ctx: &CliContext, subcmd: GitCommands) -> error::Result
             branch,
             message,
             expect_oid,
+            create,
             json,
-        } => commands::git::push(ctx, &repo, &branch, &message, expect_oid, json).await,
+        } => commands::git::push(ctx, &repo, &branch, &message, expect_oid, create, json).await,
         GitCommands::Merge {
             repo,
             ours,

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -1750,6 +1750,7 @@ impl ArtifactStorageClient {
         git_username: &str,
         git_token: &str,
     ) -> Result<(reqwest::RequestBuilder, String), SdkError> {
+        validate_repo_name(repo)?;
         let base = format!(
             "{}/project/{}/repos/{}",
             self.git_base_url,
@@ -2329,6 +2330,55 @@ fn trim_base_url(url: String) -> String {
 
 fn encode_path_segment(segment: &str) -> String {
     urlencoding::encode(segment).into_owned()
+}
+
+/// Client-side guard for the `{repo}` path segment, applied before any repo-addressed URL is
+/// built. An empty or path-shaped name must fail HERE, not on the wire: an empty segment
+/// collapses (`/repos//ingest/sessions` routes as `/repos/ingest/sessions`), which
+/// mis-addresses the request instead of erroring — observed live on 2026-08-27, when a push
+/// with an empty repo name reached the server addressed to a repo named "ingest"
+/// (tensorlakeai/tensorlake#931). Everything else (charset policy, collisions) stays the
+/// server's call; this rejects only names that cannot survive the URL round trip.
+fn validate_repo_name(repo: &str) -> Result<(), SdkError> {
+    if repo.is_empty() {
+        return Err(SdkError::ClientError(
+            "repository name is empty (the first argument of `tl git push` is the repo, \
+             not the branch)"
+                .to_string(),
+        ));
+    }
+    if repo.len() > 512 {
+        return Err(SdkError::ClientError(format!(
+            "repository name is {} bytes; the limit is 512",
+            repo.len()
+        )));
+    }
+    if repo
+        .chars()
+        .any(|c| c == '/' || c == '\\' || c.is_whitespace() || c.is_control())
+    {
+        return Err(SdkError::ClientError(format!(
+            "repository name {repo:?} contains a path separator, whitespace, or control \
+             character"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod repo_name_tests {
+    use super::*;
+
+    #[test]
+    fn repo_name_guard_rejects_unroutable_names_only() {
+        assert!(validate_repo_name("linux-local1").is_ok());
+        assert!(validate_repo_name("Repo.Name_01").is_ok());
+        assert!(validate_repo_name("").is_err());
+        assert!(validate_repo_name("a/b").is_err());
+        assert!(validate_repo_name("a b").is_err());
+        assert!(validate_repo_name("a\nb").is_err());
+        assert!(validate_repo_name(&"x".repeat(513)).is_err());
+    }
 }
 
 fn git_credential_is_fresh(credential: &GitCredential) -> bool {


### PR DESCRIPTION
Fixes the two client footguns from today's linux-local1 incident (#931), where a whole worktree was silently pushed into a freshly auto-created repo named `main`:

1. **SDK repo-name guard** — `validate_repo_name` runs before any repo-addressed URL is built (`git_request`, which every git data-plane call including ingest goes through). Empty names, path separators, whitespace/control chars, and >512-byte names fail client-side with a clear message instead of collapsing on the wire (`/repos//ingest/sessions` → `/repos/ingest/sessions` mis-addressed the request as repo `ingest`). Charset policy beyond URL survivability remains the server's call. Unit test included.

2. **No silent auto-create on push** — `tl git push` now checks the target repo exists (repo meta, 404-aware). Missing repo without `--create` is an error carrying the argument-order hint ("the first argument is the REPO, not the branch — `tl git push <repo> <branch>`") plus both remedies; `--create` creates it explicitly (default branch = the push target) and prints that it did. Lazy server-side creation is untouched for API users who rely on it — this is a CLI-UX gate.

With this merged, `tl git push main` from a repo-less project errors with the hint instead of manufacturing a repo named `main` and swallowing 10 GB of upload.

`cargo check -p tensorlake -p tensorlake-cli` and the new `repo_name_guard_rejects_unroutable_names_only` test pass. Suggest cutting the 0.5.115 release after this lands so customers get #926/#927 and these guards together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)