### PR TITLE
Wait for sandbox lifecycle completion before polling status

### DIFF
--- a/crates/cloud-sdk/src/sandboxes/mod.rs
+++ b/crates/cloud-sdk/src/sandboxes/mod.rs
@@ -577,14 +577,44 @@ impl SandboxesClient {
     }
 
     pub async fn suspend(&self, sandbox_id: &str) -> Result<Traced<()>, SdkError> {
+        self.suspend_with_wait(sandbox_id, 0).await
+    }
+
+    /// Request a bounded server-side completion wait. A 202 response (including
+    /// from older servers) still requires the caller to wait for completion.
+    pub async fn suspend_with_wait(
+        &self,
+        sandbox_id: &str,
+        wait_ms: u32,
+    ) -> Result<Traced<()>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/suspend"));
-        let req = self.client.build_empty_post_request(&uri)?;
+        let mut req = self.client.build_empty_post_request(&uri)?;
+        if wait_ms != 0 {
+            req.url_mut()
+                .query_pairs_mut()
+                .append_pair("wait_ms", &wait_ms.min(30_000).to_string());
+        }
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 
     pub async fn resume(&self, sandbox_id: &str) -> Result<Traced<()>, SdkError> {
+        self.resume_with_wait(sandbox_id, 0).await
+    }
+
+    /// Request a bounded server-side completion wait, retaining compatibility
+    /// with servers that return 202 immediately.
+    pub async fn resume_with_wait(
+        &self,
+        sandbox_id: &str,
+        wait_ms: u32,
+    ) -> Result<Traced<()>, SdkError> {
         let uri = self.endpoint(&format!("sandboxes/{sandbox_id}/resume"));
-        let req = self.client.build_empty_post_request(&uri)?;
+        let mut req = self.client.build_empty_post_request(&uri)?;
+        if wait_ms != 0 {
+            req.url_mut()
+                .query_pairs_mut()
+                .append_pair("wait_ms", &wait_ms.min(30_000).to_string());
+        }
         Ok(self.client.execute_traced(req).await?.map(|_| ()))
     }
 

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -211,7 +211,10 @@ impl From<GpuRequest> for GPUResources {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CreateSandboxResources {
-    #[serde(default = "unspecified_cpus", skip_serializing_if = "is_unspecified_f64")]
+    #[serde(
+        default = "unspecified_cpus",
+        skip_serializing_if = "is_unspecified_f64"
+    )]
     pub cpus: f64,
     #[serde(
         default = "unspecified_memory_mb",
@@ -1125,12 +1128,11 @@ mod tests {
             serde_json::json!({"snapshot_id": "snap-memory"})
         );
 
-        let cpu_override: CreateSandboxRequest =
-            serde_json::from_value(serde_json::json!({
-                "snapshot_id": "snap-memory",
-                "resources": {"cpus": 2.0}
-            }))
-            .unwrap();
+        let cpu_override: CreateSandboxRequest = serde_json::from_value(serde_json::json!({
+            "snapshot_id": "snap-memory",
+            "resources": {"cpus": 2.0}
+        }))
+        .unwrap();
         assert_eq!(cpu_override.resources.cpus, 2.0);
         assert_eq!(cpu_override.resources.memory_mb, unspecified_memory_mb());
 

--- a/crates/cloud-sdk/tests/sandboxes.rs
+++ b/crates/cloud-sdk/tests/sandboxes.rs
@@ -13,6 +13,55 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 #[tokio::test]
+async fn lifecycle_completion_wait_is_explicit_bounded_and_accepts_legacy_202() {
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for status in ["202 Accepted", "202 Accepted", "200 OK", "202 Accepted"] {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                requests.push(read_http_request(&mut socket).await);
+                socket
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 {status}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+            }
+            requests
+        });
+        let client = ClientBuilder::new(&format!("http://{address}"))
+            .build()
+            .unwrap();
+        let sandboxes = SandboxesClient::new(client, "default", false);
+        sandboxes.suspend("sbx-1").await.unwrap();
+        sandboxes.resume("sbx-1").await.unwrap();
+        sandboxes.suspend_with_wait("sbx-1", 10_000).await.unwrap();
+        sandboxes.resume_with_wait("sbx-1", u32::MAX).await.unwrap();
+        let requests = server.await.unwrap();
+        for (request, path) in requests.iter().zip([
+            "/sandboxes/sbx-1/suspend",
+            "/sandboxes/sbx-1/resume",
+            "/sandboxes/sbx-1/suspend?wait_ms=10000",
+            "/sandboxes/sbx-1/resume?wait_ms=30000",
+        ]) {
+            let request = String::from_utf8_lossy(request);
+            assert!(
+                request.starts_with(&format!("POST {path} HTTP/1.1\r\n")),
+                "{request}"
+            );
+            assert!(request.contains("\r\ncontent-length: 0\r\n"));
+        }
+    })
+    .await
+    .expect("lifecycle HTTP exchange exceeded five seconds");
+}
+
+#[tokio::test]
 async fn sandbox_proxy_raw_and_empty_posts_send_content_length_and_routing_headers() {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -624,19 +624,35 @@ impl NativeSandboxClient {
     }
 
     #[napi]
-    pub async fn suspend_sandbox(&self, sandbox_id: String) -> napi::Result<String> {
+    pub async fn suspend_sandbox(
+        &self,
+        sandbox_id: String,
+        wait_ms: Option<u32>,
+    ) -> napi::Result<String> {
         with_retry(self.client().await?, 5, move |c| {
             let sandbox_id = sandbox_id.clone();
-            async move { c.suspend(&sandbox_id).await.map(|t| t.trace_id) }
+            async move {
+                c.suspend_with_wait(&sandbox_id, wait_ms.unwrap_or(0))
+                    .await
+                    .map(|t| t.trace_id)
+            }
         })
         .await
     }
 
     #[napi]
-    pub async fn resume_sandbox(&self, sandbox_id: String) -> napi::Result<String> {
+    pub async fn resume_sandbox(
+        &self,
+        sandbox_id: String,
+        wait_ms: Option<u32>,
+    ) -> napi::Result<String> {
         with_retry(self.client().await?, 5, move |c| {
             let sandbox_id = sandbox_id.clone();
-            async move { c.resume(&sandbox_id).await.map(|t| t.trace_id) }
+            async move {
+                c.resume_with_wait(&sandbox_id, wait_ms.unwrap_or(0))
+                    .await
+                    .map(|t| t.trace_id)
+            }
         })
         .await
     }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -1664,17 +1664,29 @@ impl CloudSandboxClient {
         })
     }
 
-    fn suspend_sandbox(&self, sandbox_id: String) -> PyResult<String> {
+    #[pyo3(signature = (sandbox_id, wait_ms=0))]
+    fn suspend_sandbox(&self, sandbox_id: String, wait_ms: u32) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
-            async move { client.suspend(&sandbox_id).await.map(|t| t.trace_id) }
+            async move {
+                client
+                    .suspend_with_wait(&sandbox_id, wait_ms)
+                    .await
+                    .map(|t| t.trace_id)
+            }
         })
     }
 
-    fn resume_sandbox(&self, sandbox_id: String) -> PyResult<String> {
+    #[pyo3(signature = (sandbox_id, wait_ms=0))]
+    fn resume_sandbox(&self, sandbox_id: String, wait_ms: u32) -> PyResult<String> {
         self.run_with_retry(5, move |client| {
             let sandbox_id = sandbox_id.clone();
-            async move { client.resume(&sandbox_id).await.map(|t| t.trace_id) }
+            async move {
+                client
+                    .resume_with_wait(&sandbox_id, wait_ms)
+                    .await
+                    .map(|t| t.trace_id)
+            }
         })
     }
 
@@ -2062,16 +2074,22 @@ impl CloudSandboxClient {
         })
     }
 
+    #[pyo3(signature = (sandbox_id, wait_ms=0))]
     fn suspend_sandbox_async<'py>(
         &self,
         py: Python<'py>,
         sandbox_id: String,
+        wait_ms: u32,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
             let trace_id = retry_async_op(client, 5, move |c| {
                 let sandbox_id = sandbox_id.clone();
-                async move { c.suspend(&sandbox_id).await.map(|t| t.trace_id) }
+                async move {
+                    c.suspend_with_wait(&sandbox_id, wait_ms)
+                        .await
+                        .map(|t| t.trace_id)
+                }
             })
             .await
             .map_err(into_sandbox_py_error)?;
@@ -2079,16 +2097,22 @@ impl CloudSandboxClient {
         })
     }
 
+    #[pyo3(signature = (sandbox_id, wait_ms=0))]
     fn resume_sandbox_async<'py>(
         &self,
         py: Python<'py>,
         sandbox_id: String,
+        wait_ms: u32,
     ) -> PyResult<Bound<'py, PyAny>> {
         let client = self.client.clone();
         future_into_py(py, async move {
             let trace_id = retry_async_op(client, 5, move |c| {
                 let sandbox_id = sandbox_id.clone();
-                async move { c.resume(&sandbox_id).await.map(|t| t.trace_id) }
+                async move {
+                    c.resume_with_wait(&sandbox_id, wait_ms)
+                        .await
+                        .map(|t| t.trace_id)
+                }
             })
             .await
             .map_err(into_sandbox_py_error)?;

--- a/justfile
+++ b/justfile
@@ -249,6 +249,13 @@ test-crate crate:
 test-artifact-storage:
     cargo test --locked -p tensorlake --lib artifact_storage::
 
+# Build the native bindings first (develop-release and the TypeScript native
+# build), then verify lifecycle wire requests and sync/async client behavior.
+test-sandbox-lifecycle python="python3":
+    cargo test --locked -p tensorlake --test sandboxes lifecycle_completion_wait
+    cd typescript && npm test -- tests/client.test.ts tests/sandbox.test.ts
+    "{{python}}" -m pytest tests/sandbox/test_client_rust_backend.py tests/sandbox/test_client_rust_backend_async.py
+
 # Guard every SDK/CLI HTTP constructor, including feature-gated fast-clone paths in full CI.
 # This focused gate does not enable unrelated style lints; the existing `clippy` recipe does.
 lint-http-transports:

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -643,9 +643,11 @@ class AsyncSandboxClient:
         timeout: float = 300,
         poll_interval: float = 1.0,
     ) -> Traced[None]:
+        deadline = asyncio.get_running_loop().time() + timeout
         try:
             trace_id = await self._rust_client.suspend_sandbox_async(
-                sandbox_id=sandbox_id
+                sandbox_id=sandbox_id,
+                wait_ms=min(10_000, max(0, int(timeout * 1000))) if wait else 0,
             )
         except Exception as e:
             if _rust_status_code(e) == 404:
@@ -653,7 +655,6 @@ class AsyncSandboxClient:
             _raise_as_sandbox_error(e)
         if not wait:
             return Traced(trace_id, None)
-        deadline = asyncio.get_running_loop().time() + timeout
         while asyncio.get_running_loop().time() < deadline:
             info = (await self.get(sandbox_id)).value
             if info.status == SandboxStatus.SUSPENDED:
@@ -672,9 +673,11 @@ class AsyncSandboxClient:
         timeout: float = 300,
         poll_interval: float = 1.0,
     ) -> Traced[None]:
+        deadline = asyncio.get_running_loop().time() + timeout
         try:
             trace_id = await self._rust_client.resume_sandbox_async(
-                sandbox_id=sandbox_id
+                sandbox_id=sandbox_id,
+                wait_ms=min(10_000, max(0, int(timeout * 1000))) if wait else 0,
             )
         except Exception as e:
             if _rust_status_code(e) == 404:
@@ -682,7 +685,6 @@ class AsyncSandboxClient:
             _raise_as_sandbox_error(e)
         if not wait:
             return Traced(trace_id, None)
-        deadline = asyncio.get_running_loop().time() + timeout
         while asyncio.get_running_loop().time() < deadline:
             info = (await self.get(sandbox_id)).value
             if info.status == SandboxStatus.RUNNING:

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -689,6 +689,10 @@ class AsyncSandboxClient:
             info = (await self.get(sandbox_id)).value
             if info.status == SandboxStatus.RUNNING:
                 return Traced(trace_id, None)
+            if isinstance(info.error_details, str) and info.error_details.startswith(
+                "Resident resume failed: "
+            ):
+                raise SandboxError(info.error_details)
             if info.status == SandboxStatus.TERMINATED:
                 raise SandboxError(
                     f"Sandbox {sandbox_id!r} terminated while waiting for resume"

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -1032,6 +1032,10 @@ class SandboxClient:
             info = self.get(sandbox_id).value
             if info.status == SandboxStatus.RUNNING:
                 return Traced(trace_id, None)
+            if isinstance(info.error_details, str) and info.error_details.startswith(
+                "Resident resume failed: "
+            ):
+                raise SandboxError(info.error_details)
             if info.status == SandboxStatus.TERMINATED:
                 raise SandboxError(
                     f"Sandbox {sandbox_id!r} terminated while waiting for resume"

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -957,7 +957,8 @@ class SandboxClient:
 
         Args:
             sandbox_id: ID or name of the sandbox to suspend
-            wait: If True (default), poll until Suspended; False returns immediately.
+            wait: If True (default), wait for Suspended using server notifications
+                with polling fallback; False returns immediately.
             timeout: Max seconds to wait when wait=True (default 300)
             poll_interval: Seconds between polls when wait=True (default 1.0)
 
@@ -967,16 +968,19 @@ class SandboxClient:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
+        deadline = time.monotonic() + timeout
         try:
-            trace_id = self._rust_client.suspend_sandbox(sandbox_id=sandbox_id)
+            trace_id = self._rust_client.suspend_sandbox(
+                sandbox_id=sandbox_id,
+                wait_ms=min(10_000, max(0, int(timeout * 1000))) if wait else 0,
+            )
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
         if not wait:
             return Traced(trace_id, None)
-        deadline = time.time() + timeout
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
             info = self.get(sandbox_id).value
             if info.status == SandboxStatus.SUSPENDED:
                 return Traced(trace_id, None)
@@ -1001,7 +1005,8 @@ class SandboxClient:
 
         Args:
             sandbox_id: ID or name of the sandbox to resume
-            wait: If True (default), poll until Running; False returns immediately.
+            wait: If True (default), wait for Running using server notifications
+                with polling fallback; False returns immediately.
             timeout: Max seconds to wait when wait=True (default 300)
             poll_interval: Seconds between polls when wait=True (default 1.0)
 
@@ -1011,16 +1016,19 @@ class SandboxClient:
             RemoteAPIError: If the API request fails
             SandboxConnectionError: If the server is unreachable
         """
+        deadline = time.monotonic() + timeout
         try:
-            trace_id = self._rust_client.resume_sandbox(sandbox_id=sandbox_id)
+            trace_id = self._rust_client.resume_sandbox(
+                sandbox_id=sandbox_id,
+                wait_ms=min(10_000, max(0, int(timeout * 1000))) if wait else 0,
+            )
         except Exception as e:
             if _rust_status_code(e) == 404:
                 raise SandboxNotFoundError(sandbox_id) from None
             _raise_as_sandbox_error(e)
         if not wait:
             return Traced(trace_id, None)
-        deadline = time.time() + timeout
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
             info = self.get(sandbox_id).value
             if info.status == SandboxStatus.RUNNING:
                 return Traced(trace_id, None)

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -1097,6 +1097,39 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(fake.suspend_wait_ms, 0)
         self.assertEqual(fake.resume_calls, [])
 
+    def test_resume_polling_reports_late_failure_without_waiting_for_timeout(self):
+        for status in ("pending", "suspended"):
+
+            class FailedResumeClient(_FakeRustClient):
+                get_calls = 0
+
+                def get_sandbox_json(self, sandbox_id):
+                    self.get_calls += 1
+                    return (
+                        "trace",
+                        json.dumps(
+                            {
+                                "id": "sbx-1",
+                                "namespace": "default",
+                                "status": status,
+                                "resources": {
+                                    "cpus": 1,
+                                    "memory_mb": 512,
+                                    "ephemeral_disk_mb": 1024,
+                                },
+                                "error_details": "Resident resume failed: checkpoint owner unavailable",
+                            }
+                        ),
+                    )
+
+            fake = FailedResumeClient()
+            client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+            client._rust_client = fake
+            with self.assertRaisesRegex(SandboxError, "checkpoint owner unavailable"):
+                client.resume("sbx-1", timeout=0.2, poll_interval=0.01)
+            self.assertEqual(fake.get_calls, 1)
+            self.assertEqual(fake.resume_calls, ["sbx-1"])
+
     def test_resume_calls_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         fake = _FakeRustClient()

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -42,11 +42,13 @@ class _FakeRustClient:
     def close(self):
         return None
 
-    def suspend_sandbox(self, sandbox_id):
+    def suspend_sandbox(self, sandbox_id, wait_ms=0):
         self.suspend_calls.append(sandbox_id)
+        self.suspend_wait_ms = wait_ms
 
-    def resume_sandbox(self, sandbox_id):
+    def resume_sandbox(self, sandbox_id, wait_ms=0):
         self.resume_calls.append(sandbox_id)
+        self.resume_wait_ms = wait_ms
 
     def connect_proxy(
         self, *, proxy_url, sandbox_id, routing_hint=None, request_timeout_sec=None
@@ -1067,6 +1069,23 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         with self.assertRaisesRegex(SandboxError, "reserved for sandbox management"):
             client.expose_ports("sbx-1", [9501])
 
+    def test_lifecycle_server_wait_counts_against_timeout(self):
+        for action in ("suspend", "resume"):
+            with self.subTest(action=action):
+                fake = _FakeRustClient()
+                client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+                client._rust_client = fake
+                with (
+                    patch(
+                        "tensorlake.sandbox.client.time.monotonic", side_effect=[0, 2]
+                    ),
+                    patch.object(client, "get") as get,
+                ):
+                    with self.assertRaisesRegex(SandboxError, "within 1s"):
+                        getattr(client, action)("sbx-1", timeout=1)
+                    get.assert_not_called()
+                self.assertEqual(getattr(fake, f"{action}_wait_ms"), 1000)
+
     def test_suspend_calls_rust_backend(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
         fake = _FakeRustClient()
@@ -1075,6 +1094,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         client.suspend("my-env", wait=False)
 
         self.assertEqual(fake.suspend_calls, ["my-env"])
+        self.assertEqual(fake.suspend_wait_ms, 0)
         self.assertEqual(fake.resume_calls, [])
 
     def test_resume_calls_rust_backend(self):
@@ -1085,6 +1105,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         client.resume("my-env", wait=False)
 
         self.assertEqual(fake.resume_calls, ["my-env"])
+        self.assertEqual(fake.resume_wait_ms, 0)
         self.assertEqual(fake.suspend_calls, [])
 
     def test_handle_resume_wait_rebinds_proxy_from_fresh_info(self):
@@ -1248,7 +1269,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
             def close(self):
                 return None
 
-            def suspend_sandbox(self, sandbox_id):
+            def suspend_sandbox(self, sandbox_id, wait_ms=0):
                 raise FakeRustError(
                     ("remote_api", 404, f"sandbox {sandbox_id} not found")
                 )
@@ -1274,7 +1295,7 @@ class TestSandboxClientRustBackend(unittest.TestCase):
             def close(self):
                 return None
 
-            def resume_sandbox(self, sandbox_id):
+            def resume_sandbox(self, sandbox_id, wait_ms=0):
                 raise FakeRustError(
                     ("remote_api", 404, f"sandbox {sandbox_id} not found")
                 )

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -1055,6 +1055,41 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(fake.suspend_wait_ms, 0)
         self.assertEqual(fake.resume_calls, [])
 
+    async def test_resume_polling_reports_late_failure_without_waiting_for_timeout(
+        self,
+    ):
+        for status in ("pending", "suspended"):
+
+            class FailedResumeClient(_FakeAsyncRustClient):
+                get_calls = 0
+
+                async def get_sandbox_json_async(self, *, sandbox_id):
+                    self.get_calls += 1
+                    return (
+                        "trace",
+                        json.dumps(
+                            {
+                                "id": "sbx-1",
+                                "namespace": "default",
+                                "status": status,
+                                "resources": {
+                                    "cpus": 1,
+                                    "memory_mb": 512,
+                                    "ephemeral_disk_mb": 1024,
+                                },
+                                "error_details": "Resident resume failed: checkpoint owner unavailable",
+                            }
+                        ),
+                    )
+
+            fake = FailedResumeClient()
+            client = _make_client(fake)
+            client._rust_client = fake
+            with self.assertRaisesRegex(SandboxError, "checkpoint owner unavailable"):
+                await client.resume("sbx-1", timeout=0.2, poll_interval=0.01)
+            self.assertEqual(fake.get_calls, 1)
+            self.assertEqual(fake.resume_calls, ["sbx-1"])
+
     async def test_resume_calls_rust_backend(self):
         fake = _FakeAsyncRustClient()
         client = _make_client(fake)

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -70,12 +70,14 @@ class _FakeAsyncRustClient:
             "server response did not include sandbox_url; refusing to derive a proxy URL"
         )
 
-    async def suspend_sandbox_async(self, *, sandbox_id):
+    async def suspend_sandbox_async(self, *, sandbox_id, wait_ms=0):
         self.suspend_calls.append(sandbox_id)
+        self.suspend_wait_ms = wait_ms
         return "trace-suspend"
 
-    async def resume_sandbox_async(self, *, sandbox_id):
+    async def resume_sandbox_async(self, *, sandbox_id, wait_ms=0):
         self.resume_calls.append(sandbox_id)
+        self.resume_wait_ms = wait_ms
         return "trace-resume"
 
     async def create_snapshot_async(self, *, sandbox_id, snapshot_type=None):
@@ -1018,6 +1020,31 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(SandboxError, "reserved for sandbox management"):
             await client.expose_ports("sbx-1", [9501])
 
+    async def test_lifecycle_server_wait_counts_against_timeout(self):
+        for action in ("suspend", "resume"):
+            with self.subTest(action=action):
+                fake = _FakeAsyncRustClient()
+                client = _make_client(fake)
+
+                class Clock:
+                    def __init__(self):
+                        self.values = iter((0, 2))
+
+                    def time(self):
+                        return next(self.values)
+
+                with (
+                    patch(
+                        "tensorlake.sandbox.async_client.asyncio.get_running_loop",
+                        return_value=Clock(),
+                    ),
+                    patch.object(client, "get") as get,
+                ):
+                    with self.assertRaisesRegex(SandboxError, "within 1s"):
+                        await getattr(client, action)("sbx-1", timeout=1)
+                    get.assert_not_called()
+                self.assertEqual(getattr(fake, f"{action}_wait_ms"), 1000)
+
     async def test_suspend_calls_rust_backend(self):
         fake = _FakeAsyncRustClient()
         client = _make_client(fake)
@@ -1025,6 +1052,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         await client.suspend("my-env", wait=False)
 
         self.assertEqual(fake.suspend_calls, ["my-env"])
+        self.assertEqual(fake.suspend_wait_ms, 0)
         self.assertEqual(fake.resume_calls, [])
 
     async def test_resume_calls_rust_backend(self):
@@ -1034,6 +1062,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         await client.resume("my-env", wait=False)
 
         self.assertEqual(fake.resume_calls, ["my-env"])
+        self.assertEqual(fake.resume_wait_ms, 0)
         self.assertEqual(fake.suspend_calls, [])
 
     async def test_handle_resume_wait_rebinds_proxy_from_fresh_info(self):
@@ -1211,6 +1240,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
 
         await client.suspend("sbx-1", wait=True, timeout=2.0, poll_interval=0.01)
 
+        self.assertEqual(fake.suspend_wait_ms, 2000)
         self.assertEqual(fake.suspend_calls, ["sbx-1"])
         self.assertGreaterEqual(fake.get_calls, 2)
 
@@ -1220,6 +1250,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
 
         await client.resume("sbx-1", wait=True, timeout=2.0, poll_interval=0.01)
 
+        self.assertEqual(fake.resume_wait_ms, 2000)
         self.assertEqual(fake.resume_calls, ["sbx-1"])
         self.assertGreaterEqual(fake.get_calls, 2)
 
@@ -1231,7 +1262,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
             def close(self):
                 return None
 
-            async def suspend_sandbox_async(self, *, sandbox_id):
+            async def suspend_sandbox_async(self, *, sandbox_id, wait_ms=0):
                 raise FakeRustError(
                     ("remote_api", 404, f"sandbox {sandbox_id} not found")
                 )
@@ -1256,7 +1287,7 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
             def close(self):
                 return None
 
-            async def resume_sandbox_async(self, *, sandbox_id):
+            async def resume_sandbox_async(self, *, sandbox_id, wait_ms=0):
                 raise FakeRustError(
                     ("remote_api", 404, f"sandbox {sandbox_id} not found")
                 )

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -29,6 +29,14 @@ without generating diagnostic reports. For a nonstandard or statically linked No
 executable, set `TENSORLAKE_NODE_LIBC=gnu` or `TENSORLAKE_NODE_LIBC=musl` before using
 the SDK.
 
+Blocking sandbox suspend and resume requests ask the server to wait for up to
+10 seconds of the requested timeout using sandbox state notifications. If the
+server returns before completion, including older servers, the SDK continues
+its normal bounded status polling. `wait: false` requests no server wait and
+retains its immediate-return behavior. Server completion removes the polling
+interval from the usual lifecycle path; it does not change when the server
+considers a sandbox suspended or running.
+
 ```ts
 import { registerApplication, registerFunction } from "tensorlake/applications";
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -82,7 +82,12 @@ function requireReadOnlySnapshotPin(
  * explicit `false` (or an unknown pin field).
  */
 function fileSystemMountToWire(fs: FileSystemMount): Record<string, unknown> {
-  requireReadOnlySnapshotPin(fs.fileSystemId, fs.mountPath, fs.readOnly, fs.snapshotId);
+  requireReadOnlySnapshotPin(
+    fs.fileSystemId,
+    fs.mountPath,
+    fs.readOnly,
+    fs.snapshotId,
+  );
   return {
     file_system_id: fs.fileSystemId,
     mount_path: fs.mountPath,
@@ -498,14 +503,18 @@ export class SandboxClient {
     sandboxId: string,
     options?: SuspendResumeOptions,
   ): Promise<void> {
-    await callNative(() => this.native.suspendSandbox(sandboxId), {
+    const timeout = options?.timeout ?? 300;
+    const deadline = Date.now() + timeout * 1000;
+    const waitMs =
+      options?.wait === false
+        ? 0
+        : Math.max(0, Math.min(10_000, Math.floor(timeout * 1000)));
+    await callNative(() => this.native.suspendSandbox(sandboxId, waitMs), {
       sandboxId,
       notFoundKind: "sandbox",
     });
     if (options?.wait === false) return;
-    const timeout = options?.timeout ?? 300;
     const pollInterval = options?.pollInterval ?? 1;
-    const deadline = Date.now() + timeout * 1000;
     while (Date.now() < deadline) {
       const info = await this.get(sandboxId);
       if (info.status === SandboxStatus.SUSPENDED) return;
@@ -532,14 +541,18 @@ export class SandboxClient {
     sandboxId: string,
     options?: SuspendResumeOptions,
   ): Promise<void> {
-    await callNative(() => this.native.resumeSandbox(sandboxId), {
+    const timeout = options?.timeout ?? 300;
+    const deadline = Date.now() + timeout * 1000;
+    const waitMs =
+      options?.wait === false
+        ? 0
+        : Math.max(0, Math.min(10_000, Math.floor(timeout * 1000)));
+    await callNative(() => this.native.resumeSandbox(sandboxId, waitMs), {
       sandboxId,
       notFoundKind: "sandbox",
     });
     if (options?.wait === false) return;
-    const timeout = options?.timeout ?? 300;
     const pollInterval = options?.pollInterval ?? 1;
-    const deadline = Date.now() + timeout * 1000;
     while (Date.now() < deadline) {
       const info = await this.get(sandboxId);
       if (info.status === SandboxStatus.RUNNING) return;

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -556,6 +556,12 @@ export class SandboxClient {
     while (Date.now() < deadline) {
       const info = await this.get(sandboxId);
       if (info.status === SandboxStatus.RUNNING) return;
+      if (
+        typeof info.errorDetails === "string" &&
+        info.errorDetails.startsWith("Resident resume failed: ")
+      ) {
+        throw new SandboxError(info.errorDetails);
+      }
       if (info.status === SandboxStatus.TERMINATED) {
         throw new SandboxError(
           `Sandbox ${sandboxId} terminated while waiting for resume`,

--- a/typescript/src/native-sandbox.ts
+++ b/typescript/src/native-sandbox.ts
@@ -96,8 +96,8 @@ export interface NativeSandboxClient {
   listSandboxLogProcesses(sandboxId: string): Promise<TracedJson>;
   updateSandbox(sandboxId: string, requestJson: string): Promise<TracedJson>;
   deleteSandbox(sandboxId: string): Promise<string>;
-  suspendSandbox(sandboxId: string): Promise<string>;
-  resumeSandbox(sandboxId: string): Promise<string>;
+  suspendSandbox(sandboxId: string, waitMs?: number): Promise<string>;
+  resumeSandbox(sandboxId: string, waitMs?: number): Promise<string>;
   attachFileSystem(
     sandboxId: string,
     fileSystemId: string,
@@ -107,10 +107,7 @@ export interface NativeSandboxClient {
     snapshotId?: string | null,
     owner?: string | null,
   ): Promise<TracedJson>;
-  detachFileSystem(
-    sandboxId: string,
-    mountPath: string,
-  ): Promise<TracedJson>;
+  detachFileSystem(sandboxId: string, mountPath: string): Promise<TracedJson>;
   createSnapshot(
     sandboxId: string,
     snapshotType?: string | null,
@@ -267,7 +264,7 @@ export interface NativeSandboxBinding {
 
 let cachedBinding: NativeSandboxBinding | undefined;
 export function loadNativeSandboxBinding(): NativeSandboxBinding {
-  return cachedBinding ??= workerBinding();
+  return (cachedBinding ??= workerBinding());
 }
 
 /** Test seam: replace (or clear) the native binding. */
@@ -395,29 +392,53 @@ export async function* nativeEventStream(
   let finished = false;
   let stopped = false;
   let failure: unknown;
-  const notify = () => { const resolve = wake; wake = undefined; resolve?.(); };
+  const notify = () => {
+    const resolve = wake;
+    wake = undefined;
+    resolve?.();
+  };
   const emit: NativeEmit = (value) => {
     if (stopped) return Promise.resolve();
-    return new Promise<void>((consumed) => { queue.push({ value, consumed }); notify(); });
+    return new Promise<void>((consumed) => {
+      queue.push({ value, consumed });
+      notify();
+    });
   };
   let call: NativeCall<string> | undefined;
-  const onAbort = () => { stopped = true; call?.[cancelNativeCall]?.(); notify(); };
+  const onAbort = () => {
+    stopped = true;
+    call?.[cancelNativeCall]?.();
+    notify();
+  };
   signal?.addEventListener("abort", onAbort, { once: true });
   try {
     call = start(emit);
-    void call.catch((error: unknown) => { failure = error; }).finally(() => { finished = true; notify(); });
+    void call
+      .catch((error: unknown) => {
+        failure = error;
+      })
+      .finally(() => {
+        finished = true;
+        notify();
+      });
     while (!stopped) {
       const event = queue.shift();
       if (event) {
-        try { yield JSON.parse(event.value) as Record<string, unknown>; }
-        finally { event.consumed(); }
+        try {
+          yield JSON.parse(event.value) as Record<string, unknown>;
+        } finally {
+          event.consumed();
+        }
       } else if (finished) {
         break;
       } else {
-        await new Promise<void>((resolve) => { wake = resolve; });
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
       }
     }
-    if (!stopped && failure !== undefined) throw translateNativeError(failure, context);
+    if (!stopped && failure !== undefined)
+      throw translateNativeError(failure, context);
   } finally {
     stopped = true;
     signal?.removeEventListener("abort", onAbort);
@@ -456,5 +477,9 @@ export function assembleCommandResult(events: string[]): {
     }
   }
 
-  return { exitCode, stdout: stdoutLines.join("\n"), stderr: stderrLines.join("\n") };
+  return {
+    exitCode,
+    stdout: stdoutLines.join("\n"),
+    stderr: stderrLines.join("\n"),
+  };
 }

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -814,6 +814,24 @@ describe("SandboxClient", () => {
     });
   });
 
+  it.each(["pending", "suspended"])(
+    "reports late resume failure in %s after an asynchronous response",
+    async (status) => {
+      const stub = installNativeStub({ client: {
+        getSandbox: vi.fn(async () => ({ traceId: "t", json: JSON.stringify({
+          id: "sbx-1", namespace: "default", status,
+          resources: { cpus: 1, memory_mb: 512, ephemeral_disk_mb: 1024 },
+          error_details: "Resident resume failed: checkpoint owner unavailable",
+        }) })),
+      } });
+      const client = SandboxClient.forLocalhost();
+      await expect(client.resume("sbx-1", { timeout: 0.2, pollInterval: 0.01 })).rejects.toThrow("checkpoint owner unavailable");
+      expect(stub.client.getSandbox).toHaveBeenCalledTimes(1);
+      expect(stub.client.resumeSandbox).toHaveBeenCalledTimes(1);
+      client.close();
+    },
+  );
+
   it.each(["suspend", "resume"] as const)(
     "%s counts the server completion wait against the caller timeout",
     async (action) => {

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SandboxClient } from "../src/client.js";
-import {
-  type GpuModel,
-  SandboxStatus,
-  SnapshotStatus,
-} from "../src/models.js";
+import { type GpuModel, SandboxStatus, SnapshotStatus } from "../src/models.js";
 import { clearNativeStub, installNativeStub } from "./native-stub.js";
 
 /** Build the native error a non-2xx HTTP response now surfaces from Rust. */
@@ -41,7 +37,10 @@ describe("SandboxClient", () => {
         expect(JSON.parse(body)).toEqual({ snapshot_id: "snap-memory" });
         return {
           traceId: "t",
-          json: JSON.stringify({ sandbox_id: "sbx-restored", status: "running" }),
+          json: JSON.stringify({
+            sandbox_id: "sbx-restored",
+            status: "running",
+          }),
         };
       });
       installNativeStub({ client: { createSandbox } });
@@ -56,7 +55,10 @@ describe("SandboxClient", () => {
         expect(JSON.parse(body).resources).toEqual({ cpus: 2 });
         return {
           traceId: "t",
-          json: JSON.stringify({ sandbox_id: "sbx-restored", status: "running" }),
+          json: JSON.stringify({
+            sandbox_id: "sbx-restored",
+            status: "running",
+          }),
         };
       });
       installNativeStub({ client: { createSandbox } });
@@ -152,7 +154,10 @@ describe("SandboxClient", () => {
             expect(body.resources.gpus).toEqual([{ count: 2, model }]);
             return {
               traceId: "t",
-              json: JSON.stringify({ sandbox_id: "sbx-gpu", status: "pending" }),
+              json: JSON.stringify({
+                sandbox_id: "sbx-gpu",
+                status: "pending",
+              }),
             };
           }),
         },
@@ -172,7 +177,10 @@ describe("SandboxClient", () => {
             expect(body.resources.gpus).toEqual([{ count: 2, model: "H100" }]);
             return {
               traceId: "t",
-              json: JSON.stringify({ sandbox_id: "sbx-gpu", status: "pending" }),
+              json: JSON.stringify({
+                sandbox_id: "sbx-gpu",
+                status: "pending",
+              }),
             };
           }),
         },
@@ -744,7 +752,7 @@ describe("SandboxClient", () => {
       await expect(
         client.suspend("sbx-1", { wait: false }),
       ).resolves.toBeUndefined();
-      expect(stub.client.suspendSandbox).toHaveBeenCalledWith("sbx-1");
+      expect(stub.client.suspendSandbox).toHaveBeenCalledWith("sbx-1", 0);
       client.close();
     });
 
@@ -765,7 +773,7 @@ describe("SandboxClient", () => {
 
       const client = SandboxClient.forLocalhost();
       await expect(client.suspend("sbx-1")).resolves.toBeUndefined();
-      expect(stub.client.suspendSandbox).toHaveBeenCalledWith("sbx-1");
+      expect(stub.client.suspendSandbox).toHaveBeenCalledWith("sbx-1", 10_000);
       expect(stub.client.getSandbox).toHaveBeenCalled();
       client.close();
     });
@@ -779,7 +787,7 @@ describe("SandboxClient", () => {
       await expect(
         client.resume("sbx-1", { wait: false }),
       ).resolves.toBeUndefined();
-      expect(stub.client.resumeSandbox).toHaveBeenCalledWith("sbx-1");
+      expect(stub.client.resumeSandbox).toHaveBeenCalledWith("sbx-1", 0);
       client.close();
     });
 
@@ -800,11 +808,35 @@ describe("SandboxClient", () => {
 
       const client = SandboxClient.forLocalhost();
       await expect(client.resume("sbx-1")).resolves.toBeUndefined();
-      expect(stub.client.resumeSandbox).toHaveBeenCalledWith("sbx-1");
+      expect(stub.client.resumeSandbox).toHaveBeenCalledWith("sbx-1", 10_000);
       expect(stub.client.getSandbox).toHaveBeenCalled();
       client.close();
     });
   });
+
+  it.each(["suspend", "resume"] as const)(
+    "%s counts the server completion wait against the caller timeout",
+    async (action) => {
+      let now = 0;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      const nativeMethod =
+        action === "suspend" ? "suspendSandbox" : "resumeSandbox";
+      const stub = installNativeStub({
+        client: {
+          [nativeMethod]: vi.fn(async () => {
+            now = 2000;
+          }),
+        },
+      });
+      const client = SandboxClient.forLocalhost();
+      await expect(client[action]("sbx-1", { timeout: 1 })).rejects.toThrow(
+        `did not ${action} within 1s`,
+      );
+      expect(stub.client[nativeMethod]).toHaveBeenCalledWith("sbx-1", 1000);
+      expect(stub.client.getSandbox).not.toHaveBeenCalled();
+      client.close();
+    },
+  );
 
   describe("claim", () => {
     it("claims from pool", async () => {

--- a/typescript/tests/sandbox.test.ts
+++ b/typescript/tests/sandbox.test.ts
@@ -27,7 +27,9 @@ describe("Sandbox", () => {
 
   describe("constructor", () => {
     it("requires an explicit proxyUrl for direct construction", () => {
-      expect(() => new Sandbox({ sandboxId: "sbx-direct" })).toThrow(SandboxError);
+      expect(() => new Sandbox({ sandboxId: "sbx-direct" })).toThrow(
+        SandboxError,
+      );
       expect(() => new Sandbox({ sandboxId: "sbx-direct" })).toThrow(
         /proxyUrl is required/,
       );
@@ -225,7 +227,7 @@ describe("Sandbox", () => {
       await sbx.resume({ wait: false });
 
       expect(stub.client.connectProxy).toHaveBeenCalledOnce();
-      expect(stub.client.resumeSandbox).toHaveBeenCalledWith("sbx-1");
+      expect(stub.client.resumeSandbox).toHaveBeenCalledWith("sbx-1", 0);
       sbx.close();
     });
 
@@ -278,7 +280,8 @@ describe("Sandbox", () => {
     });
 
     it("keeps the connect-time env proxy override across resume rebind", async () => {
-      process.env.TENSORLAKE_SANDBOX_PROXY_URL = "https://initial-env.example.com";
+      process.env.TENSORLAKE_SANDBOX_PROXY_URL =
+        "https://initial-env.example.com";
       const responses = [
         sandboxInfo({
           sandbox_url: undefined,
@@ -324,7 +327,8 @@ describe("Sandbox", () => {
         requestTimeout: 7,
       });
       await sbx.health();
-      process.env.TENSORLAKE_SANDBOX_PROXY_URL = "https://later-env.example.com";
+      process.env.TENSORLAKE_SANDBOX_PROXY_URL =
+        "https://later-env.example.com";
 
       await sbx.resume({ timeout: 2, pollInterval: 0.01 });
 
@@ -417,7 +421,10 @@ describe("Sandbox", () => {
 
   describe("run", () => {
     /** A buffered run_process event list (each event a JSON string). */
-    function runEvents(events: unknown[]): { traceId: string; events: string[] } {
+    function runEvents(events: unknown[]): {
+      traceId: string;
+      events: string[];
+    } {
       return { traceId: "t", events: events.map((e) => JSON.stringify(e)) };
     }
 
@@ -437,7 +444,10 @@ describe("Sandbox", () => {
       });
 
       const sbx = makeSandbox();
-      const result = await sbx.run("echo", { args: ["hello"], user: "1000:1000" });
+      const result = await sbx.run("echo", {
+        args: ["hello"],
+        user: "1000:1000",
+      });
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toBe("hello");
       expect(result.stderr).toBe("");
@@ -467,25 +477,31 @@ describe("Sandbox", () => {
       // stream_headers/stream_complete phases were SSE artifacts of the old
       // undici path).
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[tensorlake:sdk-timing] op=sandbox.run phase=start"),
+        expect.stringContaining(
+          "[tensorlake:sdk-timing] op=sandbox.run phase=start",
+        ),
       );
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("command_length=4"),
       );
       // The command payload must not leak when payloads are disabled.
-      expect(errorSpy.mock.calls.some(([line]) => String(line).includes("command=echo"))).toBe(
-        false,
-      );
+      expect(
+        errorSpy.mock.calls.some(([line]) =>
+          String(line).includes("command=echo"),
+        ),
+      ).toBe(false);
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("phase=complete"),
       );
       // The read file path/contents must never leak into timings.
-      expect(errorSpy.mock.calls.some(([line]) => String(line).includes("secret.txt"))).toBe(
-        false,
-      );
-      expect(errorSpy.mock.calls.some(([line]) => String(line).includes("secret"))).toBe(
-        false,
-      );
+      expect(
+        errorSpy.mock.calls.some(([line]) =>
+          String(line).includes("secret.txt"),
+        ),
+      ).toBe(false);
+      expect(
+        errorSpy.mock.calls.some(([line]) => String(line).includes("secret")),
+      ).toBe(false);
       sbx.close();
     });
 
@@ -551,8 +567,22 @@ describe("Sandbox", () => {
             traceId: "t",
             json: JSON.stringify({
               processes: [
-                { pid: 1, status: "running", command: "bash", args: [], stdin_writable: false, started_at: 1700000000 },
-                { pid: 2, status: "exited", command: "ls", args: [], stdin_writable: false, started_at: 1700000001 },
+                {
+                  pid: 1,
+                  status: "running",
+                  command: "bash",
+                  args: [],
+                  stdin_writable: false,
+                  started_at: 1700000000,
+                },
+                {
+                  pid: 2,
+                  status: "exited",
+                  command: "ls",
+                  args: [],
+                  stdin_writable: false,
+                  started_at: 1700000001,
+                },
               ],
             }),
           })),
@@ -795,10 +825,7 @@ describe("Sandbox", () => {
       const stub = installNativeStub();
 
       const sbx = makeSandbox();
-      await sbx.writeFile(
-        "/tmp/out.txt",
-        new TextEncoder().encode("content"),
-      );
+      await sbx.writeFile("/tmp/out.txt", new TextEncoder().encode("content"));
       const [path, content] = stub.proxy.writeFile.mock.calls[0];
       expect(path).toBe("/tmp/out.txt");
       expect(Buffer.isBuffer(content)).toBe(true);
@@ -814,7 +841,12 @@ describe("Sandbox", () => {
             json: JSON.stringify({
               path: "/tmp",
               entries: [
-                { name: "file.txt", is_dir: false, size: 100, modified_at: 1700000000 },
+                {
+                  name: "file.txt",
+                  is_dir: false,
+                  size: 100,
+                  modified_at: 1700000000,
+                },
                 { name: "subdir", is_dir: true, size: null, modified_at: null },
               ],
             }),
@@ -999,7 +1031,11 @@ describe("Sandbox", () => {
         expect(id).toBe("sbx-1");
         return {
           traceId: "t",
-          json: sandboxInfoBody({ id: "sbx-1", name: "renamed-by-handle", status: "running" }),
+          json: sandboxInfoBody({
+            id: "sbx-1",
+            name: "renamed-by-handle",
+            status: "running",
+          }),
         };
       });
       installNativeStub({ client: { updateSandbox, getSandbox } });
@@ -1013,7 +1049,10 @@ describe("Sandbox", () => {
       expect(sbx.name).toBe("renamed-by-handle");
 
       expect(updateSandbox).toHaveBeenCalledOnce();
-      expect(updateSandbox).toHaveBeenCalledWith("my-original-name", expect.any(String));
+      expect(updateSandbox).toHaveBeenCalledWith(
+        "my-original-name",
+        expect.any(String),
+      );
       // After update resolves the canonical ID, subsequent calls use the UUID.
       expect(getSandbox).toHaveBeenCalledWith("sbx-1");
       sbx.close();
@@ -1031,12 +1070,18 @@ describe("Sandbox", () => {
         expect(id).toBe("sbx-1");
         return {
           traceId: "t",
-          json: JSON.stringify({ snapshot_id: "snap-1", status: "in_progress" }),
+          json: JSON.stringify({
+            snapshot_id: "snap-1",
+            status: "in_progress",
+          }),
         };
       });
       installNativeStub({ client: { updateSandbox, createSnapshot } });
 
-      const client = new SandboxClient({ apiUrl: "http://localhost:8900" }, true);
+      const client = new SandboxClient(
+        { apiUrl: "http://localhost:8900" },
+        true,
+      );
       const sbx = client.connect("my-original-name");
       sbx._setOwner(client);
 
@@ -1061,13 +1106,20 @@ describe("Sandbox", () => {
         json: JSON.stringify({
           snapshots: [
             { snapshot_id: "snap-1", sandbox_id: "sbx-1", status: "completed" },
-            { snapshot_id: "snap-2", sandbox_id: "other-sbx", status: "completed" },
+            {
+              snapshot_id: "snap-2",
+              sandbox_id: "other-sbx",
+              status: "completed",
+            },
           ],
         }),
       }));
       installNativeStub({ client: { updateSandbox, listSnapshots } });
 
-      const client = new SandboxClient({ apiUrl: "http://localhost:8900" }, true);
+      const client = new SandboxClient(
+        { apiUrl: "http://localhost:8900" },
+        true,
+      );
       const sbx = client.connect("my-original-name");
       sbx._setOwner(client);
 
@@ -1244,7 +1296,11 @@ describe("Sandbox", () => {
       const stub = installNativeStub({
         client: {
           attachFileSystem: vi.fn(
-            async (sandboxId: string, fileSystemId: string, mountPath: string) => {
+            async (
+              sandboxId: string,
+              fileSystemId: string,
+              mountPath: string,
+            ) => {
               expect(sandboxId).toBe("sbx-abc");
               expect(fileSystemId).toBe("file_system_abc");
               expect(mountPath).toBe("/mnt/skills");
@@ -1252,7 +1308,10 @@ describe("Sandbox", () => {
                 traceId: "t",
                 json: fsSandboxInfoBody({
                   file_systems: [
-                    { file_system_id: "file_system_abc", mount_path: "/mnt/skills" },
+                    {
+                      file_system_id: "file_system_abc",
+                      mount_path: "/mnt/skills",
+                    },
                   ],
                 }),
               };
@@ -1265,10 +1324,7 @@ describe("Sandbox", () => {
         sandboxId: "sbx-abc",
         apiUrl: "http://localhost:8900",
       });
-      const info = await sbx.attachFileSystem(
-        "file_system_abc",
-        "/mnt/skills",
-      );
+      const info = await sbx.attachFileSystem("file_system_abc", "/mnt/skills");
       expect(info.fileSystems).toEqual([
         { fileSystemId: "file_system_abc", mountPath: "/mnt/skills" },
       ]);
@@ -1314,10 +1370,14 @@ describe("Sandbox", () => {
         sandboxId: "sbx-abc",
         apiUrl: "http://localhost:8900",
       });
-      const info = await sbx.attachFileSystem("file_system_abc", "/mnt/skills", {
-        readOnly: true,
-        prefetch: true,
-      });
+      const info = await sbx.attachFileSystem(
+        "file_system_abc",
+        "/mnt/skills",
+        {
+          readOnly: true,
+          prefetch: true,
+        },
+      );
       expect(info.fileSystems).toEqual([
         {
           fileSystemId: "file_system_abc",
@@ -1345,7 +1405,10 @@ describe("Sandbox", () => {
             traceId: "t",
             json: fsSandboxInfoBody({
               file_systems: [
-                { file_system_id: "file_system_abc", mount_path: "/mnt/skills" },
+                {
+                  file_system_id: "file_system_abc",
+                  mount_path: "/mnt/skills",
+                },
               ],
             }),
           };
@@ -1405,10 +1468,14 @@ describe("Sandbox", () => {
         sandboxId: "sbx-abc",
         apiUrl: "http://localhost:8900",
       });
-      const info = await sbx.attachFileSystem("file_system_abc", "/mnt/skills", {
-        readOnly: true,
-        snapshotId: "0abc123def",
-      });
+      const info = await sbx.attachFileSystem(
+        "file_system_abc",
+        "/mnt/skills",
+        {
+          readOnly: true,
+          snapshotId: "0abc123def",
+        },
+      );
       expect(info.fileSystems).toEqual([
         {
           fileSystemId: "file_system_abc",
@@ -1471,7 +1538,10 @@ describe("Sandbox", () => {
             traceId: "t",
             json: fsSandboxInfoBody({
               file_systems: [
-                { file_system_id: "file_system_abc", mount_path: "/mnt/skills" },
+                {
+                  file_system_id: "file_system_abc",
+                  mount_path: "/mnt/skills",
+                },
               ],
             }),
           })),
@@ -1507,9 +1577,7 @@ describe("Sandbox", () => {
       installNativeStub();
       const sbx = makeSandbox("sbx-1");
       const url = sbx.ptyWsUrl("sess-1", "tok-1");
-      expect(url).toBe(
-        "ws://localhost:9443/api/v1/pty/sess-1/ws?token=tok-1",
-      );
+      expect(url).toBe("ws://localhost:9443/api/v1/pty/sess-1/ws?token=tok-1");
       sbx.close();
     });
   });


### PR DESCRIPTION
Blocking sandbox suspend/resume calls currently observe completion through a one-second status poll. Request an optional, bounded server completion wait first so a supporting server can return as soon as the lifecycle transition completes.

The Rust transport adds explicit `suspend_with_wait` and `resume_with_wait` methods. Python and TypeScript blocking calls pass up to ten seconds through the native bindings, counted against the caller's timeout. `wait=False` passes zero. Existing Rust methods, empty POST bodies, status/routing refreshes, and polling fallback for older servers returning 202 remain compatible; no new server behavior is required for rollout.

When a resident resume fails after the server has returned HTTP 202, Python sync/async and TypeScript polling now surface the server's explicit `Resident resume failed:` error immediately. The failure can describe either a confirmed paused VM or an owner requiring reconciliation. Polling does not submit another resume attempt or wait for its overall timeout. Normal Running completion, legacy 202 behavior and explicit subsequent retries remain supported.

Validation: native Node and Python release builds, Rust HTTP transport regression (including legacy 202 and the 30-second cap), 130 TypeScript tests, 115 Python tests, TypeScript typecheck, and focused ESLint pass. Real local server/dataplane tests also exercise both Python native modes and TypeScript lifecycle calls with immediate post-resume commands.

Repository-wide Clippy reproduces baseline failures at e2cfe7c (disallowed reqwest calls in the injected Function Agent core and the existing large application-event enum). Focused Clippy on the changed SDK crates passes with dependency linting disabled and that baseline enum allowed. Repository-wide ESLint reports six errors in unchanged fixture/get-or-create test files; all changed TypeScript files pass.

This does not change snapshot persistence or the runtime suspend boundary. No SDK package release is included.
