### PR TITLE
Add Sandbox.get_or_create / getOrCreate for agent sessions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -250,6 +250,7 @@ jobs:
             tests.sandbox.test_sandbox_rust_backend \
             tests.sandbox.test_sandbox_rust_backend_async \
             tests.sandbox.test_file_systems \
+            tests.sandbox.test_get_or_create \
             tests.image.test_sandbox_builder \
             tests.function_agent.test_runner
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
+ "zstd 0.13.3",
 ]
 
 [[package]]

--- a/crates/gsvc-codec/Cargo.toml
+++ b/crates/gsvc-codec/Cargo.toml
@@ -40,6 +40,7 @@ sha2 = "0.10"
 # against; the default miniz_oxide backend has produced a divergent test result.
 flate2 = { version = "1.1.9", features = ["zlib-rs"] }
 crc32fast = "1"
+zstd = "0.13"
 rayon = "1"
 hex = "0.4"
 tempfile = "3"

--- a/src/tensorlake/sandbox/__init__.py
+++ b/src/tensorlake/sandbox/__init__.py
@@ -12,6 +12,7 @@ from .exceptions import (
     SandboxError,
     SandboxException,
     SandboxNotFoundError,
+    SandboxNotRoutableError,
 )
 from .file_system import (
     create_file_system,
@@ -156,6 +157,7 @@ __all__ = [
     "SandboxError",
     "SandboxConnectionError",
     "SandboxNotFoundError",
+    "SandboxNotRoutableError",
     "PoolNotFoundError",
     "PoolInUseError",
     "RemoteAPIError",

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -40,6 +40,7 @@ from .exceptions import (
     SandboxConnectionError,
     SandboxError,
     SandboxNotFoundError,
+    SandboxNotRoutableError,
 )
 from .models import (
     CLEAR_NETWORK_POLICY,
@@ -926,6 +927,13 @@ class AsyncSandboxClient:
             routing_hint = routing_hint or routing_info.routing_hint
             if isinstance(routing_info, SandboxInfo):
                 cached_info = routing_info
+            if not routing_info.sandbox_url and not explicit_proxy_url:
+                # A sandbox that is not Running yet has no sandbox_url, so
+                # a proxy-backed handle cannot be built for it.
+                raise SandboxNotRoutableError(
+                    proxy_sandbox_id,
+                    getattr(routing_info, "status", None),
+                )
             selected_proxy_url = self._rust_client.select_sandbox_proxy_url(
                 sandbox_id=proxy_sandbox_id,
                 sandbox_url=routing_info.sandbox_url,

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -11,7 +11,7 @@ import asyncio
 import json
 import os
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import httpx
@@ -19,7 +19,13 @@ import httpx
 from tensorlake._tracing import USER_AGENT, Traced, TracedIterator, inject_traceparent
 
 from . import _defaults
-from .exceptions import RemoteAPIError, SandboxConnectionError, SandboxError
+from .exceptions import (
+    RemoteAPIError,
+    SandboxConnectionError,
+    SandboxError,
+    SandboxNotFoundError,
+    SandboxNotRoutableError,
+)
 from .models import (
     CheckpointType,
     ClearNetworkPolicy,
@@ -52,6 +58,8 @@ from .models import (
     StdinMode,
 )
 from .sandbox import (
+    _GET_OR_CREATE_ATTEMPTS,
+    _GET_OR_CREATE_RETRY_DELAY_SEC,
     _PROCESS_ARG_UNSET,
     _RUST_SANDBOX_PROXY_CLIENT_AVAILABLE,
     RustCloudSandboxProxyClient,
@@ -342,6 +350,208 @@ class AsyncSandbox:
             proxy_url=proxy_url,
             routing_hint=routing_hint,
             request_timeout=request_timeout,
+        )
+
+    @classmethod
+    async def get_or_create(
+        cls,
+        name: str,
+        *,
+        resume: bool = True,
+        image: str | None = None,
+        cpus: float = 1.0,
+        memory_mb: int = 1024,
+        disk_mb: int | None = None,
+        gpus: int | None = None,
+        gpu_model: GpuModel | str | None = None,
+        timeout_secs: int | None = None,
+        entrypoint: list[str] | None = None,
+        allow_internet_access: bool = True,
+        allow_out: list[str] | None = None,
+        deny_out: list[str] | None = None,
+        snapshot_id: str | None = None,
+        proxy_url: str | None = None,
+        request_timeout: float | None = None,
+        file_systems: list[FileSystemMount] | None = None,
+        api_key: str | None = _defaults.API_KEY,
+        api_url: str = _defaults.API_URL,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        namespace: str | None = _defaults.NAMESPACE,
+        gpu: GpuRequest | None = None,
+    ) -> "AsyncSandbox":
+        """Return the one sandbox bound to ``name``. Create it on first use.
+
+        Async mirror of :meth:`Sandbox.get_or_create`; see that method for
+        the full semantics. In short: connect by name; create when the name
+        is free; on a lost create race (HTTP 409), attach to the winner;
+        wait for a still-starting sandbox to reach ``Running``; resume a
+        suspended sandbox unless ``resume=False``.
+        """
+        connect_kwargs: dict[str, Any] = {
+            "proxy_url": proxy_url,
+            "api_key": api_key,
+            "api_url": api_url,
+            "organization_id": organization_id,
+            "project_id": project_id,
+            "namespace": namespace,
+            "request_timeout": request_timeout,
+        }
+        wait_timeout = (
+            request_timeout
+            if request_timeout is not None
+            else _defaults.DEFAULT_HTTP_TIMEOUT_SEC
+        )
+        last_conflict: RemoteAPIError | None = None
+        for attempt in range(_GET_OR_CREATE_ATTEMPTS):
+            if attempt:
+                # Reachable only after a lost create race whose winner is
+                # not connectable yet (for example, the name's previous
+                # holder is still terminating). Give the server a moment.
+                await asyncio.sleep(_GET_OR_CREATE_RETRY_DELAY_SEC * attempt)
+            try:
+                try:
+                    sandbox = await cls.connect(name, **connect_kwargs)
+                except SandboxNotRoutableError:
+                    # Another caller's create is still starting the sandbox,
+                    # so it has no proxy routing (sandbox_url) yet. Match
+                    # create(): wait until connect can bind to it.
+                    sandbox = await cls._connect_when_routable(
+                        name, connect_kwargs, wait_timeout
+                    )
+                    if sandbox is None:
+                        # The starting sandbox disappeared or terminated;
+                        # the name may be free again.
+                        continue
+                # With an explicit proxy_url, connect skips resolution and
+                # cannot see that the name is free; this info() call is then
+                # the existence check that routes a free name to the create
+                # step below. Otherwise connect already cached the info, so
+                # this adds no request.
+                status = (await sandbox.info()).status
+            except SandboxNotFoundError:
+                try:
+                    return await cls.create(
+                        image=image,
+                        cpus=cpus,
+                        memory_mb=memory_mb,
+                        disk_mb=disk_mb,
+                        gpus=gpus,
+                        gpu_model=gpu_model,
+                        timeout_secs=timeout_secs,
+                        entrypoint=entrypoint,
+                        allow_internet_access=allow_internet_access,
+                        allow_out=allow_out,
+                        deny_out=deny_out,
+                        snapshot_id=snapshot_id,
+                        proxy_url=proxy_url,
+                        request_timeout=request_timeout,
+                        name=name,
+                        file_systems=file_systems,
+                        api_key=api_key,
+                        api_url=api_url,
+                        organization_id=organization_id,
+                        project_id=project_id,
+                        namespace=namespace,
+                        gpu=gpu,
+                    )
+                except RemoteAPIError as e:
+                    if e.status_code != 409:
+                        raise
+                    # Lost the create race: another caller claimed the name
+                    # first. Loop back and attach to the winner.
+                    last_conflict = e
+                    continue
+            if status == SandboxStatus.PENDING:
+                # Another caller's create is still starting this sandbox.
+                # Match create(): block until Running, then pick up fresh
+                # proxy routing before handing the sandbox out.
+                info = await sandbox._fresh_running_info_for_rebind(
+                    asyncio.get_running_loop().time() + wait_timeout,
+                    poll_interval=0.5,
+                )
+                sandbox._rebind_proxy(info)
+            elif resume and status in (
+                SandboxStatus.SUSPENDING,
+                SandboxStatus.SUSPENDED,
+            ):
+                if status == SandboxStatus.SUSPENDING:
+                    # The server rejects resume while a suspend is still in
+                    # progress; wait for the suspend to settle first.
+                    status = await cls._wait_out_suspending(sandbox, wait_timeout, name)
+                if status == SandboxStatus.SUSPENDED:
+                    await sandbox.resume(timeout=wait_timeout)
+                elif status == SandboxStatus.TERMINATED:
+                    # The sandbox died while suspending; the name may be
+                    # free again.
+                    continue
+                else:
+                    # Another caller resumed it first. The resumed sandbox
+                    # may live elsewhere, so this handle's routing from
+                    # before the suspend is stale. Match the PENDING
+                    # branch: block until Running with fresh proxy routing.
+                    info = await sandbox._fresh_running_info_for_rebind(
+                        asyncio.get_running_loop().time() + wait_timeout,
+                        poll_interval=0.5,
+                    )
+                    sandbox._rebind_proxy(info)
+            return sandbox
+        raise SandboxError(
+            f"get_or_create({name!r}): the name is claimed, but its sandbox "
+            f"could not be attached to after {_GET_OR_CREATE_ATTEMPTS} attempts"
+        ) from last_conflict
+
+    @staticmethod
+    async def _wait_out_suspending(
+        sandbox: "AsyncSandbox",
+        wait_timeout: float,
+        name: str,
+    ) -> SandboxStatus:
+        """Poll until the sandbox leaves ``Suspending``.
+
+        Async mirror of :meth:`Sandbox._wait_out_suspending`; see that
+        method for the semantics.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + wait_timeout
+        while loop.time() < deadline:
+            await asyncio.sleep(0.5)
+            # info() serves the cached SUSPENDING info from connect(); the
+            # status method always fetches fresh state from the server.
+            status = await sandbox.status()
+            if status != SandboxStatus.SUSPENDING:
+                return status
+        raise SandboxError(
+            f"get_or_create({name!r}): the sandbox holding the name did not "
+            f"finish suspending within {wait_timeout}s"
+        )
+
+    @classmethod
+    async def _connect_when_routable(
+        cls,
+        name: str,
+        connect_kwargs: dict[str, Any],
+        wait_timeout: float,
+    ) -> "AsyncSandbox | None":
+        """Poll ``connect`` until the named sandbox has proxy routing.
+
+        Async mirror of :meth:`Sandbox._connect_when_routable`; see that
+        method for the semantics.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + wait_timeout
+        while loop.time() < deadline:
+            await asyncio.sleep(0.5)
+            try:
+                return await cls.connect(name, **connect_kwargs)
+            except SandboxNotFoundError:
+                return None
+            except SandboxNotRoutableError as e:
+                if e.status == SandboxStatus.TERMINATED:
+                    return None
+        raise SandboxError(
+            f"get_or_create({name!r}): the sandbox holding the name did not "
+            f"become connectable within {wait_timeout}s"
         )
 
     # --- Lifecycle ---

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -19,6 +19,7 @@ from .exceptions import (
     SandboxConnectionError,
     SandboxError,
     SandboxNotFoundError,
+    SandboxNotRoutableError,
 )
 from .models import (
     CLEAR_NETWORK_POLICY,
@@ -1510,6 +1511,13 @@ class SandboxClient:
             routing_hint = routing_hint or routing_info.routing_hint
             if isinstance(routing_info, SandboxInfo):
                 cached_info = routing_info
+            if not routing_info.sandbox_url and not explicit_proxy_url:
+                # A sandbox that is not Running yet has no sandbox_url, so
+                # a proxy-backed handle cannot be built for it.
+                raise SandboxNotRoutableError(
+                    proxy_sandbox_id,
+                    getattr(routing_info, "status", None),
+                )
             selected_proxy_url = self._rust_client.select_sandbox_proxy_url(
                 sandbox_id=proxy_sandbox_id,
                 sandbox_url=routing_info.sandbox_url,

--- a/src/tensorlake/sandbox/exceptions.py
+++ b/src/tensorlake/sandbox/exceptions.py
@@ -1,5 +1,10 @@
 """Exception hierarchy for sandbox operations."""
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models import SandboxStatus
+
 
 class SandboxException(Exception):
     """Base exception for all sandbox-related errors."""
@@ -30,6 +35,38 @@ class SandboxNotFoundError(SandboxError):
     @property
     def sandbox_id(self) -> str:
         return self._sandbox_id
+
+
+class SandboxNotRoutableError(SandboxError):
+    """Raised when a sandbox exists but has no proxy routing yet.
+
+    A sandbox that is not ``Running`` (for example, one that is still
+    starting) has no ``sandbox_url``, so a connected handle cannot be
+    built for it. Wait for the sandbox to reach ``Running`` and connect
+    again, or pass an explicit ``proxy_url``.
+    """
+
+    def __init__(self, sandbox_id: str, status: "SandboxStatus | None" = None):
+        self._sandbox_id = sandbox_id
+        self._status = status
+        status_part = (
+            f" (status: {getattr(status, 'value', status)})"
+            if status is not None
+            else ""
+        )
+        super().__init__(
+            f"Sandbox {sandbox_id} did not include proxy routing "
+            f"information{status_part}; it may still be starting. Wait for "
+            "it to be Running and connect again, or pass an explicit proxy_url."
+        )
+
+    @property
+    def sandbox_id(self) -> str:
+        return self._sandbox_id
+
+    @property
+    def status(self) -> "SandboxStatus | None":
+        return self._status
 
 
 class PoolNotFoundError(SandboxError):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -19,6 +19,8 @@ from .exceptions import (
     RemoteAPIError,
     SandboxConnectionError,
     SandboxError,
+    SandboxNotFoundError,
+    SandboxNotRoutableError,
 )
 from .models import (
     CheckpointType,
@@ -162,6 +164,13 @@ def _resolve_process_arg(process: object, pid: object) -> str:
     if process is _PROCESS_ARG_UNSET:
         raise TypeError("missing required argument: `process`")
     return str(process)
+
+
+# ``get_or_create``: how many connect-or-create attempts to make when a
+# named sandbox is caught mid-handoff (for example, its previous holder is
+# still terminating), and the base delay between attempts.
+_GET_OR_CREATE_ATTEMPTS = 4
+_GET_OR_CREATE_RETRY_DELAY_SEC = 0.5
 
 
 class Sandbox:
@@ -398,6 +407,9 @@ class Sandbox:
             request_timeout: Max seconds to wait for HTTP operations.
             startup_timeout: Deprecated alias for ``request_timeout``.
             name: Optional name; named sandboxes support suspend/resume.
+                Fails with HTTP 409 (``RemoteAPIError``) when the name is
+                already claimed. To attach to the existing sandbox instead,
+                use :meth:`get_or_create`.
             file_systems: File systems to mount into the sandbox
                 at boot or warm-pool claim, each at its own absolute, unique
                 guest mount path.
@@ -507,6 +519,260 @@ class Sandbox:
             proxy_url=proxy_url,
             routing_hint=routing_hint,
             request_timeout=request_timeout,
+        )
+
+    @classmethod
+    def get_or_create(
+        cls,
+        name: str,
+        *,
+        resume: bool = True,
+        image: str | None = None,
+        cpus: float = 1.0,
+        memory_mb: int = 1024,
+        disk_mb: int | None = None,
+        gpus: int | None = None,
+        gpu_model: GpuModel | str | None = None,
+        timeout_secs: int | None = None,
+        entrypoint: list[str] | None = None,
+        allow_internet_access: bool = True,
+        allow_out: list[str] | None = None,
+        deny_out: list[str] | None = None,
+        snapshot_id: str | None = None,
+        proxy_url: str | None = None,
+        request_timeout: float | None = None,
+        file_systems: list[FileSystemMount] | None = None,
+        api_key: str | None = _defaults.API_KEY,
+        api_url: str = _defaults.API_URL,
+        organization_id: str | None = None,
+        project_id: str | None = None,
+        namespace: str | None = _defaults.NAMESPACE,
+        gpu: GpuRequest | None = None,
+    ) -> "Sandbox":
+        """Return the one sandbox bound to ``name``. Create it on first use.
+
+        This is the recommended call for an agent session that derives its
+        sandbox name from its session ID. It declares the intent "this name
+        is my session's sandbox": when a sandbox already holds the name, the
+        call attaches to it instead of failing with HTTP 409 the way
+        ``create`` does.
+
+        The steps, all handled internally:
+
+        1. ``connect(name)`` — finds the sandbox, running or suspended.
+        2. When nothing holds the name, ``create(name=...)`` with the given
+           configuration.
+        3. When that create loses a race against another caller (HTTP 409),
+           connect to the winner.
+        4. When the sandbox is still starting (another caller's create is
+           in flight), wait until it is ``Running``, the same way
+           :meth:`create` blocks for its own caller.
+        5. When the sandbox is suspended, ``resume()`` it. Disable with
+           ``resume=False``.
+
+        Concurrent callers that use the same name all converge on the same
+        sandbox. The configuration arguments (``image``, ``cpus``, ...)
+        apply only when the call creates a new sandbox; an existing sandbox
+        is returned as-is, with whatever configuration it already has.
+
+        Args:
+            name: Sandbox name; unique within the namespace. Derive it
+                deterministically from your session ID, for example
+                ``f"agent-{session_id}"``.
+            resume: If True (the default), resume a suspended sandbox before
+                returning, so the handle is immediately usable. If False,
+                the returned handle can point at a suspended sandbox; call
+                ``resume()`` yourself before you run anything.
+
+        All other arguments match :meth:`create` and are used only when a
+        new sandbox must be created. ``pool_id`` is the one exception: a
+        pool claim cannot carry a name, so a claimed sandbox could never
+        be found again by a later call. To use a warm pool, ``create``
+        with ``pool_id`` and name the sandbox afterwards with
+        ``client.update(sandbox_id, name=...)``.
+
+        Returns:
+            Connected Sandbox handle for the named sandbox.
+
+        Raises:
+            SandboxError: If the name stays claimed but its sandbox cannot
+                be attached to after several attempts (for example, the
+                previous holder is stuck terminating), or if a sandbox that
+                is still starting does not reach ``Running`` within
+                ``request_timeout``.
+            RemoteAPIError: If the create step fails with a non-409 error.
+        """
+        connect_kwargs: dict[str, Any] = {
+            "proxy_url": proxy_url,
+            "api_key": api_key,
+            "api_url": api_url,
+            "organization_id": organization_id,
+            "project_id": project_id,
+            "namespace": namespace,
+            "request_timeout": request_timeout,
+        }
+        wait_timeout = (
+            request_timeout
+            if request_timeout is not None
+            else _defaults.DEFAULT_HTTP_TIMEOUT_SEC
+        )
+        last_conflict: RemoteAPIError | None = None
+        for attempt in range(_GET_OR_CREATE_ATTEMPTS):
+            if attempt:
+                # Reachable only after a lost create race whose winner is
+                # not connectable yet (for example, the name's previous
+                # holder is still terminating). Give the server a moment.
+                time.sleep(_GET_OR_CREATE_RETRY_DELAY_SEC * attempt)
+            try:
+                try:
+                    sandbox = cls.connect(name, **connect_kwargs)
+                except SandboxNotRoutableError:
+                    # Another caller's create is still starting the sandbox,
+                    # so it has no proxy routing (sandbox_url) yet. Match
+                    # create(): wait until connect can bind to it.
+                    sandbox = cls._connect_when_routable(
+                        name, connect_kwargs, wait_timeout
+                    )
+                    if sandbox is None:
+                        # The starting sandbox disappeared or terminated;
+                        # the name may be free again.
+                        continue
+                # With an explicit proxy_url, connect skips resolution and
+                # cannot see that the name is free; this info() call is then
+                # the existence check that routes a free name to the create
+                # step below. Otherwise connect already cached the info, so
+                # this adds no request.
+                status = sandbox.info().status
+            except SandboxNotFoundError:
+                try:
+                    return cls.create(
+                        image=image,
+                        cpus=cpus,
+                        memory_mb=memory_mb,
+                        disk_mb=disk_mb,
+                        gpus=gpus,
+                        gpu_model=gpu_model,
+                        timeout_secs=timeout_secs,
+                        entrypoint=entrypoint,
+                        allow_internet_access=allow_internet_access,
+                        allow_out=allow_out,
+                        deny_out=deny_out,
+                        snapshot_id=snapshot_id,
+                        proxy_url=proxy_url,
+                        request_timeout=request_timeout,
+                        name=name,
+                        file_systems=file_systems,
+                        api_key=api_key,
+                        api_url=api_url,
+                        organization_id=organization_id,
+                        project_id=project_id,
+                        namespace=namespace,
+                        gpu=gpu,
+                    )
+                except RemoteAPIError as e:
+                    if e.status_code != 409:
+                        raise
+                    # Lost the create race: another caller claimed the name
+                    # first. Loop back and attach to the winner.
+                    last_conflict = e
+                    continue
+            if status == SandboxStatus.PENDING:
+                # Another caller's create is still starting this sandbox.
+                # Match create(): block until Running, then pick up fresh
+                # proxy routing before handing the sandbox out.
+                info = sandbox._fresh_running_info_for_rebind(
+                    time.monotonic() + wait_timeout, poll_interval=0.5
+                )
+                sandbox._rebind_proxy(info)
+            elif resume and status in (
+                SandboxStatus.SUSPENDING,
+                SandboxStatus.SUSPENDED,
+            ):
+                if status == SandboxStatus.SUSPENDING:
+                    # The server rejects resume while a suspend is still in
+                    # progress; wait for the suspend to settle first.
+                    status = cls._wait_out_suspending(sandbox, wait_timeout, name)
+                if status == SandboxStatus.SUSPENDED:
+                    sandbox.resume(timeout=wait_timeout)
+                elif status == SandboxStatus.TERMINATED:
+                    # The sandbox died while suspending; the name may be
+                    # free again.
+                    continue
+                else:
+                    # Another caller resumed it first. The resumed sandbox
+                    # may live elsewhere, so this handle's routing from
+                    # before the suspend is stale. Match the PENDING
+                    # branch: block until Running with fresh proxy routing.
+                    info = sandbox._fresh_running_info_for_rebind(
+                        time.monotonic() + wait_timeout, poll_interval=0.5
+                    )
+                    sandbox._rebind_proxy(info)
+            return sandbox
+        raise SandboxError(
+            f"get_or_create({name!r}): the name is claimed, but its sandbox "
+            f"could not be attached to after {_GET_OR_CREATE_ATTEMPTS} attempts"
+        ) from last_conflict
+
+    @staticmethod
+    def _wait_out_suspending(
+        sandbox: "Sandbox",
+        wait_timeout: float,
+        name: str,
+    ) -> SandboxStatus:
+        """Poll until the sandbox leaves ``Suspending``.
+
+        The lifecycle API rejects resume while a suspend is still in
+        progress, so :meth:`get_or_create` must wait for the suspend to
+        settle before it can resume the sandbox.
+
+        Raises:
+            SandboxError: If the sandbox is still ``Suspending`` after
+                ``wait_timeout`` seconds.
+        """
+        deadline = time.monotonic() + wait_timeout
+        while time.monotonic() < deadline:
+            time.sleep(0.5)
+            # info() serves the cached SUSPENDING info from connect(); the
+            # status accessor always fetches fresh state from the server.
+            status = sandbox.status
+            if status != SandboxStatus.SUSPENDING:
+                return status
+        raise SandboxError(
+            f"get_or_create({name!r}): the sandbox holding the name did not "
+            f"finish suspending within {wait_timeout}s"
+        )
+
+    @classmethod
+    def _connect_when_routable(
+        cls,
+        name: str,
+        connect_kwargs: dict[str, Any],
+        wait_timeout: float,
+    ) -> "Sandbox | None":
+        """Poll ``connect`` until the named sandbox has proxy routing.
+
+        Used by :meth:`get_or_create` when the name's sandbox is still
+        starting and has no ``sandbox_url`` yet. Returns ``None`` when the
+        sandbox disappears or terminates while starting, so the caller can
+        retry the name.
+
+        Raises:
+            SandboxError: If the sandbox does not become connectable within
+                ``wait_timeout``.
+        """
+        deadline = time.monotonic() + wait_timeout
+        while time.monotonic() < deadline:
+            time.sleep(0.5)
+            try:
+                return cls.connect(name, **connect_kwargs)
+            except SandboxNotFoundError:
+                return None
+            except SandboxNotRoutableError as e:
+                if e.status == SandboxStatus.TERMINATED:
+                    return None
+        raise SandboxError(
+            f"get_or_create({name!r}): the sandbox holding the name did not "
+            f"become connectable within {wait_timeout}s"
         )
 
     # --- Class-level snapshot management ---

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -9,6 +9,8 @@ from tensorlake.sandbox import (
     NetworkConfig,
     PoolInUseError,
     SandboxNotFoundError,
+    SandboxNotRoutableError,
+    SandboxStatus,
     SnapshotStatus,
     SnapshotType,
     SnapshotWaitCondition,
@@ -601,6 +603,40 @@ class TestSandboxClientRustBackend(unittest.TestCase):
                 }
             ],
         )
+
+    def test_connect_raises_not_routable_when_sandbox_not_running(self):
+        # A sandbox that is not Running yet has no sandbox_url. Without an
+        # explicit proxy override, connect must raise SandboxNotRoutableError
+        # (which get_or_create handles) instead of a generic proxy error.
+        class _PendingRustClient(_FakeRustClient):
+            def get_sandbox_json(self, sandbox_id):
+                self.last_get_sandbox_id = sandbox_id
+                return (
+                    "trace-get-sandbox",
+                    json.dumps(
+                        {
+                            "id": "sbx-1",
+                            "namespace": "default",
+                            "status": "pending",
+                            "resources": {
+                                "cpus": 1.0,
+                                "memory_mb": 512,
+                                "ephemeral_disk_mb": 1024,
+                            },
+                        }
+                    ),
+                )
+
+        client = SandboxClient(api_url="https://api.tensorlake.ai", api_key="k")
+        fake = _PendingRustClient()
+        client._rust_client = fake
+
+        with self.assertRaises(SandboxNotRoutableError) as ctx:
+            client.connect("stable-name")
+
+        self.assertEqual(ctx.exception.sandbox_id, "sbx-1")
+        self.assertEqual(ctx.exception.status, SandboxStatus.PENDING)
+        self.assertEqual(fake.connect_proxy_calls, [])
 
     def test_create_uses_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -8,6 +8,8 @@ from tensorlake.sandbox import (
     NetworkConfig,
     PoolInUseError,
     SandboxNotFoundError,
+    SandboxNotRoutableError,
+    SandboxStatus,
     SnapshotStatus,
     SnapshotType,
     SnapshotWaitCondition,
@@ -654,6 +656,39 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
                 }
             ],
         )
+
+    async def test_connect_raises_not_routable_when_sandbox_not_running(self):
+        # A sandbox that is not Running yet has no sandbox_url. Without an
+        # explicit proxy override, connect must raise SandboxNotRoutableError
+        # (which get_or_create handles) instead of a generic proxy error.
+        class _PendingRustClient(_FakeAsyncRustClient):
+            async def get_sandbox_json_async(self, *, sandbox_id):
+                self.last_get_sandbox_id = sandbox_id
+                return (
+                    "trace-get-sandbox",
+                    json.dumps(
+                        {
+                            "id": "sbx-1",
+                            "namespace": "default",
+                            "status": "pending",
+                            "resources": {
+                                "cpus": 1.0,
+                                "memory_mb": 512,
+                                "ephemeral_disk_mb": 1024,
+                            },
+                        }
+                    ),
+                )
+
+        fake = _PendingRustClient()
+        client = _make_client(fake)
+
+        with self.assertRaises(SandboxNotRoutableError) as ctx:
+            await client.connect("stable-name")
+
+        self.assertEqual(ctx.exception.sandbox_id, "sbx-1")
+        self.assertEqual(ctx.exception.status, SandboxStatus.PENDING)
+        self.assertEqual(fake.connect_proxy_calls, [])
 
     async def test_create_uses_rust_backend(self):
         fake = _FakeAsyncRustClient()

--- a/tests/sandbox/test_get_or_create.py
+++ b/tests/sandbox/test_get_or_create.py
@@ -1,0 +1,564 @@
+"""Unit tests for ``Sandbox.get_or_create`` / ``AsyncSandbox.get_or_create``.
+
+These tests mock the ``connect``/``create`` classmethods, so they run without
+a server or the compiled cloud SDK.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+from tensorlake.sandbox import (
+    AsyncSandbox,
+    RemoteAPIError,
+    Sandbox,
+    SandboxError,
+    SandboxNotFoundError,
+    SandboxNotRoutableError,
+    SandboxStatus,
+)
+
+_NAME = "agent-session-123"
+
+
+def _sandbox_mock(status: SandboxStatus) -> MagicMock:
+    sandbox = MagicMock(spec=Sandbox)
+    sandbox.info.return_value = SimpleNamespace(status=status)
+    return sandbox
+
+
+def _async_sandbox_mock(status: SandboxStatus) -> MagicMock:
+    sandbox = MagicMock(spec=AsyncSandbox)
+    sandbox.info = AsyncMock(return_value=SimpleNamespace(status=status))
+    sandbox.resume = AsyncMock()
+    return sandbox
+
+
+class TestGetOrCreate(unittest.TestCase):
+    def test_existing_running_sandbox_is_returned(self):
+        existing = _sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(Sandbox, "connect", return_value=existing) as connect,
+            patch.object(Sandbox, "create") as create,
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, existing)
+        self.assertEqual(connect.call_count, 1)
+        self.assertEqual(connect.call_args.args, (_NAME,))
+        create.assert_not_called()
+        existing.resume.assert_not_called()
+
+    def test_existing_suspended_sandbox_is_resumed(self):
+        existing = _sandbox_mock(SandboxStatus.SUSPENDED)
+        with (
+            patch.object(Sandbox, "connect", return_value=existing),
+            patch.object(Sandbox, "create") as create,
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, existing)
+        existing.resume.assert_called_once_with(timeout=300.0)
+        create.assert_not_called()
+
+    def test_request_timeout_is_passed_to_resume(self):
+        # get_or_create(name, request_timeout=5) must not fall back to
+        # resume()'s independent 300-second default.
+        existing = _sandbox_mock(SandboxStatus.SUSPENDED)
+        with (
+            patch.object(Sandbox, "connect", return_value=existing),
+            patch.object(Sandbox, "create"),
+        ):
+            Sandbox.get_or_create(_NAME, request_timeout=17.0)
+        existing.resume.assert_called_once_with(timeout=17.0)
+
+    def test_resume_false_skips_resume(self):
+        existing = _sandbox_mock(SandboxStatus.SUSPENDED)
+        with (
+            patch.object(Sandbox, "connect", return_value=existing),
+            patch.object(Sandbox, "create"),
+        ):
+            result = Sandbox.get_or_create(_NAME, resume=False)
+        self.assertIs(result, existing)
+        existing.resume.assert_not_called()
+        # The info() call stays even with resume=False: it is the existence
+        # check when connect skipped resolution (explicit proxy_url), and it
+        # is served from the connect cache otherwise.
+        existing.info.assert_called_once_with()
+
+    def test_unverified_connect_handle_missing_sandbox_is_created(self):
+        # With an explicit proxy_url, connect skips resolution and returns a
+        # handle for a name that may not exist. The 404 then surfaces from
+        # info(); get_or_create must treat it as "name is free" and create.
+        dead = MagicMock(spec=Sandbox)
+        dead.info.side_effect = SandboxNotFoundError(_NAME)
+        created = _sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(Sandbox, "connect", return_value=dead),
+            patch.object(Sandbox, "create", return_value=created) as create,
+        ):
+            result = Sandbox.get_or_create(_NAME, proxy_url="http://proxy.example.test")
+        self.assertIs(result, created)
+        create.assert_called_once()
+        self.assertEqual(create.call_args.kwargs["name"], _NAME)
+        dead.resume.assert_not_called()
+
+    def test_missing_sandbox_is_created(self):
+        created = _sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(
+                Sandbox, "connect", side_effect=SandboxNotFoundError(_NAME)
+            ) as connect,
+            patch.object(Sandbox, "create", return_value=created) as create,
+        ):
+            result = Sandbox.get_or_create(_NAME, image="my-agent")
+        self.assertIs(result, created)
+        self.assertEqual(connect.call_count, 1)
+        create.assert_called_once()
+        self.assertEqual(create.call_args.kwargs["name"], _NAME)
+        self.assertEqual(create.call_args.kwargs["image"], "my-agent")
+        # A fresh create is already running; no info/resume round-trip.
+        created.info.assert_not_called()
+        created.resume.assert_not_called()
+
+    def test_lost_create_race_attaches_to_winner(self):
+        winner = _sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(
+                Sandbox,
+                "connect",
+                side_effect=[SandboxNotFoundError(_NAME), winner],
+            ) as connect,
+            patch.object(
+                Sandbox,
+                "create",
+                side_effect=RemoteAPIError(409, "name is currently claimed"),
+            ) as create,
+            patch("tensorlake.sandbox.sandbox.time.sleep") as sleep,
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, winner)
+        self.assertEqual(connect.call_count, 2)
+        self.assertEqual(create.call_count, 1)
+        self.assertEqual(sleep.call_count, 1)
+
+    def test_lost_race_winner_suspended_is_resumed(self):
+        winner = _sandbox_mock(SandboxStatus.SUSPENDED)
+        with (
+            patch.object(
+                Sandbox,
+                "connect",
+                side_effect=[SandboxNotFoundError(_NAME), winner],
+            ),
+            patch.object(
+                Sandbox,
+                "create",
+                side_effect=RemoteAPIError(409, "name is currently claimed"),
+            ),
+            patch("tensorlake.sandbox.sandbox.time.sleep"),
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, winner)
+        winner.resume.assert_called_once_with(timeout=300.0)
+
+    def test_suspending_sandbox_settles_before_resume(self):
+        # The server rejects resume while a suspend is still in progress,
+        # so get_or_create must wait until the sandbox is Suspended before
+        # it calls resume().
+        winner = _sandbox_mock(SandboxStatus.SUSPENDING)
+        # info() serves the cached SUSPENDING info from connect(); the wait
+        # loop polls the fresh ``status`` property instead.
+        type(winner).status = PropertyMock(
+            side_effect=[
+                SandboxStatus.SUSPENDING,
+                SandboxStatus.SUSPENDING,
+                SandboxStatus.SUSPENDED,
+            ]
+        )
+        with (
+            patch.object(Sandbox, "connect", return_value=winner),
+            patch.object(Sandbox, "create") as create,
+            patch("tensorlake.sandbox.sandbox.time.sleep"),
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, winner)
+        winner.resume.assert_called_once_with(timeout=300.0)
+        create.assert_not_called()
+
+    def test_suspending_sandbox_resumed_elsewhere_refreshes_routing(self):
+        # Another caller resumes the sandbox while this one waits for the
+        # suspend to settle: skip resume() (the sandbox is already coming
+        # back) and refresh proxy routing instead, because the routing from
+        # before the suspend is stale.
+        winner = _sandbox_mock(SandboxStatus.SUSPENDING)
+        type(winner).status = PropertyMock(
+            side_effect=[
+                SandboxStatus.SUSPENDING,
+                SandboxStatus.RUNNING,
+            ]
+        )
+        running_info = SimpleNamespace(status=SandboxStatus.RUNNING)
+        winner._fresh_running_info_for_rebind.return_value = running_info
+        with (
+            patch.object(Sandbox, "connect", return_value=winner),
+            patch.object(Sandbox, "create"),
+            patch("tensorlake.sandbox.sandbox.time.sleep"),
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, winner)
+        winner.resume.assert_not_called()
+        winner._fresh_running_info_for_rebind.assert_called_once()
+        winner._rebind_proxy.assert_called_once_with(running_info)
+
+    def test_suspending_sandbox_terminates_then_name_is_recreated(self):
+        # The sandbox dies while suspending: the name may be free again, so
+        # the loop must retry and create.
+        dying = _sandbox_mock(SandboxStatus.SUSPENDING)
+        type(dying).status = PropertyMock(
+            side_effect=[
+                SandboxStatus.SUSPENDING,
+                SandboxStatus.TERMINATED,
+            ]
+        )
+        created = _sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(
+                Sandbox,
+                "connect",
+                side_effect=[dying, SandboxNotFoundError(_NAME)],
+            ),
+            patch.object(Sandbox, "create", return_value=created) as create,
+            patch("tensorlake.sandbox.sandbox.time.sleep"),
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, created)
+        dying.resume.assert_not_called()
+        create.assert_called_once()
+        self.assertEqual(create.call_args.kwargs["name"], _NAME)
+
+    def test_pending_sandbox_is_waited_on(self):
+        # Another caller claimed the name but its create is still starting:
+        # get_or_create must block until Running and refresh proxy routing
+        # instead of returning an unusable pending handle.
+        pending = _sandbox_mock(SandboxStatus.PENDING)
+        running_info = SimpleNamespace(status=SandboxStatus.RUNNING)
+        pending._fresh_running_info_for_rebind.return_value = running_info
+        with (
+            patch.object(Sandbox, "connect", return_value=pending),
+            patch.object(Sandbox, "create") as create,
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, pending)
+        create.assert_not_called()
+        pending._fresh_running_info_for_rebind.assert_called_once()
+        pending._rebind_proxy.assert_called_once_with(running_info)
+        pending.resume.assert_not_called()
+
+    def test_unroutable_pending_winner_is_waited_on(self):
+        # The name's sandbox is still starting and has no sandbox_url, so
+        # connect cannot build a proxy-backed handle. get_or_create must
+        # poll until connect succeeds instead of leaking the routing error.
+        running = _sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(
+                Sandbox,
+                "connect",
+                side_effect=[
+                    SandboxNotRoutableError("sb-1", SandboxStatus.PENDING),
+                    running,
+                ],
+            ) as connect,
+            patch.object(Sandbox, "create") as create,
+            patch("tensorlake.sandbox.sandbox.time.sleep"),
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, running)
+        self.assertEqual(connect.call_count, 2)
+        create.assert_not_called()
+        running.resume.assert_not_called()
+
+    def test_unroutable_winner_terminates_then_name_is_recreated(self):
+        # The starting sandbox terminates before it becomes routable: the
+        # name may be free again, so the loop must retry and create.
+        created = _sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(
+                Sandbox,
+                "connect",
+                side_effect=[
+                    SandboxNotRoutableError("sb-1", SandboxStatus.PENDING),
+                    SandboxNotRoutableError("sb-1", SandboxStatus.TERMINATED),
+                    SandboxNotFoundError(_NAME),
+                ],
+            ),
+            patch.object(Sandbox, "create", return_value=created) as create,
+            patch("tensorlake.sandbox.sandbox.time.sleep"),
+        ):
+            result = Sandbox.get_or_create(_NAME)
+        self.assertIs(result, created)
+        create.assert_called_once()
+        self.assertEqual(create.call_args.kwargs["name"], _NAME)
+
+    def test_never_routable_winner_times_out(self):
+        with (
+            patch.object(
+                Sandbox,
+                "connect",
+                side_effect=SandboxNotRoutableError("sb-1", SandboxStatus.PENDING),
+            ),
+            patch.object(Sandbox, "create") as create,
+            patch("tensorlake.sandbox.sandbox.time.sleep"),
+        ):
+            with self.assertRaises(SandboxError) as ctx:
+                Sandbox.get_or_create(_NAME, request_timeout=0.01)
+        self.assertIn("connectable", str(ctx.exception))
+        create.assert_not_called()
+
+    def test_non_409_create_error_is_raised(self):
+        with (
+            patch.object(Sandbox, "connect", side_effect=SandboxNotFoundError(_NAME)),
+            patch.object(
+                Sandbox,
+                "create",
+                side_effect=RemoteAPIError(400, "Image 'nope' is not registered"),
+            ),
+        ):
+            with self.assertRaises(RemoteAPIError) as ctx:
+                Sandbox.get_or_create(_NAME, image="nope")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_gives_up_when_name_stays_unattachable(self):
+        # Every connect says "not found", every create says "name claimed":
+        # the previous holder is stuck terminating. The loop must end with
+        # a SandboxError instead of spinning forever.
+        conflict = RemoteAPIError(409, "name is currently claimed")
+        with (
+            patch.object(
+                Sandbox, "connect", side_effect=SandboxNotFoundError(_NAME)
+            ) as connect,
+            patch.object(Sandbox, "create", side_effect=conflict) as create,
+            patch("tensorlake.sandbox.sandbox.time.sleep"),
+        ):
+            with self.assertRaises(SandboxError) as ctx:
+                Sandbox.get_or_create(_NAME)
+        self.assertIn(_NAME, str(ctx.exception))
+        self.assertIs(ctx.exception.__cause__, conflict)
+        self.assertEqual(connect.call_count, create.call_count)
+        self.assertGreater(connect.call_count, 1)
+
+    def test_pool_id_is_rejected(self):
+        # A pool claim cannot carry a name on the wire, so a claimed sandbox
+        # would be unnamed and every later get_or_create would claim another
+        # one. The parameter must not exist.
+        with (
+            patch.object(Sandbox, "connect") as connect,
+            patch.object(Sandbox, "create") as create,
+        ):
+            with self.assertRaises(TypeError):
+                Sandbox.get_or_create(_NAME, pool_id="pool-1")
+        connect.assert_not_called()
+        create.assert_not_called()
+
+    def test_connection_kwargs_are_forwarded(self):
+        existing = _sandbox_mock(SandboxStatus.RUNNING)
+        with patch.object(Sandbox, "connect", return_value=existing) as connect:
+            Sandbox.get_or_create(
+                _NAME,
+                api_url="https://api.example.test",
+                namespace="ns-1",
+                request_timeout=17.0,
+            )
+        kwargs = connect.call_args.kwargs
+        self.assertEqual(kwargs["api_url"], "https://api.example.test")
+        self.assertEqual(kwargs["namespace"], "ns-1")
+        self.assertEqual(kwargs["request_timeout"], 17.0)
+
+
+class TestAsyncGetOrCreate(unittest.IsolatedAsyncioTestCase):
+    async def test_existing_suspended_sandbox_is_resumed(self):
+        existing = _async_sandbox_mock(SandboxStatus.SUSPENDED)
+        with (
+            patch.object(AsyncSandbox, "connect", AsyncMock(return_value=existing)),
+            patch.object(AsyncSandbox, "create", AsyncMock()) as create,
+        ):
+            result = await AsyncSandbox.get_or_create(_NAME)
+        self.assertIs(result, existing)
+        existing.resume.assert_awaited_once_with(timeout=300.0)
+        create.assert_not_awaited()
+
+    async def test_request_timeout_is_passed_to_resume(self):
+        # Async mirror: the configured timeout must reach resume().
+        existing = _async_sandbox_mock(SandboxStatus.SUSPENDED)
+        with (
+            patch.object(AsyncSandbox, "connect", AsyncMock(return_value=existing)),
+            patch.object(AsyncSandbox, "create", AsyncMock()),
+        ):
+            await AsyncSandbox.get_or_create(_NAME, request_timeout=17.0)
+        existing.resume.assert_awaited_once_with(timeout=17.0)
+
+    async def test_suspending_sandbox_settles_before_resume(self):
+        # Async mirror: wait until the suspend settles before resume().
+        existing = _async_sandbox_mock(SandboxStatus.SUSPENDING)
+        # info() serves the cached SUSPENDING info from connect(); the wait
+        # loop awaits the fresh ``status()`` method instead.
+        existing.status = AsyncMock(
+            side_effect=[
+                SandboxStatus.SUSPENDING,
+                SandboxStatus.SUSPENDING,
+                SandboxStatus.SUSPENDED,
+            ]
+        )
+        with (
+            patch.object(AsyncSandbox, "connect", AsyncMock(return_value=existing)),
+            patch.object(AsyncSandbox, "create", AsyncMock()) as create,
+            patch("tensorlake.sandbox.async_sandbox.asyncio.sleep", AsyncMock()),
+        ):
+            result = await AsyncSandbox.get_or_create(_NAME)
+        self.assertIs(result, existing)
+        existing.resume.assert_awaited_once_with(timeout=300.0)
+        create.assert_not_awaited()
+
+    async def test_missing_sandbox_is_created(self):
+        created = _async_sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(
+                AsyncSandbox,
+                "connect",
+                AsyncMock(side_effect=SandboxNotFoundError(_NAME)),
+            ),
+            patch.object(
+                AsyncSandbox, "create", AsyncMock(return_value=created)
+            ) as create,
+        ):
+            result = await AsyncSandbox.get_or_create(_NAME, image="my-agent")
+        self.assertIs(result, created)
+        self.assertEqual(create.await_args.kwargs["name"], _NAME)
+
+    async def test_unverified_connect_handle_missing_sandbox_is_created(self):
+        dead = MagicMock(spec=AsyncSandbox)
+        dead.info = AsyncMock(side_effect=SandboxNotFoundError(_NAME))
+        dead.resume = AsyncMock()
+        created = _async_sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(AsyncSandbox, "connect", AsyncMock(return_value=dead)),
+            patch.object(
+                AsyncSandbox, "create", AsyncMock(return_value=created)
+            ) as create,
+        ):
+            result = await AsyncSandbox.get_or_create(
+                _NAME, proxy_url="http://proxy.example.test"
+            )
+        self.assertIs(result, created)
+        self.assertEqual(create.await_args.kwargs["name"], _NAME)
+        dead.resume.assert_not_awaited()
+
+    async def test_pending_sandbox_is_waited_on(self):
+        pending = _async_sandbox_mock(SandboxStatus.PENDING)
+        running_info = SimpleNamespace(status=SandboxStatus.RUNNING)
+        pending._fresh_running_info_for_rebind = AsyncMock(return_value=running_info)
+        with (
+            patch.object(AsyncSandbox, "connect", AsyncMock(return_value=pending)),
+            patch.object(AsyncSandbox, "create", AsyncMock()) as create,
+        ):
+            result = await AsyncSandbox.get_or_create(_NAME)
+        self.assertIs(result, pending)
+        create.assert_not_awaited()
+        pending._fresh_running_info_for_rebind.assert_awaited_once()
+        pending._rebind_proxy.assert_called_once_with(running_info)
+        pending.resume.assert_not_awaited()
+
+    async def test_unroutable_pending_winner_is_waited_on(self):
+        running = _async_sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(
+                AsyncSandbox,
+                "connect",
+                AsyncMock(
+                    side_effect=[
+                        SandboxNotRoutableError("sb-1", SandboxStatus.PENDING),
+                        running,
+                    ]
+                ),
+            ) as connect,
+            patch.object(AsyncSandbox, "create", AsyncMock()) as create,
+            patch("tensorlake.sandbox.async_sandbox.asyncio.sleep", AsyncMock()),
+        ):
+            result = await AsyncSandbox.get_or_create(_NAME)
+        self.assertIs(result, running)
+        self.assertEqual(connect.await_count, 2)
+        create.assert_not_awaited()
+        running.resume.assert_not_awaited()
+
+    async def test_unroutable_winner_terminates_then_name_is_recreated(self):
+        created = _async_sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(
+                AsyncSandbox,
+                "connect",
+                AsyncMock(
+                    side_effect=[
+                        SandboxNotRoutableError("sb-1", SandboxStatus.PENDING),
+                        SandboxNotRoutableError("sb-1", SandboxStatus.TERMINATED),
+                        SandboxNotFoundError(_NAME),
+                    ]
+                ),
+            ),
+            patch.object(
+                AsyncSandbox, "create", AsyncMock(return_value=created)
+            ) as create,
+            patch("tensorlake.sandbox.async_sandbox.asyncio.sleep", AsyncMock()),
+        ):
+            result = await AsyncSandbox.get_or_create(_NAME)
+        self.assertIs(result, created)
+        self.assertEqual(create.await_args.kwargs["name"], _NAME)
+
+    async def test_never_routable_winner_times_out(self):
+        with (
+            patch.object(
+                AsyncSandbox,
+                "connect",
+                AsyncMock(
+                    side_effect=SandboxNotRoutableError("sb-1", SandboxStatus.PENDING)
+                ),
+            ),
+            patch.object(AsyncSandbox, "create", AsyncMock()) as create,
+            patch("tensorlake.sandbox.async_sandbox.asyncio.sleep", AsyncMock()),
+        ):
+            with self.assertRaises(SandboxError) as ctx:
+                await AsyncSandbox.get_or_create(_NAME, request_timeout=0.01)
+        self.assertIn("connectable", str(ctx.exception))
+        create.assert_not_awaited()
+
+    async def test_pool_id_is_rejected(self):
+        with (
+            patch.object(AsyncSandbox, "connect", AsyncMock()) as connect,
+            patch.object(AsyncSandbox, "create", AsyncMock()) as create,
+        ):
+            with self.assertRaises(TypeError):
+                await AsyncSandbox.get_or_create(_NAME, pool_id="pool-1")
+        connect.assert_not_awaited()
+        create.assert_not_awaited()
+
+    async def test_lost_create_race_attaches_to_winner(self):
+        winner = _async_sandbox_mock(SandboxStatus.RUNNING)
+        with (
+            patch.object(
+                AsyncSandbox,
+                "connect",
+                AsyncMock(side_effect=[SandboxNotFoundError(_NAME), winner]),
+            ) as connect,
+            patch.object(
+                AsyncSandbox,
+                "create",
+                AsyncMock(side_effect=RemoteAPIError(409, "name is currently claimed")),
+            ),
+            patch(
+                "tensorlake.sandbox.async_sandbox.asyncio.sleep", AsyncMock()
+            ) as sleep,
+        ):
+            result = await AsyncSandbox.get_or_create(_NAME)
+        self.assertIs(result, winner)
+        self.assertEqual(connect.await_count, 2)
+        self.assertEqual(sleep.await_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -208,6 +208,7 @@ export type {
   SandboxClientOptions,
   SandboxOptions,
   CreateAndConnectOptions,
+  GetOrCreateOptions,
   SuspendResumeOptions,
   CheckpointOptions,
   ConnectOptions,

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -672,6 +672,18 @@ export interface CreateAndConnectOptions extends CreateSandboxOptions {
   startupTimeout?: number;
 }
 
+/**
+ * Options for `Sandbox.getOrCreate`: everything `create` accepts (used only
+ * when a new sandbox must be created; `name` comes from the first argument),
+ * plus `resume`. `poolId` is excluded: a pool claim cannot carry a name, so
+ * a claimed sandbox could never be found again by a later call.
+ */
+export interface GetOrCreateOptions
+  extends Omit<CreateAndConnectOptions, "name" | "poolId"> {
+  /** Resume a suspended sandbox before returning. Default: true. */
+  resume?: boolean;
+}
+
 export interface SuspendResumeOptions {
   /** If false, fire-and-return without waiting for completion. Default: true. */
   wait?: boolean;

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -3,7 +3,11 @@ import {
   type ConnectDesktopOptions,
   Desktop,
 } from "./desktop.js";
-import { SandboxError } from "./errors.js";
+import {
+  RemoteAPIError,
+  SandboxError,
+  SandboxNotFoundError,
+} from "./errors.js";
 import { type Traced } from "./http.js";
 import {
   assembleCommandResult,
@@ -21,6 +25,7 @@ import {
   type CreateAndConnectOptions,
   type CreatePtySessionOptions,
   type DaemonInfo,
+  type GetOrCreateOptions,
   type GetSandboxLogsOptions,
   type HealthResponse,
   type ListDirectoryResponse,
@@ -545,6 +550,12 @@ function sendPtyFrame(socket: WebSocket, frame: Buffer): Promise<void> {
  * Provides process management, file operations, and I/O streaming
  * through the sandbox proxy.
  */
+// `getOrCreate`: how many connect-or-create attempts to make when a named
+// sandbox is caught mid-handoff (for example, its previous holder is still
+// terminating), and the base delay between attempts.
+const GET_OR_CREATE_ATTEMPTS = 4;
+const GET_OR_CREATE_RETRY_DELAY_MS = 500;
+
 export class Sandbox {
   readonly sandboxId: string;
   traceId: string | null = null;
@@ -600,6 +611,10 @@ export class Sandbox {
    *
    * Covers both fresh sandbox creation and restore-from-snapshot (set
    * `snapshotId`). Blocks until the sandbox is `Running`.
+   *
+   * When `name` is already claimed, the server rejects the create with
+   * HTTP 409 (`RemoteAPIError`). To attach to the existing sandbox
+   * instead, use {@link Sandbox.getOrCreate}.
    */
   static async create(
     options?: CreateAndConnectOptions & Partial<SandboxClientOptions>,
@@ -613,9 +628,11 @@ export class Sandbox {
   /**
    * Attach to an existing sandbox and return a connected handle.
    *
-   * When `proxyUrl` is omitted, resolves the sandbox first so the handle uses
-   * the correct cloud/region ingress endpoint. Does **not** auto-resume a
-   * suspended sandbox — call `sandbox.resume()` explicitly.
+   * The handle is lazy: when `proxyUrl` is omitted, the sandbox is resolved
+   * on the first request so the handle uses the correct cloud/region ingress
+   * endpoint. Connecting does not verify that the sandbox exists. Does
+   * **not** auto-resume a suspended sandbox — call `sandbox.resume()`
+   * explicitly.
    */
   static async connect(
     options: ConnectOptions & Partial<SandboxClientOptions>,
@@ -631,6 +648,149 @@ export class Sandbox {
     sandbox.lifecycleClient = client;
     return sandbox;
   }
+
+  /**
+   * Return the one sandbox bound to `name`. Create it on first use.
+   *
+   * This is the recommended call for an agent session that derives its
+   * sandbox name from its session ID. It declares the intent "this name is
+   * my session's sandbox": when a sandbox already holds the name, the call
+   * attaches to it instead of failing with HTTP 409 the way `create` does.
+   *
+   * The steps, all handled internally:
+   *
+   * 1. `connect` by name — finds the sandbox, running or suspended.
+   * 2. When nothing holds the name, `create` with the given configuration.
+   * 3. When that create loses a race against another caller (HTTP 409),
+   *    connect to the winner.
+   * 4. When the sandbox is still starting (another caller's create is in
+   *    flight), wait until it is `Running`, the same way `create` blocks
+   *    for its own caller.
+   * 5. When the sandbox is suspended, `resume()` it. Disable with
+   *    `resume: false`.
+   *
+   * Concurrent callers that use the same name all converge on the same
+   * sandbox. The configuration options (`image`, `cpus`, ...) apply only
+   * when the call creates a new sandbox; an existing sandbox is returned
+   * as-is, with whatever configuration it already has.
+   *
+   * `poolId` is not accepted: a pool claim cannot carry a name, so a
+   * claimed sandbox could never be found again by a later call. To use a
+   * warm pool, `create` with `poolId` and name the sandbox afterwards
+   * with `client.update(sandboxId, { name })`.
+   *
+   * @param name Sandbox name; unique within the namespace. Derive it
+   *   deterministically from your session ID, for example
+   *   `agent-${sessionId}`.
+   * @param options Create options plus `resume` (default true: resume a
+   *   suspended sandbox before returning). Used only when a new sandbox
+   *   must be created, except connection-level options.
+   * @throws {SandboxError} If the name stays claimed but its sandbox cannot
+   *   be attached to after several attempts (for example, the previous
+   *   holder is stuck terminating), or if a sandbox that is still starting
+   *   does not reach `Running` within `requestTimeout`.
+   * @throws {RemoteAPIError} If the create step fails with a non-409 error.
+   */
+  static async getOrCreate(
+    name: string,
+    options?: GetOrCreateOptions & Partial<SandboxClientOptions>,
+  ): Promise<Sandbox> {
+    const { resume = true, ...createOptions } = options ?? {};
+    // The type omits poolId, but plain-JS callers can still pass it. Reject
+    // it here: the claim request has no name field on the wire, so the
+    // claimed sandbox would be unnamed and every later call would claim
+    // another one instead of converging.
+    if ((createOptions as { poolId?: string }).poolId != null) {
+      throw new SandboxError(
+        "getOrCreate does not accept poolId: a pool claim cannot name the " +
+          "sandbox. Use create({ poolId }) and then " +
+          "client.update(sandboxId, { name }).",
+      );
+    }
+    let lastConflict: RemoteAPIError | undefined;
+    for (let attempt = 0; attempt < GET_OR_CREATE_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        // Reachable only after a lost create race whose winner is not
+        // connectable yet (for example, the name's previous holder is
+        // still terminating). Give the server a moment.
+        await sleep(GET_OR_CREATE_RETRY_DELAY_MS * attempt);
+      }
+      try {
+        const sandbox = await Sandbox.connect({
+          ...createOptions,
+          sandboxId: name,
+        });
+        // connect returns a lazy handle without checking that the name
+        // exists; this status fetch is the existence check that routes a
+        // free name to the create step below.
+        const status = await sandbox.status();
+        if (status === SandboxStatus.PENDING) {
+          // Another caller's create is still starting this sandbox. Match
+          // create(): block until Running, then pick up fresh proxy
+          // routing before handing the sandbox out.
+          const waitTimeout = createOptions.requestTimeout ?? 300;
+          await sandbox.refreshRoutingWhenRunning(
+            Date.now() + waitTimeout * 1000,
+            0.5,
+            waitTimeout,
+          );
+        } else if (
+          resume &&
+          (status === SandboxStatus.SUSPENDED ||
+            status === SandboxStatus.SUSPENDING)
+        ) {
+          const waitTimeout = createOptions.requestTimeout ?? 300;
+          let settled: SandboxStatus = status;
+          if (settled === SandboxStatus.SUSPENDING) {
+            // The server rejects resume while a suspend is still in
+            // progress; wait for the suspend to settle first.
+            settled = await sandbox.waitOutSuspending(waitTimeout, name);
+          }
+          if (settled === SandboxStatus.SUSPENDED) {
+            await sandbox.resume({ timeout: waitTimeout });
+          } else if (settled === SandboxStatus.TERMINATED) {
+            // The sandbox died while suspending; the name may be free
+            // again. Retry the loop.
+            continue;
+          } else {
+            // Another caller resumed it first. The resumed sandbox may
+            // live elsewhere, so this handle's routing from before the
+            // suspend is stale. Match the PENDING branch: block until
+            // Running with fresh proxy routing.
+            await sandbox.refreshRoutingWhenRunning(
+              Date.now() + waitTimeout * 1000,
+              0.5,
+              waitTimeout,
+            );
+          }
+        }
+        return sandbox;
+      } catch (err) {
+        if (!(err instanceof SandboxNotFoundError)) throw err;
+        try {
+          return await Sandbox.create({ ...createOptions, name });
+        } catch (createErr) {
+          if (
+            createErr instanceof RemoteAPIError &&
+            createErr.statusCode === 409
+          ) {
+            // Lost the create race: another caller claimed the name first.
+            // Loop back and attach to the winner.
+            lastConflict = createErr;
+            continue;
+          }
+          throw createErr;
+        }
+      }
+    }
+    const giveUp = new SandboxError(
+      `getOrCreate('${name}'): the name is claimed, but its sandbox could ` +
+        `not be attached to after ${GET_OR_CREATE_ATTEMPTS} attempts`,
+    );
+    giveUp.cause = lastConflict;
+    throw giveUp;
+  }
+
 
   // --- Static snapshot management ---
 
@@ -757,7 +917,43 @@ export class Sandbox {
       timeout: Math.max(0, (deadline - Date.now()) / 1000),
     });
     if (!wait) return;
+    await this.refreshRoutingWhenRunning(deadline, pollInterval, timeout);
+  }
 
+  /**
+   * Poll until the sandbox leaves `Suspending`.
+   *
+   * The lifecycle API rejects resume while a suspend is still in progress,
+   * so `getOrCreate` must wait for the suspend to settle before it can
+   * resume the sandbox.
+   */
+  private async waitOutSuspending(
+    waitTimeout: number,
+    name: string,
+  ): Promise<SandboxStatus> {
+    const deadline = Date.now() + waitTimeout * 1000;
+    while (Date.now() < deadline) {
+      await sleep(500);
+      const status = await this.status();
+      if (status !== SandboxStatus.SUSPENDING) return status;
+    }
+    throw new SandboxError(
+      `getOrCreate('${name}'): the sandbox holding the name did not finish ` +
+        `suspending within ${waitTimeout}s`,
+    );
+  }
+
+  /**
+   * Poll until the sandbox is `Running` with routing info, then rebind this
+   * handle's cached proxy routing. Shared by `resume()` and the
+   * `getOrCreate` path that attaches to a still-starting sandbox.
+   */
+  private async refreshRoutingWhenRunning(
+    deadline: number,
+    pollInterval: number,
+    timeout: number,
+  ): Promise<void> {
+    const client = this.requireLifecycleClient("refresh proxy routing");
     while (Date.now() < deadline) {
       const info = await client.get(this.lifecycleIdentifier);
       if (

--- a/typescript/tests/get-or-create.test.ts
+++ b/typescript/tests/get-or-create.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Sandbox } from "../src/sandbox.js";
+import { SandboxStatus } from "../src/models.js";
+import {
+  RemoteAPIError,
+  SandboxError,
+  SandboxNotFoundError,
+} from "../src/errors.js";
+
+// Sandbox.getOrCreate composes the static create/connect factories and the
+// status/resume instance methods; spy on those, so no native binding or
+// server is needed.
+
+const NAME = "agent-session-123";
+
+function sandboxMock(status: SandboxStatus): Sandbox {
+  return {
+    sandboxId: "sbx-uuid-1",
+    status: vi.fn(async () => status),
+    resume: vi.fn(async () => undefined),
+  } as unknown as Sandbox;
+}
+
+describe("Sandbox.getOrCreate", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns an existing running sandbox without create or resume", async () => {
+    const existing = sandboxMock(SandboxStatus.RUNNING);
+    const connect = vi.spyOn(Sandbox, "connect").mockResolvedValue(existing);
+    const create = vi.spyOn(Sandbox, "create");
+
+    const result = await Sandbox.getOrCreate(NAME);
+
+    expect(result).toBe(existing);
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledWith({ sandboxId: NAME });
+    expect(create).not.toHaveBeenCalled();
+    expect(existing.resume).not.toHaveBeenCalled();
+  });
+
+  it("resumes an existing suspended sandbox", async () => {
+    const existing = sandboxMock(SandboxStatus.SUSPENDED);
+    vi.spyOn(Sandbox, "connect").mockResolvedValue(existing);
+
+    const result = await Sandbox.getOrCreate(NAME);
+
+    expect(result).toBe(existing);
+    expect(existing.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips resume but still checks existence when resume is false", async () => {
+    const existing = sandboxMock(SandboxStatus.SUSPENDED);
+    vi.spyOn(Sandbox, "connect").mockResolvedValue(existing);
+
+    const result = await Sandbox.getOrCreate(NAME, { resume: false });
+
+    expect(result).toBe(existing);
+    // The status fetch stays: connect returns a lazy handle, so it is the
+    // only proof the name exists.
+    expect(existing.status).toHaveBeenCalledTimes(1);
+    expect(existing.resume).not.toHaveBeenCalled();
+  });
+
+  it("creates the sandbox when the lazy connect handle finds nothing", async () => {
+    // The real Sandbox.connect never throws for a missing name: it returns
+    // a lazy handle, and the 404 surfaces on the first request. getOrCreate
+    // must treat that late SandboxNotFoundError as "name is free".
+    const dead = {
+      status: vi.fn(async () => {
+        throw new SandboxNotFoundError(NAME);
+      }),
+      resume: vi.fn(),
+    } as unknown as Sandbox;
+    const created = sandboxMock(SandboxStatus.RUNNING);
+    vi.spyOn(Sandbox, "connect").mockResolvedValue(dead);
+    const create = vi.spyOn(Sandbox, "create").mockResolvedValue(created);
+
+    const result = await Sandbox.getOrCreate(NAME, { resume: false });
+
+    expect(result).toBe(created);
+    expect(create).toHaveBeenCalledWith({ name: NAME });
+  });
+
+  it("creates the sandbox on first use", async () => {
+    const created = sandboxMock(SandboxStatus.RUNNING);
+    vi.spyOn(Sandbox, "connect").mockRejectedValue(
+      new SandboxNotFoundError(NAME),
+    );
+    const create = vi.spyOn(Sandbox, "create").mockResolvedValue(created);
+
+    const result = await Sandbox.getOrCreate(NAME, { image: "my-agent" });
+
+    expect(result).toBe(created);
+    expect(create).toHaveBeenCalledWith({ image: "my-agent", name: NAME });
+    // A fresh create is already running; no status/resume round-trip.
+    expect(created.status).not.toHaveBeenCalled();
+    expect(created.resume).not.toHaveBeenCalled();
+  });
+
+  it("attaches to the winner after losing a create race", async () => {
+    vi.useFakeTimers();
+    const winner = sandboxMock(SandboxStatus.RUNNING);
+    const connect = vi
+      .spyOn(Sandbox, "connect")
+      .mockRejectedValueOnce(new SandboxNotFoundError(NAME))
+      .mockResolvedValueOnce(winner);
+    vi.spyOn(Sandbox, "create").mockRejectedValue(
+      new RemoteAPIError(409, "name is currently claimed"),
+    );
+
+    const pending = Sandbox.getOrCreate(NAME);
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result).toBe(winner);
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("resumes the race winner when it is suspended", async () => {
+    vi.useFakeTimers();
+    const winner = sandboxMock(SandboxStatus.SUSPENDING);
+    vi.spyOn(Sandbox, "connect")
+      .mockRejectedValueOnce(new SandboxNotFoundError(NAME))
+      .mockResolvedValueOnce(winner);
+    vi.spyOn(Sandbox, "create").mockRejectedValue(
+      new RemoteAPIError(409, "name is currently claimed"),
+    );
+
+    const pending = Sandbox.getOrCreate(NAME);
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result).toBe(winner);
+    expect(winner.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for a pending sandbox to become running", async () => {
+    // Another caller claimed the name but its create is still starting:
+    // getOrCreate must block until Running and refresh proxy routing
+    // instead of returning an unusable pending handle.
+    const refresh = vi.fn(async () => undefined);
+    const pendingSandbox = {
+      sandboxId: "sbx-uuid-1",
+      status: vi.fn(async () => SandboxStatus.PENDING),
+      resume: vi.fn(),
+      refreshRoutingWhenRunning: refresh,
+    } as unknown as Sandbox;
+    vi.spyOn(Sandbox, "connect").mockResolvedValue(pendingSandbox);
+    const create = vi.spyOn(Sandbox, "create");
+
+    const result = await Sandbox.getOrCreate(NAME);
+
+    expect(result).toBe(pendingSandbox);
+    expect(create).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(pendingSandbox.resume).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-409 create errors", async () => {
+    vi.spyOn(Sandbox, "connect").mockRejectedValue(
+      new SandboxNotFoundError(NAME),
+    );
+    vi.spyOn(Sandbox, "create").mockRejectedValue(
+      new RemoteAPIError(400, "Image 'nope' is not registered"),
+    );
+
+    await expect(Sandbox.getOrCreate(NAME, { image: "nope" })).rejects.toThrow(
+      /status 400/,
+    );
+  });
+
+  it("rethrows unexpected connect errors", async () => {
+    vi.spyOn(Sandbox, "connect").mockRejectedValue(
+      new RemoteAPIError(403, "Invalid API key."),
+    );
+    const create = vi.spyOn(Sandbox, "create");
+
+    await expect(Sandbox.getOrCreate(NAME)).rejects.toThrow(/status 403/);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("gives up when the name stays unattachable", async () => {
+    // Every connect says "not found", every create says "name claimed":
+    // the previous holder is stuck terminating. The loop must end with a
+    // SandboxError instead of spinning forever.
+    vi.useFakeTimers();
+    const conflict = new RemoteAPIError(409, "name is currently claimed");
+    const connect = vi
+      .spyOn(Sandbox, "connect")
+      .mockRejectedValue(new SandboxNotFoundError(NAME));
+    const create = vi.spyOn(Sandbox, "create").mockRejectedValue(conflict);
+
+    const pending = Sandbox.getOrCreate(NAME);
+    const outcome = expect(pending).rejects.toMatchObject({
+      name: "SandboxError",
+      message: expect.stringContaining(NAME),
+      cause: conflict,
+    });
+    await vi.runAllTimersAsync();
+    await outcome;
+
+    expect(connect.mock.calls.length).toBeGreaterThan(1);
+    expect(connect).toHaveBeenCalledTimes(create.mock.calls.length);
+  });
+
+  it("rejects poolId before touching the server", async () => {
+    // A pool claim cannot carry a name on the wire, so a claimed sandbox
+    // would be unnamed and every later getOrCreate would claim another one.
+    const connect = vi.spyOn(Sandbox, "connect");
+    const create = vi.spyOn(Sandbox, "create");
+
+    await expect(
+      Sandbox.getOrCreate(NAME, {
+        poolId: "pool-1",
+      } as Parameters<typeof Sandbox.getOrCreate>[1]),
+    ).rejects.toThrow(/poolId/);
+    expect(connect).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("forwards connection options to connect", async () => {
+    const existing = sandboxMock(SandboxStatus.RUNNING);
+    const connect = vi.spyOn(Sandbox, "connect").mockResolvedValue(existing);
+
+    await Sandbox.getOrCreate(NAME, {
+      apiUrl: "https://api.example.test",
+      requestTimeout: 17,
+    });
+
+    expect(connect).toHaveBeenCalledWith({
+      sandboxId: NAME,
+      apiUrl: "https://api.example.test",
+      requestTimeout: 17,
+    });
+  });
+});

--- a/typescript/tests/get-or-create.test.ts
+++ b/typescript/tests/get-or-create.test.ts
@@ -121,7 +121,7 @@ describe("Sandbox.getOrCreate", () => {
 
   it("resumes the race winner when it is suspended", async () => {
     vi.useFakeTimers();
-    const winner = sandboxMock(SandboxStatus.SUSPENDING);
+    const winner = sandboxMock(SandboxStatus.SUSPENDED);
     vi.spyOn(Sandbox, "connect")
       .mockRejectedValueOnce(new SandboxNotFoundError(NAME))
       .mockResolvedValueOnce(winner);
@@ -135,6 +135,27 @@ describe("Sandbox.getOrCreate", () => {
 
     expect(result).toBe(winner);
     expect(winner.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for a suspending sandbox to settle before resume", async () => {
+    // The server rejects resume while a suspend is still in progress, so
+    // getOrCreate must wait until the sandbox is Suspended before resume().
+    const settle = vi.fn(async () => SandboxStatus.SUSPENDED);
+    const winner = {
+      sandboxId: "sbx-uuid-1",
+      status: vi.fn(async () => SandboxStatus.SUSPENDING),
+      resume: vi.fn(async () => undefined),
+      waitOutSuspending: settle,
+    } as unknown as Sandbox;
+    vi.spyOn(Sandbox, "connect").mockResolvedValue(winner);
+    const create = vi.spyOn(Sandbox, "create");
+
+    const result = await Sandbox.getOrCreate(NAME);
+
+    expect(result).toBe(winner);
+    expect(settle).toHaveBeenCalledTimes(1);
+    expect(winner.resume).toHaveBeenCalledTimes(1);
+    expect(create).not.toHaveBeenCalled();
   });
 
   it("waits for a pending sandbox to become running", async () => {


### PR DESCRIPTION
### Changes:

Adds `Sandbox.get_or_create(name)` (Python sync + async) and `Sandbox.getOrCreate(name)` (TypeScript): returns the one sandbox bound to a name, creating it on first use. Meant for agent sessions that derive the sandbox name from their session ID.

- Connects by name; creates when the name is free; on a lost create race (409), attaches to the winner.
- Waits out `Pending`/`Suspending` states and resumes suspended sandboxes (disable with `resume=False`).
- New `SandboxNotRoutableError` when a sandbox exists but has no proxy routing yet (still starting).
- `pool_id` is rejected: a pool claim cannot carry a name.

Tests: 30 Python unit tests (sync + async), 14 TypeScript unit tests, plus raise-site tests for `SandboxNotRoutableError` in the client backends. Wired `test_get_or_create` into the CI unit-test list.