### PR TITLE
Use unscoped npm names for native platform packages

### DIFF
--- a/.github/scripts/bump_version.py
+++ b/.github/scripts/bump_version.py
@@ -20,7 +20,7 @@ DEFAULT_FILES = (
     "typescript/npm/win32-x64/package.json",
 )
 
-NATIVE_PACKAGE_PREFIX = "@tensorlake/native-"
+NATIVE_PACKAGE_PREFIX = "tensorlake-native-"
 
 
 def bump_typescript_package_lock(path: Path, version: str) -> None:

--- a/.github/workflows/publish_npm.yaml
+++ b/.github/workflows/publish_npm.yaml
@@ -181,17 +181,17 @@ jobs:
       matrix:
         include:
           - target_id: linux-x64
-            package_name: "@tensorlake/native-linux-x64-gnu"
+            package_name: "tensorlake-native-linux-x64-gnu"
           - target_id: linux-arm64
-            package_name: "@tensorlake/native-linux-arm64-gnu"
+            package_name: "tensorlake-native-linux-arm64-gnu"
           - target_id: linux-x64-musl
-            package_name: "@tensorlake/native-linux-x64-musl"
+            package_name: "tensorlake-native-linux-x64-musl"
           - target_id: linux-arm64-musl
-            package_name: "@tensorlake/native-linux-arm64-musl"
+            package_name: "tensorlake-native-linux-arm64-musl"
           - target_id: darwin-arm64
-            package_name: "@tensorlake/native-darwin-arm64"
+            package_name: "tensorlake-native-darwin-arm64"
           - target_id: win32-x64
-            package_name: "@tensorlake/native-win32-x64"
+            package_name: "tensorlake-native-win32-x64"
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/cli/src/commands/deploy/typescript.rs
+++ b/crates/cli/src/commands/deploy/typescript.rs
@@ -40,7 +40,7 @@ const MAX_CODE_SIZE: u64 = 5 * 1024 * 1024;
 const DEFAULT_NODE_IMAGE: &str = "node:24-trixie";
 const FUNCTION_RUNNER_CAPSULE_CONTEXT_PATH: &str =
     ".tensorlake/typescript-function-runner-runtime.tgz";
-const FUNCTION_RUNNER_LINUX_X64_PACKAGE: &str = "@tensorlake/native-linux-x64-gnu";
+const FUNCTION_RUNNER_LINUX_X64_PACKAGE: &str = "tensorlake-native-linux-x64-gnu";
 const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 const UNAUTHENTICATED_REQUESTS: &str = "unauthenticated_requests";
 const DISCOVERY_SCRIPT: &str = r#"

--- a/typescript/lib/runtime.cjs
+++ b/typescript/lib/runtime.cjs
@@ -6,12 +6,12 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 const NATIVE_PACKAGES = {
-  "darwin-arm64": "@tensorlake/native-darwin-arm64",
-  "linux-arm64": "@tensorlake/native-linux-arm64-gnu",
-  "linux-arm64-musl": "@tensorlake/native-linux-arm64-musl",
-  "linux-x64": "@tensorlake/native-linux-x64-gnu",
-  "linux-x64-musl": "@tensorlake/native-linux-x64-musl",
-  "win32-x64": "@tensorlake/native-win32-x64",
+  "darwin-arm64": "tensorlake-native-darwin-arm64",
+  "linux-arm64": "tensorlake-native-linux-arm64-gnu",
+  "linux-arm64-musl": "tensorlake-native-linux-arm64-musl",
+  "linux-x64": "tensorlake-native-linux-x64-gnu",
+  "linux-x64-musl": "tensorlake-native-linux-x64-musl",
+  "win32-x64": "tensorlake-native-win32-x64",
 };
 
 function packageRoot() {

--- a/typescript/npm/darwin-arm64/package.json
+++ b/typescript/npm/darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tensorlake/native-darwin-arm64",
+  "name": "tensorlake-native-darwin-arm64",
   "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for macOS arm64",
   "repository": {

--- a/typescript/npm/linux-arm64-musl/package.json
+++ b/typescript/npm/linux-arm64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tensorlake/native-linux-arm64-musl",
+  "name": "tensorlake-native-linux-arm64-musl",
   "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Linux arm64 (musl)",
   "repository": {

--- a/typescript/npm/linux-arm64/package.json
+++ b/typescript/npm/linux-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tensorlake/native-linux-arm64-gnu",
+  "name": "tensorlake-native-linux-arm64-gnu",
   "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Linux arm64 (glibc)",
   "repository": {

--- a/typescript/npm/linux-x64-musl/package.json
+++ b/typescript/npm/linux-x64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tensorlake/native-linux-x64-musl",
+  "name": "tensorlake-native-linux-x64-musl",
   "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Linux x64 (musl)",
   "repository": {

--- a/typescript/npm/linux-x64/package.json
+++ b/typescript/npm/linux-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tensorlake/native-linux-x64-gnu",
+  "name": "tensorlake-native-linux-x64-gnu",
   "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Linux x64 (glibc)",
   "repository": {

--- a/typescript/npm/win32-x64/package.json
+++ b/typescript/npm/win32-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tensorlake/native-win32-x64",
+  "name": "tensorlake-native-win32-x64",
   "version": "0.5.126",
   "description": "Tensorlake native Node.js binding for Windows x64",
   "repository": {

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -39,12 +39,12 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@tensorlake/native-darwin-arm64": "0.5.126",
-        "@tensorlake/native-linux-arm64-gnu": "0.5.126",
-        "@tensorlake/native-linux-arm64-musl": "0.5.126",
-        "@tensorlake/native-linux-x64-gnu": "0.5.126",
-        "@tensorlake/native-linux-x64-musl": "0.5.126",
-        "@tensorlake/native-win32-x64": "0.5.126"
+        "tensorlake-native-darwin-arm64": "0.5.126",
+        "tensorlake-native-linux-arm64-gnu": "0.5.126",
+        "tensorlake-native-linux-arm64-musl": "0.5.126",
+        "tensorlake-native-linux-x64-gnu": "0.5.126",
+        "tensorlake-native-linux-x64-musl": "0.5.126",
+        "tensorlake-native-win32-x64": "0.5.126"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1234,108 +1234,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@tensorlake/native-darwin-arm64": {
-      "version": "0.5.126",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-darwin-arm64/-/native-darwin-arm64-0.5.126.tgz",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@tensorlake/native-linux-arm64-gnu": {
-      "version": "0.5.126",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-arm64-gnu/-/native-linux-arm64-gnu-0.5.126.tgz",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@tensorlake/native-linux-arm64-musl": {
-      "version": "0.5.126",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-arm64-musl/-/native-linux-arm64-musl-0.5.126.tgz",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@tensorlake/native-linux-x64-gnu": {
-      "version": "0.5.126",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-x64-gnu/-/native-linux-x64-gnu-0.5.126.tgz",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@tensorlake/native-linux-x64-musl": {
-      "version": "0.5.126",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-linux-x64-musl/-/native-linux-x64-musl-0.5.126.tgz",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22.0.0"
-      }
-    },
-    "node_modules/@tensorlake/native-win32-x64": {
-      "version": "0.5.126",
-      "resolved": "https://registry.npmjs.org/@tensorlake/native-win32-x64/-/native-win32-x64-0.5.126.tgz",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=22.0.0"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3349,6 +3247,108 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tensorlake-native-darwin-arm64": {
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.126.tgz",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/tensorlake-native-linux-arm64-gnu": {
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.126.tgz",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/tensorlake-native-linux-arm64-musl": {
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.126.tgz",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/tensorlake-native-linux-x64-gnu": {
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.126.tgz",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/tensorlake-native-linux-x64-musl": {
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.126.tgz",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/tensorlake-native-win32-x64": {
+      "version": "0.5.126",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.126.tgz",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/thenify": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -96,11 +96,11 @@
     "ws": "^8.20.0"
   },
   "optionalDependencies": {
-    "@tensorlake/native-darwin-arm64": "0.5.126",
-    "@tensorlake/native-linux-arm64-gnu": "0.5.126",
-    "@tensorlake/native-linux-arm64-musl": "0.5.126",
-    "@tensorlake/native-linux-x64-gnu": "0.5.126",
-    "@tensorlake/native-linux-x64-musl": "0.5.126",
-    "@tensorlake/native-win32-x64": "0.5.126"
+    "tensorlake-native-darwin-arm64": "0.5.126",
+    "tensorlake-native-linux-arm64-gnu": "0.5.126",
+    "tensorlake-native-linux-arm64-musl": "0.5.126",
+    "tensorlake-native-linux-x64-gnu": "0.5.126",
+    "tensorlake-native-linux-x64-musl": "0.5.126",
+    "tensorlake-native-win32-x64": "0.5.126"
   }
 }

--- a/typescript/scripts/build-function-executor-capsule.mjs
+++ b/typescript/scripts/build-function-executor-capsule.mjs
@@ -59,7 +59,7 @@ const lockedProductionPackages = Object.fromEntries(
   Object.entries(packageLock.packages)
     .filter(([packagePath, metadata]) =>
       packagePath !== ""
-      && !packagePath.startsWith("node_modules/@tensorlake/native-")
+      && !packagePath.startsWith("node_modules/tensorlake-native-")
       && metadata.dev !== true
     )
     .sort(([left], [right]) => left.localeCompare(right)),

--- a/typescript/scripts/check-package-compatibility.mjs
+++ b/typescript/scripts/check-package-compatibility.mjs
@@ -108,7 +108,7 @@ const functionRunnerPackage = JSON.parse(await readFile(
 if (
   Object.keys(functionRunnerPackage.optionalDependencies ?? {}).length === 0
   || Object.keys(functionRunnerPackage.optionalDependencies).some(
-    (dependency) => !dependency.startsWith("@tensorlake/native-"),
+    (dependency) => !dependency.startsWith("tensorlake-native-"),
   )
 ) {
   throw new Error("Function runner capsule does not declare native platform packages");

--- a/typescript/src/native-binding.ts
+++ b/typescript/src/native-binding.ts
@@ -22,12 +22,12 @@ interface NativeBindingPathOptions extends TargetOptions {
 }
 
 const NATIVE_PACKAGES: Readonly<Record<string, string>> = {
-  "darwin-arm64": "@tensorlake/native-darwin-arm64",
-  "linux-arm64": "@tensorlake/native-linux-arm64-gnu",
-  "linux-arm64-musl": "@tensorlake/native-linux-arm64-musl",
-  "linux-x64": "@tensorlake/native-linux-x64-gnu",
-  "linux-x64-musl": "@tensorlake/native-linux-x64-musl",
-  "win32-x64": "@tensorlake/native-win32-x64",
+  "darwin-arm64": "tensorlake-native-darwin-arm64",
+  "linux-arm64": "tensorlake-native-linux-arm64-gnu",
+  "linux-arm64-musl": "tensorlake-native-linux-arm64-musl",
+  "linux-x64": "tensorlake-native-linux-x64-gnu",
+  "linux-x64-musl": "tensorlake-native-linux-x64-musl",
+  "win32-x64": "tensorlake-native-win32-x64",
 };
 
 function packageRoot(): string {

--- a/typescript/src/sandbox-image.ts
+++ b/typescript/src/sandbox-image.ts
@@ -12,7 +12,7 @@ import { loadNative } from "./native-binding.js";
  * Sandbox-image build engine.
  *
  * Renders the source to a Dockerfile (for `Image` inputs) and hands the
- * Dockerfile path/text + context to the Rust core via `@tensorlake/native`,
+ * Dockerfile path/text + context to the Rust core via the platform-specific native binding,
  * which parses, validates, materializes, and registers the image. The Rust
  * core owns parsing and the warnings for instructions that run during the
  * build but have no effect when a sandbox runs from the image

--- a/typescript/tests/native-packaging.test.ts
+++ b/typescript/tests/native-packaging.test.ts
@@ -21,13 +21,13 @@ interface NativeTarget {
 const targets: readonly NativeTarget[] = [
   {
     id: "darwin-arm64",
-    name: "@tensorlake/native-darwin-arm64",
+    name: "tensorlake-native-darwin-arm64",
     platform: "darwin",
     arch: "arm64",
   },
   {
     id: "linux-arm64",
-    name: "@tensorlake/native-linux-arm64-gnu",
+    name: "tensorlake-native-linux-arm64-gnu",
     platform: "linux",
     arch: "arm64",
     libc: "glibc",
@@ -35,7 +35,7 @@ const targets: readonly NativeTarget[] = [
   },
   {
     id: "linux-arm64-musl",
-    name: "@tensorlake/native-linux-arm64-musl",
+    name: "tensorlake-native-linux-arm64-musl",
     platform: "linux",
     arch: "arm64",
     libc: "musl",
@@ -43,7 +43,7 @@ const targets: readonly NativeTarget[] = [
   },
   {
     id: "linux-x64",
-    name: "@tensorlake/native-linux-x64-gnu",
+    name: "tensorlake-native-linux-x64-gnu",
     platform: "linux",
     arch: "x64",
     libc: "glibc",
@@ -51,7 +51,7 @@ const targets: readonly NativeTarget[] = [
   },
   {
     id: "linux-x64-musl",
-    name: "@tensorlake/native-linux-x64-musl",
+    name: "tensorlake-native-linux-x64-musl",
     platform: "linux",
     arch: "x64",
     libc: "musl",
@@ -59,7 +59,7 @@ const targets: readonly NativeTarget[] = [
   },
   {
     id: "win32-x64",
-    name: "@tensorlake/native-win32-x64",
+    name: "tensorlake-native-win32-x64",
     platform: "win32",
     arch: "x64",
   },
@@ -110,6 +110,7 @@ describe("native package metadata", () => {
     for (const { name } of targets) {
       expect(packageLock.packages[`node_modules/${name}`]).toMatchObject({
         version: rootPackage.version,
+        resolved: `https://registry.npmjs.org/${name}/-/${name}-${rootPackage.version}.tgz`,
         optional: true,
       });
     }

--- a/typescript/tests/runtime.test.ts
+++ b/typescript/tests/runtime.test.ts
@@ -35,16 +35,16 @@ describe("runtime native binding selection", () => {
 
   it("selects the platform-specific optional package", () => {
     expect(nativePackageName("linux", "x64", { libc: "gnu" })).toBe(
-      "@tensorlake/native-linux-x64-gnu",
+      "tensorlake-native-linux-x64-gnu",
     );
     expect(nativePackageName("linux", "arm64", { libc: "musl" })).toBe(
-      "@tensorlake/native-linux-arm64-musl",
+      "tensorlake-native-linux-arm64-musl",
     );
     expect(nativePackageName("darwin", "arm64")).toBe(
-      "@tensorlake/native-darwin-arm64",
+      "tensorlake-native-darwin-arm64",
     );
     expect(nativePackageName("win32", "x64")).toBe(
-      "@tensorlake/native-win32-x64",
+      "tensorlake-native-win32-x64",
     );
     expect(nativePackageName("darwin", "x64")).toBeUndefined();
   });
@@ -84,7 +84,7 @@ describe.each(["SDK", "CommonJS launcher"])("%s libc detection", (loader) => {
         path.join("native", target, "tensorlake-node.node"),
       );
       expect(runtime.nativePackageName("linux", "x64")).toBe(
-        libc === "musl" ? "@tensorlake/native-linux-x64-musl" : "@tensorlake/native-linux-x64-gnu",
+        libc === "musl" ? "tensorlake-native-linux-x64-musl" : "tensorlake-native-linux-x64-gnu",
       );
       expect(runtime.nativeTargetId("linux", "x64", { libc: "musl" })).toBe("linux-x64-musl");
       expect(runtime.nativeTargetId("linux", "x64", { report: { header: {} } })).toBe("linux-x64-musl");


### PR DESCRIPTION
Native package publication fails because the new `@tensorlake/native-*` names require access to the npm organization scope. Rename all six packages to unscoped `tensorlake-native-*` names and keep the SDK dependencies, lockfile URLs, runtime loaders, deployment validation, version bump script, and release workflow synchronized.

The six new names have been bootstrapped on npm as `0.5.126-bootstrap.0` under the `bootstrap` tag using the native binaries from release run 33982728395. The repository remains at `0.5.126` for the normal release after merge. Trusted publishing is configured and verified for `tensorlakeai/tensorlake`, `publish_npm.yaml`, environment `npm`.

Validation:
- Clean `npm ci --ignore-scripts`, typecheck, targeted ESLint, and SDK tests: 502 passed, 6 platform-specific skips.
- SDK/runtime builds and the Rust test validating the generated function runner capsule passed.
- Installed SDK loaded the renamed macOS native package; SDK tarball contains no native binaries.
- Version bump check updates all six dependencies and unscoped tarball URLs; unrelated lockfile entries are unchanged.
