### PR TITLE
Make SDK and TLFS transports independent of guest CA stores

### DIFF
--- a/.github/workflows/http_transport.yaml
+++ b/.github/workflows/http_transport.yaml
@@ -1,0 +1,29 @@
+name: HTTP transport policy
+
+on:
+  pull_request:
+    paths:
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'clippy.toml'
+      - 'justfile'
+      - '.github/workflows/http_transport.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  certless-transports:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@just
+      - uses: Swatinem/rust-cache@v2
+      - name: Deny implicit platform trust in SDK and CLI
+        run: just lint-http-transports
+      - name: Test socket requests and fail-closed credential handling in certless children
+        run: just test-artifact-storage

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -106,10 +106,15 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           # Stacked mount PRs pin their exact artifact_storage code commit only on their own head
           # branch; main and every other PR continue integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'fix/tlfs-certless-socket-startup' && '9e430c882e19de801dc2cb4f356e0c9049f49f7c' || github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
+
+      - uses: taiki-e/install-action@just
+
+      - name: Enforce HTTP transport policy with customer features
+        run: just lint-http-transports-full
 
       - name: Test private filesystem client engine
         run: |
@@ -151,7 +156,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'fix/tlfs-certless-socket-startup' && '9e430c882e19de801dc2cb4f356e0c9049f49f7c' || github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -106,7 +106,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           # Stacked mount PRs pin their exact artifact_storage code commit only on their own head
           # branch; main and every other PR continue integrating against artifact_storage/main.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'fix/tlfs-certless-socket-startup' && '9e430c882e19de801dc2cb4f356e0c9049f49f7c' || github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'fix/tlfs-certless-socket-startup' && 'da9c30ab076aa59a7882a072d2787b77573a1100' || github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Build full-feature CLI
         run: cargo build -p tensorlake-cli --features mount,git-clone
@@ -156,7 +156,7 @@ jobs:
           private-key: ${{ secrets.ARTIFACT_STORAGE_APP_PRIVATE_KEY }}
           include-macos-fskit: "true"
           # Keep the private Rust and FSKit sources on the same stacked revision as the Linux job.
-          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'fix/tlfs-certless-socket-startup' && '9e430c882e19de801dc2cb4f356e0c9049f49f7c' || github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
+          source-ref: ${{ github.event_name == 'pull_request' && github.head_ref == 'fix/tlfs-certless-socket-startup' && 'da9c30ab076aa59a7882a072d2787b77573a1100' || github.event_name == 'pull_request' && github.head_ref == 'agent/tlfs-mount-daemon' && '92131d3795026c33cd2edaa01fa918360bf8e94d' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-prefetch-cli' && '714d14ae13dd9f22623080703876df98c8484dd4' || github.event_name == 'pull_request' && github.head_ref == 'agent/logical-v1-dependencies' && 'c77631e7247159516e99bbaf3e68900b2ea86eae' || 'main' }}
 
       - name: Verify the CLI and FSKit source contract compile together
         run: >-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,12 +1729,14 @@ dependencies = [
  "bytes",
  "futures",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "webpki-roots 1.0.7",
  "zstd 0.13.3",
 ]
 
@@ -5512,6 +5514,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "uuid",
+ "webpki-roots 1.0.7",
  "xattr",
  "zip",
  "zstd 0.13.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,7 +1736,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "webpki-roots 1.0.7",
+ "webpki-root-certs",
  "zstd 0.13.3",
 ]
 
@@ -5514,7 +5514,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "uuid",
- "webpki-roots 1.0.7",
+ "webpki-root-certs",
  "xattr",
  "zip",
  "zstd 0.13.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde_path_to_error = "0.1.20"
 # never happen.
 reqwest = { version = "0.13.2", default-features = false, features = ["http2", "json", "multipart", "rustls-no-provider", "stream"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-webpki-roots = "1"
+webpki-root-certs = "1"
 eventsource-stream = "0.2"
 reqwest-middleware = { version = "0.5.1", features = ["json", "multipart", "query"] }
 url = "2.5.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde_path_to_error = "0.1.20"
 # never happen.
 reqwest = { version = "0.13.2", default-features = false, features = ["http2", "json", "multipart", "rustls-no-provider", "stream"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
+webpki-roots = "1"
 eventsource-stream = "0.2"
 reqwest-middleware = { version = "0.5.1", features = ["json", "multipart", "query"] }
 url = "2.5.8"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,8 @@
+disallowed-methods = [
+    { path = "reqwest::get", reason = "Use http_transport; this helper constructs a bare client" },
+    { path = "reqwest::Client::builder", reason = "Use http_transport to select bundled HTTPS roots or plaintext socket transport" },
+    { path = "reqwest::Client::new", reason = "Use http_transport; native CA discovery is forbidden in shipped clients" },
+    { path = "reqwest::Client::default", reason = "Use http_transport; native CA discovery is forbidden in shipped clients" },
+    { path = "reqwest::ClientBuilder::new", reason = "Use http_transport to select an explicit trust policy" },
+    { path = "reqwest::ClientBuilder::default", reason = "Use http_transport to select an explicit trust policy" },
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,7 +2,5 @@ disallowed-methods = [
     { path = "reqwest::get", reason = "Use http_transport; this helper constructs a bare client" },
     { path = "reqwest::Client::builder", reason = "Use http_transport to select bundled HTTPS roots or plaintext socket transport" },
     { path = "reqwest::Client::new", reason = "Use http_transport; native CA discovery is forbidden in shipped clients" },
-    { path = "reqwest::Client::default", reason = "Use http_transport; native CA discovery is forbidden in shipped clients" },
     { path = "reqwest::ClientBuilder::new", reason = "Use http_transport to select an explicit trust policy" },
-    { path = "reqwest::ClientBuilder::default", reason = "Use http_transport to select an explicit trust policy" },
 ]

--- a/crates/cli/src/commands/git/fastclone.rs
+++ b/crates/cli/src/commands/git/fastclone.rs
@@ -178,7 +178,7 @@ pub async fn fast_clone(opts: FastCloneOptions) -> Result<FastCloneStats> {
         clean_base.set_path(&path);
     }
     let ctx = HttpCtx {
-        client: reqwest::Client::builder().build()?,
+        client: crate::http::client_builder().build()?,
         origin: clean_base.clone(),
         auth: opts.credential.clone(),
         progress: opts.progress,
@@ -1232,7 +1232,7 @@ mod tests {
     fn test_ctx() -> HttpCtx {
         let _ = rustls::crypto::ring::default_provider().install_default();
         HttpCtx {
-            client: reqwest::Client::new(),
+            client: crate::http::client_builder().build().unwrap(),
             origin: Url::parse("http://127.0.0.1/").unwrap(),
             auth: None,
             progress: None,

--- a/crates/cli/src/http.rs
+++ b/crates/cli/src/http.rs
@@ -1,16 +1,6 @@
-use std::sync::Once;
-
-/// Build a reqwest client builder after ensuring rustls has a crypto provider.
+/// Use the SDK's bundled-root HTTPS policy for every CLI request.
 pub(crate) fn client_builder() -> reqwest::ClientBuilder {
-    ensure_rustls_provider();
-    reqwest::Client::builder()
-}
-
-fn ensure_rustls_provider() {
-    static INSTALL_PROVIDER: Once = Once::new();
-    INSTALL_PROVIDER.call_once(|| {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    });
+    tensorlake::http_transport::https_builder()
 }
 
 #[cfg(test)]

--- a/crates/cloud-sdk/Cargo.toml
+++ b/crates/cloud-sdk/Cargo.toml
@@ -30,7 +30,7 @@ png = { workspace = true }
 postcard = { workspace = true }
 reqwest = { workspace = true }
 rustls = { workspace = true }
-webpki-roots = { workspace = true }
+webpki-root-certs = { workspace = true }
 eventsource-stream = { workspace = true }
 reqwest-middleware = { workspace = true }
 rayon = { workspace = true }

--- a/crates/cloud-sdk/Cargo.toml
+++ b/crates/cloud-sdk/Cargo.toml
@@ -30,6 +30,7 @@ png = { workspace = true }
 postcard = { workspace = true }
 reqwest = { workspace = true }
 rustls = { workspace = true }
+webpki-roots = { workspace = true }
 eventsource-stream = { workspace = true }
 reqwest-middleware = { workspace = true }
 rayon = { workspace = true }

--- a/crates/cloud-sdk/HTTP_TRANSPORT.md
+++ b/crates/cloud-sdk/HTTP_TRANSPORT.md
@@ -1,0 +1,25 @@
+# HTTP transport policy
+
+The shipped SDK and CLI construct HTTP clients through `http_transport`, never directly through
+reqwest. HTTPS uses Rustls with Mozilla trust anchors from `webpki-roots`; it does not consult the
+host's CA store. Certificate and hostname verification stay enabled. Root rotation ships through
+dependency updates and binary releases. OS-only enterprise/private roots are not implicitly trusted.
+
+The Unix-socket factory uses plaintext HTTP with an empty TLS trust set. It routes all requests
+through the supplied socket, without DNS/TCP fallback; an HTTPS peer cannot validate. The caller
+must establish ownership and permissions of the socket (TLFS uses the root-owned host proxy).
+
+`ArtifactStorageClient::with_http_client` lets a caller supply a prebuilt transport and share it
+with wrappers using `http_client().clone()`. Clones reuse the connection pool and trust policy.
+Passing no Platform API client skips that unused transport and makes token minting fail locally;
+callers must supply scoped credentials or use the authenticated host proxy. Ordinary constructors
+retain their Platform API client and existing authentication behavior.
+
+The Rustls config is passed through reqwest's preconfigured backend because reqwest 0.13 accepts
+full certificates in `tls_certs_only`, while `webpki-roots` supplies trust anchors. Keep Rustls's
+version aligned with reqwest; the certless construction test detects an incompatible backend.
+
+`clippy.toml` rejects bare client constructors and `reqwest::get`; only the transport factories
+have narrowly scoped exceptions. CI runs `just lint-http-transports` and `just test-artifact-storage`.
+The Artifact Storage companion CI also launches the real musl TLFS daemon in a certless child and
+observes its first authenticated Unix-socket request for writable and read-only mounts.

--- a/crates/cloud-sdk/HTTP_TRANSPORT.md
+++ b/crates/cloud-sdk/HTTP_TRANSPORT.md
@@ -1,7 +1,7 @@
 # HTTP transport policy
 
 The shipped SDK and CLI construct HTTP clients through `http_transport`, never directly through
-reqwest. HTTPS uses Rustls with Mozilla trust anchors from `webpki-roots`; it does not consult the
+reqwest. HTTPS uses Rustls with Mozilla roots from `webpki-root-certs`; it does not consult the
 host's CA store. Certificate and hostname verification stay enabled. Root rotation ships through
 dependency updates and binary releases. OS-only enterprise/private roots are not implicitly trusted.
 
@@ -15,9 +15,9 @@ Passing no Platform API client skips that unused transport and makes token minti
 callers must supply scoped credentials or use the authenticated host proxy. Ordinary constructors
 retain their Platform API client and existing authentication behavior.
 
-The Rustls config is passed through reqwest's preconfigured backend because reqwest 0.13 accepts
-full certificates in `tls_certs_only`, while `webpki-roots` supplies trust anchors. Keep Rustls's
-version aligned with reqwest; the certless construction test detects an incompatible backend.
+Reqwest 0.13 accepts full certificates in `tls_certs_only`, so we use `webpki-root-certs` (the
+full-certificate sibling of `webpki-roots`). This replaces only the root source and preserves
+reqwest's TLS setup, HTTP/2 negotiation and protocol-selection settings.
 
 `clippy.toml` rejects bare client constructors and `reqwest::get`; only the transport factories
 have narrowly scoped exceptions. CI runs `just lint-http-transports` and `just test-artifact-storage`.

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -32,7 +32,7 @@ type GitCredentialCache = HashMap<(String, Option<String>), GitCredential>;
 
 #[derive(Clone)]
 pub struct ArtifactStorageClient {
-    api_client: Client,
+    api_client: Option<Client>,
     git_client: reqwest::Client,
     git_base_url: String,
     git_credentials: Arc<tokio::sync::Mutex<GitCredentialCache>>,
@@ -61,7 +61,7 @@ enum NativeReadResolution {
 impl ArtifactStorageClient {
     pub fn new(api_client: Client, git_base_url: impl Into<String>) -> Result<Self, SdkError> {
         Ok(Self {
-            api_client,
+            api_client: Some(api_client),
             git_client: reqwest::Client::builder()
                 .user_agent(concat!("tensorlake-rust-sdk/", env!("CARGO_PKG_VERSION")))
                 .build()?,
@@ -74,17 +74,26 @@ impl ArtifactStorageClient {
     /// Build an Artifact Storage client whose data-plane HTTP connections use
     /// a local Unix socket. Sandbox TLFS uses this for its root-owned relay to
     /// the authenticated dataplane-host system-storage proxy.
+    ///
+    /// Pass `None` for `api_client` when the host proxy owns credentials. This
+    /// avoids constructing an unused HTTPS client in guests without a CA store;
+    /// token minting then fails locally. Passing a [`Client`] retains ordinary
+    /// Platform API authentication. The socket transport uses an empty TLS
+    /// trust set: it needs no native roots and cannot authenticate HTTPS peers.
     #[cfg(unix)]
     pub fn new_with_unix_socket(
-        api_client: Client,
+        api_client: impl Into<Option<Client>>,
         git_base_url: impl Into<String>,
         socket_path: &Path,
     ) -> Result<Self, SdkError> {
+        // This constructor may run without ClientBuilder having installed a provider.
+        crate::client::ensure_rustls_provider();
         Ok(Self {
-            api_client,
+            api_client: api_client.into(),
             git_client: reqwest::Client::builder()
                 .user_agent(concat!("tensorlake-rust-sdk/", env!("CARGO_PKG_VERSION")))
                 .unix_socket(socket_path)
+                .tls_certs_only(Vec::<reqwest::tls::Certificate>::new())
                 .build()?,
             git_base_url: trim_base_url(git_base_url.into()),
             git_credentials: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
@@ -116,15 +125,19 @@ impl ArtifactStorageClient {
     ) -> Result<Traced<GitCredential>, SdkError> {
         // Ingress authenticates the bearer token and forwards the authorized project id to Artifact
         // Storage. Callers should build the SDK with `ClientBuilder::scope(...)` when using PATs.
+        let api_client = self.api_client.as_ref().ok_or_else(|| {
+            SdkError::Authentication(
+                "token minting requires a Platform API client; the system-storage proxy owns credentials"
+                    .to_string(),
+            )
+        })?;
         let _ = project_id;
         let path = "/artifact-storage/v1/token";
         let body = MintGitTokenRequest {
             repo: repo.map(str::to_string),
         };
-        let req = self
-            .api_client
-            .build_post_json_request(Method::POST, path, &body)?;
-        self.api_client.execute_json(req).await
+        let req = api_client.build_post_json_request(Method::POST, path, &body)?;
+        api_client.execute_json(req).await
     }
 
     /// Resolve the project selected by ingress from the ordinary Artifact Storage credential.
@@ -2635,6 +2648,92 @@ mod tests {
         NativeDirectFileWrite, NativeDirectMutation, NativeDirectPathTransfer,
         REPO_KIND_FILESYSTEM,
     };
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn unix_socket_without_platform_client_works_without_system_ca_certificates() {
+        const CHILD: &str = "TENSORLAKE_TEST_CERTLESS_SOCKET_CHILD";
+        const SUCCESS: &str = "certless socket request succeeded; minting refused";
+        if std::env::var_os(CHILD).is_none() {
+            let temp = tempfile::tempdir().unwrap();
+            let output = tokio::time::timeout(
+                std::time::Duration::from_secs(20),
+                tokio::process::Command::new(std::env::current_exe().unwrap())
+                    .args([
+                        "--exact",
+                        "artifact_storage::tests::unix_socket_without_platform_client_works_without_system_ca_certificates",
+                        "--nocapture",
+                    ])
+                    .env(CHILD, "1")
+                    .env("SSL_CERT_FILE", temp.path().join("missing-certs"))
+                    .env("SSL_CERT_DIR", temp.path().join("missing-certs"))
+                    .kill_on_drop(true)
+                    .output(),
+            )
+            .await
+            .expect("certless subprocess timed out")
+            .unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(output.status.success(), "{stdout}\n{stderr}");
+            assert!(stdout.contains(SUCCESS), "child test did not run: {stdout}");
+            return;
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let socket = temp.path().join("proxy.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let client = ArtifactStorageClient::new_with_unix_socket(
+            None,
+            "http://tensorlake-system-storage",
+            &socket,
+        )
+        .unwrap();
+        // Construct the socket client first, so no Platform API builder can
+        // initialize its crypto provider for it. Then prove the child lacks
+        // roots and that ordinary HTTPS still requires them.
+        let error = ClientBuilder::new("https://api.tensorlake.ai")
+            .build()
+            .err()
+            .expect("ordinary HTTPS client must require native roots");
+        assert!(format!("{error:?}").contains("No CA certificates were loaded"));
+        assert!(matches!(
+            client.mint_token_for_repo("project", Some("filesystem")).await,
+            Err(crate::error::SdkError::Authentication(message))
+                if message.contains("system-storage proxy owns credentials")
+        ));
+        let server = async {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                let mut chunk = [0; 1024];
+                let read = stream.read(&mut chunk).await.unwrap();
+                assert!(read > 0 && request.len() < 16384);
+                request.extend_from_slice(&chunk[..read]);
+            }
+            let request = String::from_utf8(request).unwrap().to_lowercase();
+            assert!(request.starts_with("get /project/project/repos/filesystem/fs/head "));
+            assert!(request.contains("authorization: basic "));
+            let body = r#"{"snapshot_id":"snapshot-1","generation":1}"#;
+            stream.write_all(format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len(),
+            ).as_bytes()).await.unwrap();
+        };
+        let request = async {
+            let head = client
+                .native_head_with_credential("project", "filesystem", "t", "capability")
+                .await
+                .unwrap();
+            assert_eq!(head.snapshot_id.as_deref(), Some("snapshot-1"));
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            tokio::join!(server, request);
+        })
+        .await
+        .expect("socket request timed out");
+        println!("{SUCCESS}");
+    }
 
     #[test]
     fn project_id_comes_from_normal_artifact_credential() {

--- a/crates/cloud-sdk/src/artifact_storage/mod.rs
+++ b/crates/cloud-sdk/src/artifact_storage/mod.rs
@@ -60,15 +60,13 @@ enum NativeReadResolution {
 
 impl ArtifactStorageClient {
     pub fn new(api_client: Client, git_base_url: impl Into<String>) -> Result<Self, SdkError> {
-        Ok(Self {
-            api_client: Some(api_client),
-            git_client: reqwest::Client::builder()
+        Ok(Self::with_http_client(
+            Some(api_client),
+            git_base_url,
+            crate::http_transport::https_builder()
                 .user_agent(concat!("tensorlake-rust-sdk/", env!("CARGO_PKG_VERSION")))
                 .build()?,
-            git_base_url: trim_base_url(git_base_url.into()),
-            git_credentials: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            authorized_project_id: Arc::new(tokio::sync::OnceCell::new()),
-        })
+        ))
     }
 
     /// Build an Artifact Storage client whose data-plane HTTP connections use
@@ -86,19 +84,34 @@ impl ArtifactStorageClient {
         git_base_url: impl Into<String>,
         socket_path: &Path,
     ) -> Result<Self, SdkError> {
-        // This constructor may run without ClientBuilder having installed a provider.
-        crate::client::ensure_rustls_provider();
-        Ok(Self {
-            api_client: api_client.into(),
-            git_client: reqwest::Client::builder()
+        Ok(Self::with_http_client(
+            api_client.into(),
+            git_base_url,
+            crate::http_transport::unix_socket_builder(socket_path)
                 .user_agent(concat!("tensorlake-rust-sdk/", env!("CARGO_PKG_VERSION")))
-                .unix_socket(socket_path)
-                .tls_certs_only(Vec::<reqwest::tls::Certificate>::new())
                 .build()?,
+        ))
+    }
+
+    /// Reuse a transport whose trust, routing and connection pool are already configured.
+    /// With no Platform API client, credentials must be supplied by the caller or host proxy.
+    pub fn with_http_client(
+        api_client: Option<Client>,
+        git_base_url: impl Into<String>,
+        git_client: reqwest::Client,
+    ) -> Self {
+        Self {
+            api_client,
+            git_client,
             git_base_url: trim_base_url(git_base_url.into()),
             git_credentials: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             authorized_project_id: Arc::new(tokio::sync::OnceCell::new()),
-        })
+        }
+    }
+
+    /// Share this exact transport with private filesystem and kernel-facing clients.
+    pub fn http_client(&self) -> &reqwest::Client {
+        &self.git_client
     }
 
     pub fn git_base_url(&self) -> &str {
@@ -2690,13 +2703,11 @@ mod tests {
         )
         .unwrap();
         // Construct the socket client first, so no Platform API builder can
-        // initialize its crypto provider for it. Then prove the child lacks
-        // roots and that ordinary HTTPS still requires them.
-        let error = ClientBuilder::new("https://api.tensorlake.ai")
+        // initialize its crypto provider for it. Ordinary HTTPS must also
+        // construct successfully using bundled roots in this certless child.
+        ClientBuilder::new("https://api.tensorlake.ai")
             .build()
-            .err()
-            .expect("ordinary HTTPS client must require native roots");
-        assert!(format!("{error:?}").contains("No CA certificates were loaded"));
+            .expect("HTTPS uses bundled roots even in certless guests");
         assert!(matches!(
             client.mint_token_for_repo("project", Some("filesystem")).await,
             Err(crate::error::SdkError::Authentication(message))
@@ -2712,20 +2723,20 @@ mod tests {
                 request.extend_from_slice(&chunk[..read]);
             }
             let request = String::from_utf8(request).unwrap().to_lowercase();
-            assert!(request.starts_with("get /project/project/repos/filesystem/fs/head "));
+            assert!(request.starts_with("get /project/project/repos/filesystem/refs "));
             assert!(request.contains("authorization: basic "));
-            let body = r#"{"snapshot_id":"snapshot-1","generation":1}"#;
+            let body = r#"{"repo":"filesystem","refs":[]}"#;
             stream.write_all(format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
                 body.len(),
             ).as_bytes()).await.unwrap();
         };
         let request = async {
-            let head = client
-                .native_head_with_credential("project", "filesystem", "t", "capability")
+            let refs = client
+                .list_refs_with_credential("project", "filesystem", "t", "capability")
                 .await
                 .unwrap();
-            assert_eq!(head.snapshot_id.as_deref(), Some("snapshot-1"));
+            assert!(refs.refs.is_empty());
         };
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
             tokio::join!(server, request);
@@ -3849,9 +3860,14 @@ mod tests {
         // client in an isolated test run must install it itself (AlreadyInstalled is fine).
         let _ = rustls::crypto::ring::default_provider().install_default();
         let started = std::time::Instant::now();
-        let response = super::send_idempotent(reqwest::Client::new().get(&base))
-            .await
-            .unwrap();
+        let response = super::send_idempotent(
+            crate::http_transport::https_builder()
+                .build()
+                .unwrap()
+                .get(&base),
+        )
+        .await
+        .unwrap();
         assert_eq!(response.status(), reqwest::StatusCode::OK);
         assert!(
             started.elapsed() >= std::time::Duration::from_millis(1900),

--- a/crates/cloud-sdk/src/client.rs
+++ b/crates/cloud-sdk/src/client.rs
@@ -11,7 +11,7 @@ use std::{
     ops::{Deref, DerefMut},
     pin::Pin,
     result::Result,
-    sync::{Arc, Once},
+    sync::Arc,
     time::Duration,
 };
 
@@ -545,17 +545,8 @@ fn str_to_header_value(value: &str) -> Result<HeaderValue, SdkError> {
         .map_err(|e: InvalidHeaderValue| SdkError::InvalidHeaderValue(e.to_string()))
 }
 
-pub(crate) fn ensure_rustls_provider() {
-    static INSTALL_PROVIDER: Once = Once::new();
-    INSTALL_PROVIDER.call_once(|| {
-        let _ = rustls::crypto::ring::default_provider().install_default();
-    });
-}
-
 fn new_base_client(headers: &HeaderMap, user_agent: &str) -> Result<reqwest::Client, SdkError> {
-    ensure_rustls_provider();
-
-    let builder = reqwest::Client::builder()
+    let builder = crate::http_transport::https_builder()
         .user_agent(user_agent)
         .default_headers(headers.clone());
     let client = builder.build()?;
@@ -564,7 +555,7 @@ fn new_base_client(headers: &HeaderMap, user_agent: &str) -> Result<reqwest::Cli
 
 #[cfg(test)]
 mod tests {
-    use super::{ClientBuilder, ensure_rustls_provider};
+    use super::ClientBuilder;
     use reqwest::Method;
     use std::{
         io::{Read, Write},
@@ -681,7 +672,7 @@ mod tests {
 
     #[test]
     fn installs_rustls_provider() {
-        ensure_rustls_provider();
+        let _ = crate::http_transport::https_builder();
         assert!(
             rustls::crypto::CryptoProvider::get_default().is_some(),
             "rustls crypto provider should be installed"

--- a/crates/cloud-sdk/src/error.rs
+++ b/crates/cloud-sdk/src/error.rs
@@ -160,10 +160,10 @@ mod transport_failure_tests {
     /// Build the error a refused TCP connect produces, routed through
     /// `reqwest_middleware` exactly as every client in this crate does.
     async fn middleware_connect_error() -> SdkError {
-        crate::client::ensure_rustls_provider();
-        let client =
-            reqwest_middleware::ClientBuilder::new(reqwest::Client::builder().build().unwrap())
-                .build();
+        let client = reqwest_middleware::ClientBuilder::new(
+            crate::http_transport::https_builder().build().unwrap(),
+        )
+        .build();
         // Port 1 on loopback refuses immediately; no network access needed.
         SdkError::from(client.get("http://127.0.0.1:1/x").send().await.unwrap_err())
     }
@@ -199,7 +199,6 @@ mod transport_failure_tests {
     /// non-idempotent operations.
     #[tokio::test]
     async fn middleware_timeout_is_classified_as_timeout() {
-        crate::client::ensure_rustls_provider();
         // A listener that accepts the connection and then never answers.
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("listener");
         let address = listener.local_addr().expect("address");
@@ -211,7 +210,7 @@ mod transport_failure_tests {
         });
 
         let client = reqwest_middleware::ClientBuilder::new(
-            reqwest::Client::builder()
+            crate::http_transport::https_builder()
                 .timeout(std::time::Duration::from_millis(200))
                 .build()
                 .unwrap(),

--- a/crates/cloud-sdk/src/http_transport.rs
+++ b/crates/cloud-sdk/src/http_transport.rs
@@ -1,6 +1,6 @@
 //! HTTP trust policy for shipped SDKs and CLIs.
 //!
-//! HTTPS uses Mozilla roots bundled with `webpki-roots`, independently of the
+//! HTTPS uses Mozilla roots bundled with `webpki-root-certs`, independently of the
 //! host/guest CA store. Root changes ship with dependency updates. System-storage
 //! sockets use plaintext HTTP and an empty trust set, so HTTPS fails closed.
 //! Configure request policy on these builders; never construct a bare client.
@@ -18,14 +18,14 @@ fn ensure_rustls_provider() {
 #[allow(clippy::disallowed_methods)] // The only place that selects HTTPS trust.
 pub fn https_builder() -> reqwest::ClientBuilder {
     ensure_rustls_provider();
-    // reqwest 0.13's tls_certs_only takes full certificates, not webpki trust anchors.
-    let roots = rustls::RootCertStore {
-        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
-    };
-    let tls = rustls::ClientConfig::builder()
-        .with_root_certificates(roots)
-        .with_no_client_auth();
-    reqwest::Client::builder().tls_backend_preconfigured(tls)
+    // Use full certificates (the sibling of webpki-roots' compact trust anchors), so
+    // reqwest still owns TLS/ALPN setup and respects http1_only/http2 configuration.
+    reqwest::Client::builder().tls_certs_only(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().map(
+        |cert| {
+            reqwest::tls::Certificate::from_der(cert.as_ref())
+                .expect("bundled Mozilla root is a valid X.509 certificate")
+        },
+    ))
 }
 
 /// Plaintext transport through the authenticated host's Unix socket.

--- a/crates/cloud-sdk/src/http_transport.rs
+++ b/crates/cloud-sdk/src/http_transport.rs
@@ -1,0 +1,40 @@
+//! HTTP trust policy for shipped SDKs and CLIs.
+//!
+//! HTTPS uses Mozilla roots bundled with `webpki-roots`, independently of the
+//! host/guest CA store. Root changes ship with dependency updates. System-storage
+//! sockets use plaintext HTTP and an empty trust set, so HTTPS fails closed.
+//! Configure request policy on these builders; never construct a bare client.
+
+use std::sync::Once;
+
+fn ensure_rustls_provider() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+/// HTTP(S) transport with bundled Mozilla roots and normal certificate verification.
+#[allow(clippy::disallowed_methods)] // The only place that selects HTTPS trust.
+pub fn https_builder() -> reqwest::ClientBuilder {
+    ensure_rustls_provider();
+    // reqwest 0.13's tls_certs_only takes full certificates, not webpki trust anchors.
+    let roots = rustls::RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+    let tls = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    reqwest::Client::builder().tls_backend_preconfigured(tls)
+}
+
+/// Plaintext transport through the authenticated host's Unix socket.
+/// No system roots, DNS/TCP fallback, or trusted HTTPS peers.
+#[cfg(unix)]
+#[allow(clippy::disallowed_methods)] // The only place that selects socket trust.
+pub fn unix_socket_builder(socket: &std::path::Path) -> reqwest::ClientBuilder {
+    ensure_rustls_provider();
+    reqwest::Client::builder()
+        .tls_certs_only(Vec::<reqwest::tls::Certificate>::new())
+        .unix_socket(socket)
+}

--- a/crates/cloud-sdk/src/image_service_builds.rs
+++ b/crates/cloud-sdk/src/image_service_builds.rs
@@ -579,7 +579,8 @@ async fn upload_and_seal_context(
     )));
     let file = tokio::fs::File::open(tar_file.path()).await?;
     let stream = tokio_util::io::ReaderStream::new(file);
-    let response = reqwest::Client::new()
+    let response = crate::http_transport::https_builder()
+        .build()?
         .request(method, url)
         .header(CONTENT_LENGTH, tar_bytes)
         .body(reqwest::Body::wrap_stream(stream))

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -71,6 +71,7 @@ pub mod artifact_storage;
 pub mod cron;
 pub mod document_ai;
 pub mod error;
+pub mod http_transport;
 mod image_service_builds;
 pub mod images;
 pub mod sandbox_images;

--- a/crates/gsvc-mount/Cargo.toml
+++ b/crates/gsvc-mount/Cargo.toml
@@ -44,3 +44,5 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 zstd = "0.13"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+webpki-roots = "1"

--- a/crates/gsvc-mount/Cargo.toml
+++ b/crates/gsvc-mount/Cargo.toml
@@ -45,4 +45,4 @@ tracing = "0.1"
 zstd = "0.13"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
-webpki-roots = "1"
+webpki-root-certs = "1"

--- a/justfile
+++ b/justfile
@@ -245,6 +245,10 @@ test-rust:
 test-crate crate:
     just with-function-agent-core cargo test -p {{crate}}
 
+# Artifact Storage transport unit tests; no credentials or live services required.
+test-artifact-storage:
+    cargo test --locked -p tensorlake --lib artifact_storage::
+
 
 # Run clippy lints on all crates
 clippy:

--- a/justfile
+++ b/justfile
@@ -249,6 +249,10 @@ test-crate crate:
 test-artifact-storage:
     cargo test --locked -p tensorlake --lib artifact_storage::
 
+# Guard every SDK/CLI HTTP constructor, including feature-gated fast-clone paths in full CI.
+lint-http-transports:
+    cargo clippy --locked -p tensorlake -p tensorlake-cli --all-targets -- -D warnings
+
 
 # Run clippy lints on all crates
 clippy:

--- a/justfile
+++ b/justfile
@@ -253,6 +253,10 @@ test-artifact-storage:
 lint-http-transports:
     cargo clippy --locked -p tensorlake -p tensorlake-cli --all-targets -- -D warnings
 
+# Requires private sources to have been injected by the CI vendoring action.
+lint-http-transports-full:
+    cargo clippy -p tensorlake -p tensorlake-cli --features tensorlake-cli/mount,tensorlake-cli/git-clone --all-targets -- -D warnings
+
 
 # Run clippy lints on all crates
 clippy:

--- a/justfile
+++ b/justfile
@@ -250,12 +250,13 @@ test-artifact-storage:
     cargo test --locked -p tensorlake --lib artifact_storage::
 
 # Guard every SDK/CLI HTTP constructor, including feature-gated fast-clone paths in full CI.
+# This focused gate does not enable unrelated style lints; the existing `clippy` recipe does.
 lint-http-transports:
-    cargo clippy --locked -p tensorlake -p tensorlake-cli --all-targets -- -D warnings
+    cargo clippy --locked -p tensorlake -p tensorlake-cli --all-targets -- -A clippy::all -D clippy::disallowed_methods -D warnings
 
 # Requires private sources to have been injected by the CI vendoring action.
 lint-http-transports-full:
-    cargo clippy -p tensorlake -p tensorlake-cli --features tensorlake-cli/mount,tensorlake-cli/git-clone --all-targets -- -D warnings
+    cargo clippy -p tensorlake -p tensorlake-cli --features tensorlake-cli/mount,tensorlake-cli/git-clone --all-targets -- -A clippy::all -D clippy::disallowed_methods -D warnings
 
 
 # Run clippy lints on all crates

--- a/typescript/scripts/test-native-sandbox.mjs
+++ b/typescript/scripts/test-native-sandbox.mjs
@@ -5,7 +5,6 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { rootCertificates } from "node:tls";
 import { fileURLToPath } from "node:url";
 import { setEnvironmentData } from "node:worker_threads";
 
@@ -14,7 +13,7 @@ import { setEnvironmentData } from "node:worker_threads";
 if (!process.argv.includes("--child")) {
   await import("./test-native-stream-lifetime.mjs");
   if (process.platform !== "linux") {
-    console.log("Slow certificate I/O regression requires Linux FIFOs.");
+    console.log("Forbidden certificate I/O regression requires Linux FIFOs.");
   } else {
     const child = spawn(process.execPath, [
       "--require", fileURLToPath(new URL("../tests/fixtures/delayed-native-load.cjs", import.meta.url)),
@@ -36,32 +35,23 @@ if (!process.argv.includes("--child")) {
   process.env.SSL_CERT_FILE = fifo;
   process.env.SSL_CERT_DIR = emptyDirectory;
 
-  // A separate process supplies a real CA after a 750 ms read stall. It keeps
-  // serving subsequent opens so regressions report extra initialization too.
-  const writer = spawn(process.execPath, ["--input-type=module", "-e", `
-    import { openSync, writeSync, closeSync } from 'node:fs';
-    import { rootCertificates } from 'node:tls';
-    import { setTimeout } from 'node:timers/promises';
-    let reads = 0;
-    for (;;) {
-      const fd = openSync(process.argv[1], 'w');
-      if (reads++ === 0) await setTimeout(750);
-      writeSync(fd, rootCertificates[0] + '\\n');
-      closeSync(fd);
-      process.stdout.write('read\\n');
-      await setTimeout(25);
-    }
-  `, fifo], { stdio: ["ignore", "pipe", "inherit"] });
-  let certificateReads = 0;
-  writer.stdout.setEncoding("utf8");
-  writer.stdout.on("data", (chunk) => { certificateReads += chunk.split("\n").length - 1; });
+  // No writer ever opens this FIFO. Any regression to platform CA discovery
+  // blocks initialization and is killed by the parent's 20s deadline. Shipped
+  // clients must use bundled roots, independent of guest certificate files.
 
   let connections = 0;
   let streamsClosed = 0;
   let fileContents = Buffer.from([0, 255, 128, 7]);
   const authorizations = [];
+  let failNextRequest = false;
   const server = createServer((request, response) => {
     authorizations.push(request.headers.authorization);
+    if (failNextRequest) {
+      failNextRequest = false;
+      response.writeHead(400, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ message: "injected request failure" }));
+      return;
+    }
     if (request.url.endsWith("/follow")) {
       response.setHeader("Content-Type", "text/event-stream");
       response.flushHeaders();
@@ -92,14 +82,25 @@ if (!process.argv.includes("--child")) {
   let reports = 0;
   const originalGetReport = process.report.getReport;
   const originalDlopen = process.dlopen;
-  const nativeLoads = new Int32Array(new SharedArrayBuffer(4));
+  // Shared fixture state: addon load count, blocked flag, main-thread release.
+  const nativeLoads = new Int32Array(new SharedArrayBuffer(3 * Int32Array.BYTES_PER_ELEMENT));
+  let blockedTicks = 0;
   setEnvironmentData("tensorlake-test-native-loads", nativeLoads.buffer);
   process.dlopen = () => { throw new Error("Sandbox SDK must not load native code on the main thread"); };
   process.report.getReport = () => {
     reports++;
     throw new Error("SDK must not generate diagnostic reports");
   };
-  const timer = setInterval(() => { ticks++; }, 10);
+  const timer = setInterval(() => {
+    ticks++;
+    if (Atomics.load(nativeLoads, 1) === 1 && Atomics.load(nativeLoads, 2) === 0) {
+      if (++blockedTicks === 3) {
+        console.log("Main event loop advanced while addon loading was blocked; releasing worker");
+        Atomics.store(nativeLoads, 2, 1);
+        Atomics.notify(nativeLoads, 2);
+      }
+    }
+  }, 10);
 
   try {
     const { Sandbox, SandboxClient } = await import("../dist/index.js");
@@ -110,18 +111,17 @@ if (!process.argv.includes("--child")) {
     const standalone = new Sandbox({ sandboxId: "direct-constructor", proxyUrl: url });
     const setupMs = performance.now() - setupStart;
     assert.ok(setupMs < 500, `Handle construction blocked for ${setupMs.toFixed(1)} ms`);
-    assert.equal(certificateReads, 0, "Constructors must not load certificates");
+    assert.equal(Atomics.load(nativeLoads, 0), 0, "Constructors must not load the native addon");
     assert.equal(reports, 0, "Platform detection generated a diagnostic report");
 
     ticks = 0;
     await Promise.all([client.list(), handles[0].listProcesses(), handles[1].listProcesses()]);
-    assert.ok(ticks >= 100, `Event loop stalled during slow addon/CA loading (${ticks} timer ticks)`);
-    assert.equal(certificateReads, 1, "Concurrent first requests must share initialization");
+    assert.equal(blockedTicks, 3, "Main event loop must advance while addon loading is blocked");
+    assert.equal(Atomics.load(nativeLoads, 0), 1, "Concurrent first requests must share addon loading");
     const initialConnections = connections;
     for (const handle of handles) await handle.listProcesses();
     await client.listLogProcesses("sandbox-0");
     assert.equal(connections, initialConnections, "Proxy handles rebuilt the connection pool");
-    assert.equal(certificateReads, 1, "Proxy handles reloaded certificates");
     assert.ok(authorizations.every((value) => value === "Bearer client-one"));
 
     // A distinct client must keep its own credentials even after another
@@ -163,23 +163,27 @@ if (!process.argv.includes("--child")) {
     for (let i = 0; i < 100 && streamsClosed === firstClosed + 1; i++) await new Promise((resolve) => setTimeout(resolve, 10));
     assert.equal(streamsClosed, firstClosed + 2, "Abort did not cancel a quiet native HTTP stream");
 
-    // Failed initialization must reject the operation and remain retryable.
+    // Empty/invalid platform CA files must not affect new clients either.
+    // A failed request must still leave the initialized client usable.
     const certFile = path.join(directory, "retry.pem");
     writeFileSync(certFile, "");
     process.env.SSL_CERT_FILE = certFile;
     const retry = new SandboxClient({ apiUrl: url }, true);
-    await assert.rejects(retry.list());
-    writeFileSync(certFile, rootCertificates[0] + "\n");
     await retry.list();
+    failNextRequest = true;
+    await assert.rejects(retry.list());
+    assert.equal(failNextRequest, false, "Injected failure did not reach the server");
+    await retry.list();
+    writeFileSync(certFile, "not a CA certificate\n");
+    const invalidRoots = new SandboxClient({ apiUrl: url }, true);
+    await invalidRoots.list();
     for (const handle of [...handles, direct, standalone, cjsSandbox]) handle.close();
-    client.close(); other.close(); retry.close();
-    console.log(`Native sandbox regression passed: ${setupMs.toFixed(1)} ms setup, ${ticks} timer ticks, worker-only addon loading, shared transport, stream cancellation and retry verified.`);
+    client.close(); other.close(); retry.close(); invalidRoots.close();
+    console.log(`Native sandbox regression passed: ${setupMs.toFixed(1)} ms setup, ${ticks} timer ticks, worker-only addon loading, no platform CA discovery, shared transport, stream cancellation and request retry verified.`);
   } finally {
     clearInterval(timer);
     process.report.getReport = originalGetReport;
     process.dlopen = originalDlopen;
-    writer.kill("SIGKILL");
-    await once(writer, "exit");
     server.closeAllConnections();
     server.close();
     rmSync(directory, { recursive: true, force: true });

--- a/typescript/tests/fixtures/delayed-native-load.cjs
+++ b/typescript/tests/fixtures/delayed-native-load.cjs
@@ -1,14 +1,17 @@
 const { isMainThread, getEnvironmentData } = require("node:worker_threads");
 
-// Inherited only by the SDK worker in the native regression. Make addon
-// loading exceed the production watchdog threshold, without delaying startup
-// of the test driver or depending on the host's disk cache.
+// Inherited only by the SDK worker in the native regression. Hold addon loading
+// until the main thread proves it can advance while this worker is blocked.
+// The timeout catches a blocked main thread without relying on elapsed tick counts.
 if (!isMainThread) {
   const dlopen = process.dlopen;
   process.dlopen = function (...args) {
-    const state = getEnvironmentData("tensorlake-test-native-loads");
-    if (state) Atomics.add(new Int32Array(state), 0, 1);
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 750);
+    const state = new Int32Array(getEnvironmentData("tensorlake-test-native-loads"));
+    Atomics.add(state, 0, 1); // Addon loads.
+    Atomics.store(state, 1, 1); // Loading is now blocked.
+    if (Atomics.wait(state, 2, 0, 5_000) === "timed-out") {
+      throw new Error("Main event loop did not release the blocked addon load within 5s");
+    }
     return Reflect.apply(dlopen, this, args);
   };
   process.report.getReport = () => { throw new Error("Worker must not generate diagnostic reports"); };


### PR DESCRIPTION
## Summary

- Centralize SDK/CLI HTTP construction: HTTPS uses bundled Mozilla roots; Unix-socket HTTP uses an empty trust set. No client factory consults the guest CA store.
- Add `ArtifactStorageClient::with_http_client` and `http_client` so filesystem wrappers can share one transport and connection pool.
- Permit omitting the unused Platform API client in proxy mode; token minting without it fails locally. Existing callers that pass a Platform API client retain their behavior.
- Forbid bare reqwest constructors (and the implicit `reqwest::get` constructor) with Clippy. Mirror standalone mount transport dependencies in the resolution placeholder and lockfile.
- Document the root-rotation trade-off: bundled roots update with binary releases; OS-only enterprise roots are not implicitly trusted.
- Update the native-addon regression: main-thread progress releases a blocked worker load; an unwritten CA FIFO catches forbidden platform CA discovery. Remove assumptions that loading must spend 750ms reading OS certificates or fail with an empty CA file.

## Companion and rollout

Companion to tensorlakeai/artifact_storage#376. That PR shares the socket transport through the daemon stack and tests the actual musl daemon's writable/read-only startup through its first authenticated proxy request in a certless child.

Merge this API/dependency change first, then the Artifact Storage companion. The downstream guest-runtime build must pin both resulting source revisions before release. No deployment is performed by these PRs. Coordinate the normal SDK/Python version bump before publishing a package release.

## Validation

Validation is delegated to GitHub Actions per request; no local build or test is being used to validate this revision.

- New HTTP transport policy workflow: `just lint-http-transports` and `just test-artifact-storage` on Linux, including an isolated certless child that constructs both socket and HTTPS clients, performs an authenticated UDS request, and checks token minting fails without a Platform API client.
- Existing full-feature workspace/macOS/Windows CI remains enabled; the full-feature jobs will pin the exact companion source revision for this PR.

Implementation detail: reqwest 0.13's `tls_certs_only` accepts full certificates, not `webpki-roots` trust anchors. We use its full-certificate sibling, `webpki-root-certs` (already resolved in the lockfile), so reqwest retains its normal certificate/hostname verification, ALPN negotiation and HTTP/1/HTTP/2 protocol settings. We intentionally accept that OS-only enterprise/private roots are no longer implicitly trusted.
