### PR TITLE
Bump SDK packages to 0.5.129

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.128"
+version = "0.5.129"
 dependencies = [
  "anyhow",
  "base64",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.128"
+version = "0.5.129"
 dependencies = [
  "anyhow",
  "base64",
@@ -5522,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.128"
+version = "0.5.129"
 dependencies = [
  "anyhow",
  "base64",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.128"
+version = "0.5.129"
 dependencies = [
  "anyhow",
  "base64",
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.128"
+version = "0.5.129"
 dependencies = [
  "anyhow",
  "base64",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.128"
+version = "0.5.129"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.128"
+version = "0.5.129"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.128"
+version = "0.5.129"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.128"
+version = "0.5.129"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.128"
+version = "0.5.129"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/npm/darwin-arm64/package.json
+++ b/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-darwin-arm64",
-  "version": "0.5.128",
+  "version": "0.5.129",
   "description": "Tensorlake native Node.js binding for macOS arm64",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64-musl/package.json
+++ b/typescript/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-arm64-musl",
-  "version": "0.5.128",
+  "version": "0.5.129",
   "description": "Tensorlake native Node.js binding for Linux arm64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64/package.json
+++ b/typescript/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-arm64-gnu",
-  "version": "0.5.128",
+  "version": "0.5.129",
   "description": "Tensorlake native Node.js binding for Linux arm64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64-musl/package.json
+++ b/typescript/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-x64-musl",
-  "version": "0.5.128",
+  "version": "0.5.129",
   "description": "Tensorlake native Node.js binding for Linux x64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64/package.json
+++ b/typescript/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-x64-gnu",
-  "version": "0.5.128",
+  "version": "0.5.129",
   "description": "Tensorlake native Node.js binding for Linux x64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/win32-x64/package.json
+++ b/typescript/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-win32-x64",
-  "version": "0.5.128",
+  "version": "0.5.129",
   "description": "Tensorlake native Node.js binding for Windows x64",
   "repository": {
     "type": "git",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.128",
+  "version": "0.5.129",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.128",
+      "version": "0.5.129",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",
@@ -39,12 +39,12 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "tensorlake-native-darwin-arm64": "0.5.128",
-        "tensorlake-native-linux-arm64-gnu": "0.5.128",
-        "tensorlake-native-linux-arm64-musl": "0.5.128",
-        "tensorlake-native-linux-x64-gnu": "0.5.128",
-        "tensorlake-native-linux-x64-musl": "0.5.128",
-        "tensorlake-native-win32-x64": "0.5.128"
+        "tensorlake-native-darwin-arm64": "0.5.129",
+        "tensorlake-native-linux-arm64-gnu": "0.5.129",
+        "tensorlake-native-linux-arm64-musl": "0.5.129",
+        "tensorlake-native-linux-x64-gnu": "0.5.129",
+        "tensorlake-native-linux-x64-musl": "0.5.129",
+        "tensorlake-native-win32-x64": "0.5.129"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3250,8 +3250,8 @@
       }
     },
     "node_modules/tensorlake-native-darwin-arm64": {
-      "version": "0.5.128",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.128.tgz",
+      "version": "0.5.129",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.129.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3265,8 +3265,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-arm64-gnu": {
-      "version": "0.5.128",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.128.tgz",
+      "version": "0.5.129",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.129.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3283,8 +3283,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-arm64-musl": {
-      "version": "0.5.128",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.128.tgz",
+      "version": "0.5.129",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.129.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3301,8 +3301,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-x64-gnu": {
-      "version": "0.5.128",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.128.tgz",
+      "version": "0.5.129",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.129.tgz",
       "cpu": [
         "x64"
       ],
@@ -3319,8 +3319,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-x64-musl": {
-      "version": "0.5.128",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.128.tgz",
+      "version": "0.5.129",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.129.tgz",
       "cpu": [
         "x64"
       ],
@@ -3337,8 +3337,8 @@
       }
     },
     "node_modules/tensorlake-native-win32-x64": {
-      "version": "0.5.128",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.128.tgz",
+      "version": "0.5.129",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.129.tgz",
       "cpu": [
         "x64"
       ],

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.128",
+  "version": "0.5.129",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -96,11 +96,11 @@
     "ws": "^8.20.0"
   },
   "optionalDependencies": {
-    "tensorlake-native-darwin-arm64": "0.5.128",
-    "tensorlake-native-linux-arm64-gnu": "0.5.128",
-    "tensorlake-native-linux-arm64-musl": "0.5.128",
-    "tensorlake-native-linux-x64-gnu": "0.5.128",
-    "tensorlake-native-linux-x64-musl": "0.5.128",
-    "tensorlake-native-win32-x64": "0.5.128"
+    "tensorlake-native-darwin-arm64": "0.5.129",
+    "tensorlake-native-linux-arm64-gnu": "0.5.129",
+    "tensorlake-native-linux-arm64-musl": "0.5.129",
+    "tensorlake-native-linux-x64-gnu": "0.5.129",
+    "tensorlake-native-linux-x64-musl": "0.5.129",
+    "tensorlake-native-win32-x64": "0.5.129"
   }
 }


### PR DESCRIPTION
Bump the shared Python, Rust, CLI, TypeScript, and native package version from 0.5.128 to 0.5.129 for the retry fixes merged in #968 and #969. Update Cargo and npm lockfiles; third-party dependency versions are unchanged.

Validation: the repository bump script updated the release manifests, Cargo check passed through `just with-function-agent-core cargo check --offline -p tensorlake --lib`, and all 13 changed files were verified to contain only the version replacement. All six native package versions and their npm dependency/lock entries match 0.5.129. `git diff --check` passed.
