### PR TITLE
Replay requests the Sandbox Proxy never forwarded for long enough to outlast a rollout

### DIFF
--- a/crates/cloud-sdk/src/error.rs
+++ b/crates/cloud-sdk/src/error.rs
@@ -77,18 +77,28 @@ pub enum SdkError {
     EventSourceError(String),
 }
 
-/// Error codes the Sandbox Proxy returns when it could not complete a request
-/// *before* forwarding it to the sandbox: the Indexify lookup did not answer
-/// (`SANDBOX_UPSTREAM_ERROR`), the sandbox has no route yet
-/// (`SANDBOX_NOT_READY`), or the dataplane could not be reached
-/// (`SANDBOX_UNREACHABLE`). In every case the request never reached the
-/// sandbox, so replaying it cannot duplicate a side effect — and every case is
-/// what an Indexify server rollout looks like from the client. The proxy's
-/// error body is `{"error": "...", "code": "..."}`.
+/// Error codes the Sandbox Proxy returns when it gave up on a request *before*
+/// any dataplane executed it, so replaying the request cannot duplicate a side
+/// effect:
+///
+/// - `SANDBOX_UPSTREAM_ERROR` — the Indexify lookup did not answer.
+/// - `SANDBOX_NOT_READY` — the sandbox has no route yet.
+/// - `SANDBOX_UNREACHABLE` — the dataplane could not be connected to, or a
+///   dataplane answered that it does not host the sandbox (its own
+///   `SANDBOX_NOT_FOUND` / `SANDBOX_NOT_RUNNING`, sent instead of executing
+///   the request) and the route could not be refreshed in time.
+/// - `AUTH_SERVICE_UNAVAILABLE` — the Platform auth check failed; nothing was
+///   forwarded.
+///
+/// These are what an Indexify server rollout looks like from the client. The
+/// proxy's error body is `{"error": "...", "code": "..."}`. Proxies older than
+/// compute-engine-internal #2083 report the lookup gap as a plain
+/// `SANDBOX_NOT_FOUND` 404, which is not replayed.
 pub const SANDBOX_PROXY_UNDELIVERED_CODES: &[&str] = &[
     "SANDBOX_UPSTREAM_ERROR",
     "SANDBOX_NOT_READY",
     "SANDBOX_UNREACHABLE",
+    "AUTH_SERVICE_UNAVAILABLE",
 ];
 
 /// Why a request failed below the HTTP status layer.
@@ -164,9 +174,13 @@ impl SdkError {
     /// executed it, making a replay safe even for a non-idempotent operation.
     ///
     /// True for a connect failure (see [`SdkError::transport_failure`]) and for
-    /// a 502/503 from the Sandbox Proxy carrying one of
-    /// [`SANDBOX_PROXY_UNDELIVERED_CODES`]. A timeout, or a 5xx without such a
-    /// code, gives no such guarantee.
+    /// a 5xx from the Sandbox Proxy carrying one of
+    /// [`SANDBOX_PROXY_UNDELIVERED_CODES`]. Any 5xx qualifies, not only the
+    /// 502/503 current proxies emit: older proxies relay the Indexify lookup's
+    /// own 500/504 verbatim under `SANDBOX_UPSTREAM_ERROR`, and those requests
+    /// were not forwarded either. A 4xx with one of these codes is a definitive
+    /// answer the proxy passed through (a 403, a 409) and is not replayed. A
+    /// timeout, or a 5xx without such a code, gives no guarantee at all.
     pub fn never_reached_server(&self) -> bool {
         if matches!(self.transport_failure(), Some(TransportFailure::Connect)) {
             return true;
@@ -174,9 +188,7 @@ impl SdkError {
         let Self::ServerError { status, .. } = self else {
             return false;
         };
-        if *status != reqwest::StatusCode::SERVICE_UNAVAILABLE
-            && *status != reqwest::StatusCode::BAD_GATEWAY
-        {
+        if !status.is_server_error() {
             return false;
         }
         self.upstream_error_code()
@@ -326,8 +338,12 @@ mod undelivered_tests {
     fn only_pre_forward_proxy_failures_count_as_undelivered() {
         let undelivered = [
             (503, "SANDBOX_UPSTREAM_ERROR"),
+            // Pre-#2083 proxies relay the lookup's own 5xx under this code.
+            (500, "SANDBOX_UPSTREAM_ERROR"),
+            (504, "SANDBOX_UPSTREAM_ERROR"),
             (503, "SANDBOX_NOT_READY"),
             (502, "SANDBOX_UNREACHABLE"),
+            (503, "AUTH_SERVICE_UNAVAILABLE"),
         ];
         for (status, code) in undelivered {
             let body = format!(r#"{{"error":"x","code":"{code}"}}"#);
@@ -337,11 +353,15 @@ mod undelivered_tests {
             );
         }
 
-        // Same codes on a status the proxy does not use for them: not trusted.
-        assert!(
-            !server_error(500, r#"{"error":"x","code":"SANDBOX_UPSTREAM_ERROR"}"#)
-                .never_reached_server()
-        );
+        // A 4xx under the same code is a definitive answer the proxy passed
+        // through from the lookup (forbidden, conflict): not replayed.
+        for status in [403, 409] {
+            assert!(
+                !server_error(status, r#"{"error":"x","code":"SANDBOX_UPSTREAM_ERROR"}"#)
+                    .never_reached_server(),
+                "{status} must not be replayed"
+            );
+        }
         // A 503 from something else — the sandbox daemon, an ingress — may have
         // executed the request.
         assert!(!server_error(503, r#"{"error":"daemon overloaded"}"#).never_reached_server());

--- a/crates/cloud-sdk/src/error.rs
+++ b/crates/cloud-sdk/src/error.rs
@@ -77,6 +77,20 @@ pub enum SdkError {
     EventSourceError(String),
 }
 
+/// Error codes the Sandbox Proxy returns when it could not complete a request
+/// *before* forwarding it to the sandbox: the Indexify lookup did not answer
+/// (`SANDBOX_UPSTREAM_ERROR`), the sandbox has no route yet
+/// (`SANDBOX_NOT_READY`), or the dataplane could not be reached
+/// (`SANDBOX_UNREACHABLE`). In every case the request never reached the
+/// sandbox, so replaying it cannot duplicate a side effect — and every case is
+/// what an Indexify server rollout looks like from the client. The proxy's
+/// error body is `{"error": "...", "code": "..."}`.
+pub const SANDBOX_PROXY_UNDELIVERED_CODES: &[&str] = &[
+    "SANDBOX_UPSTREAM_ERROR",
+    "SANDBOX_NOT_READY",
+    "SANDBOX_UNREACHABLE",
+];
+
 /// Why a request failed below the HTTP status layer.
 ///
 /// The distinction is load-bearing for retries: a [`TransportFailure::Connect`]
@@ -126,6 +140,47 @@ impl SdkError {
         } else {
             None
         }
+    }
+
+    /// The `code` from a JSON error body of the form
+    /// `{"error": "...", "code": "..."}`, when the server sent one.
+    ///
+    /// [`SdkError::ServerError`] keeps the raw body as its message, so the code
+    /// is recovered by parsing it here rather than carried as a field.
+    pub fn upstream_error_code(&self) -> Option<String> {
+        let Self::ServerError { message, .. } = self else {
+            return None;
+        };
+        #[derive(serde::Deserialize)]
+        struct Body {
+            code: Option<String>,
+        }
+        serde_json::from_str::<Body>(message)
+            .ok()
+            .and_then(|body| body.code)
+    }
+
+    /// Whether the request provably never reached the server that would have
+    /// executed it, making a replay safe even for a non-idempotent operation.
+    ///
+    /// True for a connect failure (see [`SdkError::transport_failure`]) and for
+    /// a 502/503 from the Sandbox Proxy carrying one of
+    /// [`SANDBOX_PROXY_UNDELIVERED_CODES`]. A timeout, or a 5xx without such a
+    /// code, gives no such guarantee.
+    pub fn never_reached_server(&self) -> bool {
+        if matches!(self.transport_failure(), Some(TransportFailure::Connect)) {
+            return true;
+        }
+        let Self::ServerError { status, .. } = self else {
+            return false;
+        };
+        if *status != reqwest::StatusCode::SERVICE_UNAVAILABLE
+            && *status != reqwest::StatusCode::BAD_GATEWAY
+        {
+            return false;
+        }
+        self.upstream_error_code()
+            .is_some_and(|code| SANDBOX_PROXY_UNDELIVERED_CODES.contains(&code.as_str()))
     }
 
     /// The error's `Display` output followed by every `source()` in its chain.
@@ -235,6 +290,68 @@ mod transport_failure_tests {
         assert!(
             detail.contains("tcp connect error"),
             "detail() must expose the source chain; got {detail:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod undelivered_tests {
+    use super::SdkError;
+
+    fn server_error(status: u16, body: &str) -> SdkError {
+        SdkError::ServerError {
+            status: reqwest::StatusCode::from_u16(status).unwrap(),
+            message: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn upstream_error_code_reads_the_proxy_body() {
+        let error = server_error(
+            503,
+            r#"{"error":"Sandbox routing is temporarily unavailable","code":"SANDBOX_UPSTREAM_ERROR"}"#,
+        );
+        assert_eq!(
+            error.upstream_error_code().as_deref(),
+            Some("SANDBOX_UPSTREAM_ERROR")
+        );
+        assert_eq!(server_error(503, "plain text").upstream_error_code(), None);
+        assert_eq!(
+            server_error(503, r#"{"error":"no code"}"#).upstream_error_code(),
+            None
+        );
+    }
+
+    #[test]
+    fn only_pre_forward_proxy_failures_count_as_undelivered() {
+        let undelivered = [
+            (503, "SANDBOX_UPSTREAM_ERROR"),
+            (503, "SANDBOX_NOT_READY"),
+            (502, "SANDBOX_UNREACHABLE"),
+        ];
+        for (status, code) in undelivered {
+            let body = format!(r#"{{"error":"x","code":"{code}"}}"#);
+            assert!(
+                server_error(status, &body).never_reached_server(),
+                "{status} {code} must be replayable"
+            );
+        }
+
+        // Same codes on a status the proxy does not use for them: not trusted.
+        assert!(
+            !server_error(500, r#"{"error":"x","code":"SANDBOX_UPSTREAM_ERROR"}"#)
+                .never_reached_server()
+        );
+        // A 503 from something else — the sandbox daemon, an ingress — may have
+        // executed the request.
+        assert!(!server_error(503, r#"{"error":"daemon overloaded"}"#).never_reached_server());
+        assert!(
+            !server_error(503, r#"{"error":"x","code":"SANDBOX_NOT_FOUND"}"#)
+                .never_reached_server()
+        );
+        assert!(
+            !server_error(404, r#"{"error":"x","code":"SANDBOX_NOT_FOUND"}"#)
+                .never_reached_server()
         );
     }
 }

--- a/crates/cloud-sdk/src/lib.rs
+++ b/crates/cloud-sdk/src/lib.rs
@@ -74,6 +74,7 @@ pub mod error;
 pub mod http_transport;
 mod image_service_builds;
 pub mod images;
+pub mod retry;
 pub mod sandbox_images;
 pub mod sandbox_templates;
 pub mod sandboxes;

--- a/crates/cloud-sdk/src/retry.rs
+++ b/crates/cloud-sdk/src/retry.rs
@@ -28,14 +28,34 @@ use crate::error::SdkError;
 /// seconds after that. Replays stop as soon as one attempt succeeds.
 pub const UNDELIVERED_REPLAY_BUDGET: Duration = Duration::from_secs(30);
 
-/// Longest single wait between attempts.
-pub const MAX_BACKOFF: Duration = Duration::from_secs(5);
+/// Cap on the doubling wait between transient retries of an idempotent
+/// operation. This is the schedule the bindings have always used; a caller
+/// asking for ten retries gets ~53 s of patience, as before.
+pub const MAX_TRANSIENT_BACKOFF: Duration = Duration::from_secs(15);
 
-/// Wait before the `attempt`-th retry (1-based): `0.1 s × 2^attempt × 0.75`,
-/// capped at [`MAX_BACKOFF`] — 0.15, 0.3, 0.6, 1.2, 2.4, 3.75, 3.75 …
-pub fn backoff(attempt: usize) -> Duration {
+/// Cap on the wait between replays of an undelivered request. Lower than the
+/// transient cap so the replays keep probing a recovering control plane every
+/// few seconds instead of sleeping through most of the budget.
+pub const MAX_UNDELIVERED_BACKOFF: Duration = Duration::from_secs(5);
+
+/// The exponential schedule shared by both caps: `min(0.1 s × 2^attempt, cap)
+/// × 0.75`, `attempt` 1-based. The 0.75 is applied after the cap, so the
+/// longest wait is three quarters of `cap`.
+fn backoff(attempt: usize, cap: Duration) -> Duration {
     let base = Duration::from_millis(100).saturating_mul(1u32 << attempt.min(31));
-    base.min(MAX_BACKOFF).mul_f64(0.75)
+    base.min(cap).mul_f64(0.75)
+}
+
+/// Wait before the `attempt`-th transient retry: 0.15, 0.3, 0.6, 1.2, 2.4,
+/// 4.8, 9.6, 11.25, 11.25 …
+pub fn transient_backoff(attempt: usize) -> Duration {
+    backoff(attempt, MAX_TRANSIENT_BACKOFF)
+}
+
+/// Wait before the `attempt`-th undelivered replay: 0.15, 0.3, 0.6, 1.2, 2.4,
+/// 3.75, 3.75 …
+pub fn undelivered_backoff(attempt: usize) -> Duration {
+    backoff(attempt, MAX_UNDELIVERED_BACKOFF)
 }
 
 /// Whether the failure is worth retrying for an operation that can safely run
@@ -119,7 +139,7 @@ impl RetryState {
                 return RetryDecision::Stop;
             }
             self.undelivered_replays += 1;
-            let wait = backoff(self.undelivered_replays);
+            let wait = undelivered_backoff(self.undelivered_replays);
             // Never wait past the budget: a replay that could not start in
             // time should fail now, with the error the caller can act on.
             return RetryDecision::Retry(wait.min(UNDELIVERED_REPLAY_BUDGET - elapsed));
@@ -129,7 +149,7 @@ impl RetryState {
             && self.transient_retries < self.policy.max_transient_retries
         {
             self.transient_retries += 1;
-            return RetryDecision::Retry(backoff(self.transient_retries));
+            return RetryDecision::Retry(transient_backoff(self.transient_retries));
         }
         RetryDecision::Stop
     }
@@ -184,12 +204,25 @@ mod tests {
     }
 
     #[test]
-    fn backoff_grows_then_caps() {
-        assert_eq!(backoff(1), Duration::from_millis(150));
-        assert_eq!(backoff(2), Duration::from_millis(300));
-        assert_eq!(backoff(5), Duration::from_millis(2_400));
-        assert_eq!(backoff(6), Duration::from_millis(3_750));
-        assert_eq!(backoff(40), Duration::from_millis(3_750));
+    fn undelivered_backoff_grows_then_caps_low() {
+        assert_eq!(undelivered_backoff(1), Duration::from_millis(150));
+        assert_eq!(undelivered_backoff(2), Duration::from_millis(300));
+        assert_eq!(undelivered_backoff(5), Duration::from_millis(2_400));
+        assert_eq!(undelivered_backoff(6), Duration::from_millis(3_750));
+        assert_eq!(undelivered_backoff(40), Duration::from_millis(3_750));
+    }
+
+    #[test]
+    fn transient_backoff_keeps_the_original_schedule() {
+        // The schedule the bindings shipped with before this module existed:
+        // 0.1 s × 2^n, capped at 15 s, × 0.75.
+        assert_eq!(transient_backoff(1), Duration::from_millis(150));
+        assert_eq!(transient_backoff(6), Duration::from_millis(4_800));
+        assert_eq!(transient_backoff(7), Duration::from_millis(9_600));
+        assert_eq!(transient_backoff(8), Duration::from_millis(11_250));
+        assert_eq!(transient_backoff(40), Duration::from_millis(11_250));
+        let ten_retries: Duration = (1..=10).map(transient_backoff).sum();
+        assert_eq!(ten_retries, Duration::from_millis(52_800));
     }
 
     #[test]

--- a/crates/cloud-sdk/src/retry.rs
+++ b/crates/cloud-sdk/src/retry.rs
@@ -1,0 +1,295 @@
+//! Retry policy shared by every binding.
+//!
+//! Two questions decide whether a failed request is replayed, and they are
+//! deliberately separate:
+//!
+//! 1. **Did the request reach the server that would have executed it?** When
+//!    it provably did not — a connect failure, or the Sandbox Proxy answering
+//!    that it could not complete the lookup before forwarding — replaying it
+//!    cannot duplicate a side effect, so even non-idempotent operations
+//!    (starting a process, creating a sandbox) are replayed. These failures
+//!    are what a control-plane rollout looks like from the outside, so they
+//!    get a time budget that spans one: [`UNDELIVERED_REPLAY_BUDGET`].
+//! 2. **Is the failure transient?** A 502/503/504 or a dropped event stream
+//!    is worth a handful of retries — but only for idempotent operations,
+//!    because the server may have executed the request before failing.
+//!
+//! Timeouts are in neither class. A timed-out request was on the wire and may
+//! be executing; nothing here replays it.
+
+use std::{future::Future, time::Duration};
+
+use crate::error::SdkError;
+
+/// How long a request that never reached the server keeps being replayed.
+///
+/// Sized to outlast an Indexify server rollout: the pod is replaced in
+/// 7–30 s and the Sandbox Proxy reports lookups as unavailable for a few
+/// seconds after that. Replays stop as soon as one attempt succeeds.
+pub const UNDELIVERED_REPLAY_BUDGET: Duration = Duration::from_secs(30);
+
+/// Longest single wait between attempts.
+pub const MAX_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Wait before the `attempt`-th retry (1-based): `0.1 s × 2^attempt × 0.75`,
+/// capped at [`MAX_BACKOFF`] — 0.15, 0.3, 0.6, 1.2, 2.4, 3.75, 3.75 …
+pub fn backoff(attempt: usize) -> Duration {
+    let base = Duration::from_millis(100).saturating_mul(1u32 << attempt.min(31));
+    base.min(MAX_BACKOFF).mul_f64(0.75)
+}
+
+/// Whether the failure is worth retrying for an operation that can safely run
+/// twice. Excludes timeouts on purpose; see the module docs.
+pub fn is_transient(error: &SdkError) -> bool {
+    match error {
+        SdkError::ServerError { status, .. } => {
+            *status == reqwest::StatusCode::BAD_GATEWAY
+                || *status == reqwest::StatusCode::SERVICE_UNAVAILABLE
+                || *status == reqwest::StatusCode::GATEWAY_TIMEOUT
+        }
+        SdkError::EventSourceError(_) => true,
+        _ => false,
+    }
+}
+
+/// What a caller is willing to replay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryPolicy {
+    /// The operation can run twice without harm, so transient failures are
+    /// retried up to `max_transient_retries` times.
+    pub idempotent: bool,
+    /// Retry cap for transient failures of idempotent operations. Failures
+    /// that never reached the server are governed by
+    /// [`UNDELIVERED_REPLAY_BUDGET`] instead, whatever this is.
+    pub max_transient_retries: usize,
+}
+
+impl RetryPolicy {
+    /// Retry transient failures up to `max_transient_retries` times, and
+    /// replay undelivered requests for the full budget.
+    pub const fn idempotent(max_transient_retries: usize) -> Self {
+        Self {
+            idempotent: true,
+            max_transient_retries,
+        }
+    }
+
+    /// Replay only requests that provably never reached the server. Safe to
+    /// wrap starting a process or creating a sandbox.
+    pub const fn non_idempotent() -> Self {
+        Self {
+            idempotent: false,
+            max_transient_retries: 0,
+        }
+    }
+}
+
+/// The outcome of asking whether to try again.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryDecision {
+    /// Wait this long, then try again.
+    Retry(Duration),
+    /// Give up and return the error.
+    Stop,
+}
+
+/// Bookkeeping for one retried operation. Pure — the caller supplies elapsed
+/// time and performs the wait — so the policy can be tested without a clock.
+#[derive(Debug, Clone)]
+pub struct RetryState {
+    policy: RetryPolicy,
+    transient_retries: usize,
+    undelivered_replays: usize,
+}
+
+impl RetryState {
+    pub fn new(policy: RetryPolicy) -> Self {
+        Self {
+            policy,
+            transient_retries: 0,
+            undelivered_replays: 0,
+        }
+    }
+
+    /// Decide what to do about `error`, given how long the whole operation has
+    /// been running.
+    pub fn decide(&mut self, error: &SdkError, elapsed: Duration) -> RetryDecision {
+        if error.never_reached_server() {
+            if elapsed >= UNDELIVERED_REPLAY_BUDGET {
+                return RetryDecision::Stop;
+            }
+            self.undelivered_replays += 1;
+            let wait = backoff(self.undelivered_replays);
+            // Never wait past the budget: a replay that could not start in
+            // time should fail now, with the error the caller can act on.
+            return RetryDecision::Retry(wait.min(UNDELIVERED_REPLAY_BUDGET - elapsed));
+        }
+        if self.policy.idempotent
+            && is_transient(error)
+            && self.transient_retries < self.policy.max_transient_retries
+        {
+            self.transient_retries += 1;
+            return RetryDecision::Retry(backoff(self.transient_retries));
+        }
+        RetryDecision::Stop
+    }
+
+    /// Attempts made so far beyond the first.
+    pub fn retries(&self) -> usize {
+        self.transient_retries + self.undelivered_replays
+    }
+}
+
+/// Run `op` under `policy`, sleeping on the tokio timer between attempts.
+pub async fn retry<C, T, F, Fut>(client: C, policy: RetryPolicy, op: F) -> Result<T, SdkError>
+where
+    C: Clone,
+    F: Fn(C) -> Fut,
+    Fut: Future<Output = Result<T, SdkError>>,
+{
+    let started = tokio::time::Instant::now();
+    let mut state = RetryState::new(policy);
+    loop {
+        match op(client.clone()).await {
+            Ok(value) => return Ok(value),
+            Err(error) => match state.decide(&error, started.elapsed()) {
+                RetryDecision::Stop => return Err(error),
+                RetryDecision::Retry(wait) => tokio::time::sleep(wait).await,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+
+    fn server_error(status: u16, body: &str) -> SdkError {
+        SdkError::ServerError {
+            status: reqwest::StatusCode::from_u16(status).unwrap(),
+            message: body.to_string(),
+        }
+    }
+
+    fn proxy_unavailable() -> SdkError {
+        server_error(
+            503,
+            r#"{"error":"Sandbox routing is temporarily unavailable: the control plane could not be reached. Retry the request.","code":"SANDBOX_UPSTREAM_ERROR"}"#,
+        )
+    }
+
+    #[test]
+    fn backoff_grows_then_caps() {
+        assert_eq!(backoff(1), Duration::from_millis(150));
+        assert_eq!(backoff(2), Duration::from_millis(300));
+        assert_eq!(backoff(5), Duration::from_millis(2_400));
+        assert_eq!(backoff(6), Duration::from_millis(3_750));
+        assert_eq!(backoff(40), Duration::from_millis(3_750));
+    }
+
+    #[test]
+    fn a_proxy_lookup_failure_is_replayed_even_for_non_idempotent_operations() {
+        let mut state = RetryState::new(RetryPolicy::non_idempotent());
+        let error = proxy_unavailable();
+
+        assert_eq!(
+            state.decide(&error, Duration::ZERO),
+            RetryDecision::Retry(Duration::from_millis(150))
+        );
+        assert_eq!(
+            state.decide(&error, Duration::from_secs(1)),
+            RetryDecision::Retry(Duration::from_millis(300))
+        );
+    }
+
+    #[test]
+    fn undelivered_replays_stop_at_the_budget_and_never_wait_past_it() {
+        let mut state = RetryState::new(RetryPolicy::non_idempotent());
+        let error = proxy_unavailable();
+
+        // Deep into the budget the capped wait would overshoot; it is clipped.
+        for _ in 0..6 {
+            state.decide(&error, Duration::from_secs(1));
+        }
+        assert_eq!(
+            state.decide(&error, Duration::from_secs(28)),
+            RetryDecision::Retry(Duration::from_secs(2))
+        );
+        assert_eq!(
+            state.decide(&error, UNDELIVERED_REPLAY_BUDGET),
+            RetryDecision::Stop
+        );
+    }
+
+    #[test]
+    fn a_plain_503_is_not_replayed_for_non_idempotent_operations() {
+        // No proxy code: this came from something that may have run the request.
+        let error = server_error(503, r#"{"error":"daemon overloaded"}"#);
+        let mut state = RetryState::new(RetryPolicy::non_idempotent());
+        assert_eq!(state.decide(&error, Duration::ZERO), RetryDecision::Stop);
+    }
+
+    #[test]
+    fn idempotent_operations_retry_transient_failures_a_bounded_number_of_times() {
+        let error = server_error(502, "bad gateway");
+        let mut state = RetryState::new(RetryPolicy::idempotent(2));
+        assert!(matches!(
+            state.decide(&error, Duration::ZERO),
+            RetryDecision::Retry(_)
+        ));
+        assert!(matches!(
+            state.decide(&error, Duration::ZERO),
+            RetryDecision::Retry(_)
+        ));
+        assert_eq!(state.decide(&error, Duration::ZERO), RetryDecision::Stop);
+
+        // 4xx is never transient.
+        let mut state = RetryState::new(RetryPolicy::idempotent(5));
+        assert_eq!(
+            state.decide(&server_error(404, "gone"), Duration::ZERO),
+            RetryDecision::Stop
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_replays_a_non_idempotent_operation_across_a_control_plane_gap() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&attempts);
+        let result = retry((), RetryPolicy::non_idempotent(), move |()| {
+            let counter = Arc::clone(&counter);
+            async move {
+                // Unavailable for the first six attempts, then the rollout is over.
+                if counter.fetch_add(1, Ordering::SeqCst) < 6 {
+                    Err(proxy_unavailable())
+                } else {
+                    Ok("started")
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(result.unwrap(), "started");
+        assert_eq!(attempts.load(Ordering::SeqCst), 7);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_gives_up_once_the_budget_is_spent() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&attempts);
+        let result: Result<(), SdkError> = retry((), RetryPolicy::non_idempotent(), move |()| {
+            counter.fetch_add(1, Ordering::SeqCst);
+            async move { Err(proxy_unavailable()) }
+        })
+        .await;
+
+        assert!(result.is_err());
+        // 0.15+0.3+0.6+1.2+2.4 = 4.65 s, then 3.75 s steps: ~7 more before 30 s.
+        let made = attempts.load(Ordering::SeqCst);
+        assert!((10..=14).contains(&made), "attempts before budget: {made}");
+    }
+}

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -39,6 +39,7 @@ use tensorlake::sandboxes::{
 use tensorlake::{
     ClientBuilder,
     error::{SdkError, TransportFailure},
+    retry::{RetryPolicy, retry},
 };
 
 // ---- Return value objects -------------------------------------------------
@@ -123,96 +124,28 @@ pub(crate) fn usage_error(message: String) -> napi::Error {
 /// deleting a sandbox — cannot absorb a second execution. Only failures that
 /// provably never reached the server are replayed here; per-operation timeout
 /// retries need an idempotency review first.
-fn is_retryable(error: &SdkError) -> bool {
-    if is_safe_to_replay(error) {
-        return true;
-    }
-    match error {
-        SdkError::ServerError { status, .. } => {
-            *status == reqwest::StatusCode::BAD_GATEWAY
-                || *status == reqwest::StatusCode::SERVICE_UNAVAILABLE
-                || *status == reqwest::StatusCode::GATEWAY_TIMEOUT
-        }
-        SdkError::EventSourceError(_) => true,
-        _ => false,
-    }
-}
-
-/// Whether replaying the request is safe even when the operation is not
-/// idempotent.
-///
-/// Only a connect failure qualifies: DNS, TCP, and TLS all fail before a single
-/// request byte reaches the server, so the operation provably did not run. A
-/// timeout gives no such guarantee — the server may have received the request
-/// and be executing it still.
-fn is_safe_to_replay(error: &SdkError) -> bool {
-    matches!(error.transport_failure(), Some(TransportFailure::Connect))
-}
-
-fn calculate_sleep_time(retries: usize) -> f64 {
-    let initial_delay_seconds: f64 = 0.1;
-    let max_delay_seconds: f64 = 15.0;
-    let jitter_multiplier: f64 = 0.75;
-    let base_delay = initial_delay_seconds * 2f64.powi(retries as i32);
-    base_delay.min(max_delay_seconds) * jitter_multiplier
-}
-
+/// Retry `op` as an idempotent operation: transient failures up to
+/// `max_retries` times, and anything that never reached the server for the
+/// full [`tensorlake::retry::UNDELIVERED_REPLAY_BUDGET`].
 async fn retry_async_op<C, T, F, Fut>(client: C, max_retries: usize, op: F) -> Result<T, SdkError>
 where
     C: Clone,
     F: Fn(C) -> Fut,
     Fut: Future<Output = Result<T, SdkError>>,
 {
-    let mut retries = 0usize;
-    loop {
-        match op(client.clone()).await {
-            Ok(value) => return Ok(value),
-            Err(err) => {
-                if !is_retryable(&err) || retries >= max_retries {
-                    return Err(err);
-                }
-                retries += 1;
-                let sleep_time = calculate_sleep_time(retries);
-                tokio::time::sleep(Duration::from_secs_f64(sleep_time)).await;
-            }
-        }
-    }
+    retry(client, RetryPolicy::idempotent(max_retries), op).await
 }
 
-/// Number of times a request that never reached the server is replayed.
-///
-/// Small on purpose: a connect failure resolves in milliseconds, so the useful
-/// case is a single transient DNS or TCP hiccup, not a sustained outage the
-/// caller should hear about promptly.
-const MAX_CONNECT_REPLAYS: usize = 2;
-
-/// Run `op`, replaying it only when the previous attempt failed before the
-/// request reached the server.
-///
-/// Unlike [`retry_async_op`], this is safe for non-idempotent operations such
-/// as starting a process: [`is_safe_to_replay`] admits connect failures only,
-/// and a connect failure means no request byte was ever transmitted, so the
-/// operation cannot have run.
-async fn replay_on_connect_failure<C, T, F, Fut>(client: C, op: F) -> Result<T, SdkError>
+/// Replay `op` only while its failures provably never reached the server — a
+/// connect failure, or the Sandbox Proxy reporting it could not complete the
+/// lookup. Safe for operations that must not run twice.
+async fn replay_if_never_delivered<C, T, F, Fut>(client: C, op: F) -> Result<T, SdkError>
 where
     C: Clone,
     F: Fn(C) -> Fut,
     Fut: Future<Output = Result<T, SdkError>>,
 {
-    let mut replays = 0usize;
-    loop {
-        match op(client.clone()).await {
-            Ok(value) => return Ok(value),
-            Err(err) => {
-                if !is_safe_to_replay(&err) || replays >= MAX_CONNECT_REPLAYS {
-                    return Err(err);
-                }
-                replays += 1;
-                let sleep_time = calculate_sleep_time(replays);
-                tokio::time::sleep(Duration::from_secs_f64(sleep_time)).await;
-            }
-        }
-    }
+    retry(client, RetryPolicy::non_idempotent(), op).await
 }
 
 /// Run `op` with bounded retries, mapping any terminal error to a napi error.
@@ -456,9 +389,14 @@ impl NativeSandboxClient {
     #[napi]
     pub async fn create_sandbox(&self, request_json: String) -> napi::Result<TracedJson> {
         let request: CreateSandboxRequest = parse_json_payload(&request_json)?;
-        let client = self.client().await?;
-        // Create is not retried: it is not idempotent.
-        let traced = client.create(&request).await.map_err(into_napi_error)?;
+        // Creating a sandbox is not idempotent, so only failures that provably
+        // never reached the server are replayed.
+        let traced = replay_if_never_delivered(self.client().await?, |client| {
+            let request = request.clone();
+            async move { client.create(&request).await }
+        })
+        .await
+        .map_err(into_napi_error)?;
         let json =
             serde_json::to_string(&*traced).map_err(|e| into_napi_error(SdkError::from(e)))?;
         Ok(TracedJson {
@@ -1171,7 +1109,7 @@ impl NativeSandboxProxyClient {
         // Running a process is not idempotent, so this is not wrapped in the
         // general retry. Connect failures are still replayed: the request never
         // reached the sandbox, so no process was started.
-        let traced = replay_on_connect_failure(self.client().await?, |client| {
+        let traced = replay_if_never_delivered(self.client().await?, |client| {
             let payload = payload.clone();
             async move { client.run_process(&payload).await }
         })

--- a/crates/rust-cloud-sdk-node/src/sandbox.rs
+++ b/crates/rust-cloud-sdk-node/src/sandbox.rs
@@ -114,16 +114,8 @@ pub(crate) fn usage_error(message: String) -> napi::Error {
     make_napi_error("sdk_usage", None, message)
 }
 
-// ---- Retry helpers (ported from the Python binding) -----------------------
+// ---- Retry helpers (policy shared with the Python binding via tensorlake::retry)
 
-/// Whether the SDK may re-send a request after this failure.
-///
-/// Deliberately excludes timeouts. A timeout means the request was already on
-/// the wire, so the server may have executed it; most operations reached
-/// through this predicate — starting a process, creating a snapshot or pool,
-/// deleting a sandbox — cannot absorb a second execution. Only failures that
-/// provably never reached the server are replayed here; per-operation timeout
-/// retries need an idempotency review first.
 /// Retry `op` as an idempotent operation: transient failures up to
 /// `max_retries` times, and anything that never reached the server for the
 /// full [`tensorlake::retry::UNDELIVERED_REPLAY_BUDGET`].
@@ -1107,8 +1099,9 @@ impl NativeSandboxProxyClient {
     pub async fn run_process(&self, payload_json: String) -> napi::Result<TracedEvents> {
         let payload: Value = parse_json_payload(&payload_json)?;
         // Running a process is not idempotent, so this is not wrapped in the
-        // general retry. Connect failures are still replayed: the request never
-        // reached the sandbox, so no process was started.
+        // general retry. Failures that never reached the sandbox — a connect
+        // failure, or the Sandbox Proxy giving up before forwarding — are still
+        // replayed: no process was started.
         let traced = replay_if_never_delivered(self.client().await?, |client| {
             let payload = payload.clone();
             async move { client.run_process(&payload).await }

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -44,6 +44,7 @@ use tensorlake::sandboxes::{
 use tensorlake::{
     Client, ClientBuilder,
     error::{SdkError, TransportFailure},
+    retry::{RetryDecision, RetryPolicy, RetryState, retry},
 };
 use tokio::runtime::Runtime;
 
@@ -1514,15 +1515,17 @@ impl CloudSandboxClient {
 
     fn create_sandbox(&self, request_json: String) -> PyResult<(String, String)> {
         let request: CreateSandboxRequest = parse_json_payload(&request_json)?;
-        let client = self.client.clone();
-        shared_runtime()
-            .block_on(async move {
+        // Creating a sandbox is not idempotent, so only failures that provably
+        // never reached the server are replayed.
+        self.run_with_connect_replay(move |client| {
+            let request = request.clone();
+            async move {
                 let traced = client.create(&request).await?;
                 let trace_id = traced.trace_id.clone();
                 let json = serde_json::to_string(&*traced).map_err(SdkError::from)?;
                 Ok((trace_id, json))
-            })
-            .map_err(into_sandbox_py_error)
+            }
+        })
     }
 
     #[pyo3(signature = (pool_id, request_json=None))]
@@ -1858,10 +1861,13 @@ impl CloudSandboxClient {
         let request: CreateSandboxRequest = parse_json_payload(&request_json)?;
         let client = self.client.clone();
         future_into_py(py, async move {
-            let traced = client
-                .create(&request)
-                .await
-                .map_err(into_sandbox_py_error)?;
+            // See `create_sandbox`: replay only what never reached the server.
+            let traced = replay_if_never_delivered(client, move |c| {
+                let request = request.clone();
+                async move { c.create(&request).await }
+            })
+            .await
+            .map_err(into_sandbox_py_error)?;
             let trace_id = traced.trace_id.clone();
             let json = serde_json::to_string(&*traced).map_err(sandbox_serde_err)?;
             Ok((trace_id, json))
@@ -3142,7 +3148,7 @@ impl CloudSandboxProxyClient {
         future_into_py(py, async move {
             // See `run_process_json`: replay only failures that never reached
             // the sandbox, so a timeout cannot start the command twice.
-            let traced = replay_on_connect_failure(client, move |c| {
+            let traced = replay_if_never_delivered(client, move |c| {
                 let payload = payload.clone();
                 async move { c.run_process(&payload).await }
             })
@@ -3446,8 +3452,7 @@ where
 {
     run_bounded_blocking(
         client,
-        max_retries,
-        is_retryable,
+        RetryPolicy::idempotent(max_retries),
         label,
         into_err,
         operation,
@@ -3470,8 +3475,7 @@ where
 {
     run_bounded_blocking(
         client,
-        MAX_CONNECT_REPLAYS,
-        is_safe_to_replay,
+        RetryPolicy::non_idempotent(),
         label,
         into_err,
         operation,
@@ -3480,8 +3484,7 @@ where
 
 fn run_bounded_blocking<C, T, F, Fut>(
     client: C,
-    max_retries: usize,
-    should_retry: fn(&SdkError) -> bool,
+    policy: RetryPolicy,
     label: &str,
     into_err: fn(SdkError) -> PyErr,
     mut operation: F,
@@ -3491,22 +3494,22 @@ where
     F: FnMut(C) -> Fut,
     Fut: Future<Output = Result<T, SdkError>>,
 {
-    let mut retries = 0usize;
+    let started = std::time::Instant::now();
+    let mut state = RetryState::new(policy);
     loop {
         match shared_runtime().block_on(operation(client.clone())) {
             Ok(value) => return Ok(value),
-            Err(err) => {
-                if !should_retry(&err) || retries >= max_retries {
-                    return Err(into_err(err));
+            Err(err) => match state.decide(&err, started.elapsed()) {
+                RetryDecision::Stop => return Err(into_err(err)),
+                RetryDecision::Retry(wait) => {
+                    eprintln!(
+                        "Retrying {label} after {:.2} seconds. Retry count: {}. Retryable exception: {err}",
+                        wait.as_secs_f64(),
+                        state.retries()
+                    );
+                    std::thread::sleep(wait);
                 }
-
-                retries += 1;
-                let sleep_time = calculate_sleep_time(retries);
-                eprintln!(
-                    "Retrying {label} after {sleep_time:.2} seconds. Retry count: {retries}. Retryable exception: {err}"
-                );
-                std::thread::sleep(Duration::from_secs_f64(sleep_time));
-            }
+            },
         }
     }
 }
@@ -3559,6 +3562,21 @@ impl CloudSandboxClient {
             operation,
         )
     }
+
+    /// Retry variant for operations that must not run twice: replays only
+    /// failures that provably never reached the server.
+    fn run_with_connect_replay<T, F, Fut>(&self, operation: F) -> PyResult<T>
+    where
+        F: FnMut(SandboxesClient) -> Fut,
+        Fut: Future<Output = Result<T, SdkError>>,
+    {
+        run_with_connect_replay_blocking(
+            self.client.clone(),
+            "rust sandbox API request",
+            into_sandbox_py_error,
+            operation,
+        )
+    }
 }
 
 impl CloudDocumentAIClient {
@@ -3583,32 +3601,11 @@ where
     F: Fn(C) -> Fut,
     Fut: Future<Output = Result<T, SdkError>>,
 {
-    let mut retries = 0usize;
-    loop {
-        match op(client.clone()).await {
-            Ok(value) => return Ok(value),
-            Err(err) => {
-                if !is_retryable(&err) || retries >= max_retries {
-                    return Err(err);
-                }
-                retries += 1;
-                let sleep_time = calculate_sleep_time(retries);
-                tokio::time::sleep(Duration::from_secs_f64(sleep_time)).await;
-            }
-        }
-    }
+    retry(client, RetryPolicy::idempotent(max_retries), op).await
 }
 
 fn sandbox_serde_err(err: serde_json::Error) -> PyErr {
     into_sandbox_py_error(SdkError::from(err))
-}
-
-fn calculate_sleep_time(retries: usize) -> f64 {
-    let initial_delay_seconds: f64 = 0.1;
-    let max_delay_seconds: f64 = 15.0;
-    let jitter_multiplier: f64 = 0.75;
-    let base_delay = initial_delay_seconds * 2f64.powi(retries as i32);
-    base_delay.min(max_delay_seconds) * jitter_multiplier
 }
 
 fn duration_from_seconds(name: &str, seconds: f64) -> PyResult<Duration> {
@@ -3630,63 +3627,17 @@ fn duration_from_seconds(name: &str, seconds: f64) -> PyResult<Duration> {
 /// deleting a sandbox — cannot absorb a second execution. Only failures that
 /// provably never reached the server are replayed here; per-operation timeout
 /// retries need an idempotency review first.
-fn is_retryable(error: &SdkError) -> bool {
-    if is_safe_to_replay(error) {
-        return true;
-    }
-    match error {
-        SdkError::ServerError { status, .. } => {
-            *status == reqwest::StatusCode::BAD_GATEWAY
-                || *status == reqwest::StatusCode::SERVICE_UNAVAILABLE
-                || *status == reqwest::StatusCode::GATEWAY_TIMEOUT
-        }
-        SdkError::EventSourceError(_) => true,
-        _ => false,
-    }
-}
-
-/// Whether replaying the request is safe even when the operation is not
-/// idempotent.
-///
-/// Only a connect failure qualifies: DNS, TCP, and TLS all fail before a single
-/// request byte reaches the server, so the operation provably did not run. A
-/// timeout gives no such guarantee — the server may have received the request
-/// and be executing it still.
-fn is_safe_to_replay(error: &SdkError) -> bool {
-    matches!(error.transport_failure(), Some(TransportFailure::Connect))
-}
-
-/// Number of times a request that never reached the server is replayed.
-///
-/// Small on purpose: a connect failure resolves in milliseconds, so the useful
-/// case is a single transient DNS or TCP hiccup, not a sustained outage the
-/// caller should hear about promptly.
-const MAX_CONNECT_REPLAYS: usize = 2;
-
-/// Run `op`, replaying it only when the previous attempt failed before the
-/// request reached the server.
-///
-/// Unlike [`retry_async_op`], this is safe for non-idempotent operations such
-/// as starting a process.
-async fn replay_on_connect_failure<C, T, F, Fut>(client: C, op: F) -> Result<T, SdkError>
+/// Replay `op` only while its failures provably never reached the server —
+/// a connect failure, or the Sandbox Proxy reporting it could not complete the
+/// lookup — for up to [`tensorlake::retry::UNDELIVERED_REPLAY_BUDGET`]. Safe
+/// for operations that must not run twice.
+async fn replay_if_never_delivered<C, T, F, Fut>(client: C, op: F) -> Result<T, SdkError>
 where
     C: Clone,
     F: Fn(C) -> Fut,
     Fut: Future<Output = Result<T, SdkError>>,
 {
-    let mut replays = 0usize;
-    loop {
-        match op(client.clone()).await {
-            Ok(value) => return Ok(value),
-            Err(err) => {
-                if !is_safe_to_replay(&err) || replays >= MAX_CONNECT_REPLAYS {
-                    return Err(err);
-                }
-                replays += 1;
-                tokio::time::sleep(Duration::from_secs_f64(calculate_sleep_time(replays))).await;
-            }
-        }
-    }
+    retry(client, RetryPolicy::non_idempotent(), op).await
 }
 
 fn into_py_error(error: SdkError) -> PyErr {

--- a/crates/rust-cloud-sdk-py/src/lib.rs
+++ b/crates/rust-cloud-sdk-py/src/lib.rs
@@ -2377,7 +2377,8 @@ impl CloudSandboxClient {
 impl CloudSandboxProxyClient {
     fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
-        F: FnMut(SandboxProxyClient) -> Fut,
+        F: FnMut(SandboxProxyClient) -> Fut + Send,
+        T: Send,
         Fut: Future<Output = Result<T, SdkError>>,
     {
         run_with_retry_blocking(
@@ -2392,7 +2393,8 @@ impl CloudSandboxProxyClient {
     /// Retry variant for operations that must not run twice.
     fn run_with_connect_replay<T, F, Fut>(&self, operation: F) -> PyResult<T>
     where
-        F: FnMut(SandboxProxyClient) -> Fut,
+        F: FnMut(SandboxProxyClient) -> Fut + Send,
+        T: Send,
         Fut: Future<Output = Result<T, SdkError>>,
     {
         run_with_connect_replay_blocking(
@@ -2719,8 +2721,9 @@ impl CloudSandboxProxyClient {
         let payload: Value = parse_json_payload(&payload_json)?;
         // Running a process is not idempotent: the general retry would replay
         // it after a timeout, when the sandbox may already be executing the
-        // command. Only connect failures — which never reached the sandbox —
-        // are replayed.
+        // command. Only failures that never reached the sandbox — a connect
+        // failure, or the Sandbox Proxy giving up before forwarding — are
+        // replayed.
         self.run_with_connect_replay(move |client| {
             let payload = payload.clone();
             async move {
@@ -3446,8 +3449,9 @@ fn run_with_retry_blocking<C, T, F, Fut>(
     operation: F,
 ) -> PyResult<T>
 where
-    C: Clone,
-    F: FnMut(C) -> Fut,
+    C: Clone + Send,
+    F: FnMut(C) -> Fut + Send,
+    T: Send,
     Fut: Future<Output = Result<T, SdkError>>,
 {
     run_bounded_blocking(
@@ -3459,7 +3463,7 @@ where
     )
 }
 
-/// Blocking counterpart of [`replay_on_connect_failure`]: replays only the
+/// Blocking counterpart of [`replay_if_never_delivered`]: replays only the
 /// failures that provably never reached the server, so it is safe to wrap a
 /// non-idempotent operation.
 fn run_with_connect_replay_blocking<C, T, F, Fut>(
@@ -3469,8 +3473,9 @@ fn run_with_connect_replay_blocking<C, T, F, Fut>(
     operation: F,
 ) -> PyResult<T>
 where
-    C: Clone,
-    F: FnMut(C) -> Fut,
+    C: Clone + Send,
+    F: FnMut(C) -> Fut + Send,
+    T: Send,
     Fut: Future<Output = Result<T, SdkError>>,
 {
     run_bounded_blocking(
@@ -3482,6 +3487,14 @@ where
     )
 }
 
+/// Drive `operation` to completion on the shared runtime, retrying under
+/// `policy`, with the GIL released for the whole loop.
+///
+/// The sync bindings reach this from `&self` methods that hold the GIL. An
+/// undelivered request can be replayed for up to
+/// [`tensorlake::retry::UNDELIVERED_REPLAY_BUDGET`], and holding the GIL
+/// across those sleeps would freeze every other Python thread for the length
+/// of a control-plane rollout.
 fn run_bounded_blocking<C, T, F, Fut>(
     client: C,
     policy: RetryPolicy,
@@ -3490,28 +3503,33 @@ fn run_bounded_blocking<C, T, F, Fut>(
     mut operation: F,
 ) -> PyResult<T>
 where
-    C: Clone,
-    F: FnMut(C) -> Fut,
+    C: Clone + Send,
+    T: Send,
+    F: FnMut(C) -> Fut + Send,
     Fut: Future<Output = Result<T, SdkError>>,
 {
-    let started = std::time::Instant::now();
-    let mut state = RetryState::new(policy);
-    loop {
-        match shared_runtime().block_on(operation(client.clone())) {
-            Ok(value) => return Ok(value),
-            Err(err) => match state.decide(&err, started.elapsed()) {
-                RetryDecision::Stop => return Err(into_err(err)),
-                RetryDecision::Retry(wait) => {
-                    eprintln!(
-                        "Retrying {label} after {:.2} seconds. Retry count: {}. Retryable exception: {err}",
-                        wait.as_secs_f64(),
-                        state.retries()
-                    );
-                    std::thread::sleep(wait);
+    Python::attach(|py| {
+        py.detach(move || {
+            let started = std::time::Instant::now();
+            let mut state = RetryState::new(policy);
+            loop {
+                match shared_runtime().block_on(operation(client.clone())) {
+                    Ok(value) => return Ok(value),
+                    Err(err) => match state.decide(&err, started.elapsed()) {
+                        RetryDecision::Stop => return Err(into_err(err)),
+                        RetryDecision::Retry(wait) => {
+                            eprintln!(
+                                "Retrying {label} after {:.2} seconds. Retry count: {}. Retryable exception: {err}",
+                                wait.as_secs_f64(),
+                                state.retries()
+                            );
+                            std::thread::sleep(wait);
+                        }
+                    },
                 }
-            },
-        }
-    }
+            }
+        })
+    })
 }
 
 impl CloudApiClient {
@@ -3521,7 +3539,8 @@ impl CloudApiClient {
 
     fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
-        F: FnMut(Client) -> Fut,
+        F: FnMut(Client) -> Fut + Send,
+        T: Send,
         Fut: Future<Output = Result<T, SdkError>>,
     {
         run_with_retry_blocking(
@@ -3535,7 +3554,8 @@ impl CloudApiClient {
 
     fn run_artifact_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
-        F: FnMut(ArtifactStorageClient) -> Fut,
+        F: FnMut(ArtifactStorageClient) -> Fut + Send,
+        T: Send,
         Fut: Future<Output = Result<T, SdkError>>,
     {
         run_with_retry_blocking(
@@ -3551,7 +3571,8 @@ impl CloudApiClient {
 impl CloudSandboxClient {
     fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
-        F: FnMut(SandboxesClient) -> Fut,
+        F: FnMut(SandboxesClient) -> Fut + Send,
+        T: Send,
         Fut: Future<Output = Result<T, SdkError>>,
     {
         run_with_retry_blocking(
@@ -3567,7 +3588,8 @@ impl CloudSandboxClient {
     /// failures that provably never reached the server.
     fn run_with_connect_replay<T, F, Fut>(&self, operation: F) -> PyResult<T>
     where
-        F: FnMut(SandboxesClient) -> Fut,
+        F: FnMut(SandboxesClient) -> Fut + Send,
+        T: Send,
         Fut: Future<Output = Result<T, SdkError>>,
     {
         run_with_connect_replay_blocking(
@@ -3582,7 +3604,8 @@ impl CloudSandboxClient {
 impl CloudDocumentAIClient {
     fn run_with_retry<T, F, Fut>(&self, max_retries: usize, operation: F) -> PyResult<T>
     where
-        F: FnMut(DocumentAiClient) -> Fut,
+        F: FnMut(DocumentAiClient) -> Fut + Send,
+        T: Send,
         Fut: Future<Output = Result<T, SdkError>>,
     {
         run_with_retry_blocking(
@@ -3619,14 +3642,6 @@ fn duration_from_seconds(name: &str, seconds: f64) -> PyResult<Duration> {
     Ok(Duration::from_secs_f64(seconds))
 }
 
-/// Whether the SDK may re-send a request after this failure.
-///
-/// Deliberately excludes timeouts. A timeout means the request was already on
-/// the wire, so the server may have executed it; most operations reached
-/// through this predicate — starting a process, creating a snapshot or pool,
-/// deleting a sandbox — cannot absorb a second execution. Only failures that
-/// provably never reached the server are replayed here; per-operation timeout
-/// retries need an idempotency review first.
 /// Replay `op` only while its failures provably never reached the server —
 /// a connect failure, or the Sandbox Proxy reporting it could not complete the
 /// lookup — for up to [`tensorlake::retry::UNDELIVERED_REPLAY_BUDGET`]. Safe


### PR DESCRIPTION
## Why

Both native bindings already retry in two tiers: transient failures (502/503/504, dropped event streams) for idempotent operations, and replays of requests that *provably never reached the server* — connect failures — for everything, including `run_process`. Both budgets were sized for a different problem: **five retries totalling ~4.65 s**, and **two connect replays**.

An Indexify server rollout takes the control plane away for 7–30 s. As of compute-engine-internal #2083 the Sandbox Proxy reports that window as a **503** with a JSON body whose `code` names the pre-forward failure — `SANDBOX_UPSTREAM_ERROR` (lookup didn't answer), `SANDBOX_NOT_READY` (no route yet), `SANDBOX_UNREACHABLE` (dataplane connect failed, or the dataplane said it doesn't host the sandbox and the route couldn't be refreshed) — instead of the 404 that told clients the sandbox was gone. The SDK retried that 503 for 4.65 s and gave up inside the outage. In Node, `run_process` didn't retry it at all, on the (generally correct) grounds that a 503 might mean the request ran.

Those codes settle that question. The proxy failed *before any dataplane executed the request*; it cannot have run. That makes them safe to replay for any operation, and worth replaying for as long as a rollout lasts.

## Change

**`tensorlake::error`** — two methods on `SdkError`, no change to the public enum:
- `upstream_error_code()` parses `code` out of the JSON body that `ServerError` already carries as its message.
- `never_reached_server()` — true for a connect failure, or **any 5xx** carrying one of `SANDBOX_PROXY_UNDELIVERED_CODES` (the three above plus `AUTH_SERVICE_UNAVAILABLE`, which the proxy also emits before forwarding). Any 5xx, not just 502/503, because proxies older than #2083 relay the lookup's own 500/504 verbatim under `SANDBOX_UPSTREAM_ERROR`. A 4xx under those codes is a definitive passthrough (403, 409) and is not trusted; neither is a timeout or an uncoded 5xx.

**`tensorlake::retry`** (new, shared by both bindings — they each had a copy "ported from the Python binding" and had already started to diverge):
- `RetryPolicy::idempotent(n)` / `RetryPolicy::non_idempotent()`.
- `RetryState::decide(&error, elapsed)` is pure, so the policy is tested without a clock; `retry(client, policy, op)` is the async loop over it.
- Never-delivered failures are replayed **regardless of idempotency** until `UNDELIVERED_REPLAY_BUDGET` (30 s) is spent, with waits capped at 5 s (so the replays keep probing) and clipped so the last one can't overshoot the budget.
- Transient failures of idempotent operations keep the **exact schedule the bindings had** — 0.1 s × 2ⁿ × 0.75, capped at 15 s — pinned by a test. Timeouts remain in neither class.

**Bindings** — local `is_retryable` / `is_safe_to_replay` / `calculate_sleep_time` / `MAX_CONNECT_REPLAYS` / loops replaced with calls into the shared module. `run_process` (both) keeps its non-idempotent replay and picks up the longer budget. The Python blocking loop keeps its stderr "Retrying …" line and now **runs with the GIL released**: it is reached from `&self` methods that hold the GIL, and a 30 s budget with the GIL held would freeze every other Python thread for the length of a rollout.

`create_sandbox` (Python sync + async, Node) is also wrapped under the non-idempotent policy — previously unretried. Note what that does and doesn't buy: sandbox creation is a lifecycle request that never goes through a sandbox lookup, so none of the coded 503s apply to it. The wrap replays **connect failures only**. A proxy-side follow-up could emit a coded 503 when the lifecycle upstream can't be connected to; today that surfaces as an uncoded `PROXY_ERROR` 502, which is correctly not replayed.

Behavioural deltas worth a reviewer's eye:
- A plain **connect failure** now also gets the 30 s budget, not two replays. From the client a proxy being rolled is indistinguishable from a control-plane gap, and both resolve on the same timescale.
- Every wrapped call — including idempotent polls like `get_sandbox` — can now block up to ~30 s during a control-plane gap where it previously failed in ~4.65 s. Callers that run their own deadline around such polls will overshoot it by up to that much. This is the intended trade (surviving the rollout beats failing fast inside it), but it is a visible change.
- `start_process_json` in Python still uses the *idempotent* policy (five retries on any 503/timeout-free transient), as do the other mutating routes that were already under `run_with_retry(5, …)` before this PR (create_snapshot, create_pool, write_file, kill/send_signal, delete_*). An uncoded 502 `PROXY_ERROR` *after* forwarding is retried for those. That predates this PR and deserves the non-idempotent policy; left alone here to keep the change to what the incident showed.

## Tests

`retry::tests` (10) and `error::undelivered_tests` (2): both backoff schedules; proxy-coded 5xx replayed for non-idempotent ops and a plain 503 / a coded 4xx not; budget exhaustion and wait clipping; idempotent transient cap; code parsing; the accepted (status, code) matrix. Two paused-clock tokio tests drive the async loop across a simulated 6-attempt gap and to budget exhaustion.

- `cargo test -p tensorlake --lib`: 227 passed
- `just with-function-agent-core cargo clippy --no-deps -p tensorlake -p tensorlake-rust-cloud-sdk-py -p tensorlake-rust-cloud-sdk-node --all-targets -- -D warnings`: clean (staged from a `main`-based CEI worktree; the primary CEI checkout's placeholder manifest has drifted, which the script rejects)
- `cargo fmt` applied

## Pairs with

- compute-engine-internal #2083 — the proxy's coded 503/502 contract this relies on. Against a proxy without it the lookup gap is still a `SANDBOX_NOT_FOUND` 404 and nothing here replays it. Its latest commit also adds `Retry-After: 1` to every proxy 503; this SDK doesn't read the header yet (`ServerError` has no headers), so the backoff schedule paces it instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
