### PR TITLE
Migrate Linux CI workloads to Tensorlake runners

### DIFF
--- a/.github/actions/setup-tensorlake-rust-cache/action.yml
+++ b/.github/actions/setup-tensorlake-rust-cache/action.yml
@@ -1,0 +1,52 @@
+name: Set up Tensorlake Rust cache
+description: Configure sccache and the repository Cloud Volume for Rust jobs on Tensorlake runners.
+
+inputs:
+  cache-namespace:
+    description: Compatibility namespace shared only by equivalent Rust builds.
+    required: true
+  cache-version:
+    description: Manual cache namespace version used for invalidation.
+    required: false
+    default: v1
+  working-directory:
+    description: Rust workspace directory used to normalize sccache paths.
+    required: false
+    default: .
+  cache-target:
+    description: Persist CARGO_TARGET_DIR; use only when the namespace has one writer.
+    required: false
+    default: "false"
+  disable-incremental:
+    description: Disable incremental compilation so Rust compilations are eligible for sccache.
+    required: false
+    default: "true"
+  prefetch:
+    description: >-
+      Eagerly prefetch the Cloud Volume cache. Disabled by default because
+      runner-side prefetch can spend minutes polling an empty cache; TLFS lazy
+      reads remain enabled.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      with:
+        version: v0.17.0
+        disable_annotations: true
+
+    - name: Configure Tensorlake Cloud Volume caches
+      uses: tensorlakeai/tensorlake-github-runners/actions/setup-rust-cache@main
+      with:
+        cache-namespace: ${{ inputs.cache-namespace }}
+        cache-version: ${{ inputs.cache-version }}
+        working-directory: ${{ inputs.working-directory }}
+        # Cargo unpacks registry sources in place. Keep that mutable tree on
+        # local disk and persist only cache-safe compiler artifacts.
+        cache-cargo-home: "false"
+        cache-target: ${{ inputs.cache-target }}
+        disable-incremental: ${{ inputs.disable-incremental }}
+        prefetch: ${{ inputs.prefetch }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
   integration-test:
     name: Integration test against TestPyPI
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-large]
     steps:
       - name: Write test application
         run: |

--- a/.github/workflows/publish_cli.yaml
+++ b/.github/workflows/publish_cli.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   artifact-storage-source:
     name: Pin private artifact_storage source
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-small]
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
     steps:
@@ -56,7 +56,7 @@ jobs:
     # `tl fs setup` installs offline. tlfs-app is continue-on-error: when it produced nothing,
     # the darwin binary falls back to downloading the release asset at setup time.
     needs: [artifact-storage-source, tlfs-app]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +64,7 @@ jobs:
           # Customer Unix binaries ship the full CLI feature set (`tl fs mount` + fast clone).
           # Linux binaries are musl-linked so they do not depend on a host glibc floor.
           - os: ubuntu-latest
+            runner: [self-hosted, tensorlake, tensorlake-xlarge]
             target: x86_64-unknown-linux-musl
             rust_target_base: x86_64-unknown-linux-musl
             target_id: linux-x86_64
@@ -72,6 +73,7 @@ jobs:
             build_tool: cargo-zigbuild
             features: mount,git-clone
           - os: ubuntu-24.04-arm
+            runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             rust_target_base: aarch64-unknown-linux-musl
             target_id: linux-aarch64
@@ -80,6 +82,7 @@ jobs:
             build_tool: cargo-zigbuild
             features: mount,git-clone
           - os: macos-14
+            runner: macos-14
             target: aarch64-apple-darwin
             rust_target_base: aarch64-apple-darwin
             target_id: darwin-aarch64
@@ -88,6 +91,7 @@ jobs:
             features: mount,git-clone
           # Windows has no `tl fs mount` backend today; it still ships fast clone.
           - os: windows-latest
+            runner: windows-latest
             target: x86_64-pc-windows-msvc
             rust_target_base: x86_64-pc-windows-msvc
             target_id: windows-x86_64
@@ -106,7 +110,14 @@ jobs:
         if: matrix.build_tool == 'cargo-zigbuild'
         uses: mlugg/setup-zig@v2
 
-      - name: Cache Rust build artifacts
+      - name: Cache Rust build artifacts (Tensorlake)
+        if: matrix.target_id == 'linux-x86_64'
+        uses: ./.github/actions/setup-tensorlake-rust-cache
+        with:
+          cache-namespace: cli-release-linux-x86_64
+
+      - name: Cache Rust build artifacts (hosted runners)
+        if: matrix.target_id != 'linux-x86_64'
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust-no-bin
@@ -302,7 +313,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: [build, tlfs-app]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-small]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish_crates_io.yaml
+++ b/.github/workflows/publish_crates_io.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   publish:
     name: Publish to crates.io
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-small]
     permissions:
       id-token: write # Required for OIDC token exchange
     steps:

--- a/.github/workflows/publish_npm.yaml
+++ b/.github/workflows/publish_npm.yaml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   build-sdk-and-test:
     name: Build SDK and test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-medium]
     steps:
       - uses: actions/checkout@v4
 
@@ -52,42 +52,48 @@ jobs:
 
   build-native-binaries:
     name: Build native binding (${{ matrix.target_id }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
+            runner: [self-hosted, tensorlake, tensorlake-xlarge]
             target_id: linux-x64
             rust_target: x86_64-unknown-linux-gnu.2.28
             rust_target_base: x86_64-unknown-linux-gnu
             libc: gnu
             native_build_tool: cargo-zigbuild
           - os: ubuntu-24.04-arm
+            runner: ubuntu-24.04-arm
             target_id: linux-arm64
             rust_target: aarch64-unknown-linux-gnu.2.28
             rust_target_base: aarch64-unknown-linux-gnu
             libc: gnu
             native_build_tool: cargo-zigbuild
           - os: ubuntu-latest
+            runner: [self-hosted, tensorlake, tensorlake-xlarge]
             target_id: linux-x64-musl
             rust_target: x86_64-unknown-linux-musl
             rust_target_base: x86_64-unknown-linux-musl
             libc: musl
             native_build_tool: cargo-zigbuild
           - os: ubuntu-24.04-arm
+            runner: ubuntu-24.04-arm
             target_id: linux-arm64-musl
             rust_target: aarch64-unknown-linux-musl
             rust_target_base: aarch64-unknown-linux-musl
             libc: musl
             native_build_tool: cargo-zigbuild
           - os: macos-14
+            runner: macos-14
             target_id: darwin-arm64
             rust_target: ""
             rust_target_base: ""
             libc: ""
             native_build_tool: cargo
           - os: windows-latest
+            runner: windows-latest
             target_id: win32-x64
             rust_target: ""
             rust_target_base: ""
@@ -116,7 +122,14 @@ jobs:
         if: matrix.native_build_tool == 'cargo-zigbuild'
         uses: mlugg/setup-zig@v2
 
-      - name: Cache Rust build artifacts
+      - name: Cache Rust build artifacts (Tensorlake)
+        if: matrix.target_id == 'linux-x64' || matrix.target_id == 'linux-x64-musl'
+        uses: ./.github/actions/setup-tensorlake-rust-cache
+        with:
+          cache-namespace: npm-native-${{ matrix.target_id }}
+
+      - name: Cache Rust build artifacts (hosted runners)
+        if: matrix.target_id != 'linux-x64' && matrix.target_id != 'linux-x64-musl'
         uses: Swatinem/rust-cache@v2
         with:
           prefix-key: v1-rust-no-bin
@@ -168,7 +181,7 @@ jobs:
     needs:
       - build-sdk-and-test
       - build-native-binaries
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-small]
     environment:
       name: npm
       url: https://www.npmjs.com/package/tensorlake

--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -14,24 +14,28 @@ permissions:
 jobs:
   build-wheels:
     name: Build wheels on ${{ matrix.platform.os }} (${{ matrix.platform.target }})
-    runs-on: ${{ matrix.platform.os }}
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - os: namespace-profile-rust-builder-amd64
+          - os: tensorlake-xlarge
+            runner: [self-hosted, tensorlake, tensorlake-xlarge]
             target: x86_64
             manylinux: auto
           # Native arm64 runner + native PyPA image: the manylinux2014-cross image's
           # GCC 4.8 miscompiles ring's aarch64 crypto (TLS BadSignature at runtime).
           - os: ubuntu-24.04-arm
+            runner: ubuntu-24.04-arm
             target: aarch64
             manylinux: '2014'
             manylinux_container: quay.io/pypa/manylinux2014_aarch64:latest
           - os: macos-14
+            runner: macos-14
             target: aarch64
             rust_target: aarch64-apple-darwin
           - os: windows-latest
+            runner: windows-latest
             target: x86_64-pc-windows-msvc
             rust_target: x86_64-pc-windows-msvc
     steps:
@@ -87,7 +91,7 @@ jobs:
     # The private Function Agent implementation is compiled into wheels. Publishing an sdist
     # would either expose that source or produce an artifact that cannot build from public files.
     needs: [build-wheels]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-small]
     environment:
       name: pypi
       url: https://pypi.org/p/tensorlake

--- a/.github/workflows/publish_test_pypi.yaml
+++ b/.github/workflows/publish_test_pypi.yaml
@@ -16,6 +16,8 @@ permissions:
 jobs:
   prepare:
     name: Generate dev version
+    # Fork pull requests execute this job, so keep it away from the shared
+    # repository cache volume mounted on Tensorlake runners.
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -35,24 +37,28 @@ jobs:
     needs: [prepare]
     name: Build wheels on ${{ matrix.platform.os }} (${{ matrix.platform.target }})
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ${{ matrix.platform.os }}
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - os: namespace-profile-rust-builder-amd64
+          - os: tensorlake-xlarge
+            runner: [self-hosted, tensorlake, tensorlake-xlarge]
             target: x86_64
             manylinux: auto
           # Native arm64 runner + native PyPA image: the manylinux2014-cross image's
           # GCC 4.8 miscompiles ring's aarch64 crypto (TLS BadSignature at runtime).
           - os: ubuntu-24.04-arm
+            runner: ubuntu-24.04-arm
             target: aarch64
             manylinux: '2014'
             manylinux_container: quay.io/pypa/manylinux2014_aarch64:latest
           - os: macos-14
+            runner: macos-14
             target: aarch64
             rust_target: aarch64-apple-darwin
           - os: windows-latest
+            runner: windows-latest
             target: x86_64-pc-windows-msvc
             rust_target: x86_64-pc-windows-msvc
     steps:
@@ -116,7 +122,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     # Only wheels are publishable: an sdist would have to contain the private Function Agent core.
     needs: [build-wheels]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-small]
     environment:
       name: test-pypi
       url: https://test.pypi.org/p/tensorlake
@@ -140,7 +146,7 @@ jobs:
   wait-for-propagation:
     name: Wait for TestPyPI propagation
     needs: [publish]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-small]
     steps:
       - name: Sleep 60s for TestPyPI index propagation
         run: sleep 60

--- a/.github/workflows/sandbox_local_tests.yaml
+++ b/.github/workflows/sandbox_local_tests.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   test_sandbox_local:
     name: Sandbox integration tests (local)
-    runs-on: ubuntu-latest-xlarge
+    runs-on: [self-hosted, tensorlake, tensorlake-xlarge]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -31,10 +31,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/setup-tensorlake-rust-cache
         with:
-          prefix-key: v1-rust-no-bin
-          cache-bin: false
+          cache-namespace: sandbox-local
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   public_source_checks:
     name: Public Python source checks
+    # Fork pull requests execute this job, so keep it away from the shared
+    # repository cache volume mounted on Tensorlake runners.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -61,7 +63,7 @@ jobs:
     # The customer CLI and native function runners need private source from artifact_storage and
     # compute-engine-internal. Fork pull requests cannot read either repository-scoped App secret.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest-xlarge
+    runs-on: [self-hosted, tensorlake, tensorlake-xlarge]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -88,10 +90,9 @@ jobs:
           cache-dependency-path: typescript/package-lock.json
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/setup-tensorlake-rust-cache
         with:
-          prefix-key: v1-rust-full-feature
-          cache-bin: false
+          cache-namespace: tests-rust-full-feature
 
       - name: Build TypeScript SDK and Function Service runner capsule
         working-directory: typescript
@@ -204,7 +205,7 @@ jobs:
   run_tests:
     name: Lint and test
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest-xlarge
+    runs-on: [self-hosted, tensorlake, tensorlake-xlarge]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -225,10 +226,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/setup-tensorlake-rust-cache
         with:
-          prefix-key: v1-rust-no-bin
-          cache-bin: false
+          cache-namespace: tests-lint-and-test
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -257,7 +257,7 @@ jobs:
   test_sandbox:
     name: Sandbox integration tests
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-large]
     timeout-minutes: 30
     environment: prod
     steps:
@@ -279,10 +279,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/setup-tensorlake-rust-cache
         with:
-          prefix-key: v1-rust-no-bin
-          cache-bin: false
+          cache-namespace: tests-sandbox-integration
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/typescript_sdk.yaml
+++ b/.github/workflows/typescript_sdk.yaml
@@ -9,6 +9,7 @@ on:
       - "crates/rust-cloud-sdk-node/**"
       - "crates/function-agent-core/**"
       - ".github/actions/vendor-function-agent-core/**"
+      - ".github/actions/setup-tensorlake-rust-cache/**"
       - ".github/scripts/stage_function_agent_core.sh"
       - "Cargo.lock"
       - "proto/**"
@@ -28,6 +29,7 @@ on:
       - "crates/rust-cloud-sdk-node/**"
       - "crates/function-agent-core/**"
       - ".github/actions/vendor-function-agent-core/**"
+      - ".github/actions/setup-tensorlake-rust-cache/**"
       - ".github/scripts/stage_function_agent_core.sh"
       - "Cargo.lock"
       - "proto/**"
@@ -50,6 +52,8 @@ defaults:
 jobs:
   function-executor-compatibility:
     name: Python/TypeScript function executor compatibility
+    # Fork pull requests execute this job, so keep it away from the shared
+    # repository cache volume mounted on Tensorlake runners.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -95,6 +99,8 @@ jobs:
 
   unit-tests:
     name: Unit tests
+    # Fork pull requests execute this job, so keep it away from the shared
+    # repository cache volume mounted on Tensorlake runners.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -126,7 +132,7 @@ jobs:
   native-binding-smoke:
     name: Native Function Agent binding smoke tests
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-xlarge]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -149,10 +155,9 @@ jobs:
         uses: mlugg/setup-zig@v2
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/setup-tensorlake-rust-cache
         with:
-          prefix-key: v1-rust-no-bin
-          cache-bin: false
+          cache-namespace: typescript-native-binding-smoke
 
       - name: Install cargo-zigbuild
         run: cargo install cargo-zigbuild --locked
@@ -209,7 +214,7 @@ jobs:
   integration-tests:
     name: Integration tests
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tensorlake, tensorlake-large]
     timeout-minutes: 30
     environment: prod
     steps:
@@ -233,10 +238,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust build artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: ./.github/actions/setup-tensorlake-rust-cache
         with:
-          prefix-key: v1-rust-no-bin
-          cache-bin: false
+          cache-namespace: typescript-integration
 
       - name: Build native binding
         run: npm run build:native


### PR DESCRIPTION
Summary

- Route trusted Linux x86 build, test, integration, and release jobs to size-appropriate Tensorlake runners.
- Keep native ARM, macOS, Windows, and fork-facing public checks on hosted runners.
- Use Tensorlake Cloud Volume-backed sccache for Rust jobs, with TLFS prefetch disabled and mutable Cargo registry state kept on local disk.

Validation

- actionlint
- Parsed all workflow and composite-action YAML with Psych
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI topology and Rust caching behavior change across release and test pipelines; misconfigured runner labels or cache namespaces could slow or break builds, but application runtime code is untouched.
> 
> **Overview**
> Moves trusted **Linux x86** CI and release jobs from GitHub-hosted runners onto **self-hosted Tensorlake** labels (`tensorlake-small` through `tensorlake-xlarge`), while **ARM Linux, macOS, and Windows** matrix legs keep explicit hosted `runner` values.
> 
> Adds composite action **`setup-tensorlake-rust-cache`**, which installs **sccache** and wires **Tensorlake Cloud Volume** caching (via `tensorlake-github-runners/actions/setup-rust-cache`), with **Cargo registry on local disk**, **incremental off** for sccache, and **prefetch off** by default. Tensorlake Linux Rust jobs swap **`Swatinem/rust-cache`** for this action with per-job **`cache-namespace`**; non-Linux-x86 matrix builds still use `rust-cache`.
> 
> **PyPI/TestPyPI** x86_64 wheel builds move from `namespace-profile-rust-builder-amd64` to **`tensorlake-xlarge`**. Jobs that **fork PRs** can run (public checks, TestPyPI `prepare`, TS unit/compatibility) **stay on `ubuntu-latest`** with comments to avoid the **shared repo cache volume** on Tensorlake runners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b0626f650321ee4512856a93b471bbf2c26a11a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->