### PR TITLE
Bump SDK packages to 0.5.130

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.129"
+version = "0.5.130"
 dependencies = [
  "anyhow",
  "base64",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.129"
+version = "0.5.130"
 dependencies = [
  "anyhow",
  "base64",
@@ -5522,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.129"
+version = "0.5.130"
 dependencies = [
  "anyhow",
  "base64",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.129"
+version = "0.5.130"
 dependencies = [
  "anyhow",
  "base64",
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.129"
+version = "0.5.130"
 dependencies = [
  "anyhow",
  "base64",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.129"
+version = "0.5.130"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.129"
+version = "0.5.130"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.129"
+version = "0.5.130"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.129"
+version = "0.5.130"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.129"
+version = "0.5.130"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/typescript/npm/darwin-arm64/package.json
+++ b/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-darwin-arm64",
-  "version": "0.5.129",
+  "version": "0.5.130",
   "description": "Tensorlake native Node.js binding for macOS arm64",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64-musl/package.json
+++ b/typescript/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-arm64-musl",
-  "version": "0.5.129",
+  "version": "0.5.130",
   "description": "Tensorlake native Node.js binding for Linux arm64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64/package.json
+++ b/typescript/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-arm64-gnu",
-  "version": "0.5.129",
+  "version": "0.5.130",
   "description": "Tensorlake native Node.js binding for Linux arm64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64-musl/package.json
+++ b/typescript/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-x64-musl",
-  "version": "0.5.129",
+  "version": "0.5.130",
   "description": "Tensorlake native Node.js binding for Linux x64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64/package.json
+++ b/typescript/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-x64-gnu",
-  "version": "0.5.129",
+  "version": "0.5.130",
   "description": "Tensorlake native Node.js binding for Linux x64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/win32-x64/package.json
+++ b/typescript/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-win32-x64",
-  "version": "0.5.129",
+  "version": "0.5.130",
   "description": "Tensorlake native Node.js binding for Windows x64",
   "repository": {
     "type": "git",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -3251,7 +3251,7 @@
     },
     "node_modules/tensorlake-native-darwin-arm64": {
       "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.129.tgz",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.130.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3266,7 +3266,7 @@
     },
     "node_modules/tensorlake-native-linux-arm64-gnu": {
       "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.129.tgz",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.130.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3284,7 +3284,7 @@
     },
     "node_modules/tensorlake-native-linux-arm64-musl": {
       "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.129.tgz",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.130.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3302,7 +3302,7 @@
     },
     "node_modules/tensorlake-native-linux-x64-gnu": {
       "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.129.tgz",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.130.tgz",
       "cpu": [
         "x64"
       ],
@@ -3320,7 +3320,7 @@
     },
     "node_modules/tensorlake-native-linux-x64-musl": {
       "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.129.tgz",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.130.tgz",
       "cpu": [
         "x64"
       ],
@@ -3338,7 +3338,7 @@
     },
     "node_modules/tensorlake-native-win32-x64": {
       "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.129.tgz",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.130.tgz",
       "cpu": [
         "x64"
       ],

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.129",
+  "version": "0.5.130",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.129",
+      "version": "0.5.130",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",
@@ -39,12 +39,12 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "tensorlake-native-darwin-arm64": "0.5.129",
-        "tensorlake-native-linux-arm64-gnu": "0.5.129",
-        "tensorlake-native-linux-arm64-musl": "0.5.129",
-        "tensorlake-native-linux-x64-gnu": "0.5.129",
-        "tensorlake-native-linux-x64-musl": "0.5.129",
-        "tensorlake-native-win32-x64": "0.5.129"
+        "tensorlake-native-darwin-arm64": "0.5.130",
+        "tensorlake-native-linux-arm64-gnu": "0.5.130",
+        "tensorlake-native-linux-arm64-musl": "0.5.130",
+        "tensorlake-native-linux-x64-gnu": "0.5.130",
+        "tensorlake-native-linux-x64-musl": "0.5.130",
+        "tensorlake-native-win32-x64": "0.5.130"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3250,7 +3250,7 @@
       }
     },
     "node_modules/tensorlake-native-darwin-arm64": {
-      "version": "0.5.129",
+      "version": "0.5.130",
       "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.129.tgz",
       "cpu": [
         "arm64"
@@ -3265,7 +3265,7 @@
       }
     },
     "node_modules/tensorlake-native-linux-arm64-gnu": {
-      "version": "0.5.129",
+      "version": "0.5.130",
       "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.129.tgz",
       "cpu": [
         "arm64"
@@ -3283,7 +3283,7 @@
       }
     },
     "node_modules/tensorlake-native-linux-arm64-musl": {
-      "version": "0.5.129",
+      "version": "0.5.130",
       "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.129.tgz",
       "cpu": [
         "arm64"
@@ -3301,7 +3301,7 @@
       }
     },
     "node_modules/tensorlake-native-linux-x64-gnu": {
-      "version": "0.5.129",
+      "version": "0.5.130",
       "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.129.tgz",
       "cpu": [
         "x64"
@@ -3319,7 +3319,7 @@
       }
     },
     "node_modules/tensorlake-native-linux-x64-musl": {
-      "version": "0.5.129",
+      "version": "0.5.130",
       "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.129.tgz",
       "cpu": [
         "x64"
@@ -3337,7 +3337,7 @@
       }
     },
     "node_modules/tensorlake-native-win32-x64": {
-      "version": "0.5.129",
+      "version": "0.5.130",
       "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.129.tgz",
       "cpu": [
         "x64"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.129",
+  "version": "0.5.130",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -96,11 +96,11 @@
     "ws": "^8.20.0"
   },
   "optionalDependencies": {
-    "tensorlake-native-darwin-arm64": "0.5.129",
-    "tensorlake-native-linux-arm64-gnu": "0.5.129",
-    "tensorlake-native-linux-arm64-musl": "0.5.129",
-    "tensorlake-native-linux-x64-gnu": "0.5.129",
-    "tensorlake-native-linux-x64-musl": "0.5.129",
-    "tensorlake-native-win32-x64": "0.5.129"
+    "tensorlake-native-darwin-arm64": "0.5.130",
+    "tensorlake-native-linux-arm64-gnu": "0.5.130",
+    "tensorlake-native-linux-arm64-musl": "0.5.130",
+    "tensorlake-native-linux-x64-gnu": "0.5.130",
+    "tensorlake-native-linux-x64-musl": "0.5.130",
+    "tensorlake-native-win32-x64": "0.5.130"
   }
 }


### PR DESCRIPTION
Version bump for the next CLI release, which must include the private-source pin from #971 (mount-daemon renewal fix, artifact_storage#412). Merge #971 first, then this, then dispatch `publish_cli.yaml` from `main`.

Same 13-file shape as #970.

🤖 Generated with [Claude Code](https://claude.com/claude-code)