### PR TITLE
Expose sandbox failure diagnostics in SDKs and CLI

### DIFF
--- a/.github/actions/vendor-private-crates/action.yml
+++ b/.github/actions/vendor-private-crates/action.yml
@@ -101,10 +101,11 @@ runs:
             exit 1
           fi
           # Keep the placeholder's tensorlake-adapted Cargo.toml; replace only the source tree.
-          rm -f "$placeholder"/*.rs
-          cp "$real"/*.rs "$placeholder"/
-          count=$(ls "$placeholder"/*.rs | wc -l | tr -d ' ')
-          echo "Vendored ${count} ${crate} source file(s)."
+          rm -rf "$placeholder"
+          mkdir -p "$placeholder"
+          cp -R "$real"/. "$placeholder"/
+          diff -qr "$real" "$placeholder"
+          echo "Vendored the complete ${crate} source tree."
         done
         echo "The CLI can now build with --features mount,git-clone."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Two execution modes:
 
 ## Key Conventions
 
+- **Typed API responses**: Deserialize response and error bodies into explicit structs/enums (`serde::Deserialize` in Rust) and access named fields. Do not parse a body into `serde_json::Value` and extract known fields with `.get()` / `.as_str()`. Reuse wire models or add a focused response struct; represent supported legacy shapes with types, defaults, and aliases. Reserve dynamic JSON for individual fields whose contract permits arbitrary JSON, such as `error_details`. Preserve raw-body fallback for unrecognized or non-JSON error responses.
 - **Python 3.10+**, managed with **Poetry 2.0.0**
 - **Formatting**: Black + isort (profile "black"). Pre-commit hooks enforce this.
 - **Tests**: Standard `unittest` framework with `parameterized` for parameterized tests. Parameterized tests are main used to run the same test code in local and remote modes and ensure the same results. Claude must not create new Python environments to run test. Instead it should use currrent Poetry environment by i.e. using `poetry run python tests/path_to/test_file.py`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.127"
+version = "0.5.128"
 dependencies = [
  "anyhow",
  "base64",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.127"
+version = "0.5.128"
 dependencies = [
  "anyhow",
  "base64",
@@ -5522,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.127"
+version = "0.5.128"
 dependencies = [
  "anyhow",
  "base64",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.127"
+version = "0.5.128"
 dependencies = [
  "anyhow",
  "base64",
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.127"
+version = "0.5.128"
 dependencies = [
  "anyhow",
  "base64",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.127"
+version = "0.5.128"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,7 +1664,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha1 0.11.0",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.127"
+version = "0.5.128"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ remove it. On a change the service recycles the pool's unclaimed warm
 containers onto the new policy, while containers already claimed by sandboxes
 keep the policy they booted with.
 
+Sandbox startup errors include the server's reason and actionable diagnostic.
+The Python and TypeScript `RemoteAPIError` exposes structured failure fields;
+the CLI shows the same details in create/copy errors and `tl sbx describe`.
+See [sandbox failure diagnostics](docs/sandbox-errors.md) for error handling examples.
+
 ---
 
 ## Cloud Volumes

--- a/crates/VENDORED_FROM
+++ b/crates/VENDORED_FROM
@@ -11,6 +11,9 @@ are swapped in EPHEMERALLY only for builds that enable the features needing them
               (ARTIFACT_STORAGE_APP_ID / _PRIVATE_KEY), sparse-checks-out the required sources,
               and swaps them over the placeholders for the job only
 
+Staging copies the complete src tree, including nested Rust modules and embedded assets.
+CI compares the staged tree with the private checkout before compiling.
+
 The swapped source compiles against the PLACEHOLDER manifests, so each placeholder Cargo.toml's
 dependency list must mirror the corresponding artifact_storage crate. If upstream dependencies
 change, update the placeholder manifest in the same companion change. Native filesystem SDK and

--- a/crates/cli/src/commands/sbx/copy.rs
+++ b/crates/cli/src/commands/sbx/copy.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
 use crate::auth::context::CliContext;
-use crate::commands::sbx::{parse_sandbox_path, sandbox_endpoint};
+use crate::commands::sbx::{format_failure_detail, parse_sandbox_path, sandbox_endpoint};
 use crate::error::{CliError, Result};
 
 const REQUEST_TIMEOUT_HEADER: &str = "X-Tensorlake-Request-Timeout-Ms";
@@ -21,6 +21,8 @@ struct CopiedSandbox {
     reason: Option<String>,
     #[serde(default)]
     termination_reason: Option<String>,
+    #[serde(default)]
+    error_details: Option<serde_json::Value>,
 }
 
 pub async fn run(
@@ -138,10 +140,12 @@ fn summarize_sandboxes(sandboxes: &[&CopiedSandbox]) -> String {
             let reason = sandbox
                 .reason
                 .as_deref()
-                .or(sandbox.termination_reason.as_deref())
-                .map(|reason| format!(": {reason}"))
+                .or(sandbox.termination_reason.as_deref());
+            let detail = format_failure_detail(reason, sandbox.error_details.as_ref())
+                .or_else(|| reason.map(str::to_string))
+                .map(|detail| format!(": {detail}"))
                 .unwrap_or_default();
-            format!("{} ({}){}", sandbox.sandbox_id, sandbox.status, reason)
+            format!("{} ({}){}", sandbox.sandbox_id, sandbox.status, detail)
         })
         .collect::<Vec<_>>()
         .join(", ")
@@ -168,12 +172,14 @@ mod tests {
                 status: "running".to_string(),
                 reason: None,
                 termination_reason: None,
+                error_details: None,
             },
             CopiedSandbox {
                 sandbox_id: "sbx-2".to_string(),
                 status: "running".to_string(),
                 reason: None,
                 termination_reason: None,
+                error_details: None,
             },
         ];
 

--- a/crates/cli/src/commands/sbx/copy.rs
+++ b/crates/cli/src/commands/sbx/copy.rs
@@ -1,7 +1,9 @@
 use serde::Deserialize;
 
 use crate::auth::context::CliContext;
-use crate::commands::sbx::{format_failure_detail, parse_sandbox_path, sandbox_endpoint};
+use crate::commands::sbx::{
+    SandboxFailureDetails, format_failure_detail, parse_sandbox_path, sandbox_endpoint,
+};
 use crate::error::{CliError, Result};
 
 const REQUEST_TIMEOUT_HEADER: &str = "X-Tensorlake-Request-Timeout-Ms";
@@ -17,12 +19,8 @@ struct CopiedSandbox {
     #[serde(alias = "id")]
     sandbox_id: String,
     status: String,
-    #[serde(default)]
-    reason: Option<String>,
-    #[serde(default)]
-    termination_reason: Option<String>,
-    #[serde(default)]
-    error_details: Option<serde_json::Value>,
+    #[serde(flatten)]
+    failure: SandboxFailureDetails,
 }
 
 pub async fn run(
@@ -138,10 +136,11 @@ fn summarize_sandboxes(sandboxes: &[&CopiedSandbox]) -> String {
         .iter()
         .map(|sandbox| {
             let reason = sandbox
+                .failure
                 .reason
                 .as_deref()
-                .or(sandbox.termination_reason.as_deref());
-            let detail = format_failure_detail(reason, sandbox.error_details.as_ref())
+                .or(sandbox.failure.termination_reason.as_deref());
+            let detail = format_failure_detail(reason, sandbox.failure.error_details.as_ref())
                 .or_else(|| reason.map(str::to_string))
                 .map(|detail| format!(": {detail}"))
                 .unwrap_or_default();
@@ -170,16 +169,12 @@ mod tests {
             CopiedSandbox {
                 sandbox_id: "sbx-1".to_string(),
                 status: "running".to_string(),
-                reason: None,
-                termination_reason: None,
-                error_details: None,
+                failure: SandboxFailureDetails::default(),
             },
             CopiedSandbox {
                 sandbox_id: "sbx-2".to_string(),
                 status: "running".to_string(),
-                reason: None,
-                termination_reason: None,
-                error_details: None,
+                failure: SandboxFailureDetails::default(),
             },
         ];
 

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -1,7 +1,7 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
     DEFAULT_SANDBOX_WAIT_TIMEOUT, apply_proxy_access_settings, build_network_config,
-    sandbox_endpoint, wait_for_sandbox_status,
+    sandbox_endpoint, sandbox_failure_detail, wait_for_sandbox_status,
 };
 use crate::error::{CliError, Result};
 use serde::Deserialize;
@@ -70,6 +70,15 @@ pub async fn create_with_request(
 }
 
 fn format_create_error(status: reqwest::StatusCode, body: &str) -> String {
+    if let Ok(payload) = serde_json::from_str::<serde_json::Value>(body)
+        && payload.get("status").and_then(|value| value.as_str()) == Some("failed")
+        && let Some(sandbox_id) = payload.get("sandbox_id").and_then(|value| value.as_str())
+    {
+        let detail = sandbox_failure_detail(&payload)
+            .map(|detail| format!(": {detail}"))
+            .unwrap_or_default();
+        return format!("failed to create sandbox {sandbox_id} (HTTP {status}){detail}");
+    }
     #[derive(Deserialize)]
     struct ServerError<'a> {
         #[serde(default)]

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -1,7 +1,7 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
-    DEFAULT_SANDBOX_WAIT_TIMEOUT, apply_proxy_access_settings, build_network_config,
-    sandbox_endpoint, sandbox_failure_detail, wait_for_sandbox_status,
+    DEFAULT_SANDBOX_WAIT_TIMEOUT, SandboxFailureDetails, apply_proxy_access_settings,
+    build_network_config, sandbox_endpoint, sandbox_failure_detail, wait_for_sandbox_status,
 };
 use crate::error::{CliError, Result};
 use serde::Deserialize;
@@ -70,29 +70,34 @@ pub async fn create_with_request(
 }
 
 fn format_create_error(status: reqwest::StatusCode, body: &str) -> String {
-    if let Ok(payload) = serde_json::from_str::<serde_json::Value>(body)
-        && payload.get("status").and_then(|value| value.as_str()) == Some("failed")
-        && let Some(sandbox_id) = payload.get("sandbox_id").and_then(|value| value.as_str())
-        && let Some(detail) = sandbox_failure_detail(&payload)
+    #[derive(Deserialize)]
+    struct SandboxCreateFailure {
+        sandbox_id: String,
+        status: String,
+        #[serde(flatten)]
+        failure: SandboxFailureDetails,
+    }
+
+    if let Ok(payload) = serde_json::from_str::<SandboxCreateFailure>(body)
+        && payload.status == "failed"
+        && let Some(detail) = sandbox_failure_detail(&payload.failure)
     {
+        let sandbox_id = payload.sandbox_id;
         return format!("failed to create sandbox {sandbox_id} (HTTP {status}): {detail}");
     }
     #[derive(Deserialize)]
-    struct ServerError<'a> {
-        #[serde(default)]
-        code: Option<&'a str>,
-        message: &'a str,
+    struct ServerError {
+        code: Option<String>,
+        message: String,
     }
 
-    if let Ok(error) = serde_json::from_str::<ServerError<'_>>(body)
-        && error.code == Some("GPU_REQUIRES_CAS_SNAPSHOT")
-    {
-        return format!(
-            "{}\n\nTo see compatible images, run `tl sbx image ls --cas`.",
-            error.message
-        );
-    }
-    if let Ok(error) = serde_json::from_str::<ServerError<'_>>(body) {
+    if let Ok(error) = serde_json::from_str::<ServerError>(body) {
+        if error.code.as_deref() == Some("GPU_REQUIRES_CAS_SNAPSHOT") {
+            return format!(
+                "{}\n\nTo see compatible images, run `tl sbx image ls --cas`.",
+                error.message
+            );
+        }
         return format!(
             "failed to create sandbox (HTTP {status}): {}",
             error.message
@@ -491,6 +496,33 @@ mod tests {
             ),
             "failed to create sandbox (HTTP 400 Bad Request): bad request"
         );
+    }
+
+    #[test]
+    fn server_error_decodes_escaped_messages() {
+        assert_eq!(
+            format_create_error(
+                reqwest::StatusCode::BAD_REQUEST,
+                r#"{"message":"Mount \"/tools\" is invalid.\nChoose another path."}"#,
+            ),
+            "failed to create sandbox (HTTP 400 Bad Request): Mount \"/tools\" is invalid.\nChoose another path."
+        );
+    }
+
+    #[test]
+    fn unrecognized_create_errors_keep_the_raw_body() {
+        for body in [
+            "upstream unavailable",
+            r#"{"diagnostic":"unrecognized response"}"#,
+            r#"{"sandbox_id":"sbx-1","status":"failed"}"#,
+            // A malformed known field must not be silently treated as a typed failure.
+            r#"{"sandbox_id":123,"status":"failed","reason":"ConfigurationError"}"#,
+        ] {
+            assert_eq!(
+                format_create_error(reqwest::StatusCode::BAD_GATEWAY, body),
+                format!("failed to create sandbox (HTTP 502 Bad Gateway): {body}")
+            );
+        }
     }
 
     #[test]

--- a/crates/cli/src/commands/sbx/create.rs
+++ b/crates/cli/src/commands/sbx/create.rs
@@ -73,11 +73,9 @@ fn format_create_error(status: reqwest::StatusCode, body: &str) -> String {
     if let Ok(payload) = serde_json::from_str::<serde_json::Value>(body)
         && payload.get("status").and_then(|value| value.as_str()) == Some("failed")
         && let Some(sandbox_id) = payload.get("sandbox_id").and_then(|value| value.as_str())
+        && let Some(detail) = sandbox_failure_detail(&payload)
     {
-        let detail = sandbox_failure_detail(&payload)
-            .map(|detail| format!(": {detail}"))
-            .unwrap_or_default();
-        return format!("failed to create sandbox {sandbox_id} (HTTP {status}){detail}");
+        return format!("failed to create sandbox {sandbox_id} (HTTP {status}): {detail}");
     }
     #[derive(Deserialize)]
     struct ServerError<'a> {

--- a/crates/cli/src/commands/sbx/describe.rs
+++ b/crates/cli/src/commands/sbx/describe.rs
@@ -1,6 +1,7 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
-    DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME, format_created_at, native_ssh, sandbox_endpoint,
+    DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME, error_details_message, format_created_at, native_ssh,
+    sandbox_endpoint,
 };
 use crate::error::{CliError, Result};
 
@@ -229,6 +230,9 @@ fn print_sandbox_details(item: &serde_json::Value) {
             .and_then(|v| v.as_str())
             .unwrap_or("");
         println!("Reason:          {}", reason);
+        if let Some(details) = item.get("error_details").and_then(error_details_message) {
+            println!("Error details:   {}", details);
+        }
 
         let outcome = item.get("outcome").and_then(|v| v.as_str()).unwrap_or("");
         println!("Outcome:         {}", outcome);
@@ -236,6 +240,11 @@ fn print_sandbox_details(item: &serde_json::Value) {
 }
 
 fn print_ssh_config_details(item: &serde_json::Value) -> Result<()> {
+    // Terminated sandboxes have no routable guest. Their diagnosis must remain
+    // inspectable even when the server has already removed sandbox_url.
+    if item.get("status").and_then(|value| value.as_str()) == Some("terminated") {
+        return Ok(());
+    }
     let id = item
         .get("sandbox_id")
         .or_else(|| item.get("id"))

--- a/crates/cli/src/commands/sbx/describe.rs
+++ b/crates/cli/src/commands/sbx/describe.rs
@@ -242,7 +242,11 @@ fn print_sandbox_details(item: &serde_json::Value) {
 fn print_ssh_config_details(item: &serde_json::Value) -> Result<()> {
     // Terminated sandboxes have no routable guest. Their diagnosis must remain
     // inspectable even when the server has already removed sandbox_url.
-    if item.get("status").and_then(|value| value.as_str()) == Some("terminated") {
+    if item
+        .get("status")
+        .and_then(|value| value.as_str())
+        .is_some_and(|status| status.eq_ignore_ascii_case("terminated"))
+    {
         return Ok(());
     }
     let id = item

--- a/crates/cli/src/commands/sbx/describe.rs
+++ b/crates/cli/src/commands/sbx/describe.rs
@@ -1,9 +1,50 @@
 use crate::auth::context::CliContext;
 use crate::commands::sbx::{
-    DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME, error_details_message, format_created_at, native_ssh,
-    sandbox_endpoint,
+    DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME, SandboxFailureDetails, SandboxTimestamp,
+    error_details_message, native_ssh, sandbox_endpoint,
 };
 use crate::error::{CliError, Result};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct SandboxDescription {
+    #[serde(alias = "id")]
+    sandbox_id: Option<String>,
+    name: Option<String>,
+    namespace: Option<String>,
+    status: Option<String>,
+    #[serde(flatten)]
+    failure: SandboxFailureDetails,
+    resources: Option<SandboxResources>,
+    #[serde(alias = "allow_unauthenticated_proxy_access")]
+    allow_unauthenticated_access: Option<bool>,
+    network: Option<SandboxNetwork>,
+    created_at: Option<SandboxTimestamp>,
+    terminated_at: Option<SandboxTimestamp>,
+    archived_at: Option<SandboxTimestamp>,
+    timeout_secs: Option<i64>,
+    #[serde(alias = "sandboxUrl")]
+    sandbox_url: Option<String>,
+    entrypoint: Option<Vec<String>>,
+    #[serde(alias = "exposedPorts")]
+    exposed_ports: Option<Vec<u64>>,
+    outcome: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SandboxResources {
+    cpus: Option<f64>,
+    memory_mb: Option<i64>,
+    disk_mb: Option<i64>,
+    ephemeral_disk_mb: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct SandboxNetwork {
+    allow_internet_access: Option<bool>,
+    allow_out: Option<Vec<String>>,
+    deny_out: Option<Vec<String>>,
+}
 
 pub async fn run(ctx: &CliContext, sandbox_id: &str) -> Result<()> {
     let client = ctx.client()?;
@@ -27,7 +68,7 @@ pub async fn run(ctx: &CliContext, sandbox_id: &str) -> Result<()> {
     }
 
     let item = resp
-        .json::<serde_json::Value>()
+        .json::<SandboxDescription>()
         .await
         .map_err(CliError::Http)?;
     print_sandbox_details(&item);
@@ -60,7 +101,7 @@ async fn run_archived(ctx: &CliContext, sandbox_id: &str) -> Result<()> {
     }
 
     let item = resp
-        .json::<serde_json::Value>()
+        .json::<SandboxDescription>()
         .await
         .map_err(CliError::Http)?;
     print_archived_sandbox_details(&item);
@@ -68,33 +109,27 @@ async fn run_archived(ctx: &CliContext, sandbox_id: &str) -> Result<()> {
     Ok(())
 }
 
-fn print_archived_sandbox_details(item: &serde_json::Value) {
+fn print_archived_sandbox_details(item: &SandboxDescription) {
     print_sandbox_details(item);
     let archived_at = item
-        .get("archived_at")
-        .filter(|v| !v.is_null())
-        .map(|v| format_created_at(Some(v)))
+        .archived_at
+        .as_ref()
+        .map(SandboxTimestamp::format)
         .unwrap_or_default();
     println!("Archived:        {}", archived_at);
 }
 
-fn print_sandbox_details(item: &serde_json::Value) {
-    let id = item
-        .get("sandbox_id")
-        .or_else(|| item.get("id"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("-");
-    let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
-    let status = item.get("status").and_then(|v| v.as_str()).unwrap_or("-");
+fn print_sandbox_details(item: &SandboxDescription) {
+    let id = item.sandbox_id.as_deref().unwrap_or("-");
+    let name = item.name.as_deref().unwrap_or("");
+    let status = item.status.as_deref().unwrap_or("-");
     let image = item
-        .get("image")
-        .and_then(|v| v.as_str())
+        .failure
+        .image
+        .as_deref()
         .filter(|s| !s.is_empty())
         .unwrap_or(DEFAULT_SANDBOX_IMAGE_DISPLAY_NAME);
-    let namespace = item
-        .get("namespace")
-        .and_then(|v| v.as_str())
-        .unwrap_or("-");
+    let namespace = item.namespace.as_deref().unwrap_or("-");
 
     println!("ID:              {}", id);
     println!("Name:            {}", name);
@@ -102,31 +137,24 @@ fn print_sandbox_details(item: &serde_json::Value) {
     println!("Status:          {}", status);
     println!("Image:           {}", image);
 
-    let resources = item.get("resources");
+    let resources = item.resources.as_ref();
     let cpus = resources
-        .and_then(|r| r.get("cpus"))
-        .and_then(|v| v.as_f64())
+        .and_then(|r| r.cpus)
         .map(|v| format!("{}", v))
         .unwrap_or_else(|| "-".to_string());
     let memory = resources
-        .and_then(|r| r.get("memory_mb"))
-        .and_then(|v| v.as_i64())
+        .and_then(|r| r.memory_mb)
         .map(|v| format!("{} MB", v))
         .unwrap_or_else(|| "-".to_string());
     let disk = resources
-        .and_then(|r| r.get("disk_mb").or_else(|| r.get("ephemeral_disk_mb")))
-        .and_then(|v| v.as_i64())
+        .and_then(|r| r.disk_mb.or(r.ephemeral_disk_mb))
         .map(|v| format!("{} MB", v))
         .unwrap_or_else(|| "-".to_string());
     println!("CPUs:            {}", cpus);
     println!("Memory:          {}", memory);
     println!("Disk:            {}", disk);
 
-    let allow_unauthenticated = item
-        .get("allow_unauthenticated_access")
-        .or_else(|| item.get("allow_unauthenticated_proxy_access"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let allow_unauthenticated = item.allow_unauthenticated_access.unwrap_or(false);
     println!(
         "Proxy auth:      {}",
         if allow_unauthenticated {
@@ -136,10 +164,9 @@ fn print_sandbox_details(item: &serde_json::Value) {
         }
     );
 
-    let network = item.get("network");
+    let network = item.network.as_ref();
     let internet = network
-        .and_then(|n| n.get("allow_internet_access"))
-        .and_then(|v| v.as_bool())
+        .and_then(|n| n.allow_internet_access)
         .unwrap_or(true);
     println!(
         "Internet:        {}",
@@ -148,44 +175,36 @@ fn print_sandbox_details(item: &serde_json::Value) {
 
     println!(
         "Created:         {}",
-        format_created_at(item.get("created_at"))
+        item.created_at
+            .as_ref()
+            .map(SandboxTimestamp::format)
+            .unwrap_or_else(|| "-".to_string())
     );
 
     // Optional fields
     let timeout = item
-        .get("timeout_secs")
-        .and_then(|v| v.as_i64())
+        .timeout_secs
         .map(|v| format!("{}s", v))
         .unwrap_or_default();
     println!("Timeout:         {}", timeout);
 
-    let sandbox_url = item
-        .get("sandbox_url")
-        .or_else(|| item.get("sandboxUrl"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let sandbox_url = item.sandbox_url.as_deref().unwrap_or("");
     println!("URL:             {}", sandbox_url);
 
     let entrypoint = item
-        .get("entrypoint")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str())
-                .collect::<Vec<_>>()
-                .join(" ")
-        })
+        .entrypoint
+        .as_ref()
+        .map(|args| args.join(" "))
         .unwrap_or_default();
     println!("Entrypoint:      {}", entrypoint);
 
     let ports = item
-        .get("exposed_ports")
-        .or_else(|| item.get("exposedPorts"))
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_u64())
-                .map(|p| p.to_string())
+        .exposed_ports
+        .as_ref()
+        .map(|ports| {
+            ports
+                .iter()
+                .map(|port| port.to_string())
                 .collect::<Vec<_>>()
                 .join(", ")
         })
@@ -193,73 +212,59 @@ fn print_sandbox_details(item: &serde_json::Value) {
     println!("Ports:           {}", ports);
 
     let allow_out = network
-        .and_then(|n| n.get("allow_out"))
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
-        })
+        .and_then(|n| n.allow_out.as_ref())
+        .map(|rules| rules.join(", "))
         .unwrap_or_default();
     println!("Allow out:       {}", allow_out);
 
     let deny_out = network
-        .and_then(|n| n.get("deny_out"))
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
-        })
+        .and_then(|n| n.deny_out.as_ref())
+        .map(|rules| rules.join(", "))
         .unwrap_or_default();
     println!("Deny out:        {}", deny_out);
 
     // Termination group — only shown for terminated sandboxes
     if status.eq_ignore_ascii_case("terminated") {
         let terminated_at = item
-            .get("terminated_at")
-            .filter(|v| !v.is_null())
-            .map(|v| format_created_at(Some(v)))
+            .terminated_at
+            .as_ref()
+            .map(SandboxTimestamp::format)
             .unwrap_or_default();
         println!("Terminated:      {}", terminated_at);
 
-        let reason = item
-            .get("termination_reason")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let reason = item.failure.termination_reason.as_deref().unwrap_or("");
         println!("Reason:          {}", reason);
-        if let Some(details) = item.get("error_details").and_then(error_details_message) {
+        if let Some(details) = item
+            .failure
+            .error_details
+            .as_ref()
+            .and_then(error_details_message)
+        {
             println!("Error details:   {}", details);
         }
 
-        let outcome = item.get("outcome").and_then(|v| v.as_str()).unwrap_or("");
+        let outcome = item.outcome.as_deref().unwrap_or("");
         println!("Outcome:         {}", outcome);
     }
 }
 
-fn print_ssh_config_details(item: &serde_json::Value) -> Result<()> {
+fn print_ssh_config_details(item: &SandboxDescription) -> Result<()> {
     // Terminated sandboxes have no routable guest. Their diagnosis must remain
     // inspectable even when the server has already removed sandbox_url.
     if item
-        .get("status")
-        .and_then(|value| value.as_str())
+        .status
+        .as_deref()
         .is_some_and(|status| status.eq_ignore_ascii_case("terminated"))
     {
         return Ok(());
     }
     let id = item
-        .get("sandbox_id")
-        .or_else(|| item.get("id"))
-        .and_then(|v| v.as_str())
+        .sandbox_id
+        .as_deref()
         .filter(|value| !value.is_empty())
         .unwrap_or("-");
-    let name = item.get("name").and_then(|v| v.as_str());
-    let sandbox_url = item
-        .get("sandbox_url")
-        .or_else(|| item.get("sandboxUrl"))
-        .and_then(|v| v.as_str());
+    let name = item.name.as_deref();
+    let sandbox_url = item.sandbox_url.as_deref();
     let sandbox = native_ssh::ResolvedSandbox::with_sandbox_url(id, name, sandbox_url)?;
     let config = native_ssh::format_ssh_config(&sandbox, None, None)?;
 

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -320,7 +320,8 @@ fn is_localhost(url: &str) -> bool {
 fn sandbox_termination_detail(info: &serde_json::Value) -> Option<String> {
     let reason = info
         .get("termination_reason")
-        .and_then(|value| value.as_str())?;
+        .and_then(|value| value.as_str())
+        .or_else(|| info.get("reason").and_then(|value| value.as_str()))?;
     match reason {
         "ImageNotFound" => Some(
             info.get("image")
@@ -363,10 +364,25 @@ fn error_details_message(value: &serde_json::Value) -> Option<String> {
     }
 }
 
+fn format_failure_detail(
+    reason: Option<&str>,
+    error_details: Option<&serde_json::Value>,
+) -> Option<String> {
+    let detail = error_details.and_then(error_details_message)?;
+    Some(match reason.filter(|reason| !reason.is_empty()) {
+        Some(reason) => format!("{reason}: {detail}"),
+        None => detail,
+    })
+}
+
 fn sandbox_failure_detail(info: &serde_json::Value) -> Option<String> {
-    info.get("error_details")
-        .and_then(error_details_message)
-        .or_else(|| sandbox_termination_detail(info))
+    format_failure_detail(
+        info.get("termination_reason")
+            .and_then(|value| value.as_str())
+            .or_else(|| info.get("reason").and_then(|value| value.as_str())),
+        info.get("error_details"),
+    )
+    .or_else(|| sandbox_termination_detail(info))
 }
 
 fn format_sandbox_wait_termination_message(
@@ -671,7 +687,7 @@ mod tests {
 
         assert_eq!(
             message,
-            "Sandbox failed to reach 'running': failed to pull image tensorlake/missing-image"
+            "Sandbox failed to reach 'running': StartupFailedInternalError: failed to pull image tensorlake/missing-image"
         );
     }
 }

--- a/crates/cli/src/commands/sbx/mod.rs
+++ b/crates/cli/src/commands/sbx/mod.rs
@@ -25,11 +25,47 @@ pub mod update;
 use crate::auth::context::CliContext;
 use crate::error::{CliError, Result};
 use chrono::{DateTime, Local, TimeZone, Utc};
+use serde::Deserialize;
 use tensorlake::sandboxes::{
     models::NetworkConfig, resolve_default_sandbox_proxy_url,
     resolve_sandbox_proxy_target as resolve_core_proxy_target, select_sandbox_proxy_url,
 };
 use tokio::time::{Duration, Instant};
+
+#[derive(Debug, Default, Deserialize)]
+struct SandboxFailureDetails {
+    reason: Option<String>,
+    termination_reason: Option<String>,
+    image: Option<String>,
+    // The API permits arbitrary JSON here, including legacy objects and lists.
+    error_details: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct SandboxStatusResponse {
+    status: String,
+    #[serde(flatten)]
+    failure: SandboxFailureDetails,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SandboxTimestamp {
+    Rfc3339(String),
+    Numeric(f64),
+}
+
+impl SandboxTimestamp {
+    fn format(&self) -> String {
+        let timestamp = match self {
+            Self::Rfc3339(timestamp) => DateTime::parse_from_rfc3339(timestamp)
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc)),
+            Self::Numeric(timestamp) => parse_numeric_timestamp(*timestamp),
+        };
+        format_timestamp(timestamp)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedSandboxProxyTarget {
@@ -159,12 +195,8 @@ pub async fn wait_for_sandbox_status(
             .map_err(CliError::Http)?;
 
         if info_resp.status().is_success() {
-            let info: serde_json::Value = info_resp.json().await.map_err(CliError::Http)?;
-            let current_status = info
-                .get("status")
-                .and_then(|value| value.as_str())
-                .unwrap_or("")
-                .to_string();
+            let info: SandboxStatusResponse = info_resp.json().await.map_err(CliError::Http)?;
+            let current_status = info.status;
 
             if current_status == target_status {
                 if let Some(ref s) = spinner {
@@ -177,8 +209,11 @@ pub async fn wait_for_sandbox_status(
                 if let Some(ref s) = spinner {
                     s.finish_and_clear();
                 }
-                let message =
-                    format_sandbox_wait_termination_message("Sandbox", target_status, &info);
+                let message = format_sandbox_wait_termination_message(
+                    "Sandbox",
+                    target_status,
+                    &info.failure,
+                );
                 return Err(CliError::Other(anyhow::anyhow!(message)));
             }
         }
@@ -317,15 +352,15 @@ fn is_localhost(url: &str) -> bool {
     false
 }
 
-fn sandbox_termination_detail(info: &serde_json::Value) -> Option<String> {
+fn sandbox_termination_detail(info: &SandboxFailureDetails) -> Option<String> {
     let reason = info
-        .get("termination_reason")
-        .and_then(|value| value.as_str())
-        .or_else(|| info.get("reason").and_then(|value| value.as_str()))?;
+        .termination_reason
+        .as_deref()
+        .or(info.reason.as_deref())?;
     match reason {
         "ImageNotFound" => Some(
-            info.get("image")
-                .and_then(|value| value.as_str())
+            info.image
+                .as_deref()
                 .filter(|image| !image.is_empty())
                 .map(|image| format!("image not found: {image}"))
                 .unwrap_or_else(|| "image not found".to_string()),
@@ -375,12 +410,12 @@ fn format_failure_detail(
     })
 }
 
-fn sandbox_failure_detail(info: &serde_json::Value) -> Option<String> {
+fn sandbox_failure_detail(info: &SandboxFailureDetails) -> Option<String> {
     format_failure_detail(
-        info.get("termination_reason")
-            .and_then(|value| value.as_str())
-            .or_else(|| info.get("reason").and_then(|value| value.as_str())),
-        info.get("error_details"),
+        info.termination_reason
+            .as_deref()
+            .or(info.reason.as_deref()),
+        info.error_details.as_ref(),
     )
     .or_else(|| sandbox_termination_detail(info))
 }
@@ -388,7 +423,7 @@ fn sandbox_failure_detail(info: &serde_json::Value) -> Option<String> {
 fn format_sandbox_wait_termination_message(
     subject: &str,
     target_status: &str,
-    info: &serde_json::Value,
+    info: &SandboxFailureDetails,
 ) -> String {
     if let Some(detail) = sandbox_failure_detail(info) {
         format!("{subject} failed to reach '{target_status}': {detail}")
@@ -518,7 +553,11 @@ mod network_config_tests {
 }
 
 pub fn format_created_at(value: Option<&serde_json::Value>) -> String {
-    let Some(timestamp) = created_at_sort_key(value) else {
+    format_timestamp(created_at_sort_key(value))
+}
+
+fn format_timestamp(timestamp: Option<DateTime<Utc>>) -> String {
+    let Some(timestamp) = timestamp else {
         return "-".to_string();
     };
 
@@ -580,8 +619,8 @@ fn parse_numeric_timestamp(timestamp: f64) -> Option<DateTime<Utc>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        error_details_message, format_created_at, format_sandbox_wait_termination_message,
-        sandbox_termination_detail,
+        SandboxFailureDetails, error_details_message, format_created_at,
+        format_sandbox_wait_termination_message, sandbox_termination_detail,
     };
     use chrono::{Duration, Utc};
 
@@ -605,10 +644,11 @@ mod tests {
 
     #[test]
     fn sandbox_termination_detail_formats_image_not_found() {
-        let info = serde_json::json!({
-            "termination_reason": "ImageNotFound",
-            "image": "foo",
-        });
+        let info = SandboxFailureDetails {
+            termination_reason: Some("ImageNotFound".to_string()),
+            image: Some("foo".to_string()),
+            ..Default::default()
+        };
 
         let detail = sandbox_termination_detail(&info);
 
@@ -617,10 +657,11 @@ mod tests {
 
     #[test]
     fn sandbox_wait_termination_message_includes_image_not_found_detail() {
-        let info = serde_json::json!({
-            "termination_reason": "ImageNotFound",
-            "image": "foo",
-        });
+        let info = SandboxFailureDetails {
+            termination_reason: Some("ImageNotFound".to_string()),
+            image: Some("foo".to_string()),
+            ..Default::default()
+        };
 
         let message = format_sandbox_wait_termination_message("Sandbox", "running", &info);
 
@@ -632,9 +673,7 @@ mod tests {
 
     #[test]
     fn sandbox_wait_termination_message_falls_back_without_reason() {
-        let info = serde_json::json!({
-            "status": "terminated",
-        });
+        let info = SandboxFailureDetails::default();
 
         let message = format_sandbox_wait_termination_message("Sandbox", "running", &info);
 
@@ -646,9 +685,10 @@ mod tests {
 
     #[test]
     fn sandbox_wait_termination_message_includes_generic_reason() {
-        let info = serde_json::json!({
-            "termination_reason": "StartupFailedInternalError",
-        });
+        let info = SandboxFailureDetails {
+            termination_reason: Some("StartupFailedInternalError".to_string()),
+            ..Default::default()
+        };
 
         let message = format_sandbox_wait_termination_message("Sandbox", "running", &info);
 
@@ -675,13 +715,13 @@ mod tests {
 
     #[test]
     fn sandbox_wait_termination_message_prefers_error_details() {
-        let info = serde_json::json!({
-            "status": "terminated",
-            "termination_reason": "StartupFailedInternalError",
-            "error_details": {
+        let info = SandboxFailureDetails {
+            termination_reason: Some("StartupFailedInternalError".to_string()),
+            error_details: Some(serde_json::json!({
                 "message": "failed to pull image tensorlake/missing-image",
-            },
-        });
+            })),
+            ..Default::default()
+        };
 
         let message = format_sandbox_wait_termination_message("Sandbox", "running", &info);
 

--- a/crates/cli/tests/sandbox_diagnostics.rs
+++ b/crates/cli/tests/sandbox_diagnostics.rs
@@ -49,6 +49,7 @@ async fn run_cli(args: &[&str], responses: Vec<(u16, Value)>) -> std::process::O
             .current_dir(temp.path())
             .env_remove("TENSORLAKE_GIT_TOKEN")
             .env("NO_COLOR", "1")
+            .env("TZ", "UTC")
             .kill_on_drop(true)
             .output().await.unwrap();
         server.await.unwrap();
@@ -131,4 +132,114 @@ async fn describe_prints_live_and_archived_diagnostics() {
             "{stdout}"
         );
     }
+}
+
+#[tokio::test]
+async fn create_wait_reports_a_typed_termination_with_legacy_details() {
+    let output = run_cli(
+        &["create"],
+        vec![
+            (
+                200,
+                json!({"sandbox_id": "sbx-config", "status": "pending"}),
+            ),
+            (
+                200,
+                json!({
+                    "sandbox_id": "sbx-config", "status": "terminated",
+                    "termination_reason": "ConfigurationError",
+                    "error_details": [{"message": DIAGNOSIS}, "Rebuild the snapshot."],
+                    "future_field": {"ignored": true},
+                }),
+            ),
+        ],
+    )
+    .await;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains(&format!("Sandbox failed to reach 'running': ConfigurationError: {DIAGNOSIS}; Rebuild the snapshot.")),
+        "{stderr}"
+    );
+}
+
+#[tokio::test]
+async fn describe_preserves_legacy_fields_and_timestamp_formats() {
+    for created_at in [
+        json!("2020-01-02T12:00:00Z"),
+        json!(1577966400),
+        json!(1577966400000_u64),
+        json!(1577966400000000_u64),
+    ] {
+        let output = run_cli(
+            &["describe", "sbx-legacy"],
+            vec![(200, json!({
+                "id": "sbx-legacy", "status": "terminated", "image": "example-image",
+                "namespace": "example-namespace", "name": "example-name",
+                "resources": {"cpus": 0.5, "memory_mb": 1024, "ephemeral_disk_mb": 2048},
+                "allow_unauthenticated_proxy_access": true,
+                "network": {"allow_internet_access": false, "allow_out": ["allowed.example"], "deny_out": ["denied.example"]},
+                "created_at": created_at, "terminated_at": null,
+                "timeout_secs": 120, "sandboxUrl": "https://sbx-legacy.example.com",
+                "entrypoint": ["/bin/sh", "-l"], "exposedPorts": [8080, 9090],
+                "termination_reason": "FutureReason",
+                "error_details": {"message": DIAGNOSIS, "phase": "mount"},
+                "outcome": "failure", "future_field": {"ignored": true},
+            }))],
+        ).await;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "{stdout}\n{stderr}");
+        for line in [
+            "ID:              sbx-legacy",
+            "Name:            example-name",
+            "Namespace:       example-namespace",
+            "Image:           example-image",
+            "CPUs:            0.5",
+            "Memory:          1024 MB",
+            "Disk:            2048 MB",
+            "Proxy auth:      unauthenticated",
+            "Internet:        blocked",
+            "Created:         2020-01-02",
+            "Timeout:         120s",
+            "URL:             https://sbx-legacy.example.com",
+            "Entrypoint:      /bin/sh -l",
+            "Ports:           8080, 9090",
+            "Allow out:       allowed.example",
+            "Deny out:        denied.example",
+            "Reason:          FutureReason",
+            "Outcome:         failure",
+        ] {
+            assert!(stdout.contains(line), "Missing {line:?}: {stdout}");
+        }
+        assert!(
+            stdout.contains(&format!("Error details:   {DIAGNOSIS}")),
+            "{stdout}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn describe_running_sandbox_still_prints_ssh_config() {
+    let output = run_cli(
+        &["describe", "sbx-running"],
+        vec![(
+            200,
+            json!({
+                "sandbox_id": "sbx-running", "status": "running",
+                "sandbox_url": "https://sbx-running.example.com",
+            }),
+        )],
+    )
+    .await;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stdout}\n{stderr}");
+    assert!(stdout.contains("SSH Config:"), "{stdout}");
+    assert!(
+        stdout.contains("HostName sbx-running.example.com"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("User sbx-running"), "{stdout}");
+    assert!(!stdout.contains("Error details:"), "{stdout}");
 }

--- a/crates/cli/tests/sandbox_diagnostics.rs
+++ b/crates/cli/tests/sandbox_diagnostics.rs
@@ -62,16 +62,26 @@ async fn create_and_copy_print_the_reason_and_diagnostic() {
         "sandbox_id": "sbx-config", "status": "failed",
         "reason": "ConfigurationError", "error_details": DIAGNOSIS,
     });
-    for (args, body) in [
-        (vec!["create"], failure.clone()),
+    for (args, status, body) in [
+        (vec!["create"], 422, failure.clone()),
         (
             vec!["copy", "sbx-source"],
+            422,
             json!({
-                "source_sandbox_id": "sbx-source", "sandboxes": [failure],
+                "source_sandbox_id": "sbx-source", "sandboxes": [failure.clone()],
+            }),
+        ),
+        (
+            vec!["copy", "sbx-source"],
+            207,
+            json!({
+                "source_sandbox_id": "sbx-source", "sandboxes": [
+                    {"sandbox_id": "sbx-running", "status": "running"}, failure,
+                ],
             }),
         ),
     ] {
-        let output = run_cli(&args, vec![(422, body)]).await;
+        let output = run_cli(&args, vec![(status, body)]).await;
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(!output.status.success(), "{stderr}");
         assert!(stderr.contains("sbx-config"), "{stderr}");
@@ -79,6 +89,23 @@ async fn create_and_copy_print_the_reason_and_diagnostic() {
         assert!(stderr.contains(DIAGNOSIS), "{stderr}");
         assert!(!stderr.contains("error_details"), "{stderr}");
     }
+}
+
+#[tokio::test]
+async fn legacy_create_errors_keep_their_diagnosis() {
+    let output = run_cli(
+        &["create"],
+        vec![(
+            422,
+            json!({
+                "sandbox_id": "sbx-legacy", "status": "failed", "message": "legacy diagnosis",
+            }),
+        )],
+    )
+    .await;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "{stderr}");
+    assert!(stderr.contains("legacy diagnosis"), "{stderr}");
 }
 
 #[tokio::test]

--- a/crates/cli/tests/sandbox_diagnostics.rs
+++ b/crates/cli/tests/sandbox_diagnostics.rs
@@ -1,0 +1,107 @@
+use serde_json::{Value, json};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    process::Command,
+    time::{Duration, timeout},
+};
+
+const DIAGNOSIS: &str = "Cannot mount /tools: overlaps the registered mount /tools. Remove the conflicting registration.";
+
+async fn run_cli(args: &[&str], responses: Vec<(u16, Value)>) -> std::process::Output {
+    timeout(Duration::from_secs(20), async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            // API key introspection precedes the sandbox request.
+            let responses = std::iter::once((200, json!({
+                "organizationId": "org-test", "projectId": "project-test",
+            }))).chain(responses);
+            for (status, body) in responses {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = Vec::new();
+                let mut byte = [0];
+                while !request.ends_with(b"\r\n\r\n") {
+                    assert!(request.len() < 65536, "bounded request headers");
+                    stream.read_exact(&mut byte).await.unwrap();
+                    request.push(byte[0]);
+                }
+                let headers = String::from_utf8(request).unwrap();
+                let length = headers.lines().find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().unwrap())
+                }).unwrap_or(0);
+                assert!(length < 65536, "bounded request body");
+                stream.read_exact(&mut vec![0; length]).await.unwrap();
+                let body = body.to_string();
+                let response = format!(
+                    "HTTP/1.1 {status} Test\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        let temp = tempfile::tempdir().unwrap();
+        let output = Command::new(env!("CARGO_BIN_EXE_tl"))
+            .args(["--api-url", &format!("http://{address}"), "--api-key", "test-key", "sbx"])
+            .args(args)
+            .current_dir(temp.path())
+            .env_remove("TENSORLAKE_GIT_TOKEN")
+            .env("NO_COLOR", "1")
+            .kill_on_drop(true)
+            .output().await.unwrap();
+        server.await.unwrap();
+        output
+    }).await.expect("CLI and fixture must finish within 20 seconds")
+}
+
+#[tokio::test]
+async fn create_and_copy_print_the_reason_and_diagnostic() {
+    let failure = json!({
+        "sandbox_id": "sbx-config", "status": "failed",
+        "reason": "ConfigurationError", "error_details": DIAGNOSIS,
+    });
+    for (args, body) in [
+        (vec!["create"], failure.clone()),
+        (
+            vec!["copy", "sbx-source"],
+            json!({
+                "source_sandbox_id": "sbx-source", "sandboxes": [failure],
+            }),
+        ),
+    ] {
+        let output = run_cli(&args, vec![(422, body)]).await;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "{stderr}");
+        assert!(stderr.contains("sbx-config"), "{stderr}");
+        assert!(stderr.contains("ConfigurationError"), "{stderr}");
+        assert!(stderr.contains(DIAGNOSIS), "{stderr}");
+        assert!(!stderr.contains("error_details"), "{stderr}");
+    }
+}
+
+#[tokio::test]
+async fn describe_prints_live_and_archived_diagnostics() {
+    let sandbox = json!({
+        "id": "sbx-config", "status": "terminated",
+        "termination_reason": "ConfigurationError", "error_details": DIAGNOSIS,
+    });
+    for responses in [
+        vec![(200, sandbox.clone())],
+        vec![(404, json!({})), (200, sandbox)],
+    ] {
+        let output = run_cli(&["describe", "sbx-config"], responses).await;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "{stdout}\n{stderr}");
+        assert!(
+            stdout.contains("Reason:          ConfigurationError"),
+            "{stdout}"
+        );
+        assert!(
+            stdout.contains(&format!("Error details:   {DIAGNOSIS}")),
+            "{stdout}"
+        );
+    }
+}

--- a/crates/gsvc-codec/Cargo.toml
+++ b/crates/gsvc-codec/Cargo.toml
@@ -35,7 +35,8 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 bytes = "1"
 sha1 = "0.11"
-sha2 = "0.10"
+# Both hash crates must use the same Digest trait generation, as in artifact_storage.
+sha2 = "0.11"
 # zlib-rs matches artifact_storage's flate2 backend choice, which the real codec is tested
 # against; the default miniz_oxide backend has produced a divergent test result.
 flate2 = { version = "1.1.9", features = ["zlib-rs"] }

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.127"
+version = "0.5.128"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.127"
+version = "0.5.128"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/docs/sandbox-errors.md
+++ b/docs/sandbox-errors.md
@@ -1,0 +1,68 @@
+# Sandbox failure diagnostics
+
+Sandbox failures carry a server reason and, when available, an actionable
+diagnostic. `ConfigurationError` means the server identified an invalid sandbox
+configuration, such as a conflicting filesystem mount or a root disk smaller
+than the captured filesystem. Internal and unknown failures retain their own
+reasons; clients do not infer responsibility from diagnostic text.
+
+Blocking create and claim failures raise the existing `RemoteAPIError`. The
+exception's text includes the sandbox ID, reason, and diagnostic. The exception
+also exposes those fields for programmatic use:
+
+```python
+from tensorlake.sandbox import RemoteAPIError, SandboxClient
+
+client = SandboxClient.for_cloud()
+try:
+    sandbox = client.create_and_connect(image="my-image")
+except RemoteAPIError as error:
+    print(str(error))
+    if error.reason == "ConfigurationError":
+        print(error.sandbox_id, error.error_details)
+    raise
+```
+
+The same fields are available with `AsyncSandboxClient`.
+
+```typescript
+import { RemoteAPIError, SandboxClient } from "tensorlake";
+
+const client = SandboxClient.forCloud();
+try {
+  await client.createAndConnect({ image: "my-image" });
+} catch (error) {
+  if (error instanceof RemoteAPIError) {
+    console.error(error.message);
+    if (error.reason === "ConfigurationError") {
+      console.error(error.sandboxId, error.errorDetails);
+    }
+  }
+  throw error;
+}
+```
+
+The original response body remains available as Python `error.message` or
+TypeScript `error.responseMessage`; the HTTP status remains `status_code` or
+`statusCode`. The new fields are absent (`None` in Python) for unrelated API
+errors. Reasons are strings so future server reasons remain readable. Older
+servers that omit diagnostics still produce a useful reason or their original
+error message. Diagnostic values may be strings or legacy JSON objects/arrays.
+
+When a create operation returns a pending sandbox, the readiness helper includes
+the eventual termination reason and diagnostic in its `SandboxError`. To inspect
+a sandbox directly, use `client.get(...)`: the returned object has
+`termination_reason` and `error_details` in Python, or `terminationReason` and
+`errorDetails` in TypeScript. Copy operations can return partial failures; inspect
+each entry's `status`, `reason`, and diagnostic in the returned `sandboxes` list.
+
+`tl sbx create` and `tl sbx copy` print the reason and diagnostic on failure.
+`tl sbx describe <id>` shows an **Error details** line for terminated sandboxes,
+including archived sandboxes. Diagnoses remain available when the terminated
+sandbox no longer has an SSH endpoint.
+
+These clients display the information supplied by the server. Detailed
+configuration diagnoses require the server/dataplane changes in
+[compute-engine-internal #2040](https://github.com/tensorlakeai/compute-engine-internal/pull/2040)
+to be deployed. Updating the client alone does not add details to historic
+failures.

--- a/justfile
+++ b/justfile
@@ -92,9 +92,10 @@ build-cli-full *ARGS:
     trap restore EXIT
     # Swap in the real sources, keeping the placeholders' tensorlake-adapted Cargo.tomls.
     for crate in gsvc-mount gsvc-codec gsvc-fs-client; do
-        rm -f "crates/$crate/src"/*.rs
+        rm -rf "crates/$crate/src"
+        mkdir -p "crates/$crate/src"
         echo "swapping crates/$crate/src with $artifact_storage/crates/$crate/src"
-        cp "$artifact_storage/crates/$crate/src"/*.rs "crates/$crate/src"/
+        cp -R "$artifact_storage/crates/$crate/src"/. "crates/$crate/src"/
     done
     # macOS-only tests compile a source-level wire/coherence contract against the private FSKit
     # bridge. Sources and resources are staged with the Rust crates and removed by the trap. The
@@ -130,8 +131,9 @@ build-tlfs-mount-daemon *ARGS:
     }
     trap restore EXIT
     for crate in gsvc-mount gsvc-fs-client; do
-        rm -f "crates/$crate/src"/*.rs
-        cp "$artifact_storage/crates/$crate/src"/*.rs "crates/$crate/src"/
+        rm -rf "crates/$crate/src"
+        mkdir -p "crates/$crate/src"
+        cp -R "$artifact_storage/crates/$crate/src"/. "crates/$crate/src"/
     done
     cargo build --manifest-path crates/gsvc-fs-client/Cargo.toml \
         --bin tlfs-mount-daemon {{ARGS}}
@@ -210,8 +212,9 @@ test-cli-full *ARGS:
     }
     trap restore EXIT
     for crate in gsvc-mount gsvc-codec gsvc-fs-client; do
-        rm -f "crates/$crate/src"/*.rs
-        cp "$artifact_storage/crates/$crate/src"/*.rs "crates/$crate/src"/
+        rm -rf "crates/$crate/src"
+        mkdir -p "crates/$crate/src"
+        cp -R "$artifact_storage/crates/$crate/src"/. "crates/$crate/src"/
     done
     if [ "$stage_macos_tlfs" = true ]; then
         rm -rf "platform/macos/tlfs/Sources" "platform/macos/tlfs/Resources"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.127"
+version = "0.5.128"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/async_client.py
+++ b/src/tensorlake/sandbox/async_client.py
@@ -1059,13 +1059,17 @@ class AsyncSandboxClient:
                 name=result.name or requested_name,
             )
             return sandbox
-        if result.status in (SandboxStatus.SUSPENDED, SandboxStatus.TERMINATED):
+        if result.status in (
+            SandboxStatus.SUSPENDED,
+            SandboxStatus.TERMINATED,
+            SandboxStatus.FAILED,
+        ):
             raise SandboxError(
                 _startup_failure_message(
                     result.sandbox_id,
                     result.status,
                     error_details=result.error_details,
-                    termination_reason=result.termination_reason,
+                    termination_reason=result.termination_reason or result.reason,
                 )
             )
         if result.status == SandboxStatus.TIMEOUT:

--- a/src/tensorlake/sandbox/client.py
+++ b/src/tensorlake/sandbox/client.py
@@ -20,6 +20,7 @@ from .exceptions import (
     SandboxError,
     SandboxNotFoundError,
     SandboxNotRoutableError,
+    _format_error_details,
 )
 from .models import (
     CLEAR_NETWORK_POLICY,
@@ -206,32 +207,6 @@ def _normalize_user_ports(ports: list[int]) -> list[int]:
     return sorted(normalized)
 
 
-def _format_error_details(error_details: object | None) -> str | None:
-    if error_details is None:
-        return None
-    if isinstance(error_details, str):
-        detail = error_details.strip()
-        return detail or None
-    if isinstance(error_details, dict):
-        for key in ("message", "detail", "error", "reason"):
-            value = error_details.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-        if error_details:
-            return json.dumps(error_details, sort_keys=True)
-        return None
-    if isinstance(error_details, list):
-        parts = [
-            formatted
-            for item in error_details
-            if (formatted := _format_error_details(item)) is not None
-        ]
-        if parts:
-            return "; ".join(parts)
-        return json.dumps(error_details)
-    return str(error_details)
-
-
 def _startup_failure_message(
     sandbox_id: str,
     status: SandboxStatus | str,
@@ -245,11 +220,11 @@ def _startup_failure_message(
         if status_value == SandboxStatus.TERMINATED.value
         else f"Sandbox {sandbox_id} became {status_value} during startup"
     )
+    if termination_reason:
+        prefix += f" ({termination_reason})"
     detail = _format_error_details(error_details)
     if detail:
         return f"{prefix}: {detail}"
-    if termination_reason:
-        return f"{prefix}: termination reason: {termination_reason}"
     return prefix
 
 
@@ -1711,13 +1686,17 @@ class SandboxClient:
                 name=result.name or requested_name,
             )
             return sandbox
-        if result.status in (SandboxStatus.SUSPENDED, SandboxStatus.TERMINATED):
+        if result.status in (
+            SandboxStatus.SUSPENDED,
+            SandboxStatus.TERMINATED,
+            SandboxStatus.FAILED,
+        ):
             raise SandboxError(
                 _startup_failure_message(
                     result.sandbox_id,
                     result.status,
                     error_details=result.error_details,
-                    termination_reason=result.termination_reason,
+                    termination_reason=result.termination_reason or result.reason,
                 )
             )
         if result.status == SandboxStatus.TIMEOUT:

--- a/src/tensorlake/sandbox/exceptions.py
+++ b/src/tensorlake/sandbox/exceptions.py
@@ -154,6 +154,8 @@ class RemoteAPIError(SandboxError):
             detail = _format_error_details(self._error_details)
             if detail:
                 display_message += f": {detail}"
+            if not self._reason and not detail:
+                display_message = message
         super().__init__(f"API error (status {status_code}): {display_message}")
 
     @property

--- a/src/tensorlake/sandbox/exceptions.py
+++ b/src/tensorlake/sandbox/exceptions.py
@@ -1,5 +1,6 @@
 """Exception hierarchy for sandbox operations."""
 
+import json
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -96,13 +97,79 @@ class PoolInUseError(SandboxError):
         return self._pool_id
 
 
+def _format_error_details(error_details: object | None) -> str | None:
+    if error_details is None:
+        return None
+    if isinstance(error_details, str):
+        detail = error_details.strip()
+        return detail or None
+    if isinstance(error_details, dict):
+        for key in ("message", "detail", "error", "reason"):
+            value = error_details.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        if error_details:
+            return json.dumps(error_details, sort_keys=True)
+        return None
+    if isinstance(error_details, list):
+        parts = [
+            formatted
+            for item in error_details
+            if (formatted := _format_error_details(item)) is not None
+        ]
+        if parts:
+            return "; ".join(parts)
+        return json.dumps(error_details)
+    return str(error_details)
+
+
 class RemoteAPIError(SandboxError):
     """Raised when the remote API returns an error."""
 
     def __init__(self, status_code: int, message: str):
         self._status_code = status_code
         self._message = message
-        super().__init__(f"API error (status {status_code}): {message}")
+        self._sandbox_id: str | None = None
+        self._reason: str | None = None
+        self._error_details: object | None = None
+        display_message = message
+        try:
+            payload = json.loads(message)
+        except (ValueError, TypeError):
+            payload = None
+        # Only interpret sandbox lifecycle responses. Keep other API errors intact.
+        if (
+            isinstance(payload, dict)
+            and isinstance(payload.get("sandbox_id"), str)
+            and payload["sandbox_id"].strip()
+            and payload.get("status") in ("failed", "terminated")
+        ):
+            self._sandbox_id = payload["sandbox_id"]
+            reason = payload.get("reason") or payload.get("termination_reason")
+            self._reason = reason if isinstance(reason, str) else None
+            self._error_details = payload.get("error_details")
+            display_message = f"Sandbox {self._sandbox_id} {payload['status']}"
+            if self._reason:
+                display_message += f" ({self._reason})"
+            detail = _format_error_details(self._error_details)
+            if detail:
+                display_message += f": {detail}"
+        super().__init__(f"API error (status {status_code}): {display_message}")
+
+    @property
+    def sandbox_id(self) -> str | None:
+        """Sandbox that failed, when this is a sandbox lifecycle response."""
+        return self._sandbox_id
+
+    @property
+    def reason(self) -> str | None:
+        """Server reason, such as ConfigurationError; unknown reasons are preserved."""
+        return self._reason
+
+    @property
+    def error_details(self) -> object | None:
+        """Original diagnostic supplied by the server, without text parsing."""
+        return self._error_details
 
     @property
     def status_code(self) -> int:

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -85,6 +85,8 @@ class SandboxStatus(str, Enum):
     SUSPENDED = "suspended"
     TERMINATED = "terminated"
     TIMEOUT = "timeout"
+    # Terminal status used by blocking create/claim responses.
+    FAILED = "failed"
 
 
 class SnapshotStatus(str, Enum):

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -109,7 +109,8 @@ class _FakeRustClient:
                         {
                             "sandbox_id": "copy-2",
                             "status": "failed",
-                            "reason": "no capacity",
+                            "reason": "ConfigurationError",
+                            "error_details": "Cannot mount /tools: conflicting registration",
                         },
                     ],
                 }
@@ -997,7 +998,11 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(response.sandboxes[0].sandbox_id, "copy-1")
         self.assertEqual(response.sandboxes[0].status, "running")
         self.assertEqual(response.sandboxes[1].status, "failed")
-        self.assertEqual(response.sandboxes[1].reason, "no capacity")
+        self.assertEqual(response.sandboxes[1].reason, "ConfigurationError")
+        self.assertEqual(
+            response.sandboxes[1].error_details,
+            "Cannot mount /tools: conflicting registration",
+        )
 
     def test_copy_rejects_invalid_times(self):
         client = SandboxClient(api_url="http://localhost:8900", api_key="k")
@@ -1605,6 +1610,13 @@ class TestSandboxClientRustBackend(unittest.TestCase):
 
 
 class TestSandboxFailureCompatibility(unittest.TestCase):
+    def test_unrecognized_failure_fields_keep_the_original_body(self):
+        body = '{"sandbox_id":"sbx","status":"failed","message":"legacy diagnosis"}'
+        error = RemoteAPIError(422, body)
+        self.assertEqual(str(error), f"API error (status 422): {body}")
+        self.assertEqual(error.sandbox_id, "sbx")
+        self.assertIsNone(error.reason)
+
     def test_unrelated_and_malformed_errors_keep_the_original_message(self):
         for body in (
             "upstream unavailable",

--- a/tests/sandbox/test_client_rust_backend.py
+++ b/tests/sandbox/test_client_rust_backend.py
@@ -17,7 +17,7 @@ from tensorlake.sandbox import (
     _defaults,
 )
 from tensorlake.sandbox.client import SandboxClient
-from tensorlake.sandbox.exceptions import SandboxError
+from tensorlake.sandbox.exceptions import RemoteAPIError, SandboxError
 
 
 class _FakeRustProxyClient:
@@ -266,6 +266,63 @@ def _sandbox_info_json(
 class TestSandboxClientRustBackend(unittest.TestCase):
     def setUp(self):
         _RecordingCreateRustClient.instances = []
+
+    def test_create_configuration_failure_preserves_diagnostic_fields(self):
+        class FakeRustError(Exception):
+            pass
+
+        diagnosis = "Cannot mount /tools: overlaps the registered mount /tools. Remove the conflicting registration."
+        body = json.dumps(
+            {
+                "sandbox_id": "sbx-config",
+                "status": "failed",
+                "reason": "ConfigurationError",
+                "error_details": diagnosis,
+            }
+        )
+
+        class FailedClient(_FakeRustClient):
+            def create_sandbox(self, request_json):
+                raise FakeRustError(("remote_api", 422, body))
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = FailedClient()
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClientError", FakeRustError
+        ):
+            with self.assertRaises(RemoteAPIError) as caught:
+                client.create()
+        error = caught.exception
+        self.assertEqual(error.status_code, 422)
+        self.assertEqual(error.sandbox_id, "sbx-config")
+        self.assertEqual(error.reason, "ConfigurationError")
+        self.assertEqual(error.error_details, diagnosis)
+        self.assertEqual(error.message, body)
+        self.assertIn(
+            f"Sandbox sbx-config failed (ConfigurationError): {diagnosis}", str(error)
+        )
+
+    def test_create_and_connect_reports_immediate_failure_without_polling(self):
+        class FailedClient(_FakeRustClient):
+            def create_sandbox(self, request_json):
+                return "trace-failed", json.dumps(
+                    {
+                        "sandbox_id": "sbx-config",
+                        "status": "failed",
+                        "reason": "ConfigurationError",
+                        "error_details": "Cannot shrink rootfs from 20 GiB to 10 GiB",
+                    }
+                )
+
+            def get_sandbox_json(self, sandbox_id):
+                raise AssertionError("An explicit failure must not be polled")
+
+        client = SandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = FailedClient()
+        with self.assertRaisesRegex(
+            SandboxError, "ConfigurationError.*Cannot shrink rootfs"
+        ):
+            client.create_and_connect()
 
     def test_constructor_passes_default_request_timeout_to_rust_backend(self):
         class _RecordingRustClient:
@@ -1545,6 +1602,48 @@ class TestSandboxClientRustBackend(unittest.TestCase):
         self.assertEqual(len(fake.create_snapshot_calls), 1)
         _, snapshot_type = fake.create_snapshot_calls[0]
         self.assertIsNone(snapshot_type)
+
+
+class TestSandboxFailureCompatibility(unittest.TestCase):
+    def test_unrelated_and_malformed_errors_keep_the_original_message(self):
+        for body in (
+            "upstream unavailable",
+            "{broken",
+            "null",
+            "[]",
+            '{"message":"invalid input"}',
+            '{"sandbox_id":42,"status":"failed","reason":"ConfigurationError"}',
+            '{"sandbox_id":"sbx","status":"running"}',
+        ):
+            with self.subTest(body=body):
+                error = RemoteAPIError(422, body)
+                self.assertEqual(str(error), f"API error (status 422): {body}")
+                self.assertIsNone(error.sandbox_id)
+                self.assertIsNone(error.reason)
+                self.assertIsNone(error.error_details)
+
+    def test_legacy_details_and_unknown_reasons_are_preserved(self):
+        for reason in ("InternalError", "FileSystemNotFound", "FutureReason"):
+            for details in (None, "", {"message": "diagnosis"}, ["one", "two"]):
+                with self.subTest(reason=reason, details=details):
+                    error = RemoteAPIError(
+                        422,
+                        json.dumps(
+                            {
+                                "sandbox_id": "sbx",
+                                "status": "failed",
+                                "termination_reason": reason,
+                                "error_details": details,
+                            }
+                        ),
+                    )
+                    self.assertEqual(error.reason, reason)
+                    self.assertEqual(error.error_details, details)
+                    self.assertIn(reason, str(error))
+                    if isinstance(details, dict):
+                        self.assertIn(": diagnosis", str(error))
+                    if isinstance(details, list):
+                        self.assertIn(": one; two", str(error))
 
 
 if __name__ == "__main__":

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -113,7 +113,8 @@ class _FakeAsyncRustClient:
                         {
                             "sandbox_id": "copy-2",
                             "status": "failed",
-                            "reason": "no capacity",
+                            "reason": "ConfigurationError",
+                            "error_details": "Cannot mount /tools: conflicting registration",
                         },
                     ],
                 }
@@ -956,7 +957,11 @@ class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.sandboxes[0].sandbox_id, "copy-1")
         self.assertEqual(response.sandboxes[0].status, "running")
         self.assertEqual(response.sandboxes[1].status, "failed")
-        self.assertEqual(response.sandboxes[1].reason, "no capacity")
+        self.assertEqual(response.sandboxes[1].reason, "ConfigurationError")
+        self.assertEqual(
+            response.sandboxes[1].error_details,
+            "Cannot mount /tools: conflicting registration",
+        )
 
     async def test_copy_rejects_invalid_times(self):
         client = _make_client()

--- a/tests/sandbox/test_client_rust_backend_async.py
+++ b/tests/sandbox/test_client_rust_backend_async.py
@@ -16,7 +16,7 @@ from tensorlake.sandbox import (
     _defaults,
 )
 from tensorlake.sandbox.async_client import AsyncSandboxClient
-from tensorlake.sandbox.exceptions import SandboxError
+from tensorlake.sandbox.exceptions import RemoteAPIError, SandboxError
 
 
 class _FakeAsyncRustProxyClient:
@@ -312,6 +312,63 @@ class _StatusSequenceRustClient(_FakeAsyncRustClient):
 class TestAsyncSandboxClientRustBackend(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         _RecordingCreateRustClient.instances = []
+
+    async def test_create_configuration_failure_preserves_diagnostic_fields(self):
+        class FakeRustError(Exception):
+            pass
+
+        diagnosis = "Cannot mount /tools: overlaps the registered mount /tools. Remove the conflicting registration."
+        body = json.dumps(
+            {
+                "sandbox_id": "sbx-config",
+                "status": "failed",
+                "reason": "ConfigurationError",
+                "error_details": diagnosis,
+            }
+        )
+
+        class FailedClient(_FakeAsyncRustClient):
+            async def create_sandbox_async(self, request_json):
+                raise FakeRustError(("remote_api", 422, body))
+
+        client = AsyncSandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = FailedClient()
+        with patch(
+            "tensorlake.sandbox.client.RustCloudSandboxClientError", FakeRustError
+        ):
+            with self.assertRaises(RemoteAPIError) as caught:
+                await client.create()
+        error = caught.exception
+        self.assertEqual(error.status_code, 422)
+        self.assertEqual(error.sandbox_id, "sbx-config")
+        self.assertEqual(error.reason, "ConfigurationError")
+        self.assertEqual(error.error_details, diagnosis)
+        self.assertEqual(error.message, body)
+        self.assertIn(
+            f"Sandbox sbx-config failed (ConfigurationError): {diagnosis}", str(error)
+        )
+
+    async def test_create_and_connect_reports_immediate_failure_without_polling(self):
+        class FailedClient(_FakeAsyncRustClient):
+            async def create_sandbox_async(self, request_json):
+                return "trace-failed", json.dumps(
+                    {
+                        "sandbox_id": "sbx-config",
+                        "status": "failed",
+                        "reason": "ConfigurationError",
+                        "error_details": "Cannot shrink rootfs from 20 GiB to 10 GiB",
+                    }
+                )
+
+            async def get_sandbox_json_async(self, sandbox_id):
+                raise AssertionError("An explicit failure must not be polled")
+
+        client = AsyncSandboxClient(api_url="http://localhost:8900", api_key="k")
+        client._rust_client = FailedClient()
+        with self.assertRaisesRegex(
+            SandboxError, "ConfigurationError.*Cannot shrink rootfs"
+        ):
+            await client.create_and_connect()
 
     async def test_constructor_passes_default_request_timeout_to_rust_backend(self):
         class _RecordingRustClient:

--- a/typescript/npm/darwin-arm64/package.json
+++ b/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-darwin-arm64",
-  "version": "0.5.127",
+  "version": "0.5.128",
   "description": "Tensorlake native Node.js binding for macOS arm64",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64-musl/package.json
+++ b/typescript/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-arm64-musl",
-  "version": "0.5.127",
+  "version": "0.5.128",
   "description": "Tensorlake native Node.js binding for Linux arm64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64/package.json
+++ b/typescript/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-arm64-gnu",
-  "version": "0.5.127",
+  "version": "0.5.128",
   "description": "Tensorlake native Node.js binding for Linux arm64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64-musl/package.json
+++ b/typescript/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-x64-musl",
-  "version": "0.5.127",
+  "version": "0.5.128",
   "description": "Tensorlake native Node.js binding for Linux x64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64/package.json
+++ b/typescript/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-x64-gnu",
-  "version": "0.5.127",
+  "version": "0.5.128",
   "description": "Tensorlake native Node.js binding for Linux x64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/win32-x64/package.json
+++ b/typescript/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-win32-x64",
-  "version": "0.5.127",
+  "version": "0.5.128",
   "description": "Tensorlake native Node.js binding for Windows x64",
   "repository": {
     "type": "git",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.127",
+  "version": "0.5.128",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.127",
+      "version": "0.5.128",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",
@@ -39,12 +39,12 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "tensorlake-native-darwin-arm64": "0.5.127",
-        "tensorlake-native-linux-arm64-gnu": "0.5.127",
-        "tensorlake-native-linux-arm64-musl": "0.5.127",
-        "tensorlake-native-linux-x64-gnu": "0.5.127",
-        "tensorlake-native-linux-x64-musl": "0.5.127",
-        "tensorlake-native-win32-x64": "0.5.127"
+        "tensorlake-native-darwin-arm64": "0.5.128",
+        "tensorlake-native-linux-arm64-gnu": "0.5.128",
+        "tensorlake-native-linux-arm64-musl": "0.5.128",
+        "tensorlake-native-linux-x64-gnu": "0.5.128",
+        "tensorlake-native-linux-x64-musl": "0.5.128",
+        "tensorlake-native-win32-x64": "0.5.128"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3250,8 +3250,8 @@
       }
     },
     "node_modules/tensorlake-native-darwin-arm64": {
-      "version": "0.5.127",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.127.tgz",
+      "version": "0.5.128",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.128.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3265,8 +3265,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-arm64-gnu": {
-      "version": "0.5.127",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.127.tgz",
+      "version": "0.5.128",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.128.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3283,8 +3283,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-arm64-musl": {
-      "version": "0.5.127",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.127.tgz",
+      "version": "0.5.128",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.128.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3301,8 +3301,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-x64-gnu": {
-      "version": "0.5.127",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.127.tgz",
+      "version": "0.5.128",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.128.tgz",
       "cpu": [
         "x64"
       ],
@@ -3319,8 +3319,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-x64-musl": {
-      "version": "0.5.127",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.127.tgz",
+      "version": "0.5.128",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.128.tgz",
       "cpu": [
         "x64"
       ],
@@ -3337,8 +3337,8 @@
       }
     },
     "node_modules/tensorlake-native-win32-x64": {
-      "version": "0.5.127",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.127.tgz",
+      "version": "0.5.128",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.128.tgz",
       "cpu": [
         "x64"
       ],

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.127",
+  "version": "0.5.128",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -96,11 +96,11 @@
     "ws": "^8.20.0"
   },
   "optionalDependencies": {
-    "tensorlake-native-darwin-arm64": "0.5.127",
-    "tensorlake-native-linux-arm64-gnu": "0.5.127",
-    "tensorlake-native-linux-arm64-musl": "0.5.127",
-    "tensorlake-native-linux-x64-gnu": "0.5.127",
-    "tensorlake-native-linux-x64-musl": "0.5.127",
-    "tensorlake-native-win32-x64": "0.5.127"
+    "tensorlake-native-darwin-arm64": "0.5.128",
+    "tensorlake-native-linux-arm64-gnu": "0.5.128",
+    "tensorlake-native-linux-arm64-musl": "0.5.128",
+    "tensorlake-native-linux-x64-gnu": "0.5.128",
+    "tensorlake-native-linux-x64-musl": "0.5.128",
+    "tensorlake-native-win32-x64": "0.5.128"
   }
 }

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1,5 +1,5 @@
 import * as defaults from "./defaults.js";
-import { SandboxError } from "./errors.js";
+import { SandboxError, formatErrorDetails } from "./errors.js";
 import type { Traced } from "./http.js";
 import { releaseNativeHandle } from "./native-worker-client.js";
 import {
@@ -960,12 +960,13 @@ export class SandboxClient {
     }
     if (
       result.status === SandboxStatus.SUSPENDED ||
-      result.status === SandboxStatus.TERMINATED
+      result.status === SandboxStatus.TERMINATED ||
+      result.status === SandboxStatus.FAILED
     ) {
       throw new SandboxError(
         formatStartupFailureMessage(result.sandboxId, result.status, {
           errorDetails: result.errorDetails,
-          terminationReason: result.terminationReason,
+          terminationReason: result.terminationReason ?? result.reason,
         }),
       );
     }
@@ -1081,42 +1082,18 @@ function formatStartupFailureMessage(
     terminationReason?: string;
   },
 ): string {
-  const prefix =
+  let prefix =
     status === SandboxStatus.TERMINATED
       ? `Sandbox ${sandboxId} terminated during startup`
       : `Sandbox ${sandboxId} became ${status} during startup`;
+  if (options.terminationReason) {
+    prefix += ` (${options.terminationReason})`;
+  }
   const detail = formatErrorDetails(options.errorDetails);
   if (detail) {
     return `${prefix}: ${detail}`;
   }
-  if (options.terminationReason) {
-    return `${prefix}: termination reason: ${options.terminationReason}`;
-  }
   return prefix;
-}
-
-function formatErrorDetails(errorDetails: unknown): string | undefined {
-  if (errorDetails == null) return undefined;
-  if (typeof errorDetails === "string") {
-    const detail = errorDetails.trim();
-    return detail || undefined;
-  }
-  if (Array.isArray(errorDetails)) {
-    const parts = errorDetails
-      .map((item) => formatErrorDetails(item))
-      .filter((item): item is string => Boolean(item));
-    return parts.length > 0 ? parts.join("; ") : JSON.stringify(errorDetails);
-  }
-  if (typeof errorDetails === "object") {
-    for (const key of ["message", "detail", "error", "reason"]) {
-      const value = (errorDetails as Record<string, unknown>)[key];
-      if (typeof value === "string" && value.trim()) {
-        return value.trim();
-      }
-    }
-    return JSON.stringify(errorDetails);
-  }
-  return String(errorDetails);
 }
 
 const RESERVED_SANDBOX_MANAGEMENT_PORT = 9501;

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -163,6 +163,7 @@ export class RemoteAPIError extends SandboxError {
       if (reason) displayMessage += ` (${reason})`;
       const detail = formatErrorDetails(errorDetails);
       if (detail) displayMessage += `: ${detail}`;
+      if (!reason && !detail) displayMessage = message;
     }
     super(`API error (status ${statusCode}): ${displayMessage}`);
     this.sandboxId = sandboxId;

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -103,13 +103,71 @@ export class PoolInUseError extends SandboxError {
   }
 }
 
+export function formatErrorDetails(errorDetails: unknown): string | undefined {
+  if (errorDetails == null) return undefined;
+  if (typeof errorDetails === "string") {
+    const detail = errorDetails.trim();
+    return detail || undefined;
+  }
+  if (Array.isArray(errorDetails)) {
+    const parts = errorDetails
+      .map((item) => formatErrorDetails(item))
+      .filter((item): item is string => Boolean(item));
+    return parts.length > 0 ? parts.join("; ") : JSON.stringify(errorDetails);
+  }
+  if (typeof errorDetails === "object") {
+    for (const key of ["message", "detail", "error", "reason"]) {
+      const value = (errorDetails as Record<string, unknown>)[key];
+      if (typeof value === "string" && value.trim()) {
+        return value.trim();
+      }
+    }
+    return JSON.stringify(errorDetails);
+  }
+  return String(errorDetails);
+}
+
 /** Raised when the remote API returns an error. */
 export class RemoteAPIError extends SandboxError {
   readonly statusCode: number;
+  /** Original response body, retained for compatibility and diagnostics. */
   readonly responseMessage: string;
+  readonly sandboxId?: string;
+  /** Server reason, including unknown future reasons. */
+  readonly reason?: string;
+  readonly errorDetails?: unknown;
 
   constructor(statusCode: number, message: string) {
-    super(`API error (status ${statusCode}): ${message}`);
+    let failure: Record<string, unknown> | undefined;
+    try {
+      const payload: unknown = JSON.parse(message);
+      if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+        const record = payload as Record<string, unknown>;
+        if (
+          typeof record.sandbox_id === "string" &&
+          record.sandbox_id.trim() &&
+          (record.status === "failed" || record.status === "terminated")
+        )
+          failure = record;
+      }
+    } catch {
+      // Non-JSON errors keep their existing message.
+    }
+    const sandboxId = failure?.sandbox_id as string | undefined;
+    const rawReason = failure?.reason ?? failure?.termination_reason;
+    const reason = typeof rawReason === "string" ? rawReason : undefined;
+    const errorDetails = failure?.error_details;
+    let displayMessage = message;
+    if (failure) {
+      displayMessage = `Sandbox ${sandboxId} ${failure.status}`;
+      if (reason) displayMessage += ` (${reason})`;
+      const detail = formatErrorDetails(errorDetails);
+      if (detail) displayMessage += `: ${detail}`;
+    }
+    super(`API error (status ${statusCode}): ${displayMessage}`);
+    this.sandboxId = sandboxId;
+    this.reason = reason;
+    this.errorDetails = errorDetails;
     this.name = "RemoteAPIError";
     this.statusCode = statusCode;
     this.responseMessage = message;

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -8,6 +8,8 @@ export enum SandboxStatus {
   SUSPENDED = "suspended",
   TERMINATED = "terminated",
   TIMEOUT = "timeout",
+  /** Terminal status used by blocking create/claim responses. */
+  FAILED = "failed",
 }
 
 export enum SnapshotStatus {

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1067,7 +1067,12 @@ describe("SandboxClient", () => {
             source_sandbox_id: "sbx-1",
             sandboxes: [
               { sandbox_id: "copy-1", status: "running" },
-              { sandbox_id: "copy-2", status: "failed", reason: "no capacity" },
+              {
+                sandbox_id: "copy-2",
+                status: "failed",
+                reason: "ConfigurationError",
+                error_details: "Cannot mount /tools: conflicting registration",
+              },
             ],
           }),
         };
@@ -1087,7 +1092,10 @@ describe("SandboxClient", () => {
       expect(response.sandboxes[0].status).toBe("running");
       expect(response.sandboxes[1].sandboxId).toBe("copy-2");
       expect(response.sandboxes[1].status).toBe("failed");
-      expect(response.sandboxes[1].reason).toBe("no capacity");
+      expect(response.sandboxes[1].reason).toBe("ConfigurationError");
+      expect(response.sandboxes[1].errorDetails).toBe(
+        "Cannot mount /tools: conflicting registration",
+      );
       expect(response.traceId).toBeDefined();
       client.close();
     });
@@ -1822,6 +1830,15 @@ describe("SandboxClient", () => {
 });
 
 describe("sandbox API error compatibility", () => {
+  it("preserves the body when a failure uses unrecognized diagnostic fields", () => {
+    const body =
+      '{"sandbox_id":"sbx","status":"failed","message":"legacy diagnosis"}';
+    const error = new RemoteAPIError(422, body);
+    expect(error.message).toBe(`API error (status 422): ${body}`);
+    expect(error.sandboxId).toBe("sbx");
+    expect(error.reason).toBeUndefined();
+  });
+
   it.each([
     "upstream unavailable",
     "{broken",

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { RemoteAPIError } from "../src/errors.js";
 import { SandboxClient } from "../src/client.js";
-import {
-  type GpuModel,
-  SandboxStatus,
-  SnapshotStatus,
-} from "../src/models.js";
+import { type GpuModel, SandboxStatus, SnapshotStatus } from "../src/models.js";
 import { clearNativeStub, installNativeStub } from "./native-stub.js";
 
 /** Build the native error a non-2xx HTTP response now surfaces from Rust. */
@@ -36,12 +33,73 @@ describe("SandboxClient", () => {
   });
 
   describe("create", () => {
+    it("surfaces structured configuration diagnostics from the native HTTP error", async () => {
+      const diagnosis =
+        "Cannot mount /tools: overlaps the registered mount /tools. Remove the conflicting registration.";
+      const body = JSON.stringify({
+        sandbox_id: "sbx-config",
+        status: "failed",
+        reason: "ConfigurationError",
+        error_details: diagnosis,
+      });
+      const createSandbox = vi.fn(async () => {
+        throw nativeError(422, body);
+      });
+      installNativeStub({ client: { createSandbox } });
+      const client = SandboxClient.forLocalhost();
+      try {
+        const error = await client.create().catch((error: unknown) => error);
+        expect(error).toBeInstanceOf(RemoteAPIError);
+        expect(error).toMatchObject({
+          statusCode: 422,
+          sandboxId: "sbx-config",
+          reason: "ConfigurationError",
+          errorDetails: diagnosis,
+          responseMessage: body,
+          message: `API error (status 422): Sandbox sbx-config failed (ConfigurationError): ${diagnosis}`,
+        });
+        expect(createSandbox).toHaveBeenCalledOnce();
+      } finally {
+        client.close();
+      }
+    });
+
+    it("reports an immediate failed response without polling", async () => {
+      const getSandbox = vi.fn();
+      installNativeStub({
+        client: {
+          createSandbox: vi.fn(async () => ({
+            traceId: "t",
+            json: JSON.stringify({
+              sandbox_id: "sbx-config",
+              status: "failed",
+              reason: "ConfigurationError",
+              error_details: "Cannot shrink rootfs from 20 GiB to 10 GiB",
+            }),
+          })),
+          getSandbox,
+        },
+      });
+      const client = SandboxClient.forLocalhost();
+      try {
+        await expect(client.createAndConnect()).rejects.toThrow(
+          "ConfigurationError): Cannot shrink rootfs",
+        );
+        expect(getSandbox).not.toHaveBeenCalled();
+      } finally {
+        client.close();
+      }
+    });
+
     it("inherits snapshot resources when no overrides are provided", async () => {
       const createSandbox = vi.fn(async (body: string) => {
         expect(JSON.parse(body)).toEqual({ snapshot_id: "snap-memory" });
         return {
           traceId: "t",
-          json: JSON.stringify({ sandbox_id: "sbx-restored", status: "running" }),
+          json: JSON.stringify({
+            sandbox_id: "sbx-restored",
+            status: "running",
+          }),
         };
       });
       installNativeStub({ client: { createSandbox } });
@@ -56,7 +114,10 @@ describe("SandboxClient", () => {
         expect(JSON.parse(body).resources).toEqual({ cpus: 2 });
         return {
           traceId: "t",
-          json: JSON.stringify({ sandbox_id: "sbx-restored", status: "running" }),
+          json: JSON.stringify({
+            sandbox_id: "sbx-restored",
+            status: "running",
+          }),
         };
       });
       installNativeStub({ client: { createSandbox } });
@@ -152,7 +213,10 @@ describe("SandboxClient", () => {
             expect(body.resources.gpus).toEqual([{ count: 2, model }]);
             return {
               traceId: "t",
-              json: JSON.stringify({ sandbox_id: "sbx-gpu", status: "pending" }),
+              json: JSON.stringify({
+                sandbox_id: "sbx-gpu",
+                status: "pending",
+              }),
             };
           }),
         },
@@ -172,7 +236,10 @@ describe("SandboxClient", () => {
             expect(body.resources.gpus).toEqual([{ count: 2, model: "H100" }]);
             return {
               traceId: "t",
-              json: JSON.stringify({ sandbox_id: "sbx-gpu", status: "pending" }),
+              json: JSON.stringify({
+                sandbox_id: "sbx-gpu",
+                status: "pending",
+              }),
             };
           }),
         },
@@ -1752,4 +1819,51 @@ describe("SandboxClient", () => {
       client.close();
     });
   });
+});
+
+describe("sandbox API error compatibility", () => {
+  it.each([
+    "upstream unavailable",
+    "{broken",
+    "null",
+    "[]",
+    '{"message":"invalid input"}',
+    '{"sandbox_id":42,"status":"failed","reason":"ConfigurationError"}',
+    '{"sandbox_id":"sbx","status":"running"}',
+  ])("preserves unrelated or malformed error %s", (body) => {
+    const error = new RemoteAPIError(422, body);
+    expect(error.message).toBe(`API error (status 422): ${body}`);
+    expect(error.responseMessage).toBe(body);
+    expect(error.sandboxId).toBeUndefined();
+    expect(error.reason).toBeUndefined();
+    expect(error.errorDetails).toBeUndefined();
+  });
+
+  it.each(["InternalError", "FileSystemNotFound", "FutureReason"])(
+    "preserves legacy details and reason %s",
+    (reason) => {
+      for (const details of [
+        null,
+        "",
+        { message: "diagnosis" },
+        ["one", "two"],
+      ]) {
+        const error = new RemoteAPIError(
+          422,
+          JSON.stringify({
+            sandbox_id: "sbx",
+            status: "failed",
+            termination_reason: reason,
+            error_details: details,
+          }),
+        );
+        expect(error.reason).toBe(reason);
+        expect(error.errorDetails).toEqual(details);
+        expect(error.message).toContain(reason);
+        if (Array.isArray(details))
+          expect(error.message).toContain(": one; two");
+        else if (details) expect(error.message).toContain(": diagnosis");
+      }
+    },
+  );
 });


### PR DESCRIPTION
Sandbox boot failures now expose the server's actionable diagnostic in Python/TypeScript exceptions and CLI output. An HTTP 422 with `reason: ConfigurationError` renders the sandbox ID, reason, and diagnosis; SDK callers can inspect those fields without parsing JSON.

- Preserve the existing `RemoteAPIError` types, HTTP status, and original response body. Keep unknown reasons and non-sandbox error fallbacks intact.
- Handle immediate `failed` readiness responses and include both reason and detail after polling.
- Show diagnostics in `tl sbx create`, `copy`, and `describe`, including archived sandboxes without an SSH endpoint. Decode create errors, polling responses, copies, and descriptions through explicit response structs; share typed diagnostic fields and retain arbitrary JSON only for the polymorphic `error_details` field. Add the typed-response rule to `CLAUDE.md`.
- Preserve legacy aliases and timestamp formats, unknown reasons, missing diagnostics, and non-JSON error fallbacks. Decode escaped server messages correctly and cover polling termination, legacy payloads, and healthy SSH output through CLI subprocess tests.
- Repair the CI/private-source staging path to include nested modules and embedded files, and align the codec SHA-2 dependency with its upstream SHA-1/Digest generation. This unblocks the full-feature CLI build.
- Add SDK native-boundary regression coverage, compatibility cases, and CLI subprocess tests against HTTP fixtures. Document the public fields and partial-copy behavior.
- Bump the Python, TypeScript, Rust, native binding packages and standalone CLI together to `0.5.128`, including npm optional dependencies and both lockfiles.

Requires the server/dataplane diagnostics from https://github.com/tensorlakeai/compute-engine-internal/pull/2040 for newly classified failures; compatible with older responses.

Rebase/release validation: fetched remote `main` (`e2cfe7c6`) and ran the rebase; this branch was already current. Used the repository version-bump script and `cargo update --workspace --offline`; Cargo changed only the six local package versions. All 37 checked release metadata entries agree on `0.5.128`, npm native archive URLs match, and `git diff --check` passes. No local tests run. The changed Rust files also pass focused formatting checks. No local tests were run.

Current-head CI (`a43426aa`) passed all 21 reported checks, including the full-feature Rust workspace, all six CLI HTTP subprocess regressions, the new escaped-message and raw-body fallback unit cases, Python unit/live sandbox checks, TypeScript SDK checks, Linux/macOS/Windows package builds, Windows Python/Node smoke, and CodeQL. Three TestPyPI publication-dependent jobs were skipped. Validation evidence: https://github.com/tensorlakeai/tensorlake/actions/runs/34299998680 . Earlier full local TypeScript lint reported existing errors in unchanged `tests/fixtures/delayed-native-load.cjs` and `tests/get-or-create.test.ts`.
