### PR TITLE
Reject deploying an application file from a virtualenv root

### DIFF
--- a/src/tensorlake/applications/remote/code/ignored_code_paths.py
+++ b/src/tensorlake/applications/remote/code/ignored_code_paths.py
@@ -1,7 +1,12 @@
 import os
 import subprocess
 from pathlib import Path
-from typing import Optional, Set
+from typing import List, Optional, Set
+
+from ...interface import SDKUsageError
+
+# Marker file present in the root of every Python virtualenv.
+_VENV_MARKER_FILE = "pyvenv.cfg"
 
 
 def ignored_code_paths(root_dir: str) -> Set[str]:
@@ -13,26 +18,9 @@ def ignored_code_paths(root_dir: str) -> Set[str]:
     macOS where /var -> /private/var, causing exclusion checks to silently fail.
     """
     root = Path(os.path.abspath(root_dir))
+    _raise_if_virtualenv_root(root)
+
     exclude_paths = set()
-
-    # Exclude the active virtualenv if it's inside the root directory.
-    venv_path = os.environ.get("VIRTUAL_ENV")
-    if venv_path:
-        venv_path = Path(os.path.abspath(venv_path))
-        try:
-            venv_path.relative_to(root)
-            exclude_paths.add(str(venv_path))
-        except ValueError:
-            # venv is not inside root_dir, ignore
-            pass
-
-    # Exclude any other virtualenvs inside the root directory by looking for
-    # pyvenv.cfg — the standard marker file present in every Python venv.
-    for child in root.iterdir():
-        if child.is_dir() and (child / "pyvenv.cfg").exists():
-            abs_child = str(Path(os.path.abspath(child)))
-            if abs_child not in exclude_paths:
-                exclude_paths.add(abs_child)
 
     gitignore_path = root / ".gitignore"
     if gitignore_path.exists():
@@ -42,7 +30,79 @@ def ignored_code_paths(root_dir: str) -> Set[str]:
         else:
             exclude_paths.update(_parse_gitignore(root, gitignore_path))
 
+    # Computed after the gitignored paths so the scan can skip descending into them.
+    exclude_paths.update(_virtualenv_paths(root, exclude_paths))
+
     return exclude_paths
+
+
+def _is_inside(path: Path, root: Path) -> bool:
+    """Returns True if path is root itself or below it."""
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _raise_if_virtualenv_root(root: Path) -> None:
+    """Rejects deploying an application file that sits in the root of a virtualenv.
+
+    The directory holding the application file is what gets deployed as the application
+    code. When that directory is a virtualenv there is no way to ship the application
+    without shipping the virtualenv around it, so the deploy has to fail here rather than
+    succeed and leave the application failing to load in the Function Executor.
+    """
+    if not (root / _VENV_MARKER_FILE).is_file():
+        return
+
+    raise SDKUsageError(
+        f"The application file is in `{root}`, which is the root directory of a Python "
+        "virtualenv. The directory that holds the application file is deployed as the "
+        "application code, so deploying from here would ship the virtualenv instead of the "
+        "application and the application would fail to load. Please move the application "
+        "file into its own directory outside of the virtualenv and deploy it from there."
+    )
+
+
+def _virtualenv_paths(root: Path, already_excluded: Set[str]) -> Set[str]:
+    """Returns absolute paths of all virtualenvs inside the root directory, at any depth.
+
+    Virtualenvs are identified by the pyvenv.cfg marker file that every Python venv has.
+    A virtualenv must never end up in the application code ZIP: it is large, its contents
+    are platform specific, and its modules shadow the application modules once the ZIP is
+    unpacked.
+
+    Symlinks are not followed, so a virtualenv reachable only through a symlink is found
+    only when it is the active one.
+    """
+    venv_paths: Set[str] = set()
+
+    # The active virtualenv is checked explicitly because it can be reached through a
+    # symlink that the walk below does not follow. Excluding the root itself is
+    # meaningless because walk_code only compares the paths under the root, so a
+    # virtualenv that is the root is rejected by _raise_if_virtualenv_root() instead.
+    active_venv: Optional[str] = os.environ.get("VIRTUAL_ENV")
+    if active_venv:
+        active_venv_path = Path(os.path.abspath(active_venv))
+        if active_venv_path != root and _is_inside(active_venv_path, root):
+            venv_paths.add(str(active_venv_path))
+
+    for dir_path, dir_names, _ in os.walk(root):
+        kept: List[str] = []
+        for dir_name in dir_names:
+            child: str = os.path.abspath(os.path.join(dir_path, dir_name))
+            # Don't descend into directories that are already excluded or already known
+            # to be virtualenvs.
+            if child in already_excluded or child in venv_paths:
+                continue
+            if os.path.isfile(os.path.join(child, _VENV_MARKER_FILE)):
+                venv_paths.add(child)
+                continue
+            kept.append(dir_name)
+        dir_names[:] = kept
+
+    return venv_paths
 
 
 def _git_ignored_paths(root: Path) -> Optional[Set[str]]:

--- a/tests/applications/test_parse_gitignore.py
+++ b/tests/applications/test_parse_gitignore.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+from tensorlake.applications.interface.exceptions import SDKUsageError
 from tensorlake.applications.remote.code.ignored_code_paths import (
     _parse_gitignore,
     ignored_code_paths,
@@ -553,6 +554,164 @@ class TestWalkCodeEndToEnd(unittest.TestCase):
             self.assertIn(_abspath(root, "src/utils.py"), walked_files)
             self.assertNotIn(_abspath(root, "build/generated.py"), walked_files)
             self.assertNotIn(_abspath(root, "dist/bundle.py"), walked_files)
+
+
+class TestVirtualenvExclusion(unittest.TestCase):
+    """Virtualenvs must never reach the application code ZIP.
+
+    Regression tests for issue #523: an application file deployed from the root of a
+    virtualenv deployed successfully but then failed to load in the Function Executor.
+    """
+
+    def test_rejects_application_file_in_virtualenv_root(self):
+        """Deploying from the root of a virtualenv must fail with an actionable error."""
+        with TemporaryDirectory() as root:
+            root = Path(root)
+            _make_tree(
+                root,
+                [
+                    "pyvenv.cfg",
+                    "agent.py",
+                    "bin/activate",
+                    "lib/python3.12/site-packages/somepkg/__init__.py",
+                ],
+            )
+
+            with patch.dict(os.environ, {"VIRTUAL_ENV": str(root)}, clear=False):
+                with self.assertRaises(SDKUsageError) as ctx:
+                    ignored_code_paths(str(root))
+
+            # The message has to tell the user what to do about it.
+            self.assertIn("virtualenv", str(ctx.exception))
+            self.assertIn(str(root), str(ctx.exception))
+
+    def test_rejects_virtualenv_root_without_virtual_env_set(self):
+        """The marker file alone is enough; the virtualenv need not be activated."""
+        with TemporaryDirectory() as root:
+            root = Path(root)
+            _make_tree(root, ["pyvenv.cfg", "agent.py"])
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("VIRTUAL_ENV", None)
+                with self.assertRaises(SDKUsageError):
+                    ignored_code_paths(str(root))
+
+    def test_ordinary_directory_is_not_rejected(self):
+        with TemporaryDirectory() as root:
+            root = Path(root)
+            _make_tree(root, ["agent.py", "src/utils.py"])
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("VIRTUAL_ENV", None)
+                excluded = ignored_code_paths(str(root))
+
+            walked_files = list(walk_code(str(root), excluded))
+
+            self.assertIn(_abspath(root, "agent.py"), walked_files)
+            self.assertIn(_abspath(root, "src/utils.py"), walked_files)
+
+    def test_excludes_nested_virtualenv(self):
+        """A virtualenv below the top level must be excluded, not just a direct child."""
+        with TemporaryDirectory() as root:
+            root = Path(root)
+            _make_tree(
+                root,
+                [
+                    "app.py",
+                    "envs/myenv/pyvenv.cfg",
+                    "envs/myenv/lib/site-packages/pkg/mod.py",
+                ],
+            )
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("VIRTUAL_ENV", None)
+                excluded = ignored_code_paths(str(root))
+
+            self.assertIn(_abspath(root, "envs/myenv"), excluded)
+
+            walked_files = list(walk_code(str(root), excluded))
+
+            self.assertIn(_abspath(root, "app.py"), walked_files)
+            self.assertNotIn(
+                _abspath(root, "envs/myenv/lib/site-packages/pkg/mod.py"), walked_files
+            )
+
+    def test_excludes_multiple_virtualenvs_at_different_depths(self):
+        with TemporaryDirectory() as root:
+            root = Path(root)
+            _make_tree(
+                root,
+                [
+                    "app.py",
+                    ".venv/pyvenv.cfg",
+                    ".venv/lib/site-packages/a/mod.py",
+                    "tools/envs/other/pyvenv.cfg",
+                    "tools/envs/other/lib/site-packages/b/mod.py",
+                    "tools/helper.py",
+                ],
+            )
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("VIRTUAL_ENV", None)
+                excluded = ignored_code_paths(str(root))
+
+            walked_files = list(walk_code(str(root), excluded))
+
+            self.assertIn(_abspath(root, "app.py"), walked_files)
+            self.assertIn(_abspath(root, "tools/helper.py"), walked_files)
+            self.assertNotIn(
+                _abspath(root, ".venv/lib/site-packages/a/mod.py"), walked_files
+            )
+            self.assertNotIn(
+                _abspath(root, "tools/envs/other/lib/site-packages/b/mod.py"),
+                walked_files,
+            )
+
+    def test_excludes_active_virtualenv_reached_through_a_symlink(self):
+        """The active virtualenv is checked explicitly because the scan skips symlinks."""
+        with TemporaryDirectory() as outer:
+            outer = Path(outer)
+            root = outer / "project"
+            real_venv = outer / "real-venv"
+            _make_tree(root, ["app.py"])
+            _make_tree(real_venv, ["pyvenv.cfg", "lib/site-packages/pkg/mod.py"])
+
+            linked_venv = root / ".venv"
+            try:
+                linked_venv.symlink_to(real_venv, target_is_directory=True)
+            except (OSError, NotImplementedError):
+                self.skipTest("symlinks are not supported on this platform")
+
+            with patch.dict(os.environ, {"VIRTUAL_ENV": str(linked_venv)}, clear=False):
+                excluded = ignored_code_paths(str(root))
+
+            self.assertIn(_abspath(root, ".venv"), excluded)
+
+    def test_does_not_descend_into_gitignored_directories(self):
+        """A gitignored directory stays excluded and is not scanned for virtualenvs."""
+        with TemporaryDirectory() as root:
+            root = Path(root)
+            _make_tree(
+                root,
+                [
+                    "app.py",
+                    "build/pyvenv.cfg",
+                    "build/lib/site-packages/pkg/mod.py",
+                ],
+            )
+            (root / ".gitignore").write_text("/build/\n")
+
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("VIRTUAL_ENV", None)
+                excluded = ignored_code_paths(str(root))
+
+            walked_files = list(walk_code(str(root), excluded))
+
+            self.assertIn(_abspath(root, "build"), excluded)
+            self.assertIn(_abspath(root, "app.py"), walked_files)
+            self.assertNotIn(
+                _abspath(root, "build/lib/site-packages/pkg/mod.py"), walked_files
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #523.

## Why the deploy succeeded and the load failed

`ignored_code_paths()` tries to exclude the active virtualenv:

```python
venv_path = Path(os.path.abspath(venv_path))
try:
    venv_path.relative_to(root)
    exclude_paths.add(str(venv_path))
except ValueError:
    pass
```

When the virtualenv **is** the root, `relative_to()` succeeds (it returns `.`), so the root itself
lands in the exclusion set. But `walk_code()` only compares the paths *below* the root against that
set:

```python
dir_names[:] = [d for d in dir_names if os.path.join(dir_path, d) not in ignored_absolute_paths]
```

The root is never one of those, so the entry matches nothing and **the exclusion is a silent no-op**.
Reproduced on `main` — `agent.py` at a virtualenv root:

```
IGNORED = {'<root>'}          # the root itself
walk_code yields:
    <root>/agent.py
    <root>/lib/python3.12/site-packages/somepkg/__init__.py    ← whole venv swept into the ZIP
    <root>/lib/python3.12/site-packages/somepkg/big.py
```

So the ZIP is the virtualenv with the application buried in it, which is why deploy reports success
and the Function Executor then can't load the module.

## A second gap found while testing this

Virtualenv detection also only scanned **direct children** of the root:

```python
for child in root.iterdir():
    if child.is_dir() and (child / "pyvenv.cfg").exists():
```

So the common `./envs/myenv` or `./tools/envs/myenv` layout was not excluded at all. Reproduced on
`main` with no `.gitignore` present:

```
nested venv (envs/myenv), no VIRTUAL_ENV set
IGNORED = {}                  ← nothing excluded
  zipped: <root>/app.py
  zipped: <root>/envs/myenv/lib/site-packages/pkg/mod.py
```

This one is quieter than #523 — you get a bloated ZIP and possible module shadowing rather than a
clean failure — but it's the same defect.

## Changes

**1. Fail fast when the code directory is a virtualenv root.** Raises `SDKUsageError` naming the
directory and telling the user to move the application file into its own directory outside the
virtualenv. `cli/deploy.py` already catches `SDKUsageError` and reports it as `invalid usage` with
exit 1, so this needs no CLI change. It's raised in `ignored_code_paths()`, which `deploy()` calls
before loading code, building images or contacting the API — nothing is uploaded first.

This is the behavior the issue asked for:
> This is non-standard workflow so we don't really support it, but also looks like a UX miss that the
> deployment doesn't fail in this case at the very least.

**2. Detect virtualenvs at any depth.** The scan prunes as it walks, so it never descends into a
virtualenv it just found or into an already-excluded directory, and it runs *after* the gitignore
rules so those prune it too. The active `VIRTUAL_ENV` is still checked explicitly, because the scan
doesn't follow symlinks and a venv is often symlinked in.

Excluding the root itself is now recognised as meaningless rather than added to the set.

## Tests

7 tests in a new `TestVirtualenvExclusion` class in the existing `test_parse_gitignore.py` — already
in the CI allowlist, so no workflow change needed. Covers: rejection at a virtualenv root with and
without `VIRTUAL_ENV` set, nested virtualenvs at one and two levels, multiple virtualenvs at
different depths, an ordinary directory still deploying normally, a symlinked active virtualenv, and
gitignored directories staying pruned.

**4 of the 7 fail against `main`**; all 32 tests in the file pass with the fix, as do
`test_code_zip` and the rest of the CI allowlist. `black --check` / `isort --check-only` clean
repo-wide.

## Note

I couldn't exercise `tl deploy` end to end against a live API, so the Function-Executor-side symptom
is inferred from the ZIP contents rather than observed directly. The exclusion no-op and the nested
virtualenv gap are both reproduced directly, and both are covered by tests that fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)