### PR TITLE
Bump Tensorlake packages to 0.5.119

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "base64",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "base64",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "base64",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "anyhow",
  "napi",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.118"
+version = "0.5.119"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.118"
+version = "0.5.119"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.118"
+version = "0.5.119"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.118"
+version = "0.5.119"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.118"
+version = "0.5.119"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.118",
+  "version": "0.5.119",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.118",
+      "version": "0.5.119",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.118",
+  "version": "0.5.119",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- bump the Tensorlake CLI and Rust workspace packages to 0.5.119
- bump the Python SDK and native Python package to 0.5.119
- bump the TypeScript SDK and filesystem client to 0.5.119
- update Cargo and npm lockfiles

## Validation

- `cargo check --locked -p tensorlake-cli`
- `npm ci --dry-run --ignore-scripts --offline`
- verified all release manifests resolve to 0.5.119