### PR TITLE
Expose the file-system mount owner across SDKs and the CLI

### DIFF
--- a/crates/cli/src/commands/sbx/fs.rs
+++ b/crates/cli/src/commands/sbx/fs.rs
@@ -43,10 +43,13 @@ fn print_mounts_table(mounts: &[FileSystemMount]) {
     for mount in mounts {
         let mut options = Vec::new();
         if mount.read_only {
-            options.push("ro");
+            options.push("ro".to_string());
         }
         if mount.prefetch {
-            options.push("prefetch");
+            options.push("prefetch".to_string());
+        }
+        if let Some(owner) = &mount.owner {
+            options.push(format!("owner={owner}"));
         }
         let source = match &mount.snapshot_id {
             Some(snapshot_id) => format!("{}@{snapshot_id}", mount.file_system_id),
@@ -72,6 +75,7 @@ fn build_attach_body(
     read_only: bool,
     prefetch: bool,
     snapshot_id: Option<&str>,
+    owner: Option<&str>,
 ) -> Result<serde_json::Value> {
     if snapshot_id.is_some() && !read_only {
         return Err(CliError::usage(
@@ -91,6 +95,9 @@ fn build_attach_body(
     if let Some(snapshot_id) = snapshot_id {
         body["snapshot_id"] = serde_json::Value::String(snapshot_id.to_string());
     }
+    if let Some(owner) = owner {
+        body["owner"] = serde_json::Value::String(owner.to_string());
+    }
     Ok(body)
 }
 
@@ -103,11 +110,19 @@ pub async fn attach(
     read_only: bool,
     prefetch: bool,
     snapshot_id: Option<&str>,
+    owner: Option<&str>,
     output_json: bool,
 ) -> Result<()> {
     let client = ctx.client()?;
     let url = sandbox_endpoint(ctx, &format!("sandboxes/{sandbox_id}/file_systems"));
-    let body = build_attach_body(file_system_id, mount_path, read_only, prefetch, snapshot_id)?;
+    let body = build_attach_body(
+        file_system_id,
+        mount_path,
+        read_only,
+        prefetch,
+        snapshot_id,
+        owner,
+    )?;
 
     let resp = client
         .post(&url)
@@ -183,7 +198,7 @@ mod tests {
 
     #[test]
     fn attach_body_omits_unset_mount_modes() {
-        let body = build_attach_body("skills", "/mnt/skills", false, false, None).unwrap();
+        let body = build_attach_body("skills", "/mnt/skills", false, false, None, None).unwrap();
         assert_eq!(
             body,
             serde_json::json!({
@@ -195,8 +210,15 @@ mod tests {
 
     #[test]
     fn attach_body_includes_snapshot_pin_with_read_only() {
-        let body =
-            build_attach_body("skills", "/mnt/skills", true, false, Some("0abc123def")).unwrap();
+        let body = build_attach_body(
+            "skills",
+            "/mnt/skills",
+            true,
+            false,
+            Some("0abc123def"),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             body,
             serde_json::json!({
@@ -210,13 +232,34 @@ mod tests {
 
     #[test]
     fn attach_body_rejects_snapshot_pin_without_read_only() {
-        let error = build_attach_body("skills", "/mnt/skills", false, true, Some("0abc123def"))
-            .unwrap_err();
+        let error = build_attach_body(
+            "skills",
+            "/mnt/skills",
+            false,
+            true,
+            Some("0abc123def"),
+            None,
+        )
+        .unwrap_err();
         assert!(
             error
                 .to_string()
                 .contains("snapshot-pinned mounts are read-only"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn attach_body_includes_owner_only_when_set() {
+        let body =
+            build_attach_body("skills", "/mnt/skills", false, false, None, Some("agent")).unwrap();
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "file_system_id": "skills",
+                "mount_path": "/mnt/skills",
+                "owner": "agent",
+            })
         );
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1550,6 +1550,13 @@ enum SbxFsCommands {
         #[arg(long = "snapshot", value_name = "SNAPSHOT_ID")]
         snapshot_id: Option<String>,
 
+        /// Present the mounted files as owned by this guest user: NAME, UID,
+        /// NAME:GROUP, or UID:GID (e.g. `agent` or `1001:1001`), resolved
+        /// against the sandbox image's own user database. Defaults to the
+        /// image's baked `tl-user` account, else root.
+        #[arg(long, value_name = "OWNER")]
+        owner: Option<String>,
+
         /// Print the updated sandbox as JSON
         #[arg(long)]
         json: bool,
@@ -2520,6 +2527,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                             read_only,
                             prefetch,
                             snapshot_id,
+                            owner,
                             json,
                         } => {
                             commands::sbx::fs::attach(
@@ -2530,6 +2538,7 @@ async fn run_command(ctx: &mut CliContext, command: Commands) -> error::Result<(
                                 read_only,
                                 prefetch,
                                 snapshot_id.as_deref(),
+                                owner.as_deref(),
                                 json,
                             )
                             .await

--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -64,6 +64,47 @@ fn validate_mount_snapshot_pins(mounts: &[FileSystemMount]) -> Result<(), SdkErr
     Ok(())
 }
 
+/// Client-side mirror of the server's HTTP 400 for malformed mount owner
+/// specs (`NAME`, `UID`, `NAME:GROUP`, or `UID:GID`), so callers fail fast
+/// (and offline) instead of round-tripping to the server. Only the shape is
+/// checked — a named user or group resolves against the sandbox image's own
+/// user database when the mount attaches.
+fn validate_mount_owners(mounts: &[FileSystemMount]) -> Result<(), SdkError> {
+    const MAX_MOUNT_OWNER_BYTES: usize = 256;
+    for mount in mounts {
+        let Some(owner) = mount.owner.as_deref() else {
+            continue;
+        };
+        let reject = |reason: &str| {
+            Err(SdkError::ClientError(format!(
+                "file system mount {:?} at {:?} has an invalid owner {owner:?}: {reason}",
+                mount.file_system_id, mount.mount_path
+            )))
+        };
+        if owner.is_empty() || owner.len() > MAX_MOUNT_OWNER_BYTES {
+            return reject("owner must contain 1 to 256 bytes");
+        }
+        if !owner
+            .bytes()
+            .all(|byte| byte.is_ascii_graphic() && byte != b'"' && byte != b'\'')
+        {
+            return reject("owner must contain only non-whitespace printable ASCII characters");
+        }
+        let parts = owner.split(':').collect::<Vec<_>>();
+        if parts.len() > 2 || parts.iter().any(|part| part.is_empty()) {
+            return reject("owner must be NAME, UID, NAME:GROUP, or UID:GID");
+        }
+        // An all-digit part is unconditionally numeric to the guest resolver,
+        // so a u32 overflow can never resolve.
+        for part in parts {
+            if part.bytes().all(|byte| byte.is_ascii_digit()) && part.parse::<u32>().is_err() {
+                return reject("a numeric owner id must fit a 32-bit uid/gid");
+            }
+        }
+    }
+    Ok(())
+}
+
 /// A reference to a sandbox process: either its OS **pid** or a managed-process **name**
 /// given at creation. This is the single place the pid/name path segment is built, reused by
 /// the Rust SDK, the Python/Node bindings, and the CLI.
@@ -342,6 +383,7 @@ impl SandboxesClient {
         request: &CreateSandboxRequest,
     ) -> Result<Traced<CreateSandboxResponse>, SdkError> {
         validate_mount_snapshot_pins(&request.file_systems)?;
+        validate_mount_owners(&request.file_systems)?;
         let uri = self.endpoint("sandboxes");
         let req = self
             .client
@@ -370,6 +412,7 @@ impl SandboxesClient {
         request: &ClaimSandboxRequest,
     ) -> Result<Traced<CreateSandboxResponse>, SdkError> {
         validate_mount_snapshot_pins(&request.file_systems)?;
+        validate_mount_owners(&request.file_systems)?;
         let uri = self.endpoint(&format!("sandbox-pools/{pool_id}/sandboxes"));
         let req = self
             .client
@@ -557,6 +600,12 @@ impl SandboxesClient {
     /// `snapshot_id` pins the mount to a specific filesystem snapshot and
     /// requires `read_only`; it is sent only when set for the same
     /// compatibility reason.
+    ///
+    /// `owner` presents the mounted files as owned by a guest user spec
+    /// (`NAME`, `UID`, `NAME:GROUP`, or `UID:GID`), resolved against the
+    /// sandbox image's own user database at attach time; unset keeps the
+    /// image default. It is sent only when set for the same compatibility
+    /// reason.
     pub async fn attach_file_system(
         &self,
         sandbox_id: &str,
@@ -565,6 +614,7 @@ impl SandboxesClient {
         read_only: bool,
         prefetch: bool,
         snapshot_id: Option<&str>,
+        owner: Option<&str>,
     ) -> Result<Traced<SandboxInfo>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/file_systems"));
         let body = FileSystemMount {
@@ -573,8 +623,10 @@ impl SandboxesClient {
             read_only,
             prefetch,
             snapshot_id: snapshot_id.map(str::to_string),
+            owner: owner.map(str::to_string),
         };
         validate_mount_snapshot_pins(std::slice::from_ref(&body))?;
+        validate_mount_owners(std::slice::from_ref(&body))?;
         let req = self
             .client
             .build_post_json_request(Method::POST, &uri, &body)?;
@@ -1217,7 +1269,7 @@ mod process_ref_tests {
     use super::{
         FileSystemMount, ProcessRef, resolve_sandbox_proxy_target, sandbox_proxy_hostname,
         sandbox_url_from_ingress_endpoint, select_sandbox_proxy_url, validate_managed_name,
-        validate_mount_snapshot_pins,
+        validate_mount_owners, validate_mount_snapshot_pins,
     };
 
     #[test]
@@ -1357,6 +1409,7 @@ mod process_ref_tests {
             read_only: false,
             prefetch: false,
             snapshot_id: Some("0abc123def".to_string()),
+            owner: None,
         };
         let error = validate_mount_snapshot_pins(std::slice::from_ref(&pinned_writable))
             .expect_err("a writable snapshot pin must be rejected client-side");
@@ -1377,5 +1430,31 @@ mod process_ref_tests {
         };
         validate_mount_snapshot_pins(&[pinned_read_only, unpinned])
             .expect("read-only pins and unpinned mounts are valid");
+    }
+
+    #[test]
+    fn malformed_mount_owner_is_a_client_error() {
+        let mount = |owner: Option<&str>| FileSystemMount {
+            file_system_id: "skills".to_string(),
+            mount_path: "/mnt/skills".to_string(),
+            read_only: false,
+            prefetch: false,
+            snapshot_id: None,
+            owner: owner.map(str::to_string),
+        };
+
+        for good in [None, Some("agent"), Some("1001:1001"), Some("agent:wheel")] {
+            validate_mount_owners(std::slice::from_ref(&mount(good)))
+                .expect("well-formed owners are valid");
+        }
+
+        for bad in ["", ":", "agent:", "a:b:c", "with space", "4294967296"] {
+            let error = validate_mount_owners(std::slice::from_ref(&mount(Some(bad))))
+                .expect_err("malformed owner specs must be rejected client-side");
+            assert!(
+                error.to_string().contains("invalid owner"),
+                "unexpected error for {bad:?}: {error}"
+            );
+        }
     }
 }

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -248,6 +248,13 @@ fn default_allow_internet_access() -> bool {
 /// writable pin with HTTP 400). The field serializes only when set: older
 /// servers reject mount bodies carrying unknown fields, so "unpinned" is
 /// expressed by omission.
+///
+/// `owner` optionally presents the mounted files as owned by a guest user:
+/// `NAME`, `UID`, `NAME:GROUP`, or `UID:GID` (e.g. `agent` or `1001:1001`),
+/// resolved against the sandbox image's own user database when the mount
+/// attaches. Unset means the image default (the baked `tl-user` account when
+/// the image has one, otherwise root). The field serializes only when set,
+/// for the same compatibility reason as the pin.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct FileSystemMount {
     pub file_system_id: String,
@@ -262,6 +269,9 @@ pub struct FileSystemMount {
     /// `read_only`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snapshot_id: Option<String>,
+    /// Present the mounted files as owned by this guest user spec.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -1043,6 +1053,7 @@ mod tests {
             read_only: false,
             prefetch: false,
             snapshot_id: None,
+            owner: None,
         };
         assert_eq!(
             serde_json::to_value(&mount).unwrap(),
@@ -1061,6 +1072,7 @@ mod tests {
             read_only: true,
             prefetch: true,
             snapshot_id: None,
+            owner: None,
         };
         assert_eq!(
             serde_json::to_value(&mount).unwrap(),
@@ -1081,6 +1093,7 @@ mod tests {
             read_only: true,
             prefetch: false,
             snapshot_id: Some("0abc123def".to_string()),
+            owner: None,
         };
         assert_eq!(
             serde_json::to_value(&pinned).unwrap(),

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -561,6 +561,7 @@ impl NativeSandboxClient {
         read_only: Option<bool>,
         prefetch: Option<bool>,
         snapshot_id: Option<String>,
+        owner: Option<String>,
     ) -> napi::Result<TracedJson> {
         let read_only = read_only.unwrap_or(false);
         let prefetch = prefetch.unwrap_or(false);
@@ -569,6 +570,7 @@ impl NativeSandboxClient {
             let file_system_id = file_system_id.clone();
             let mount_path = mount_path.clone();
             let snapshot_id = snapshot_id.clone();
+            let owner = owner.clone();
             async move {
                 let traced = c
                     .attach_file_system(
@@ -578,6 +580,7 @@ impl NativeSandboxClient {
                         read_only,
                         prefetch,
                         snapshot_id.as_deref(),
+                        owner.as_deref(),
                     )
                     .await?;
                 let trace_id = traced.trace_id.clone();

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -1652,7 +1652,7 @@ impl CloudSandboxClient {
         })
     }
 
-    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false, snapshot_id=None))]
+    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false, snapshot_id=None, owner=None))]
     fn attach_file_system(
         &self,
         sandbox_id: String,
@@ -1661,12 +1661,14 @@ impl CloudSandboxClient {
         read_only: bool,
         prefetch: bool,
         snapshot_id: Option<String>,
+        owner: Option<String>,
     ) -> PyResult<(String, String)> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
             let file_system_id = file_system_id.clone();
             let mount_path = mount_path.clone();
             let snapshot_id = snapshot_id.clone();
+            let owner = owner.clone();
             async move {
                 let traced = client
                     .attach_file_system(
@@ -1676,6 +1678,7 @@ impl CloudSandboxClient {
                         read_only,
                         prefetch,
                         snapshot_id.as_deref(),
+                        owner.as_deref(),
                     )
                     .await?;
                 let trace_id = traced.trace_id.clone();
@@ -2067,7 +2070,7 @@ impl CloudSandboxClient {
         })
     }
 
-    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false, snapshot_id=None))]
+    #[pyo3(signature = (sandbox_id, file_system_id, mount_path, read_only=false, prefetch=false, snapshot_id=None, owner=None))]
     fn attach_file_system_async<'py>(
         &self,
         py: Python<'py>,
@@ -2077,6 +2080,7 @@ impl CloudSandboxClient {
         read_only: bool,
         prefetch: bool,
         snapshot_id: Option<String>,
+        owner: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
@@ -2085,6 +2089,7 @@ impl CloudSandboxClient {
                 let file_system_id = file_system_id.clone();
                 let mount_path = mount_path.clone();
                 let snapshot_id = snapshot_id.clone();
+                let owner = owner.clone();
                 async move {
                     c.attach_file_system(
                         &sandbox_id,
@@ -2093,6 +2098,7 @@ impl CloudSandboxClient {
                         read_only,
                         prefetch,
                         snapshot_id.as_deref(),
+                        owner.as_deref(),
                     )
                     .await
                 }

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -74,6 +74,7 @@ from .models import (
     SnapshotType,
     SnapshotWaitCondition,
     UpdateSandboxRequest,
+    _validate_mount_owners,
     _validate_mount_snapshot_pins,
     snapshot_satisfies_wait_condition,
 )
@@ -253,6 +254,7 @@ class AsyncSandboxClient:
         gpu: GpuRequest | None = None,
     ) -> Traced[CreateSandboxResponse]:
         _validate_mount_snapshot_pins(file_systems)
+        _validate_mount_owners(file_systems)
         network = None
         if not allow_internet_access or allow_out is not None or deny_out is not None:
             network = NetworkConfig(
@@ -294,6 +296,7 @@ class AsyncSandboxClient:
         file_systems: list[FileSystemMount] | None = None,
     ) -> Traced[CreateSandboxResponse]:
         _validate_mount_snapshot_pins(file_systems)
+        _validate_mount_owners(file_systems)
         try:
             claim_kwargs: dict[str, str] = {"pool_id": pool_id}
             if file_systems:
@@ -454,6 +457,7 @@ class AsyncSandboxClient:
         read_only: bool = False,
         prefetch: bool = False,
         snapshot_id: str | None = None,
+        owner: str | None = None,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to a running sandbox.
 
@@ -462,19 +466,22 @@ class AsyncSandboxClient:
         dataplane. ``read_only`` mounts the file system read-only;
         ``prefetch`` eagerly downloads its contents; ``snapshot_id`` pins
         the mount to a specific filesystem snapshot and requires
-        ``read_only=True``.
+        ``read_only=True``; ``owner`` presents the mounted files as owned by
+        a guest user spec (``NAME``, ``UID``, ``NAME:GROUP``, or ``UID:GID``),
+        resolved against the sandbox image's own user database at attach time.
         """
-        _validate_mount_snapshot_pins(
-            [
-                FileSystemMount(
-                    file_system_id=file_system_id,
-                    mount_path=mount_path,
-                    read_only=read_only,
-                    prefetch=prefetch,
-                    snapshot_id=snapshot_id,
-                )
-            ]
-        )
+        _attach_mounts = [
+            FileSystemMount(
+                file_system_id=file_system_id,
+                mount_path=mount_path,
+                read_only=read_only,
+                prefetch=prefetch,
+                snapshot_id=snapshot_id,
+                owner=owner,
+            )
+        ]
+        _validate_mount_snapshot_pins(_attach_mounts)
+        _validate_mount_owners(_attach_mounts)
         try:
             trace_id, response_json = await self._rust_client.attach_file_system_async(
                 sandbox_id=sandbox_id,
@@ -483,6 +490,7 @@ class AsyncSandboxClient:
                 read_only=read_only,
                 prefetch=prefetch,
                 snapshot_id=snapshot_id,
+                owner=owner,
             )
             return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -408,6 +408,7 @@ class AsyncSandbox:
         read_only: bool = False,
         prefetch: bool = False,
         snapshot_id: str | None = None,
+        owner: str | None = None,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to this running sandbox.
 
@@ -419,6 +420,12 @@ class AsyncSandbox:
             prefetch: Eagerly download the file system's contents.
             snapshot_id: Pin the mount to a specific filesystem snapshot.
                 Requires ``read_only=True``.
+            owner: Present the mounted files as owned by this guest user:
+                ``NAME``, ``UID``, ``NAME:GROUP``, or ``UID:GID`` (e.g.
+                ``"agent"`` or ``"1001:1001"``), resolved against the sandbox
+                image's own user database when the mount attaches. Unset keeps
+                the image default (the baked ``tl-user`` account when the
+                image has one, otherwise root).
 
         Returns:
             Traced[SandboxInfo] with this sandbox's updated file systems.
@@ -431,6 +438,7 @@ class AsyncSandbox:
             read_only=read_only,
             prefetch=prefetch,
             snapshot_id=snapshot_id,
+            owner=owner,
         )
         self._sandbox_id = traced.sandbox_id
         self._cached_info = traced.value

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -53,6 +53,7 @@ from .models import (
     SnapshotType,
     SnapshotWaitCondition,
     UpdateSandboxRequest,
+    _validate_mount_owners,
     _validate_mount_snapshot_pins,
     snapshot_satisfies_wait_condition,
 )
@@ -501,6 +502,7 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         _validate_mount_snapshot_pins(file_systems)
+        _validate_mount_owners(file_systems)
         network = None
         if not allow_internet_access or allow_out is not None or deny_out is not None:
             network = NetworkConfig(
@@ -563,6 +565,7 @@ class SandboxClient:
             SandboxConnectionError: If the server is unreachable
         """
         _validate_mount_snapshot_pins(file_systems)
+        _validate_mount_owners(file_systems)
         try:
             claim_kwargs: dict[str, str] = {"pool_id": pool_id}
             if file_systems:
@@ -1024,6 +1027,7 @@ class SandboxClient:
         read_only: bool = False,
         prefetch: bool = False,
         snapshot_id: str | None = None,
+        owner: str | None = None,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to a running sandbox.
 
@@ -1040,6 +1044,12 @@ class SandboxClient:
             prefetch: Eagerly download the file system's contents.
             snapshot_id: Pin the mount to a specific filesystem snapshot.
                 Requires ``read_only=True``.
+            owner: Present the mounted files as owned by this guest user:
+                ``NAME``, ``UID``, ``NAME:GROUP``, or ``UID:GID`` (e.g.
+                ``"agent"`` or ``"1001:1001"``), resolved against the sandbox
+                image's own user database when the mount attaches. Unset keeps
+                the image default (the baked ``tl-user`` account when the
+                image has one, otherwise root).
 
         Returns:
             Traced[SandboxInfo] with the sandbox's updated file systems.
@@ -1050,17 +1060,18 @@ class SandboxClient:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
-        _validate_mount_snapshot_pins(
-            [
-                FileSystemMount(
-                    file_system_id=file_system_id,
-                    mount_path=mount_path,
-                    read_only=read_only,
-                    prefetch=prefetch,
-                    snapshot_id=snapshot_id,
-                )
-            ]
-        )
+        _attach_mounts = [
+            FileSystemMount(
+                file_system_id=file_system_id,
+                mount_path=mount_path,
+                read_only=read_only,
+                prefetch=prefetch,
+                snapshot_id=snapshot_id,
+                owner=owner,
+            )
+        ]
+        _validate_mount_snapshot_pins(_attach_mounts)
+        _validate_mount_owners(_attach_mounts)
         try:
             trace_id, response_json = self._rust_client.attach_file_system(
                 sandbox_id=sandbox_id,
@@ -1069,6 +1080,7 @@ class SandboxClient:
                 read_only=read_only,
                 prefetch=prefetch,
                 snapshot_id=snapshot_id,
+                owner=owner,
             )
             return Traced(trace_id, SandboxInfo.model_validate_json(response_json))
         except Exception as e:

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -261,6 +261,16 @@ class FileSystemMount(BaseModel):
     pinned mount must also set ``read_only=True`` (the server rejects a
     writable pin with HTTP 400). It serializes only when set, for the same
     compatibility reason as the mount modes.
+
+    ``owner`` presents the mounted files as owned by a guest user: ``NAME``,
+    ``UID``, ``NAME:GROUP``, or ``UID:GID`` (e.g. ``"agent"`` or
+    ``"1001:1001"``), resolved against the sandbox image's own user database
+    when the mount attaches. A named user or group must exist in the image; a
+    bare numeric id is used as-is. Unset means the image default: the baked
+    ``tl-user`` account when the image has one, otherwise root. The mount is
+    reachable by every guest user either way; the owner decides which file
+    modes apply to whom. It serializes only when set, for the same
+    compatibility reason as the mount modes.
     """
 
     file_system_id: str
@@ -268,6 +278,7 @@ class FileSystemMount(BaseModel):
     read_only: bool = False
     prefetch: bool = False
     snapshot_id: str | None = None
+    owner: str | None = None
 
     @model_serializer(mode="wrap")
     def _omit_unset_mount_modes(self, handler):
@@ -279,6 +290,8 @@ class FileSystemMount(BaseModel):
                 data.pop("prefetch", None)
             if self.snapshot_id is None:
                 data.pop("snapshot_id", None)
+            if self.owner is None:
+                data.pop("owner", None)
         return data
 
 
@@ -296,6 +309,39 @@ def _validate_mount_snapshot_pins(mounts: "list[FileSystemMount] | None") -> Non
                 f"{mount.mount_path!r} sets snapshot_id without read_only=True: "
                 "snapshot-pinned mounts are read-only"
             )
+
+
+def _validate_mount_owners(mounts: "list[FileSystemMount] | None") -> None:
+    """Client-side mirror of the server's HTTP 400 for malformed mount owners.
+
+    Only the shape is checked (``NAME``, ``UID``, ``NAME:GROUP``, or
+    ``UID:GID``); a named user or group resolves against the sandbox image's
+    own user database when the mount attaches. Raising here lets callers fail
+    fast (and offline) instead of round-tripping to the server.
+    """
+    for mount in mounts or []:
+        owner = mount.owner
+        if owner is None:
+            continue
+
+        def _reject(reason: str) -> None:
+            raise ValueError(
+                f"file system mount {mount.file_system_id!r} at "
+                f"{mount.mount_path!r} has an invalid owner {owner!r}: {reason}"
+            )
+
+        if not owner or len(owner.encode()) > 256:
+            _reject("owner must contain 1 to 256 bytes")
+        if not all(33 <= ord(ch) <= 126 and ch not in "\"'" for ch in owner):
+            _reject("owner must contain only non-whitespace printable ASCII characters")
+        parts = owner.split(":")
+        if len(parts) > 2 or any(not part for part in parts):
+            _reject("owner must be NAME, UID, NAME:GROUP, or UID:GID")
+        # An all-digit part is unconditionally numeric to the guest resolver,
+        # so an id that does not fit a 32-bit uid/gid can never resolve.
+        for part in parts:
+            if part.isascii() and part.isdigit() and int(part) > 0xFFFFFFFF:
+                _reject("a numeric owner id must fit a 32-bit uid/gid")
 
 
 class FileSystem(BaseModel):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -706,6 +706,7 @@ class Sandbox:
         read_only: bool = False,
         prefetch: bool = False,
         snapshot_id: str | None = None,
+        owner: str | None = None,
     ) -> Traced[SandboxInfo]:
         """Attach a registered file system to this running sandbox.
 
@@ -717,6 +718,12 @@ class Sandbox:
             prefetch: Eagerly download the file system's contents.
             snapshot_id: Pin the mount to a specific filesystem snapshot.
                 Requires ``read_only=True``.
+            owner: Present the mounted files as owned by this guest user:
+                ``NAME``, ``UID``, ``NAME:GROUP``, or ``UID:GID`` (e.g.
+                ``"agent"`` or ``"1001:1001"``), resolved against the sandbox
+                image's own user database when the mount attaches. Unset keeps
+                the image default (the baked ``tl-user`` account when the
+                image has one, otherwise root).
 
         Returns:
             Traced[SandboxInfo] with this sandbox's updated file systems.
@@ -729,6 +736,7 @@ class Sandbox:
             read_only=read_only,
             prefetch=prefetch,
             snapshot_id=snapshot_id,
+            owner=owner,
         )
         self._sandbox_id = traced.sandbox_id
         self._cached_info = traced.value

--- a/tests/sandbox/test_file_systems.py
+++ b/tests/sandbox/test_file_systems.py
@@ -58,9 +58,18 @@ class _FakeRustClient:
         read_only,
         prefetch,
         snapshot_id,
+        owner,
     ):
         self.attach_calls.append(
-            (sandbox_id, file_system_id, mount_path, read_only, prefetch, snapshot_id)
+            (
+                sandbox_id,
+                file_system_id,
+                mount_path,
+                read_only,
+                prefetch,
+                snapshot_id,
+                owner,
+            )
         )
         mount = {"file_system_id": file_system_id, "mount_path": mount_path}
         if read_only:
@@ -69,6 +78,8 @@ class _FakeRustClient:
             mount["prefetch"] = True
         if snapshot_id is not None:
             mount["snapshot_id"] = snapshot_id
+        if owner is not None:
+            mount["owner"] = owner
         return ("trace-attach", _sandbox_info_json([mount]))
 
     def detach_file_system(self, *, sandbox_id, mount_path):
@@ -101,9 +112,18 @@ class _FakeAsyncRustClient:
         read_only,
         prefetch,
         snapshot_id,
+        owner,
     ):
         self.attach_calls.append(
-            (sandbox_id, file_system_id, mount_path, read_only, prefetch, snapshot_id)
+            (
+                sandbox_id,
+                file_system_id,
+                mount_path,
+                read_only,
+                prefetch,
+                snapshot_id,
+                owner,
+            )
         )
         mount = {"file_system_id": file_system_id, "mount_path": mount_path}
         if read_only:
@@ -112,6 +132,8 @@ class _FakeAsyncRustClient:
             mount["prefetch"] = True
         if snapshot_id is not None:
             mount["snapshot_id"] = snapshot_id
+        if owner is not None:
+            mount["owner"] = owner
         return ("trace-attach", _sandbox_info_json([mount]))
 
     async def claim_sandbox_async(self, **kwargs):
@@ -276,6 +298,42 @@ class TestFileSystemModels(unittest.TestCase):
         )
         self.assertEqual(present.snapshot_id, "0abc123def")
 
+    def test_file_system_mount_serializes_owner_only_when_set(self):
+        default_owner = FileSystemMount(
+            file_system_id="file_system_abc",
+            mount_path="/mnt/skills",
+        )
+        self.assertNotIn("owner", json.loads(default_owner.model_dump_json()))
+
+        owned = FileSystemMount(
+            file_system_id="file_system_abc",
+            mount_path="/mnt/skills",
+            owner="agent",
+        )
+        self.assertEqual(
+            json.loads(owned.model_dump_json()),
+            {
+                "file_system_id": "file_system_abc",
+                "mount_path": "/mnt/skills",
+                "owner": "agent",
+            },
+        )
+
+    def test_file_system_mount_parses_absent_and_present_owner(self):
+        absent = FileSystemMount.model_validate(
+            {"file_system_id": "file_system_abc", "mount_path": "/mnt/skills"}
+        )
+        self.assertIsNone(absent.owner)
+
+        present = FileSystemMount.model_validate(
+            {
+                "file_system_id": "file_system_abc",
+                "mount_path": "/mnt/skills",
+                "owner": "1001:1001",
+            }
+        )
+        self.assertEqual(present.owner, "1001:1001")
+
     def test_create_request_serializes_file_systems_to_wire_key(self):
         request = CreateSandboxRequest(
             resources=CreateSandboxResources(cpus=1.0, memory_mb=1024),
@@ -366,7 +424,7 @@ class TestSandboxClientFileSystems(unittest.TestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", False, False, None)],
+            [("sbx-1", "file_system_abc", "/mnt/skills", False, False, None, None)],
         )
         self.assertEqual(traced.trace_id, "trace-attach")
         self.assertEqual(
@@ -392,7 +450,7 @@ class TestSandboxClientFileSystems(unittest.TestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", True, True, None)],
+            [("sbx-1", "file_system_abc", "/mnt/skills", True, True, None, None)],
         )
         self.assertEqual(
             traced.value.file_systems,
@@ -420,7 +478,17 @@ class TestSandboxClientFileSystems(unittest.TestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", True, False, "0abc123def")],
+            [
+                (
+                    "sbx-1",
+                    "file_system_abc",
+                    "/mnt/skills",
+                    True,
+                    False,
+                    "0abc123def",
+                    None,
+                )
+            ],
         )
         self.assertEqual(
             traced.value.file_systems,
@@ -432,6 +500,22 @@ class TestSandboxClientFileSystems(unittest.TestCase):
                     snapshot_id="0abc123def",
                 )
             ],
+        )
+
+    def test_attach_file_system_rejects_malformed_owner_offline(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        for bad in ["", ":", "agent:", "a:b:c", "with space", "4294967296"]:
+            with self.assertRaisesRegex(ValueError, "invalid owner"):
+                client.attach_file_system(
+                    "sbx-1",
+                    "file_system_abc",
+                    "/mnt/skills",
+                    owner=bad,
+                )
+        self.assertEqual(
+            fake.attach_calls, [], "malformed owners must fail before the wire"
         )
 
     def test_attach_file_system_rejects_snapshot_pin_without_read_only(self):
@@ -446,6 +530,32 @@ class TestSandboxClientFileSystems(unittest.TestCase):
                 snapshot_id="0abc123def",
             )
         self.assertEqual(fake.attach_calls, [])
+
+    def test_attach_file_system_threads_owner(self):
+        fake = _FakeRustClient()
+        client = _sync_client(fake)
+
+        traced = client.attach_file_system(
+            "sbx-1",
+            "file_system_abc",
+            "/mnt/skills",
+            owner="agent",
+        )
+
+        self.assertEqual(
+            fake.attach_calls,
+            [("sbx-1", "file_system_abc", "/mnt/skills", False, False, None, "agent")],
+        )
+        self.assertEqual(
+            traced.value.file_systems,
+            [
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    owner="agent",
+                )
+            ],
+        )
 
     def test_detach_file_system(self):
         fake = _FakeRustClient()
@@ -675,7 +785,7 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", False, False, None)],
+            [("sbx-1", "file_system_abc", "/mnt/skills", False, False, None, None)],
         )
         self.assertEqual(traced.trace_id, "trace-attach")
         self.assertEqual(
@@ -701,7 +811,7 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", True, True, None)],
+            [("sbx-1", "file_system_abc", "/mnt/skills", True, True, None, None)],
         )
         self.assertEqual(
             traced.value.file_systems,
@@ -729,7 +839,17 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             fake.attach_calls,
-            [("sbx-1", "file_system_abc", "/mnt/skills", True, False, "0abc123def")],
+            [
+                (
+                    "sbx-1",
+                    "file_system_abc",
+                    "/mnt/skills",
+                    True,
+                    False,
+                    "0abc123def",
+                    None,
+                )
+            ],
         )
         self.assertEqual(
             traced.value.file_systems,
@@ -739,6 +859,42 @@ class TestAsyncSandboxClientFileSystems(unittest.IsolatedAsyncioTestCase):
                     mount_path="/mnt/skills",
                     read_only=True,
                     snapshot_id="0abc123def",
+                )
+            ],
+        )
+
+    async def test_attach_file_system_threads_owner(self):
+        fake = _FakeAsyncRustClient()
+        client = _async_client(fake)
+
+        traced = await client.attach_file_system(
+            "sbx-1",
+            "file_system_abc",
+            "/mnt/skills",
+            owner="1001:1001",
+        )
+
+        self.assertEqual(
+            fake.attach_calls,
+            [
+                (
+                    "sbx-1",
+                    "file_system_abc",
+                    "/mnt/skills",
+                    False,
+                    False,
+                    None,
+                    "1001:1001",
+                )
+            ],
+        )
+        self.assertEqual(
+            traced.value.file_systems,
+            [
+                FileSystemMount(
+                    file_system_id="file_system_abc",
+                    mount_path="/mnt/skills",
+                    owner="1001:1001",
                 )
             ],
         )

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -88,6 +88,7 @@ function fileSystemMountToWire(fs: FileSystemMount): Record<string, unknown> {
     ...(fs.readOnly === true ? { read_only: true } : {}),
     ...(fs.prefetch === true ? { prefetch: true } : {}),
     ...(fs.snapshotId != null ? { snapshot_id: fs.snapshotId } : {}),
+    ...(fs.owner != null ? { owner: fs.owner } : {}),
   };
 }
 
@@ -578,6 +579,7 @@ export class SandboxClient {
           options?.readOnly === true,
           options?.prefetch === true,
           options?.snapshotId ?? null,
+          options?.owner ?? null,
         ),
       "sandboxId",
       { sandboxId, notFoundKind: "sandbox" },

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -120,6 +120,13 @@ export interface NetworkConfig {
  * mount must also set `readOnly: true` (the server rejects a writable pin
  * with HTTP 400). It is sent only when set, for the same compatibility
  * reason as the mount modes.
+ *
+ * `owner` presents the mounted files as owned by a guest user: `NAME`,
+ * `UID`, `NAME:GROUP`, or `UID:GID` (e.g. `"agent"` or `"1001:1001"`),
+ * resolved against the sandbox image's own user database when the mount
+ * attaches. Unset keeps the image default (the baked `tl-user` account when
+ * the image has one, otherwise root). It is sent only when set, for the
+ * same compatibility reason as the mount modes.
  */
 export interface FileSystemMount {
   fileSystemId: string;
@@ -130,6 +137,8 @@ export interface FileSystemMount {
   prefetch?: boolean;
   /** Pin the mount to a specific filesystem snapshot (requires `readOnly`). */
   snapshotId?: string;
+  /** Present the mounted files as owned by this guest user spec. */
+  owner?: string;
 }
 
 /** Optional mount modes for attaching a file system to a running sandbox. */
@@ -140,6 +149,8 @@ export interface AttachFileSystemOptions {
   prefetch?: boolean;
   /** Pin the mount to a specific filesystem snapshot (requires `readOnly`). */
   snapshotId?: string;
+  /** Present the mounted files as owned by this guest user spec. */
+  owner?: string;
 }
 
 export interface ClaimSandboxOptions {

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -104,6 +104,7 @@ export interface NativeSandboxClient {
     readOnly?: boolean | null,
     prefetch?: boolean | null,
     snapshotId?: string | null,
+    owner?: string | null,
   ): Promise<TracedJson>;
   detachFileSystem(
     sandboxId: string,


### PR DESCRIPTION
## What

Client-side surface for the new per-mount `owner` spec on sandbox file-system mounts (server side: tensorlakeai/compute-engine-internal#1918; the FUSE reachability fix it pairs with: tensorlakeai/artifact_storage#282). `owner` presents the mounted files as owned by a guest user — `NAME`, `UID`, `NAME:GROUP`, or `UID:GID` (e.g. `"agent"`, `"1001:1001"`) — resolved against the sandbox image's own user database at attach time. Unset keeps the image default (`tl-user` when baked, else root). This is what lets a custom image whose default user is non-root get writable, correctly-owned TLFS mounts.

- **Rust cloud-sdk**: `FileSystemMount.owner` (serialized only when set, same compatibility convention as `snapshot_id`); `attach_file_system` gains an `owner: Option<&str>` parameter (source-breaking like the earlier `snapshot_id` addition — bindings updated in this PR).
- **Python SDK**: `owner` on `FileSystemMount` and `attach_file_system` across sync/async clients and the `Sandbox`/`AsyncSandbox` wrappers.
- **Node/TypeScript SDK**: `owner` on `FileSystemMount` and `AttachFileSystemOptions`, threaded through the napi binding, the native interface, and the create/claim wire mapper (which whitelists keys and would otherwise have silently dropped it).
- **CLI**: `tl sbx fs attach --owner <spec>`, and `tl sbx fs list` renders `owner=<spec>` in the Options column.
- **Fail-fast validation** in Rust and Python mirroring the snapshot-pin pattern: malformed specs (empty parts, >1 colon, non-printable/quote characters, oversized, all-digit ids overflowing u32) raise offline instead of round-tripping to the server.

## Tests

- Rust: 207 lib tests green, including new `malformed_mount_owner_is_a_client_error` and the updated `FileSystemMount` serialization fixtures; CLI `attach_body_*` tests (4) green.
- Python: 39 tests green, including owner serialization/parse, sync+async threading through the rust-client fakes, and offline rejection of malformed specs.
- TypeScript: `tsc --noEmit` clean.

## Release note

Per repo policy, remember to bump the lockstep version (`python .github/scripts/bump_version.py <new-version>`) before releasing — this adds a public API field across Python, Rust, TypeScript, and the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)