### PR TITLE
Report get_or_create outcome on sandbox handles; bump to 0.5.120

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.119"
+version = "0.5.120"
 dependencies = [
  "anyhow",
  "base64",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.119"
+version = "0.5.120"
 dependencies = [
  "anyhow",
  "base64",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.119"
+version = "0.5.120"
 dependencies = [
  "anyhow",
  "base64",
@@ -5388,7 +5388,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.119"
+version = "0.5.120"
 dependencies = [
  "anyhow",
  "base64",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.119"
+version = "0.5.120"
 dependencies = [
  "anyhow",
  "napi",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.119"
+version = "0.5.120"
 dependencies = [
  "futures",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.119"
+version = "0.5.120"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.119"
+version = "0.5.120"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.119"
+version = "0.5.120"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.119"
+version = "0.5.120"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/__init__.py
+++ b/src/tensorlake/sandbox/__init__.py
@@ -35,6 +35,7 @@ from .models import (
     DirectoryEntry,
     FileSystem,
     FileSystemMount,
+    GetOrCreateOutcome,
     GpuModel,
     GpuRequest,
     GPUResources,
@@ -90,6 +91,7 @@ __all__ = [
     "Desktop",
     # Lifecycle models
     "SandboxStatus",
+    "GetOrCreateOutcome",
     "SandboxInfo",
     "SandboxPortAccess",
     "CreateSandboxResponse",

--- a/src/tensorlake/sandbox/async_sandbox.py
+++ b/src/tensorlake/sandbox/async_sandbox.py
@@ -33,6 +33,7 @@ from .models import (
     CopySandboxResponse,
     DaemonInfo,
     FileSystemMount,
+    GetOrCreateOutcome,
     GpuModel,
     GpuRequest,
     HealthResponse,
@@ -119,6 +120,7 @@ class AsyncSandbox:
 
         self._identifier = sandbox_identifier
         self._sandbox_id: str | None = None
+        self._bind_outcome: GetOrCreateOutcome | None = None
         self._trace_id: str | None = None
         self._cached_info: SandboxInfo | None = None
         self._owns_sandbox: bool = False
@@ -386,7 +388,8 @@ class AsyncSandbox:
         the full semantics. In short: connect by name; create when the name
         is free; on a lost create race (HTTP 409), attach to the winner;
         wait for a still-starting sandbox to reach ``Running``; resume a
-        suspended sandbox unless ``resume=False``.
+        suspended sandbox unless ``resume=False``. The returned handle
+        records what the call did in :attr:`bind_outcome`.
         """
         connect_kwargs: dict[str, Any] = {
             "proxy_url": proxy_url,
@@ -431,7 +434,7 @@ class AsyncSandbox:
                 status = (await sandbox.info()).status
             except SandboxNotFoundError:
                 try:
-                    return await cls.create(
+                    created = await cls.create(
                         image=image,
                         cpus=cpus,
                         memory_mb=memory_mb,
@@ -462,6 +465,8 @@ class AsyncSandbox:
                     # first. Loop back and attach to the winner.
                     last_conflict = e
                     continue
+                created._bind_outcome = "created"
+                return created
             if status == SandboxStatus.PENDING:
                 # Another caller's create is still starting this sandbox.
                 # Match create(): block until Running, then pick up fresh
@@ -495,6 +500,9 @@ class AsyncSandbox:
                         poll_interval=0.5,
                     )
                     sandbox._rebind_proxy(info)
+                sandbox._bind_outcome = "resumed"
+                return sandbox
+            sandbox._bind_outcome = "attached"
             return sandbox
         raise SandboxError(
             f"get_or_create({name!r}): the name is claimed, but its sandbox "
@@ -793,6 +801,15 @@ class AsyncSandbox:
             )
         self._sandbox_id = self._cached_info.sandbox_id
         return self._sandbox_id
+
+    @property
+    def bind_outcome(self) -> GetOrCreateOutcome | None:
+        """What :meth:`get_or_create` did to bind the name.
+
+        ``"created"``, ``"attached"``, or ``"resumed"``; ``None`` for
+        handles from :meth:`create` or :meth:`connect`.
+        """
+        return self._bind_outcome
 
     @property
     def trace_id(self) -> str | None:

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from urllib.parse import urlparse, urlunparse
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_serializer
@@ -61,6 +61,18 @@ def _parse_timestamp(v: int | float | datetime | None) -> datetime | None:
 
 OptionalTimestamp = Annotated[datetime | None, BeforeValidator(_parse_timestamp)]
 Timestamp = Annotated[datetime, BeforeValidator(_parse_timestamp)]
+
+
+# What ``Sandbox.get_or_create`` did to bind the name, exposed as
+# ``sandbox.bind_outcome``:
+#
+# - ``"created"``: nothing held the name; the call created a new sandbox.
+# - ``"attached"``: a sandbox already held the name and needed no resume.
+#   Includes a sandbox that was still starting (the call waited for it) and
+#   a suspended sandbox when ``resume=False``.
+# - ``"resumed"``: the sandbox was suspended when the call found it and is
+#   running now.
+GetOrCreateOutcome = Literal["created", "attached", "resumed"]
 
 
 class SandboxStatus(str, Enum):

--- a/src/tensorlake/sandbox/sandbox.py
+++ b/src/tensorlake/sandbox/sandbox.py
@@ -29,6 +29,7 @@ from .models import (
     CopySandboxResponse,
     DaemonInfo,
     FileSystemMount,
+    GetOrCreateOutcome,
     GpuModel,
     GpuRequest,
     HealthResponse,
@@ -222,6 +223,7 @@ class Sandbox:
 
         self._identifier = sandbox_identifier
         self._sandbox_id: str | None = None
+        self._bind_outcome: GetOrCreateOutcome | None = None
         self._trace_id: str | None = None
         self._cached_info: SandboxInfo | None = None
         self._owns_sandbox: bool = False
@@ -577,6 +579,16 @@ class Sandbox:
         apply only when the call creates a new sandbox; an existing sandbox
         is returned as-is, with whatever configuration it already has.
 
+        The returned handle records what the call did in
+        :attr:`bind_outcome`: ``"created"``, ``"attached"``, or
+        ``"resumed"``. See :data:`~tensorlake.sandbox.GetOrCreateOutcome`.
+
+        For about a second after ``terminate()``, the name still resolves
+        and the sandbox still reports ``running``. A ``get_or_create`` in
+        that window attaches to the dying sandbox. When you recreate right
+        after a terminate, check ``status`` after the call, or wait for the
+        old sandbox to report ``terminated`` first.
+
         Args:
             name: Sandbox name; unique within the namespace. Derive it
                 deterministically from your session ID, for example
@@ -647,7 +659,7 @@ class Sandbox:
                 status = sandbox.info().status
             except SandboxNotFoundError:
                 try:
-                    return cls.create(
+                    created = cls.create(
                         image=image,
                         cpus=cpus,
                         memory_mb=memory_mb,
@@ -678,6 +690,8 @@ class Sandbox:
                     # first. Loop back and attach to the winner.
                     last_conflict = e
                     continue
+                created._bind_outcome = "created"
+                return created
             if status == SandboxStatus.PENDING:
                 # Another caller's create is still starting this sandbox.
                 # Match create(): block until Running, then pick up fresh
@@ -709,6 +723,9 @@ class Sandbox:
                         time.monotonic() + wait_timeout, poll_interval=0.5
                     )
                     sandbox._rebind_proxy(info)
+                sandbox._bind_outcome = "resumed"
+                return sandbox
+            sandbox._bind_outcome = "attached"
             return sandbox
         raise SandboxError(
             f"get_or_create({name!r}): the name is claimed, but its sandbox "
@@ -1194,6 +1211,15 @@ class Sandbox:
             return self._sandbox_id
         self._sandbox_id = self._fetch_info().sandbox_id
         return self._sandbox_id
+
+    @property
+    def bind_outcome(self) -> GetOrCreateOutcome | None:
+        """What :meth:`get_or_create` did to bind the name.
+
+        ``"created"``, ``"attached"``, or ``"resumed"``; ``None`` for
+        handles from :meth:`create` or :meth:`connect`.
+        """
+        return self._bind_outcome
 
     @property
     def trace_id(self) -> str | None:

--- a/tests/sandbox/test_get_or_create.py
+++ b/tests/sandbox/test_get_or_create.py
@@ -43,6 +43,7 @@ class TestGetOrCreate(unittest.TestCase):
         ):
             result = Sandbox.get_or_create(_NAME)
         self.assertIs(result, existing)
+        self.assertEqual(existing._bind_outcome, "attached")
         self.assertEqual(connect.call_count, 1)
         self.assertEqual(connect.call_args.args, (_NAME,))
         create.assert_not_called()
@@ -56,6 +57,7 @@ class TestGetOrCreate(unittest.TestCase):
         ):
             result = Sandbox.get_or_create(_NAME)
         self.assertIs(result, existing)
+        self.assertEqual(existing._bind_outcome, "resumed")
         existing.resume.assert_called_once_with(timeout=300.0)
         create.assert_not_called()
 
@@ -78,6 +80,9 @@ class TestGetOrCreate(unittest.TestCase):
         ):
             result = Sandbox.get_or_create(_NAME, resume=False)
         self.assertIs(result, existing)
+        # No resume happened, so the outcome is a plain attach even though
+        # the sandbox is suspended.
+        self.assertEqual(existing._bind_outcome, "attached")
         existing.resume.assert_not_called()
         # The info() call stays even with resume=False: it is the existence
         # check when connect skipped resolution (explicit proxy_url), and it
@@ -111,6 +116,7 @@ class TestGetOrCreate(unittest.TestCase):
         ):
             result = Sandbox.get_or_create(_NAME, image="my-agent")
         self.assertIs(result, created)
+        self.assertEqual(created._bind_outcome, "created")
         self.assertEqual(connect.call_count, 1)
         create.assert_called_once()
         self.assertEqual(create.call_args.kwargs["name"], _NAME)
@@ -204,6 +210,10 @@ class TestGetOrCreate(unittest.TestCase):
         ):
             result = Sandbox.get_or_create(_NAME)
         self.assertIs(result, winner)
+        # The sandbox was suspended when found and is running on return; the
+        # outcome describes what happened to the sandbox, not who sent the
+        # resume request.
+        self.assertEqual(winner._bind_outcome, "resumed")
         winner.resume.assert_not_called()
         winner._fresh_running_info_for_rebind.assert_called_once()
         winner._rebind_proxy.assert_called_once_with(running_info)
@@ -247,6 +257,7 @@ class TestGetOrCreate(unittest.TestCase):
         ):
             result = Sandbox.get_or_create(_NAME)
         self.assertIs(result, pending)
+        self.assertEqual(pending._bind_outcome, "attached")
         create.assert_not_called()
         pending._fresh_running_info_for_rebind.assert_called_once()
         pending._rebind_proxy.assert_called_once_with(running_info)
@@ -381,6 +392,7 @@ class TestAsyncGetOrCreate(unittest.IsolatedAsyncioTestCase):
         ):
             result = await AsyncSandbox.get_or_create(_NAME)
         self.assertIs(result, existing)
+        self.assertEqual(existing._bind_outcome, "resumed")
         existing.resume.assert_awaited_once_with(timeout=300.0)
         create.assert_not_awaited()
 
@@ -413,6 +425,7 @@ class TestAsyncGetOrCreate(unittest.IsolatedAsyncioTestCase):
         ):
             result = await AsyncSandbox.get_or_create(_NAME)
         self.assertIs(result, existing)
+        self.assertEqual(existing._bind_outcome, "resumed")
         existing.resume.assert_awaited_once_with(timeout=300.0)
         create.assert_not_awaited()
 
@@ -430,6 +443,7 @@ class TestAsyncGetOrCreate(unittest.IsolatedAsyncioTestCase):
         ):
             result = await AsyncSandbox.get_or_create(_NAME, image="my-agent")
         self.assertIs(result, created)
+        self.assertEqual(created._bind_outcome, "created")
         self.assertEqual(create.await_args.kwargs["name"], _NAME)
 
     async def test_unverified_connect_handle_missing_sandbox_is_created(self):
@@ -460,6 +474,7 @@ class TestAsyncGetOrCreate(unittest.IsolatedAsyncioTestCase):
         ):
             result = await AsyncSandbox.get_or_create(_NAME)
         self.assertIs(result, pending)
+        self.assertEqual(pending._bind_outcome, "attached")
         create.assert_not_awaited()
         pending._fresh_running_info_for_rebind.assert_awaited_once()
         pending._rebind_proxy.assert_called_once_with(running_info)

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.119",
+  "version": "0.5.120",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.119",
+      "version": "0.5.120",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.119",
+  "version": "0.5.120",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -209,6 +209,7 @@ export type {
   SandboxOptions,
   CreateAndConnectOptions,
   GetOrCreateOptions,
+  GetOrCreateOutcome,
   SuspendResumeOptions,
   CheckpointOptions,
   ConnectOptions,

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -684,6 +684,19 @@ export interface GetOrCreateOptions
   resume?: boolean;
 }
 
+/**
+ * What `Sandbox.getOrCreate` did to bind the name, exposed as
+ * `sandbox.bindOutcome`:
+ *
+ * - `"created"`: nothing held the name; the call created a new sandbox.
+ * - `"attached"`: a sandbox already held the name and needed no resume.
+ *   Includes a sandbox that was still starting (the call waited for it)
+ *   and a suspended sandbox when `resume: false`.
+ * - `"resumed"`: the sandbox was suspended when the call found it and is
+ *   running now.
+ */
+export type GetOrCreateOutcome = "created" | "attached" | "resumed";
+
 export interface SuspendResumeOptions {
   /** If false, fire-and-return without waiting for completion. Default: true. */
   wait?: boolean;

--- a/typescript/src/sandbox.ts
+++ b/typescript/src/sandbox.ts
@@ -26,6 +26,7 @@ import {
   type CreatePtySessionOptions,
   type DaemonInfo,
   type GetOrCreateOptions,
+  type GetOrCreateOutcome,
   type GetSandboxLogsOptions,
   type HealthResponse,
   type ListDirectoryResponse,
@@ -556,9 +557,20 @@ function sendPtyFrame(socket: WebSocket, frame: Buffer): Promise<void> {
 const GET_OR_CREATE_ATTEMPTS = 4;
 const GET_OR_CREATE_RETRY_DELAY_MS = 500;
 
+// `bindOutcome` is read-only for callers; `getOrCreate` is the one writer.
+function markBindOutcome(sandbox: Sandbox, outcome: GetOrCreateOutcome): Sandbox {
+  (sandbox as { bindOutcome: GetOrCreateOutcome }).bindOutcome = outcome;
+  return sandbox;
+}
+
 export class Sandbox {
-  readonly sandboxId: string;
   traceId: string | null = null;
+  /**
+   * What {@link Sandbox.getOrCreate} did to bind the name: `"created"`,
+   * `"attached"`, or `"resumed"`. `null` for handles from `create` or
+   * `connect`.
+   */
+  readonly bindOutcome: GetOrCreateOutcome | null = null;
   private readonly proxy: SandboxProxyConnection;
   private ownsSandbox = false;
   private lifecycleClient: SandboxClient | null = null;
@@ -566,9 +578,19 @@ export class Sandbox {
   private sandboxName: string | null = null;
 
   constructor(options: SandboxOptions) {
-    this.sandboxId = options.sandboxId;
     this.lifecycleIdentifier = options.sandboxId;
     this.proxy = new SandboxProxyConnection(this, options);
+  }
+
+  /**
+   * The server-assigned sandbox ID.
+   *
+   * A handle opened by name (`connect({ sandboxId: name })`) reports the
+   * name until its first server response, then the canonical ID. Handles
+   * from `create` and `getOrCreate` carry the canonical ID from the start.
+   */
+  get sandboxId(): string {
+    return this.lifecycleIdentifier;
   }
 
   private get baseUrl(): string {
@@ -674,6 +696,16 @@ export class Sandbox {
    * when the call creates a new sandbox; an existing sandbox is returned
    * as-is, with whatever configuration it already has.
    *
+   * The returned handle carries the canonical `sandboxId` (not the name)
+   * and records what the call did in `bindOutcome`: `"created"`,
+   * `"attached"`, or `"resumed"`. See {@link GetOrCreateOutcome}.
+   *
+   * For about a second after `terminate()`, the name still resolves and
+   * the sandbox still reports `running`. A `getOrCreate` in that window
+   * attaches to the dying sandbox. When you recreate right after a
+   * terminate, check `status()` after the call, or wait for the old
+   * sandbox to report `terminated` first.
+   *
    * `poolId` is not accepted: a pool claim cannot carry a name, so a
    * claimed sandbox could never be found again by a later call. To use a
    * warm pool, `create` with `poolId` and name the sandbox afterwards
@@ -763,12 +795,14 @@ export class Sandbox {
               waitTimeout,
             );
           }
+          return markBindOutcome(sandbox, "resumed");
         }
-        return sandbox;
+        return markBindOutcome(sandbox, "attached");
       } catch (err) {
         if (!(err instanceof SandboxNotFoundError)) throw err;
         try {
-          return await Sandbox.create({ ...createOptions, name });
+          const created = await Sandbox.create({ ...createOptions, name });
+          return markBindOutcome(created, "created");
         } catch (createErr) {
           if (
             createErr instanceof RemoteAPIError &&

--- a/typescript/tests/get-or-create.test.ts
+++ b/typescript/tests/get-or-create.test.ts
@@ -35,6 +35,7 @@ describe("Sandbox.getOrCreate", () => {
     const result = await Sandbox.getOrCreate(NAME);
 
     expect(result).toBe(existing);
+    expect(result.bindOutcome).toBe("attached");
     expect(connect).toHaveBeenCalledTimes(1);
     expect(connect).toHaveBeenCalledWith({ sandboxId: NAME });
     expect(create).not.toHaveBeenCalled();
@@ -48,6 +49,7 @@ describe("Sandbox.getOrCreate", () => {
     const result = await Sandbox.getOrCreate(NAME);
 
     expect(result).toBe(existing);
+    expect(result.bindOutcome).toBe("resumed");
     expect(existing.resume).toHaveBeenCalledTimes(1);
   });
 
@@ -58,6 +60,9 @@ describe("Sandbox.getOrCreate", () => {
     const result = await Sandbox.getOrCreate(NAME, { resume: false });
 
     expect(result).toBe(existing);
+    // No resume happened, so the outcome is a plain attach even though the
+    // sandbox is suspended.
+    expect(result.bindOutcome).toBe("attached");
     // The status fetch stays: connect returns a lazy handle, so it is the
     // only proof the name exists.
     expect(existing.status).toHaveBeenCalledTimes(1);
@@ -94,6 +99,7 @@ describe("Sandbox.getOrCreate", () => {
     const result = await Sandbox.getOrCreate(NAME, { image: "my-agent" });
 
     expect(result).toBe(created);
+    expect(result.bindOutcome).toBe("created");
     expect(create).toHaveBeenCalledWith({ image: "my-agent", name: NAME });
     // A fresh create is already running; no status/resume round-trip.
     expect(created.status).not.toHaveBeenCalled();
@@ -153,9 +159,32 @@ describe("Sandbox.getOrCreate", () => {
     const result = await Sandbox.getOrCreate(NAME);
 
     expect(result).toBe(winner);
+    expect(result.bindOutcome).toBe("resumed");
     expect(settle).toHaveBeenCalledTimes(1);
     expect(winner.resume).toHaveBeenCalledTimes(1);
     expect(create).not.toHaveBeenCalled();
+  });
+
+  it("reports resumed when another caller resumed the suspending sandbox", async () => {
+    // The sandbox was suspended when found and is running on return; the
+    // outcome describes what happened to the sandbox, not who sent the
+    // resume request.
+    const refresh = vi.fn(async () => undefined);
+    const winner = {
+      sandboxId: "sbx-uuid-1",
+      status: vi.fn(async () => SandboxStatus.SUSPENDING),
+      resume: vi.fn(async () => undefined),
+      waitOutSuspending: vi.fn(async () => SandboxStatus.RUNNING),
+      refreshRoutingWhenRunning: refresh,
+    } as unknown as Sandbox;
+    vi.spyOn(Sandbox, "connect").mockResolvedValue(winner);
+
+    const result = await Sandbox.getOrCreate(NAME);
+
+    expect(result).toBe(winner);
+    expect(result.bindOutcome).toBe("resumed");
+    expect(winner.resume).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it("waits for a pending sandbox to become running", async () => {
@@ -175,6 +204,7 @@ describe("Sandbox.getOrCreate", () => {
     const result = await Sandbox.getOrCreate(NAME);
 
     expect(result).toBe(pendingSandbox);
+    expect(result.bindOutcome).toBe("attached");
     expect(create).not.toHaveBeenCalled();
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(pendingSandbox.resume).not.toHaveBeenCalled();

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -69,6 +69,37 @@ describe("Sandbox", () => {
     });
   });
 
+  describe("sandboxId", () => {
+    it("is null-outcome and switches from name to canonical id after status()", async () => {
+      const stub = installNativeStub({
+        client: {
+          getSandbox: vi.fn(async (id: string) => ({
+            traceId: "t",
+            json: JSON.stringify({
+              sandbox_id: "sbx-canonical",
+              name: id,
+              status: "running",
+              sandbox_url: "https://sbx-canonical.sandbox.tensorlake.ai",
+            }),
+          })),
+        },
+      });
+
+      const sbx = await Sandbox.connect({ sandboxId: "demo-name" });
+      // A handle opened by name knows only the name until the server
+      // answers; `create`/`connect` handles have no bind outcome.
+      expect(sbx.sandboxId).toBe("demo-name");
+      expect(sbx.bindOutcome).toBeNull();
+
+      await sbx.status();
+
+      expect(stub.client.getSandbox).toHaveBeenCalledWith("demo-name");
+      expect(sbx.sandboxId).toBe("sbx-canonical");
+      expect(sbx.name).toBe("demo-name");
+      sbx.close();
+    });
+  });
+
   describe("copy", () => {
     it("uses the lifecycle client", async () => {
       const stub = installNativeStub({


### PR DESCRIPTION
### Changes:
Handles from `get_or_create` / `getOrCreate` now expose `bind_outcome` /`bindOutcome`: `"created"`, `"attached"`, or `"resumed"`. TypeScript `getOrCreate` handles now report the canonical `sandboxId`, not the name.

Bumps all packages to 0.5.120 and regenerates the lockfiles.

Additive only; no existing behavior changes.