### PR TITLE
Retry transient S3 failures that arrive as HTTP 400

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,6 +45,7 @@ jobs:
         run: |
           set -euo pipefail
           for module in \
+            tests.applications.blob_store.test_s3_blob_store_retries \
             tests.applications.test_application_manifest \
             tests.applications.test_code_zip \
             tests.applications.test_future_validation \

--- a/src/tensorlake/applications/blob_store/s3_blob_store.py
+++ b/src/tensorlake/applications/blob_store/s3_blob_store.py
@@ -1,4 +1,5 @@
-from typing import List
+import re
+from typing import List, Optional
 
 import httpx
 
@@ -8,13 +9,38 @@ from tensorlake.utils.retries import exponential_backoff
 
 # Customers can upload and download large files, allow up to 1 hour per S3 operation.
 _S3_OPERATION_TIMEOUT_SEC = 1 * 60 * 60  # 1 hour
-# Keep established connections around for up to 1 hour to maximize download/upload throughput
-# when we download function inputs and when we upload the function outputs.
-_CONNECTION_KEEP_ALIVE_EXPIRY_SEC = 1 * 60 * 60  # 1 hour
+# S3 closes idle keep-alive connections on its own after a short period (tens of seconds).
+# If the client pool holds an idle connection for longer than the server keeps it, the pool
+# eventually hands out a socket S3 has already closed or is about to close. That surfaces as
+# `httpx.RemoteProtocolError: Server disconnected without sending a response` or as an HTTP 400
+# with S3 error code `RequestTimeout`. Keep the client side expiry well below the server side so
+# the pool never reuses a connection S3 considers idle. Connections used back to back while
+# transferring chunks are never idle, so download/upload throughput is unaffected.
+_CONNECTION_KEEP_ALIVE_EXPIRY_SEC = 10.0
 # Do fast retries because we don't want to slow down functions too much due to S3 issues.
 _MAX_RETRIES = 3
 _INITIAL_RETRY_DELAY_SEC = 0.1
 _MAX_RETRY_DELAY_SEC = 10.0
+
+# S3 reports a few transient conditions with HTTP status codes that are otherwise permanent
+# client errors, so the status code alone is not enough to classify a failure. The error code
+# in the XML response body is what distinguishes them:
+#   * RequestTimeout (400) - "Your socket connection to the server was not read from or written
+#     to within the timeout period. Idle connections will be closed."
+#   * RequestTimeTooSkewed (403) - local clock drifted from S3's; typically resolves on retry.
+#   * SlowDown / ServiceUnavailable / InternalError - explicit "retry me" responses.
+_RETRIABLE_S3_ERROR_CODES = frozenset(
+    {
+        "InternalError",
+        "RequestTimeout",
+        "RequestTimeTooSkewed",
+        "ServiceUnavailable",
+        "SlowDown",
+    }
+)
+# Status codes that are permanent client errors unless the S3 error code says otherwise.
+_NON_RETRIABLE_STATUS_CODES = frozenset({400, 403, 404})
+_S3_ERROR_CODE_RE = re.compile(r"<Code>([^<]+)</Code>")
 
 
 class S3BLOBStore:
@@ -52,9 +78,7 @@ class S3BLOBStore:
             try:
                 if isinstance(e, httpx.HTTPStatusError):
                     status_code = e.response.status_code
-                    # .read() is required before accessing .text
-                    # because we're in streaming mode.
-                    e.response.read()
+                    # get_with_retries() reads error bodies before closing the stream.
                     response = e.response.text
             except Exception as extract_response_exception:
                 logger.error(
@@ -90,6 +114,11 @@ class S3BLOBStore:
                 _to_https_uri_schema(uri),
                 headers={"Range": f"bytes={offset}-{offset + len(destination) - 1}"},
             ) as streaming_response:
+                if streaming_response.is_error:
+                    # Error bodies are small and must be read before the stream is closed,
+                    # otherwise neither retry classification nor logging can see the S3 error
+                    # code. Reading it here leaves it cached on the response object.
+                    streaming_response.read()
                 streaming_response.raise_for_status()
                 read_size: int = 0
                 for partial_data in streaming_response.iter_bytes():
@@ -108,9 +137,7 @@ class S3BLOBStore:
             response: str = "None"
             try:
                 status_code = e.response.status_code
-                # .read() is required before accessing .text
-                # because we're in streaming mode.
-                e.response.read()
+                # get_with_retries() reads error bodies before closing the stream.
                 response = e.response.text
             except Exception as extract_response_exception:
                 logger.error(
@@ -223,10 +250,31 @@ class S3BLOBStore:
             raise InternalError("Failed to put S3 object")
 
 
+def _s3_error_code(response: httpx.Response) -> Optional[str]:
+    """Returns the error code from an S3 XML error response, None if it can't be determined.
+
+    The body of a streaming response is only available if it was read before the stream was
+    closed; callers that stream must read the body of an error response themselves.
+    """
+    try:
+        body: str = response.text
+    except Exception:
+        # The response was streamed and the stream is already closed, so the body is gone.
+        return None
+
+    match = _S3_ERROR_CODE_RE.search(body)
+    return None if match is None else match.group(1)
+
+
 def _is_retriable_exception(e: Exception) -> bool:
     if isinstance(e, httpx.HTTPStatusError):
-        # Let's simply retry everything which is not 404 (not found) or 400 (bad request) or 403 (forbidden).
-        return e.response.status_code not in [400, 403, 404]
+        if e.response.status_code not in _NON_RETRIABLE_STATUS_CODES:
+            # Retry everything else, i.e. 5xx and 429.
+            return True
+        # The status code alone says "permanent client error", but S3 uses these status codes
+        # for a few transient conditions too. Only the error code in the body can tell them
+        # apart, so a body we can't read has to stay non retriable.
+        return _s3_error_code(e.response) in _RETRIABLE_S3_ERROR_CODES
     else:
         # Retry anything else like network errors, request timeouts, etc.
         return True

--- a/tests/applications/blob_store/test_s3_blob_store_retries.py
+++ b/tests/applications/blob_store/test_s3_blob_store_retries.py
@@ -1,0 +1,255 @@
+"""Unit tests for S3BLOBStore retry classification.
+
+These tests mock the S3 HTTP responses with respx so they need no AWS credentials and no
+network, unlike test_s3_blob_store.py which talks to a real bucket.
+"""
+
+import unittest
+
+import httpx
+import respx
+
+from tensorlake.applications.blob_store.s3_blob_store import (
+    S3BLOBStore,
+    _is_retriable_exception,
+)
+from tensorlake.applications.interface.exceptions import InternalError
+from tensorlake.applications.internal_logger import InternalLogger
+
+_URI = "s3://test-bucket.s3.amazonaws.com/test-key"
+_URL = "https://test-bucket.s3.amazonaws.com/test-key"
+_PAYLOAD = b"0123456789"
+
+
+def _s3_error_body(code: str, message: str = "") -> str:
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        f"<Error><Code>{code}</Code><Message>{message}</Message>"
+        "<RequestId>REQ</RequestId><HostId>HOST</HostId></Error>"
+    )
+
+
+# The exact body S3 returns when it closes a connection that went idle mid request.
+_REQUEST_TIMEOUT_BODY = _s3_error_body(
+    "RequestTimeout",
+    "Your socket connection to the server was not read from or written to within "
+    "the timeout period. Idle connections will be closed.",
+)
+
+
+def _status_error(status_code: int, body: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("PUT", _URL)
+    response = httpx.Response(status_code, text=body, request=request)
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+class TestIsRetriableException(unittest.TestCase):
+    def test_transient_s3_error_codes_are_retriable(self):
+        for status_code, code in [
+            (400, "RequestTimeout"),
+            (403, "RequestTimeTooSkewed"),
+            (400, "SlowDown"),
+            (400, "InternalError"),
+            (400, "ServiceUnavailable"),
+        ]:
+            with self.subTest(status_code=status_code, code=code):
+                self.assertTrue(
+                    _is_retriable_exception(
+                        _status_error(status_code, _s3_error_body(code))
+                    )
+                )
+
+    def test_permanent_s3_error_codes_are_not_retriable(self):
+        for status_code, code in [
+            (400, "InvalidRequest"),
+            (400, "EntityTooLarge"),
+            (403, "AccessDenied"),
+            (403, "SignatureDoesNotMatch"),
+            (404, "NoSuchKey"),
+        ]:
+            with self.subTest(status_code=status_code, code=code):
+                self.assertFalse(
+                    _is_retriable_exception(
+                        _status_error(status_code, _s3_error_body(code))
+                    )
+                )
+
+    def test_unreadable_body_stays_non_retriable(self):
+        # Without an error code there is no way to tell a transient 400 from a permanent one,
+        # so the status code decides and the request is not retried.
+        self.assertFalse(_is_retriable_exception(_status_error(400, "")))
+        self.assertFalse(_is_retriable_exception(_status_error(400, "not xml at all")))
+
+    def test_server_errors_are_retriable(self):
+        for status_code in [429, 500, 502, 503, 504]:
+            with self.subTest(status_code=status_code):
+                self.assertTrue(_is_retriable_exception(_status_error(status_code, "")))
+
+    def test_transport_errors_are_retriable(self):
+        # This is what a connection closed by S3 while pooled looks like.
+        self.assertTrue(
+            _is_retriable_exception(
+                httpx.RemoteProtocolError(
+                    "Server disconnected without sending a response."
+                )
+            )
+        )
+        self.assertTrue(_is_retriable_exception(httpx.ConnectTimeout("timed out")))
+        self.assertTrue(_is_retriable_exception(httpx.ReadError("reset")))
+
+
+class TestS3BLOBStoreRetries(unittest.TestCase):
+    def setUp(self):
+        self.store = S3BLOBStore(io_workers_count=2)
+        self.logger = InternalLogger.get_logger()
+
+    def _put(self) -> str:
+        return self.store.put(_URI, [memoryview(_PAYLOAD)], self.logger)
+
+    def _get(self) -> bytes:
+        destination = memoryview(bytearray(len(_PAYLOAD)))
+        self.store.get(_URI, 0, destination, self.logger)
+        return bytes(destination)
+
+    @respx.mock
+    def test_put_retries_400_request_timeout(self):
+        # Regression test for issue #469: S3 answers a stalled upload with HTTP 400
+        # RequestTimeout, which used to be classified as a permanent client error.
+        route = respx.put(_URL).mock(
+            side_effect=[
+                httpx.Response(400, text=_REQUEST_TIMEOUT_BODY),
+                httpx.Response(400, text=_REQUEST_TIMEOUT_BODY),
+                httpx.Response(200, headers={"ETag": '"etag-value"'}),
+            ]
+        )
+
+        self.assertEqual(self._put(), '"etag-value"')
+        self.assertEqual(route.call_count, 3)
+
+    @respx.mock
+    def test_put_resends_the_whole_body_on_every_attempt(self):
+        # A retry is only correct if the body is re-sent in full; memoryviews must not be
+        # consumed by the first attempt.
+        route = respx.put(_URL).mock(
+            side_effect=[
+                httpx.Response(400, text=_REQUEST_TIMEOUT_BODY),
+                httpx.Response(200, headers={"ETag": '"etag-value"'}),
+            ]
+        )
+
+        self._put()
+
+        self.assertEqual(route.call_count, 2)
+        for call in route.calls:
+            self.assertEqual(call.request.content, _PAYLOAD)
+            self.assertEqual(call.request.headers["Content-Length"], str(len(_PAYLOAD)))
+
+    @respx.mock
+    def test_put_does_not_retry_permanent_400(self):
+        route = respx.put(_URL).mock(
+            return_value=httpx.Response(400, text=_s3_error_body("InvalidRequest"))
+        )
+
+        with self.assertRaises(InternalError):
+            self._put()
+
+        self.assertEqual(route.call_count, 1)
+
+    @respx.mock
+    def test_put_does_not_retry_access_denied(self):
+        route = respx.put(_URL).mock(
+            return_value=httpx.Response(403, text=_s3_error_body("AccessDenied"))
+        )
+
+        with self.assertRaises(InternalError):
+            self._put()
+
+        self.assertEqual(route.call_count, 1)
+
+    @respx.mock
+    def test_put_gives_up_after_max_retries(self):
+        route = respx.put(_URL).mock(
+            return_value=httpx.Response(400, text=_REQUEST_TIMEOUT_BODY)
+        )
+
+        with self.assertRaises(InternalError):
+            self._put()
+
+        # The initial attempt plus _MAX_RETRIES retries.
+        self.assertEqual(route.call_count, 4)
+
+    @respx.mock
+    def test_put_retries_disconnected_connection(self):
+        # A connection S3 already closed fails before any response is received.
+        route = respx.put(_URL).mock(
+            side_effect=[
+                httpx.RemoteProtocolError(
+                    "Server disconnected without sending a response."
+                ),
+                httpx.Response(200, headers={"ETag": '"etag-value"'}),
+            ]
+        )
+
+        self.assertEqual(self._put(), '"etag-value"')
+        self.assertEqual(route.call_count, 2)
+
+    @respx.mock
+    def test_get_retries_400_request_timeout(self):
+        route = respx.get(_URL).mock(
+            side_effect=[
+                httpx.Response(400, text=_REQUEST_TIMEOUT_BODY),
+                httpx.Response(206, content=_PAYLOAD),
+            ]
+        )
+
+        self.assertEqual(self._get(), _PAYLOAD)
+        self.assertEqual(route.call_count, 2)
+
+    @respx.mock
+    def test_get_does_not_retry_missing_key(self):
+        route = respx.get(_URL).mock(
+            return_value=httpx.Response(404, text=_s3_error_body("NoSuchKey"))
+        )
+
+        with self.assertRaises(InternalError):
+            self._get()
+
+        self.assertEqual(route.call_count, 1)
+
+    @respx.mock
+    def test_get_tells_transient_and_permanent_400_apart(self):
+        # get() streams responses. Unless the error body is read inside the stream context,
+        # reading it afterwards raises httpx.StreamClosed, the S3 error code is lost, and every
+        # 400 looks alike to the retry layer. Two 400s classified differently prove the body
+        # reached the classifier.
+        route = respx.get(_URL).mock(
+            return_value=httpx.Response(400, text=_s3_error_body("InvalidRequest"))
+        )
+        with self.assertRaises(InternalError):
+            self._get()
+        self.assertEqual(route.call_count, 1)
+
+        respx.reset()
+        route = respx.get(_URL).mock(
+            return_value=httpx.Response(400, text=_REQUEST_TIMEOUT_BODY)
+        )
+        with self.assertRaises(InternalError):
+            self._get()
+        self.assertEqual(route.call_count, 4)
+
+
+class TestConnectionPoolConfiguration(unittest.TestCase):
+    def test_keepalive_expiry_is_shorter_than_s3_idle_timeout(self):
+        # S3 closes idle connections after tens of seconds. Holding them client side for
+        # longer than that makes the pool hand out sockets S3 has already closed, which is
+        # what produced the HTTP 400 RequestTimeout and "Server disconnected" failures in
+        # issue #469.
+        from tensorlake.applications.blob_store.s3_blob_store import (
+            _CONNECTION_KEEP_ALIVE_EXPIRY_SEC,
+        )
+
+        self.assertLessEqual(_CONNECTION_KEEP_ALIVE_EXPIRY_SEC, 20.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #469.

## The reported symptom

A 15 MB function output upload failed with:

```
<Error><Code>RequestTimeout</Code><Message>Your socket connection to the server was not read
from or written to within the timeout period. Idle connections will be closed.</Message></Error>
```

`_is_retriable_exception()` excluded `400` wholesale, so this was classified as a permanent
client error and the allocation failed instead of retrying.

## Root cause

@eabatalov noted on the issue that failing on 400 is legitimate and asked why we get one at all.
I believe the answer is the connection pool configuration:

```python
_CONNECTION_KEEP_ALIVE_EXPIRY_SEC = 1 * 60 * 60  # 1 hour
```

S3 closes idle keep-alive connections after tens of seconds. Holding them client-side for an hour
means the pool keeps handing out sockets S3 has already closed or is about to close. That explains
**both** failure modes reported on the issue:

- the request body stalls on a half-dead socket → S3 replies `400 RequestTimeout`
- the socket is fully closed before the response → `httpx.RemoteProtocolError: Server disconnected
  without sending a response` (the second comment)

So this PR fixes the cause and hardens the retry path around it.

## Changes

**1. Cap client-side keep-alive below S3's idle timeout** (`1 hour` → `10s`). Connections used back
to back while transferring chunks are never idle, so download/upload throughput is unaffected — only
genuinely idle connections are dropped rather than reused after S3 has discarded them.

**2. Classify by S3 error code, not status code alone.** S3 reports several transient conditions
with status codes that are otherwise permanent client errors. `RequestTimeout`,
`RequestTimeTooSkewed`, `SlowDown`, `ServiceUnavailable` and `InternalError` are now retried;
`AccessDenied`, `NoSuchKey`, `InvalidRequest` etc. still fail fast on the first attempt. A body that
can't be parsed stays non-retriable, so the fallback is exactly today's behavior.

**3. Fix `get()` error handling.** `get()` streams, and its error paths called `response.read()`
*after* the stream context had exited, which raises `httpx.StreamClosed`. The effect was that error
logs recorded `"response": "None"` plus a spurious traceback, and the S3 error code never reached
the classifier at all. Reproduced before the fix:

```
"event": "failed to extract status code and response from failed S3 get response"
httpx.StreamClosed: Attempted to read or stream content, but the stream has been closed.
"event": "failed to get S3 object", "response": "None"
```

Error bodies are now read inside the stream context.

## Tests

New `tests/applications/blob_store/test_s3_blob_store_retries.py` — 15 tests mocking S3 with
`respx`, so unlike the existing `test_s3_blob_store.py` they need no AWS credentials, no bucket and
no network, and run in CI. Added to the public Python unit test job in `tests.yaml`.

Coverage: transient vs. permanent error codes on `PUT` and `GET`, retry exhaustion, unparseable
bodies, transport errors, and that the full body is re-sent on each `PUT` attempt (memoryviews are
not consumed by the first try).

Verified they are genuine regression tests — against `main`'s `s3_blob_store.py` **11 of the 15
fail**; all 15 pass with the fix. The rest of the CI allowlist still passes.

## Notes

- I couldn't run the applications suite in remote mode (needs `indexify-server` + `indexify-dataplane`),
  but this change is confined to the S3 blob store client and its new tests.
- Happy to drop the keep-alive change into a separate commit or PR if you'd rather land the retry
  classification first and measure the pool change separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)