### PR TITLE
Classify SDK transport failures by cause, not by message text

### DIFF
--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -545,7 +545,7 @@ fn str_to_header_value(value: &str) -> Result<HeaderValue, SdkError> {
         .map_err(|e: InvalidHeaderValue| SdkError::InvalidHeaderValue(e.to_string()))
 }
 
-fn ensure_rustls_provider() {
+pub(crate) fn ensure_rustls_provider() {
     static INSTALL_PROVIDER: Once = Once::new();
     INSTALL_PROVIDER.call_once(|| {
         let _ = rustls::crypto::ring::default_provider().install_default();

--- a/crates/cloud-sdk/src/error.rs
+++ b/crates/cloud-sdk/src/error.rs
@@ -76,3 +76,166 @@ pub enum SdkError {
     #[error("EventSource error: {0}")]
     EventSourceError(String),
 }
+
+/// Why a request failed below the HTTP status layer.
+///
+/// The distinction is load-bearing for retries: a [`TransportFailure::Connect`]
+/// error means the request was never written to the wire, so replaying it
+/// cannot duplicate a side effect, even for a non-idempotent operation. A
+/// [`TransportFailure::Timeout`] carries no such guarantee — the request may
+/// have been received and executed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportFailure {
+    /// DNS resolution, TCP connect, or the TLS handshake failed. The server
+    /// never saw the request.
+    Connect,
+    /// The request was sent but no response completed within the deadline.
+    Timeout,
+}
+
+impl SdkError {
+    /// The underlying [`reqwest::Error`], whether it surfaced directly or
+    /// wrapped by `reqwest_middleware`.
+    ///
+    /// Every client in this crate issues requests through
+    /// [`reqwest_middleware::ClientWithMiddleware`], so transport failures
+    /// arrive as [`SdkError::Middleware`] and never as [`SdkError::Http`].
+    /// Callers that need `reqwest`'s own classification must go through here
+    /// rather than matching on [`SdkError::Http`] alone.
+    pub fn as_reqwest(&self) -> Option<&reqwest::Error> {
+        match self {
+            Self::Http(error) => Some(error),
+            Self::Middleware(reqwest_middleware::Error::Reqwest(error)) => Some(error),
+            _ => None,
+        }
+    }
+
+    /// Classify a transport-level failure, or `None` when the request reached
+    /// the server and failed for some other reason.
+    ///
+    /// Do not attempt this by inspecting the message: `reqwest` renders every
+    /// connect failure as `error sending request for url (...)`, and the words
+    /// that identify it (`tcp connect error`, `dns error`) appear only in the
+    /// [`std::error::Error::source`] chain.
+    pub fn transport_failure(&self) -> Option<TransportFailure> {
+        let error = self.as_reqwest()?;
+        if error.is_timeout() {
+            Some(TransportFailure::Timeout)
+        } else if error.is_connect() {
+            Some(TransportFailure::Connect)
+        } else {
+            None
+        }
+    }
+
+    /// The error's `Display` output followed by every `source()` in its chain.
+    ///
+    /// `reqwest` keeps the useful part of a transport failure in the chain, so
+    /// reporting only `to_string()` yields `error sending request for url
+    /// (...)` with no indication of whether DNS, TCP, or TLS failed.
+    pub fn detail(&self) -> String {
+        format_error_chain(self)
+    }
+}
+
+/// Join an error's `Display` with every `source()` below it.
+pub fn format_error_chain(error: &dyn std::error::Error) -> String {
+    let mut message = error.to_string();
+    let mut source = error.source();
+    while let Some(cause) = source {
+        let cause_message = cause.to_string();
+        if !cause_message.is_empty() && !message.ends_with(&cause_message) {
+            message.push_str(": ");
+            message.push_str(&cause_message);
+        }
+        source = cause.source();
+    }
+    message
+}
+
+#[cfg(test)]
+mod transport_failure_tests {
+    use super::{SdkError, TransportFailure};
+
+    /// Build the error a refused TCP connect produces, routed through
+    /// `reqwest_middleware` exactly as every client in this crate does.
+    async fn middleware_connect_error() -> SdkError {
+        crate::client::ensure_rustls_provider();
+        let client =
+            reqwest_middleware::ClientBuilder::new(reqwest::Client::builder().build().unwrap())
+                .build();
+        // Port 1 on loopback refuses immediately; no network access needed.
+        SdkError::from(client.get("http://127.0.0.1:1/x").send().await.unwrap_err())
+    }
+
+    #[tokio::test]
+    async fn middleware_connect_failure_is_classified_as_connect() {
+        let error = middleware_connect_error().await;
+
+        assert_eq!(
+            error.transport_failure(),
+            Some(TransportFailure::Connect),
+            "a connect failure through middleware must classify as Connect, not fall through \
+             to the untyped arm"
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_connect_failure_message_alone_names_no_cause() {
+        let error = middleware_connect_error().await;
+
+        // This is the regression that made the failure undiagnosable in the
+        // field: the rendered message never contains "connect" or "timeout",
+        // so any substring-based classifier reports it as an internal error.
+        let rendered = error.to_string().to_lowercase();
+        assert!(
+            !rendered.contains("connect") && !rendered.contains("timeout"),
+            "reqwest's Display is expected to hide the cause; got {rendered:?}"
+        );
+    }
+
+    /// A timeout must not be mistaken for a connect failure: only a connect
+    /// failure proves the request never ran, and that is what gates replaying
+    /// non-idempotent operations.
+    #[tokio::test]
+    async fn middleware_timeout_is_classified_as_timeout() {
+        crate::client::ensure_rustls_provider();
+        // A listener that accepts the connection and then never answers.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
+        let address = listener.local_addr().expect("address");
+        std::thread::spawn(move || {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept() {
+                held.push(stream);
+            }
+        });
+
+        let client = reqwest_middleware::ClientBuilder::new(
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_millis(200))
+                .build()
+                .unwrap(),
+        )
+        .build();
+        let error = SdkError::from(
+            client
+                .get(format!("http://{address}/x"))
+                .send()
+                .await
+                .unwrap_err(),
+        );
+
+        assert_eq!(error.transport_failure(), Some(TransportFailure::Timeout));
+    }
+
+    #[tokio::test]
+    async fn detail_surfaces_the_underlying_cause() {
+        let error = middleware_connect_error().await;
+
+        let detail = error.detail().to_lowercase();
+        assert!(
+            detail.contains("tcp connect error"),
+            "detail() must expose the source chain; got {detail:?}"
+        );
+    }
+}

--- a/crates/rust-cloud-sdk-node/src/repositories.rs
+++ b/crates/rust-cloud-sdk-node/src/repositories.rs
@@ -11,7 +11,10 @@ use tensorlake::artifact_storage::models::REPO_KIND_FILESYSTEM;
 use tensorlake::artifact_storage::models::{
     NativeDirectFilePathWrite, NativeDirectFileWrite, NativeDirectPathTransfer,
 };
-use tensorlake::{ClientBuilder, error::SdkError};
+use tensorlake::{
+    ClientBuilder,
+    error::{SdkError, TransportFailure},
+};
 
 use crate::sandbox::{
     TracedBytes, TracedJson, duration_from_seconds, into_napi_error, usage_error, with_retry,
@@ -45,9 +48,11 @@ pub struct FilesystemFilePathWrite {
 /// never transmitted). Gates the 409/404-on-retry forgiveness in the
 /// filesystem create/delete bindings.
 fn request_may_have_executed(err: &SdkError) -> bool {
+    if err.transport_failure() == Some(TransportFailure::Timeout) {
+        return true;
+    }
     match err {
         SdkError::ServerError { status, .. } => status.is_server_error(),
-        SdkError::Http(e) => e.is_timeout(),
         _ => false,
     }
 }

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -36,7 +36,10 @@ use tensorlake::sandboxes::{
     SandboxProxyClient, SandboxProxyTarget, SandboxesClient, resolve_sandbox_proxy_target,
     select_sandbox_proxy_url,
 };
-use tensorlake::{ClientBuilder, error::SdkError};
+use tensorlake::{
+    ClientBuilder,
+    error::{SdkError, TransportFailure},
+};
 
 // ---- Return value objects -------------------------------------------------
 
@@ -77,6 +80,13 @@ fn make_napi_error(category: &str, status: Option<u16>, message: String) -> napi
 
 /// Map an [`SdkError`] to a structured napi error. Mirrors the Python binding's
 /// `into_sandbox_py_error` so both SDKs classify failures identically.
+///
+/// Transport failures are classified with [`SdkError::transport_failure`], not
+/// by inspecting the message. Every request in this binding goes through
+/// `reqwest_middleware`, so a connect failure arrives as
+/// `SdkError::Middleware` rendering as `error sending request for url (...)` —
+/// a string that contains neither "connect" nor "timeout". Classifying it by
+/// substring reported real DNS and TCP failures as opaque internal errors.
 pub(crate) fn into_napi_error(error: SdkError) -> napi::Error {
     match error {
         SdkError::Authentication(message) => make_napi_error("sdk_usage", Some(401), message),
@@ -84,25 +94,18 @@ pub(crate) fn into_napi_error(error: SdkError) -> napi::Error {
         SdkError::ServerError { status, message } => {
             make_napi_error("remote_api", Some(status.as_u16()), message)
         }
-        SdkError::Http(http_error) => {
-            if http_error.is_timeout() {
-                make_napi_error("connection", Some(504), http_error.to_string())
-            } else if http_error.is_connect() {
-                make_napi_error("connection", Some(503), http_error.to_string())
-            } else {
-                make_napi_error("internal", None, http_error.to_string())
+        other => match other.transport_failure() {
+            // `detail()` appends the source chain, which is where reqwest keeps
+            // the part that names the failure (`tcp connect error`, `dns
+            // error`). Without it the caller sees only the generic wrapper.
+            Some(TransportFailure::Timeout) => {
+                make_napi_error("connection", Some(504), other.detail())
             }
-        }
-        SdkError::Middleware(middleware_error) => {
-            let message = middleware_error.to_string();
-            let lower = message.to_lowercase();
-            if lower.contains("timeout") || lower.contains("connect") {
-                make_napi_error("connection", None, message)
-            } else {
-                make_napi_error("internal", None, message)
+            Some(TransportFailure::Connect) => {
+                make_napi_error("connection", Some(503), other.detail())
             }
-        }
-        other => make_napi_error("internal", None, other.to_string()),
+            None => make_napi_error("internal", None, other.detail()),
+        },
     }
 }
 
@@ -112,21 +115,38 @@ pub(crate) fn usage_error(message: String) -> napi::Error {
 
 // ---- Retry helpers (ported from the Python binding) -----------------------
 
+/// Whether the SDK may re-send a request after this failure.
+///
+/// Deliberately excludes timeouts. A timeout means the request was already on
+/// the wire, so the server may have executed it; most operations reached
+/// through this predicate — starting a process, creating a snapshot or pool,
+/// deleting a sandbox — cannot absorb a second execution. Only failures that
+/// provably never reached the server are replayed here; per-operation timeout
+/// retries need an idempotency review first.
 fn is_retryable(error: &SdkError) -> bool {
+    if is_safe_to_replay(error) {
+        return true;
+    }
     match error {
         SdkError::ServerError { status, .. } => {
             *status == reqwest::StatusCode::BAD_GATEWAY
                 || *status == reqwest::StatusCode::SERVICE_UNAVAILABLE
                 || *status == reqwest::StatusCode::GATEWAY_TIMEOUT
         }
-        SdkError::Http(http_error) => http_error.is_connect() || http_error.is_timeout(),
-        SdkError::Middleware(middleware_error) => {
-            let source = middleware_error.to_string().to_lowercase();
-            source.contains("timeout") || source.contains("connect")
-        }
         SdkError::EventSourceError(_) => true,
         _ => false,
     }
+}
+
+/// Whether replaying the request is safe even when the operation is not
+/// idempotent.
+///
+/// Only a connect failure qualifies: DNS, TCP, and TLS all fail before a single
+/// request byte reaches the server, so the operation provably did not run. A
+/// timeout gives no such guarantee — the server may have received the request
+/// and be executing it still.
+fn is_safe_to_replay(error: &SdkError) -> bool {
+    matches!(error.transport_failure(), Some(TransportFailure::Connect))
 }
 
 fn calculate_sleep_time(retries: usize) -> f64 {
@@ -153,6 +173,42 @@ where
                 }
                 retries += 1;
                 let sleep_time = calculate_sleep_time(retries);
+                tokio::time::sleep(Duration::from_secs_f64(sleep_time)).await;
+            }
+        }
+    }
+}
+
+/// Number of times a request that never reached the server is replayed.
+///
+/// Small on purpose: a connect failure resolves in milliseconds, so the useful
+/// case is a single transient DNS or TCP hiccup, not a sustained outage the
+/// caller should hear about promptly.
+const MAX_CONNECT_REPLAYS: usize = 2;
+
+/// Run `op`, replaying it only when the previous attempt failed before the
+/// request reached the server.
+///
+/// Unlike [`retry_async_op`], this is safe for non-idempotent operations such
+/// as starting a process: [`is_safe_to_replay`] admits connect failures only,
+/// and a connect failure means no request byte was ever transmitted, so the
+/// operation cannot have run.
+async fn replay_on_connect_failure<C, T, F, Fut>(client: C, op: F) -> Result<T, SdkError>
+where
+    C: Clone,
+    F: Fn(C) -> Fut,
+    Fut: Future<Output = Result<T, SdkError>>,
+{
+    let mut replays = 0usize;
+    loop {
+        match op(client.clone()).await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if !is_safe_to_replay(&err) || replays >= MAX_CONNECT_REPLAYS {
+                    return Err(err);
+                }
+                replays += 1;
+                let sleep_time = calculate_sleep_time(replays);
                 tokio::time::sleep(Duration::from_secs_f64(sleep_time)).await;
             }
         }
@@ -1112,13 +1168,15 @@ impl NativeSandboxProxyClient {
     #[napi]
     pub async fn run_process(&self, payload_json: String) -> napi::Result<TracedEvents> {
         let payload: Value = parse_json_payload(&payload_json)?;
-        // Not retried: running a process is not idempotent.
-        let traced = self
-            .client()
-            .await?
-            .run_process(&payload)
-            .await
-            .map_err(into_napi_error)?;
+        // Running a process is not idempotent, so this is not wrapped in the
+        // general retry. Connect failures are still replayed: the request never
+        // reached the sandbox, so no process was started.
+        let traced = replay_on_connect_failure(self.client().await?, |client| {
+            let payload = payload.clone();
+            async move { client.run_process(&payload).await }
+        })
+        .await
+        .map_err(into_napi_error)?;
         let trace_id = traced.trace_id.clone();
         let events = traced
             .into_inner()

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -6,7 +6,6 @@
 
 mod function_agent;
 
-use std::error::Error as StdError;
 use std::future::Future;
 use std::io::Write;
 use std::path::PathBuf;
@@ -42,7 +41,10 @@ use tensorlake::sandboxes::{
     SandboxDesktopClient as RustSandboxDesktopClient, SandboxProxyClient, SandboxesClient,
     resolve_sandbox_proxy_target, select_sandbox_proxy_url,
 };
-use tensorlake::{Client, ClientBuilder, error::SdkError};
+use tensorlake::{
+    Client, ClientBuilder,
+    error::{SdkError, TransportFailure},
+};
 use tokio::runtime::Runtime;
 
 create_exception!(_cloud_sdk, CloudApiClientError, PyException);
@@ -65,9 +67,11 @@ fn shared_runtime() -> &'static Runtime {
 /// never transmitted). Gates the 409/404-on-retry forgiveness in the
 /// filesystem create/delete bindings.
 fn request_may_have_executed(err: &SdkError) -> bool {
+    if err.transport_failure() == Some(TransportFailure::Timeout) {
+        return true;
+    }
     match err {
         SdkError::ServerError { status, .. } => status.is_server_error(),
-        SdkError::Http(e) => e.is_timeout(),
         _ => false,
     }
 }
@@ -2378,6 +2382,20 @@ impl CloudSandboxProxyClient {
             operation,
         )
     }
+
+    /// Retry variant for operations that must not run twice.
+    fn run_with_connect_replay<T, F, Fut>(&self, operation: F) -> PyResult<T>
+    where
+        F: FnMut(SandboxProxyClient) -> Fut,
+        Fut: Future<Output = Result<T, SdkError>>,
+    {
+        run_with_connect_replay_blocking(
+            self.client.clone(),
+            "rust sandbox proxy request",
+            into_sandbox_py_error,
+            operation,
+        )
+    }
 }
 
 #[pyclass]
@@ -2693,7 +2711,11 @@ impl CloudSandboxProxyClient {
 
     fn run_process_json(&self, payload_json: String) -> PyResult<(String, Vec<String>)> {
         let payload: Value = parse_json_payload(&payload_json)?;
-        self.run_with_retry(5, move |client| {
+        // Running a process is not idempotent: the general retry would replay
+        // it after a timeout, when the sandbox may already be executing the
+        // command. Only connect failures — which never reached the sandbox —
+        // are replayed.
+        self.run_with_connect_replay(move |client| {
             let payload = payload.clone();
             async move {
                 let traced = client.run_process(&payload).await?;
@@ -3118,7 +3140,9 @@ impl CloudSandboxProxyClient {
         let payload: Value = parse_json_payload(&payload_json)?;
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = retry_async_op(client, 5, move |c| {
+            // See `run_process_json`: replay only failures that never reached
+            // the sandbox, so a timeout cannot start the command twice.
+            let traced = replay_on_connect_failure(client, move |c| {
                 let payload = payload.clone();
                 async move { c.run_process(&payload).await }
             })
@@ -3413,6 +3437,53 @@ fn run_with_retry_blocking<C, T, F, Fut>(
     max_retries: usize,
     label: &str,
     into_err: fn(SdkError) -> PyErr,
+    operation: F,
+) -> PyResult<T>
+where
+    C: Clone,
+    F: FnMut(C) -> Fut,
+    Fut: Future<Output = Result<T, SdkError>>,
+{
+    run_bounded_blocking(
+        client,
+        max_retries,
+        is_retryable,
+        label,
+        into_err,
+        operation,
+    )
+}
+
+/// Blocking counterpart of [`replay_on_connect_failure`]: replays only the
+/// failures that provably never reached the server, so it is safe to wrap a
+/// non-idempotent operation.
+fn run_with_connect_replay_blocking<C, T, F, Fut>(
+    client: C,
+    label: &str,
+    into_err: fn(SdkError) -> PyErr,
+    operation: F,
+) -> PyResult<T>
+where
+    C: Clone,
+    F: FnMut(C) -> Fut,
+    Fut: Future<Output = Result<T, SdkError>>,
+{
+    run_bounded_blocking(
+        client,
+        MAX_CONNECT_REPLAYS,
+        is_safe_to_replay,
+        label,
+        into_err,
+        operation,
+    )
+}
+
+fn run_bounded_blocking<C, T, F, Fut>(
+    client: C,
+    max_retries: usize,
+    should_retry: fn(&SdkError) -> bool,
+    label: &str,
+    into_err: fn(SdkError) -> PyErr,
     mut operation: F,
 ) -> PyResult<T>
 where
@@ -3425,7 +3496,7 @@ where
         match shared_runtime().block_on(operation(client.clone())) {
             Ok(value) => return Ok(value),
             Err(err) => {
-                if !is_retryable(&err) || retries >= max_retries {
+                if !should_retry(&err) || retries >= max_retries {
                     return Err(into_err(err));
                 }
 
@@ -3551,20 +3622,70 @@ fn duration_from_seconds(name: &str, seconds: f64) -> PyResult<Duration> {
     Ok(Duration::from_secs_f64(seconds))
 }
 
+/// Whether the SDK may re-send a request after this failure.
+///
+/// Deliberately excludes timeouts. A timeout means the request was already on
+/// the wire, so the server may have executed it; most operations reached
+/// through this predicate — starting a process, creating a snapshot or pool,
+/// deleting a sandbox — cannot absorb a second execution. Only failures that
+/// provably never reached the server are replayed here; per-operation timeout
+/// retries need an idempotency review first.
 fn is_retryable(error: &SdkError) -> bool {
+    if is_safe_to_replay(error) {
+        return true;
+    }
     match error {
         SdkError::ServerError { status, .. } => {
             *status == reqwest::StatusCode::BAD_GATEWAY
                 || *status == reqwest::StatusCode::SERVICE_UNAVAILABLE
                 || *status == reqwest::StatusCode::GATEWAY_TIMEOUT
         }
-        SdkError::Http(http_error) => http_error.is_connect() || http_error.is_timeout(),
-        SdkError::Middleware(middleware_error) => {
-            let source = middleware_error.to_string().to_lowercase();
-            source.contains("timeout") || source.contains("connect")
-        }
         SdkError::EventSourceError(_) => true,
         _ => false,
+    }
+}
+
+/// Whether replaying the request is safe even when the operation is not
+/// idempotent.
+///
+/// Only a connect failure qualifies: DNS, TCP, and TLS all fail before a single
+/// request byte reaches the server, so the operation provably did not run. A
+/// timeout gives no such guarantee — the server may have received the request
+/// and be executing it still.
+fn is_safe_to_replay(error: &SdkError) -> bool {
+    matches!(error.transport_failure(), Some(TransportFailure::Connect))
+}
+
+/// Number of times a request that never reached the server is replayed.
+///
+/// Small on purpose: a connect failure resolves in milliseconds, so the useful
+/// case is a single transient DNS or TCP hiccup, not a sustained outage the
+/// caller should hear about promptly.
+const MAX_CONNECT_REPLAYS: usize = 2;
+
+/// Run `op`, replaying it only when the previous attempt failed before the
+/// request reached the server.
+///
+/// Unlike [`retry_async_op`], this is safe for non-idempotent operations such
+/// as starting a process.
+async fn replay_on_connect_failure<C, T, F, Fut>(client: C, op: F) -> Result<T, SdkError>
+where
+    C: Clone,
+    F: Fn(C) -> Fut,
+    Fut: Future<Output = Result<T, SdkError>>,
+{
+    let mut replays = 0usize;
+    loop {
+        match op(client.clone()).await {
+            Ok(value) => return Ok(value),
+            Err(err) => {
+                if !is_safe_to_replay(&err) || replays >= MAX_CONNECT_REPLAYS {
+                    return Err(err);
+                }
+                replays += 1;
+                tokio::time::sleep(Duration::from_secs_f64(calculate_sleep_time(replays))).await;
+            }
+        }
     }
 }
 
@@ -3579,44 +3700,15 @@ fn into_py_error(error: SdkError) -> PyErr {
         SdkError::ServerError { status, message } => {
             CloudApiClientError::new_err(("remote_api", Some(status.as_u16()), message))
         }
-        SdkError::Http(http_error) => {
-            let message = format_error_chain(&http_error);
-            if http_error.is_timeout() || http_error.is_connect() {
+        other => {
+            let message = other.detail();
+            if other.transport_failure().is_some() {
                 CloudApiClientError::new_err(("connection", Option::<u16>::None, message))
             } else {
                 CloudApiClientError::new_err(("internal", Option::<u16>::None, message))
             }
         }
-        SdkError::Middleware(middleware_error) => {
-            let message = format_error_chain(&middleware_error);
-            let lower = message.to_lowercase();
-            if lower.contains("connect")
-                || lower.contains("connection refused")
-                || lower.contains("dns")
-                || lower.contains("timed out")
-                || lower.contains("timeout")
-            {
-                CloudApiClientError::new_err(("connection", Option::<u16>::None, message))
-            } else {
-                CloudApiClientError::new_err(("internal", Option::<u16>::None, message))
-            }
-        }
-        other => CloudApiClientError::new_err(("internal", Option::<u16>::None, other.to_string())),
     }
-}
-
-fn format_error_chain(error: &dyn StdError) -> String {
-    let mut message = error.to_string();
-    let mut source = error.source();
-    while let Some(cause) = source {
-        let cause_message = cause.to_string();
-        if !cause_message.is_empty() {
-            message.push_str(": ");
-            message.push_str(&cause_message);
-        }
-        source = cause.source();
-    }
-    message
 }
 
 fn into_sandbox_py_error(error: SdkError) -> PyErr {
@@ -3630,38 +3722,19 @@ fn into_sandbox_py_error(error: SdkError) -> PyErr {
         SdkError::ServerError { status, message } => {
             CloudSandboxClientError::new_err(("remote_api", Some(status.as_u16()), message))
         }
-        SdkError::Http(http_error) => {
-            if http_error.is_timeout() {
-                CloudSandboxClientError::new_err((
-                    "connection",
-                    Some(504u16),
-                    http_error.to_string(),
-                ))
-            } else if http_error.is_connect() {
-                CloudSandboxClientError::new_err((
-                    "connection",
-                    Some(503u16),
-                    http_error.to_string(),
-                ))
-            } else {
-                CloudSandboxClientError::new_err((
-                    "internal",
-                    Option::<u16>::None,
-                    http_error.to_string(),
-                ))
-            }
-        }
-        SdkError::Middleware(middleware_error) => {
-            let message = middleware_error.to_string();
-            let lower = message.to_lowercase();
-            if lower.contains("timeout") || lower.contains("connect") {
-                CloudSandboxClientError::new_err(("connection", Option::<u16>::None, message))
-            } else {
-                CloudSandboxClientError::new_err(("internal", Option::<u16>::None, message))
-            }
-        }
         other => {
-            CloudSandboxClientError::new_err(("internal", Option::<u16>::None, other.to_string()))
+            let message = other.detail();
+            match other.transport_failure() {
+                Some(TransportFailure::Timeout) => {
+                    CloudSandboxClientError::new_err(("connection", Some(504u16), message))
+                }
+                Some(TransportFailure::Connect) => {
+                    CloudSandboxClientError::new_err(("connection", Some(503u16), message))
+                }
+                None => {
+                    CloudSandboxClientError::new_err(("internal", Option::<u16>::None, message))
+                }
+            }
         }
     }
 }
@@ -3677,41 +3750,20 @@ fn into_document_ai_py_error(error: SdkError) -> PyErr {
         SdkError::ServerError { status, message } => {
             CloudDocumentAIClientError::new_err(("remote_api", Some(status.as_u16()), message))
         }
-        SdkError::Http(http_error) => {
-            if http_error.is_timeout() {
-                CloudDocumentAIClientError::new_err((
-                    "connection",
-                    Some(504u16),
-                    http_error.to_string(),
-                ))
-            } else if http_error.is_connect() {
-                CloudDocumentAIClientError::new_err((
-                    "connection",
-                    Some(503u16),
-                    http_error.to_string(),
-                ))
-            } else {
-                CloudDocumentAIClientError::new_err((
-                    "internal",
-                    Option::<u16>::None,
-                    http_error.to_string(),
-                ))
+        other => {
+            let message = other.detail();
+            match other.transport_failure() {
+                Some(TransportFailure::Timeout) => {
+                    CloudDocumentAIClientError::new_err(("connection", Some(504u16), message))
+                }
+                Some(TransportFailure::Connect) => {
+                    CloudDocumentAIClientError::new_err(("connection", Some(503u16), message))
+                }
+                None => {
+                    CloudDocumentAIClientError::new_err(("internal", Option::<u16>::None, message))
+                }
             }
         }
-        SdkError::Middleware(middleware_error) => {
-            let message = middleware_error.to_string();
-            let lower = message.to_lowercase();
-            if lower.contains("timeout") || lower.contains("connect") {
-                CloudDocumentAIClientError::new_err(("connection", Option::<u16>::None, message))
-            } else {
-                CloudDocumentAIClientError::new_err(("internal", Option::<u16>::None, message))
-            }
-        }
-        other => CloudDocumentAIClientError::new_err((
-            "internal",
-            Option::<u16>::None,
-            other.to_string(),
-        )),
     }
 }
 


### PR DESCRIPTION
## Why

A customer reported `Sandbox.create()` resolving before the process proxy accepted commands, with this error from `sandbox.run()`:

```
SandboxError: error sending request for url (https://<sandbox-id>.sandbox.tensorlake.ai/api/v1/processes/run)
```

Server-side evidence ruled out a readiness gap. Across the four affected sandboxes the server promoted each one to `running` only after the dataplane confirmed the route (the `ContainerStarted` binding echo), several `run()` calls on the *same* sandbox had already returned 200 before the failing one, all 201 `POST /api/v1/processes/run` requests from that project in the window returned 200, and the NLB access logs show every TLS connection for those hostnames handshaking cleanly with zero ELB resets or TLS negotiation errors. The failing request never reached our edge.

The reason nobody could tell that from the error is this bug.

Every client issues requests through `reqwest_middleware`, so a transport failure arrives as `SdkError::Middleware` and **never** as `SdkError::Http`. Both bindings classified that arm by lowercasing the message and testing for `"connect"` or `"timeout"` — but reqwest renders a refused TCP connect and a failed DNS lookup identically:

```
error sending request for url (https://...)
```

with the identifying text only in the `source()` chain, which was discarded. Verified empirically (`reqwest` + `reqwest_middleware`, both TCP-refused and DNS-failure): the substring test is `false` in both cases, and the chain reads `client error (Connect): tcp connect error: Connection refused` / `client error (Connect): dns error: failed to lookup address information`.

So a plain connect failure surfaced as `category: "internal"`, `status: null`, which `translateNativeError` falls through to a bare `SandboxError` — no cause, no classification, and none of the connect retries either binding intended.

## What changed

`SdkError::transport_failure()` and `SdkError::detail()` in the core crate, and every binding site routed through them:

- `into_napi_error`, `into_py_error`, `into_sandbox_py_error`, `into_document_ai_py_error` classify by reqwest's own predicates and report the full source chain. A connect failure now reaches TypeScript as `SandboxConnectionError` and Python as `kind == "connection"`.
- `request_may_have_executed` (both bindings) now sees middleware timeouts, which it previously could not. It gates the 409/404-on-retry forgiveness in the filesystem create/delete paths.
- `run_process` gets a bounded connect-only replay. It is not idempotent, so the Node binding did not retry it at all and the Python binding retried it on timeouts and 5xx — replaying a command the sandbox may already be running. A connect failure is the one provably safe case: no request byte reached the sandbox, so no process was started.

## Behaviour change to review

`is_retryable` no longer claims to retry **timeouts**. A timeout means the request was already on the wire, and the operations behind that predicate — `start_process`, `create_snapshot`, `create_pool`, `delete_sandbox` — cannot absorb a second execution.

This preserves what actually ships today rather than changing it: because the substring test never matched, no timeout has ever been retried on the middleware path (the only code path that still produces `SdkError::Http` is the one `base_client` SSE GET). Fixing the classifier without this would have silently activated timeout replay across ~40 call sites, including creates and deletes, in the same commit that fixed the reporting. Per-operation timeout retries want an idempotency review first — happy to split that out if you'd rather have it here.

## Tests

Four tests in `cloud-sdk` pin the classification, including a negative test asserting that the rendered message names no cause — so a future substring-based classifier cannot pass silently.

```
test error::transport_failure_tests::middleware_connect_failure_is_classified_as_connect ... ok
test error::transport_failure_tests::middleware_connect_failure_message_alone_names_no_cause ... ok
test error::transport_failure_tests::middleware_timeout_is_classified_as_timeout ... ok
test error::transport_failure_tests::detail_surfaces_the_underlying_cause ... ok
```

`cargo test -p tensorlake` passes (214 tests) and the Node and Python bindings type-check under `just with-function-agent-core`. Two `commands::deploy::typescript` CLI tests and two clippy lints (`large_enum_variant`, `too_many_arguments`) fail identically on unmodified `origin/main` in my environment; both are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)