### PR TITLE
Enable reqwest's http2 feature in the SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,6 +1739,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "halfbrown"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1930,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -4188,6 +4208,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,11 @@ serde_with = { version = "3.17", default-features = false, features = ["base64",
 serde_path_to_error = "0.1.20"
 
 # HTTP
-reqwest = { version = "0.13.2", default-features = false, features = ["json", "multipart", "rustls-no-provider", "stream"] }
+# `http2` is required, not optional: without it reqwest advertises only
+# `http/1.1` in ALPN, so every concurrent request opens its own TCP connection
+# and `Client::with_base_url`'s connection coalescing (which it documents) can
+# never happen.
+reqwest = { version = "0.13.2", default-features = false, features = ["http2", "json", "multipart", "rustls-no-provider", "stream"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 eventsource-stream = "0.2"
 reqwest-middleware = { version = "0.5.1", features = ["json", "multipart", "query"] }


### PR DESCRIPTION
## Why

The workspace pins reqwest with `default-features = false` and never re-enables `http2`, so every SDK client advertises only `http/1.1` in ALPN. Confirmed in production NLB access logs, where the SDK's connections record `alpn_client_preference_list "http/1.1"`, and reproduced directly — the same probe against a production sandbox negotiates:

| workspace `reqwest` features | negotiated |
|---|---|
| as on `main` | `HTTP/1.1` |
| + `http2` | `HTTP/2.0` |

Two consequences:

1. **Every concurrent call needs its own TCP connection.** Six parallel `run()` calls mean six connections, six TLS handshakes, and six chances for a transport failure. That is worst for clients behind a NAT with a small source-port range — the customer whose report prompted #955 was making its connections from a ~250-port range.
2. **Connection coalescing never happens.** `Client::with_base_url` documents that it shares a pool so "HTTP/2 connections established for one base URL can be reused (via connection coalescing) when talking to another host that resolves to the same IP with the same TLS certificate." Every `*.sandbox.tensorlake.ai` host resolves to the same NLB behind the same wildcard certificate, so that is exactly the intended case — and it is unreachable today.

## Risk

Websockets are unaffected: the desktop tunnel, PTY, and `tl sbx tunnel` paths use `tokio-tungstenite` directly, and nothing in the workspace uses reqwest's HTTP/1.1 upgrade support, so no upgrade path loses its transport. `Cargo.lock` gains one crate (`h2`).

This does move all API and sandbox traffic onto h2 wherever the server offers it, including the `processes/run` SSE stream — a real behaviour change, which is why it is separate from #955 and can be rolled independently.

## Validation

End to end against production on both sandbox proxy fleets (AWS `sandbox.tensorlake.ai` and GCP `sandbox.gcp-use4.tensorlake.ai`): `tl sbx create`, `exec` (the streaming `processes/run` SSE path), `cp` upload and read-back, and `ps`. `cargo test -p tensorlake` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)