### PR TITLE
Keep the service error message when the error code is unrecognized

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,6 +51,7 @@ jobs:
             tests.applications.test_parse_gitignore \
             tests.applications.test_request_context_headers \
             tests.cli.test_parse \
+            tests.document_ai.test_error_response \
             tests.utils.test_retries
           do
             poetry run python -m unittest "$module"

--- a/src/tensorlake/documentai/_base.py
+++ b/src/tensorlake/documentai/_base.py
@@ -265,14 +265,36 @@ def _deserialize_error_response(resp: _RustHTTPResponse) -> ErrorResponse:
     try:
         error_response = ErrorResponse.model_validate(resp.json())
         return error_response
-    except (ValidationError, ValueError) as e:
-        print(f"Failed to deserialize error response: {e}", file=sys.stderr)
+    except (ValidationError, ValueError):
+        # The body is not a well formed error response. The deserialization failure itself
+        # is an SDK detail that tells the user nothing about what went wrong, so it is not
+        # reported; what the service said is recovered instead, as far as that is possible.
         return ErrorResponse(
-            message=str(resp.text),
-            code=ErrorCode.INTERNAL_ERROR,
+            message=_error_message_from_body(resp),
+            code=ErrorCode.UNKNOWN,
             trace_id=resp.headers.get("x-trace-id") or resp.headers.get("X-Trace-ID"),
             details=None,
         )
+
+
+def _error_message_from_body(resp: _RustHTTPResponse) -> str:
+    """Returns the most human-readable error message the response body offers.
+
+    Falls back to the raw body, which is still more useful to the user than a report that
+    the SDK could not parse it.
+    """
+    try:
+        body = resp.json()
+    except Exception:
+        return str(resp.text)
+
+    if isinstance(body, dict):
+        for key in ("message", "error", "detail"):
+            value = body.get(key)
+            if isinstance(value, str) and value:
+                return value
+
+    return str(resp.text)
 
 
 # --- simple color helpers ---

--- a/src/tensorlake/documentai/models/_errors.py
+++ b/src/tensorlake/documentai/models/_errors.py
@@ -1,7 +1,7 @@
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class DocumentAIError(Exception):
@@ -39,6 +39,9 @@ class ErrorCode(str, Enum):
     INVALID_MULTIPART = "INVALID_MULTIPART"
     MULTIPART_STREAM_END = "MULTIPART_STREAM_END"
     INVALID_QUERY_PARAMS = "INVALID_QUERY_PARAMS"
+    # Returned by the SDK, never by the service: the error carried a code this SDK version
+    # does not know, no code at all, or the response body was not a valid error response.
+    UNKNOWN = "UNKNOWN"
 
 
 class ErrorResponse(BaseModel):
@@ -50,10 +53,34 @@ class ErrorResponse(BaseModel):
     """
 
     message: str = Field(..., description="A human-readable error message")
-    code: ErrorCode = Field(..., description="The error code for programmatic handling")
+    code: ErrorCode = Field(
+        ErrorCode.UNKNOWN, description="The error code for programmatic handling"
+    )
     trace_id: Optional[str] = Field(
         None, description="Optional correlation ID for distributed tracing"
     )
     details: Optional[dict] = Field(
         None, description="Optional extra details (e.g., field-level validation errors)"
     )
+
+    @field_validator("code", mode="before")
+    @classmethod
+    def _tolerate_unrecognized_code(cls, value: Any) -> Any:
+        """Maps a code this SDK version does not know onto ErrorCode.UNKNOWN.
+
+        `code` is chosen by the service, so treating an unrecognized value as a validation
+        error would mean the service could not add an error code without breaking error
+        reporting in every released SDK: the whole response would fail to deserialize and
+        the human-readable message would be lost along with it. The message is the part
+        users need, so it must survive a code this SDK cannot interpret.
+        """
+        if value is None:
+            return ErrorCode.UNKNOWN
+        if isinstance(value, ErrorCode):
+            return value
+        if isinstance(value, str):
+            try:
+                return ErrorCode(value)
+            except ValueError:
+                return ErrorCode.UNKNOWN
+        return ErrorCode.UNKNOWN

--- a/tests/document_ai/test_error_response.py
+++ b/tests/document_ai/test_error_response.py
@@ -1,0 +1,157 @@
+"""Unit tests for Document AI error response deserialization.
+
+These are pure unit tests: unlike the rest of tests/document_ai they need no API key and
+make no network calls.
+"""
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr
+
+from tensorlake.documentai._base import (
+    _deserialize_error_response,
+    _RustHTTPResponse,
+)
+from tensorlake.documentai.models import ErrorCode, ErrorResponse
+
+
+def _response(body, status_code: int = 400, headers: dict = None) -> _RustHTTPResponse:
+    if not isinstance(body, str):
+        body = json.dumps(body)
+    return _RustHTTPResponse(status_code=status_code, headers=headers or {}, body=body)
+
+
+class TestErrorResponseModel(unittest.TestCase):
+    def test_known_code_is_parsed_as_enum(self):
+        response = ErrorResponse.model_validate(
+            {"message": "bad mime type", "code": "INVALID_MIME_TYPE"}
+        )
+
+        self.assertEqual(response.code, ErrorCode.INVALID_MIME_TYPE)
+        self.assertEqual(response.message, "bad mime type")
+
+    def test_null_code_keeps_the_message(self):
+        # The payload from issue #408. A null code used to fail validation, which cost the
+        # user the message and produced a pydantic error about the SDK's own model instead.
+        response = ErrorResponse.model_validate(
+            {
+                "message": "Expecting value: line 1 column 1 (char 0)",
+                "code": None,
+                "details": None,
+            }
+        )
+
+        self.assertEqual(response.code, ErrorCode.UNKNOWN)
+        self.assertEqual(response.message, "Expecting value: line 1 column 1 (char 0)")
+
+    def test_unrecognized_code_keeps_the_message(self):
+        # The service must be able to add an error code without breaking error reporting
+        # in SDK versions that predate it.
+        response = ErrorResponse.model_validate(
+            {"message": "Too many requests", "code": "SOME_FUTURE_ERROR_CODE"}
+        )
+
+        self.assertEqual(response.code, ErrorCode.UNKNOWN)
+        self.assertEqual(response.message, "Too many requests")
+
+    def test_missing_code_keeps_the_message(self):
+        response = ErrorResponse.model_validate({"message": "something broke"})
+
+        self.assertEqual(response.code, ErrorCode.UNKNOWN)
+        self.assertEqual(response.message, "something broke")
+
+    def test_optional_fields_are_preserved(self):
+        response = ErrorResponse.model_validate(
+            {
+                "message": "quota exceeded",
+                "code": "QUOTA_EXCEEDED",
+                "trace_id": "trace-123",
+                "details": {"field": "page_range"},
+            }
+        )
+
+        self.assertEqual(response.code, ErrorCode.QUOTA_EXCEEDED)
+        self.assertEqual(response.trace_id, "trace-123")
+        self.assertEqual(response.details, {"field": "page_range"})
+
+    def test_message_is_still_required(self):
+        # An error response without a message carries no information, so it must fall
+        # through to the raw body handling in _deserialize_error_response().
+        with self.assertRaises(Exception):
+            ErrorResponse.model_validate({"code": "INVALID_MIME_TYPE"})
+
+
+class TestDeserializeErrorResponse(unittest.TestCase):
+    def test_well_formed_error_response(self):
+        result = _deserialize_error_response(
+            _response({"message": "bad mime type", "code": "INVALID_MIME_TYPE"})
+        )
+
+        self.assertEqual(result.code, ErrorCode.INVALID_MIME_TYPE)
+        self.assertEqual(result.message, "bad mime type")
+
+    def test_null_code_surfaces_the_service_message(self):
+        # Regression test for issue #408: the message used to be replaced by the whole raw
+        # JSON body because the response failed to deserialize.
+        result = _deserialize_error_response(
+            _response(
+                {
+                    "message": "Expecting value: line 1 column 1 (char 0)",
+                    "code": None,
+                    "details": None,
+                }
+            )
+        )
+
+        self.assertEqual(result.message, "Expecting value: line 1 column 1 (char 0)")
+        self.assertNotIn("{", result.message)
+
+    def test_body_without_a_message_field_falls_back_to_the_raw_body(self):
+        body = {"unexpected": "shape"}
+        result = _deserialize_error_response(_response(body))
+
+        self.assertEqual(result.code, ErrorCode.UNKNOWN)
+        self.assertEqual(result.message, json.dumps(body))
+
+    def test_non_json_body_falls_back_to_the_raw_body(self):
+        result = _deserialize_error_response(_response("502 Bad Gateway"))
+
+        self.assertEqual(result.code, ErrorCode.UNKNOWN)
+        self.assertEqual(result.message, "502 Bad Gateway")
+
+    def test_empty_body_does_not_raise(self):
+        result = _deserialize_error_response(_response(""))
+
+        self.assertEqual(result.code, ErrorCode.UNKNOWN)
+        self.assertEqual(result.message, "")
+
+    def test_alternative_message_keys_are_recovered(self):
+        for key in ("error", "detail"):
+            with self.subTest(key=key):
+                result = _deserialize_error_response(
+                    _response({key: "upstream failed"})
+                )
+
+                self.assertEqual(result.message, "upstream failed")
+
+    def test_trace_id_is_read_from_headers_case_insensitively(self):
+        result = _deserialize_error_response(
+            _response({"unexpected": "shape"}, headers={"X-Trace-ID": "trace-abc"})
+        )
+
+        self.assertEqual(result.trace_id, "trace-abc")
+
+    def test_nothing_is_printed_to_stderr(self):
+        # Deserialization failures used to be printed straight to stderr from library
+        # code. The reported error is the caller's to surface, not the SDK's to narrate.
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            _deserialize_error_response(_response("not json at all"))
+            _deserialize_error_response(_response({"unexpected": "shape"}))
+
+        self.assertEqual(stderr.getvalue(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #408.

## The reported symptom

Parsing raw text without a mime type surfaced a pydantic error about the SDK's own model instead of
what the service said:

```
1 validation error for ErrorResponse
timestamp
  Field required [type=missing, input_value={'message': 'Expecting va...', 'code': None, 'details': None}
```

The `timestamp` field is long gone, but the failure just moved to `code` — the issue still
reproduces today.

## What's wrong

`ErrorResponse.code` is a **required, closed enum**, and the field is chosen by the service. I ran
the current model against four realistic payloads:

```
FAIL  issue #408 payload (code=null):     code: enum
FAIL  server adds a NEW error code:       code: enum
OK    known code (happy path):            code=ErrorCode.INVALID_MIME_TYPE
FAIL  no code field at all:               code: missing
```

Three of four fail, and a failure discards the whole response — including the human-readable
`message`, which is the part the user actually needs.

Beyond this issue, that makes the enum a **forward compatibility hazard**: the service can't add an
error code without breaking error reporting in every already-released SDK. The moment a new code
appears in a response, every deployed version stops showing the message that came with it.

The fallback in `_deserialize_error_response()` compounded it:

```python
except (ValidationError, ValueError) as e:
    print(f"Failed to deserialize error response: {e}", file=sys.stderr)
    return ErrorResponse(
        message=str(resp.text),          # the whole JSON blob replaces the message
        code=ErrorCode.INTERNAL_ERROR,
        ...
```

so the user got the raw body instead of the sentence inside it, plus pydantic internals printed
straight to stderr from library code. That result then feeds `_print_error_line()` and the
`DocumentAIError` the caller catches.

## Changes

**1. Tolerate an unrecognized code.** New `ErrorCode.UNKNOWN` member, and a `mode="before"` validator
maps an unknown, null or absent code onto it. Known codes still parse to their typed enum member, so
`err.code == ErrorCode.QUOTA_EXCEEDED` keeps working and `code.value` at the call site is unchanged.
The message now survives a code the SDK can't interpret.

**2. Recover the message on the fallback path.** When the body genuinely isn't an error response, the
message is taken from `message`/`error`/`detail` if present, and only otherwise from the raw body.

**3. Stop printing the deserialization failure to stderr.** That the SDK couldn't parse the body tells
the user nothing about what went wrong; the error is surfaced to the caller either way.

**4. Fallback code is `UNKNOWN` rather than `INTERNAL_ERROR`,** which claimed a service-side failure
for what is really an unparseable body. Flagging this one explicitly since it changes the `code` a
caller sees on that path — happy to revert it if you'd rather keep the old value.

## Tests

`tests/document_ai/test_error_response.py` — 14 tests needing no API key and no network, unlike the
rest of `tests/document_ai`. Added to the public Python unit test job in `tests.yaml`. Covers the
issue's exact payload, unknown/missing/null codes, known codes still typed, message recovery from
each body shape, empty and non-JSON bodies, trace_id headers, and that nothing reaches stderr.

**10 of the 14 fail against `main`**; all pass with the fix, as does the rest of the CI allowlist.
`black --check` / `isort --check-only` clean repo-wide.

## Notes

- I couldn't reproduce end to end against the live API, so the fix is driven by the payload in the
  issue and by the model's behavior, both verified directly.
- #963 also adds a line to the same `tests.yaml` list. Different lines, so it should merge cleanly in
  either order, but flagging it.
- Adjacent but deliberately not included: #318 asks for a default mime type for raw text, which is a
  separate change in `_parse.py`. Happy to follow up on that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)