### PR TITLE
Bump Tensorlake packages to 0.5.126

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.125"
+version = "0.5.126"
 dependencies = [
  "anyhow",
  "base64",
@@ -5466,7 +5466,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.125"
+version = "0.5.126"
 dependencies = [
  "anyhow",
  "base64",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.125"
+version = "0.5.126"
 dependencies = [
  "anyhow",
  "base64",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.125"
+version = "0.5.126"
 dependencies = [
  "anyhow",
  "base64",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.125"
+version = "0.5.126"
 dependencies = [
  "anyhow",
  "base64",
@@ -5618,7 +5618,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.125"
+version = "0.5.126"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.125"
+version = "0.5.126"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.125"
+version = "0.5.126"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.125"
+version = "0.5.126"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.125"
+version = "0.5.126"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/npm/darwin-arm64/package.json
+++ b/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorlake/native-darwin-arm64",
-  "version": "0.5.125",
+  "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for macOS arm64",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64-musl/package.json
+++ b/typescript/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorlake/native-linux-arm64-musl",
-  "version": "0.5.125",
+  "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Linux arm64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64/package.json
+++ b/typescript/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorlake/native-linux-arm64-gnu",
-  "version": "0.5.125",
+  "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Linux arm64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64-musl/package.json
+++ b/typescript/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorlake/native-linux-x64-musl",
-  "version": "0.5.125",
+  "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Linux x64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64/package.json
+++ b/typescript/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorlake/native-linux-x64-gnu",
-  "version": "0.5.125",
+  "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Linux x64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/win32-x64/package.json
+++ b/typescript/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorlake/native-win32-x64",
-  "version": "0.5.125",
+  "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Windows x64",
   "repository": {
     "type": "git",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.125",
+  "version": "0.5.126",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.125",
+      "version": "0.5.126",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",
@@ -39,12 +39,12 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@tensorlake/native-darwin-arm64": "0.5.125",
-        "@tensorlake/native-linux-arm64-gnu": "0.5.125",
-        "@tensorlake/native-linux-arm64-musl": "0.5.125",
-        "@tensorlake/native-linux-x64-gnu": "0.5.125",
-        "@tensorlake/native-linux-x64-musl": "0.5.125",
-        "@tensorlake/native-win32-x64": "0.5.125"
+        "@tensorlake/native-darwin-arm64": "0.5.126",
+        "@tensorlake/native-linux-arm64-gnu": "0.5.126",
+        "@tensorlake/native-linux-arm64-musl": "0.5.126",
+        "@tensorlake/native-linux-x64-gnu": "0.5.126",
+        "@tensorlake/native-linux-x64-musl": "0.5.126",
+        "@tensorlake/native-win32-x64": "0.5.126"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1236,8 +1236,8 @@
       ]
     },
     "node_modules/@tensorlake/native-darwin-arm64": {
-      "version": "0.5.125",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-darwin-arm64/-/native-darwin-arm64-0.5.125.tgz",
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/@tensorlake/native-darwin-arm64/-/native-darwin-arm64-0.5.126.tgz",
       "cpu": [
         "arm64"
       ],
@@ -1251,8 +1251,8 @@
       }
     },
     "node_modules/@tensorlake/native-linux-arm64-gnu": {
-      "version": "0.5.125",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-arm64-gnu/-/native-linux-arm64-gnu-0.5.125.tgz",
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-arm64-gnu/-/native-linux-arm64-gnu-0.5.126.tgz",
       "cpu": [
         "arm64"
       ],
@@ -1269,8 +1269,8 @@
       }
     },
     "node_modules/@tensorlake/native-linux-arm64-musl": {
-      "version": "0.5.125",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-arm64-musl/-/native-linux-arm64-musl-0.5.125.tgz",
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-arm64-musl/-/native-linux-arm64-musl-0.5.126.tgz",
       "cpu": [
         "arm64"
       ],
@@ -1287,8 +1287,8 @@
       }
     },
     "node_modules/@tensorlake/native-linux-x64-gnu": {
-      "version": "0.5.125",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-x64-gnu/-/native-linux-x64-gnu-0.5.125.tgz",
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-x64-gnu/-/native-linux-x64-gnu-0.5.126.tgz",
       "cpu": [
         "x64"
       ],
@@ -1305,8 +1305,8 @@
       }
     },
     "node_modules/@tensorlake/native-linux-x64-musl": {
-      "version": "0.5.125",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-x64-musl/-/native-linux-x64-musl-0.5.125.tgz",
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-x64-musl/-/native-linux-x64-musl-0.5.126.tgz",
       "cpu": [
         "x64"
       ],
@@ -1323,8 +1323,8 @@
       }
     },
     "node_modules/@tensorlake/native-win32-x64": {
-      "version": "0.5.125",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-win32-x64/-/native-win32-x64-0.5.125.tgz",
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/@tensorlake/native-win32-x64/-/native-win32-x64-0.5.126.tgz",
       "cpu": [
         "x64"
       ],

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.125",
+  "version": "0.5.126",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -96,11 +96,11 @@
     "ws": "^8.20.0"
   },
   "optionalDependencies": {
-    "@tensorlake/native-darwin-arm64": "0.5.125",
-    "@tensorlake/native-linux-arm64-gnu": "0.5.125",
-    "@tensorlake/native-linux-arm64-musl": "0.5.125",
-    "@tensorlake/native-linux-x64-gnu": "0.5.125",
-    "@tensorlake/native-linux-x64-musl": "0.5.125",
-    "@tensorlake/native-win32-x64": "0.5.125"
+    "@tensorlake/native-darwin-arm64": "0.5.126",
+    "@tensorlake/native-linux-arm64-gnu": "0.5.126",
+    "@tensorlake/native-linux-arm64-musl": "0.5.126",
+    "@tensorlake/native-linux-x64-gnu": "0.5.126",
+    "@tensorlake/native-linux-x64-musl": "0.5.126",
+    "@tensorlake/native-win32-x64": "0.5.126"
   }
 }


### PR DESCRIPTION
## What

Lockstep version bump `0.5.125` → `0.5.126` across every release surface, via `python .github/scripts/bump_version.py 0.5.126`:

- `pyproject.toml` (PyPI `tensorlake`)
- `Cargo.toml` (workspace version — all crates inherit through `version.workspace = true`, including `crates/cli`)
- `crates/gsvc-fs-client/Cargo.toml`
- `crates/rust-cloud-sdk-py/pyproject.toml`
- `typescript/package.json` (npm, including the six `@tensorlake/native-*` optional dependency pins) and the per-platform `typescript/npm/*/package.json`

`Cargo.lock` and `typescript/package-lock.json` were refreshed by the tooling, not hand-edited. No `0.5.125` reference remains in any tracked manifest or lockfile.

## Release contents

`0.5.125` is the current published version on both [PyPI](https://pypi.org/project/tensorlake/) and npm, and `main` sits at `0.5.125`, so this is the next release.

Branched from `bcc004aa`, so merging this as-is releases:

- #956 — enable reqwest's `http2` feature (SDK now negotiates HTTP/2 to the sandbox and API edges)
- #953 — move native SDK ownership off the Node.js event loop

⚠️ **It does not include #955** (classify SDK transport failures by cause), which is still open. That is the fix for the customer report of `SandboxError: error sending request for url (...)` arriving with no cause and no retry. If you want it in `0.5.126`, merge #955 before this PR; otherwise it ships in the next bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)