### PR TITLE
Add Blackwell Server and L40 GPU models to SDKs and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,7 @@ dependencies = [
 
 [[package]]
 name = "gsvc-fs-client"
-version = "0.5.130"
+version = "0.5.131"
 dependencies = [
  "anyhow",
  "base64",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake"
-version = "0.5.130"
+version = "0.5.131"
 dependencies = [
  "anyhow",
  "base64",
@@ -5522,7 +5522,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-cli"
-version = "0.5.130"
+version = "0.5.131"
 dependencies = [
  "anyhow",
  "base64",
@@ -5576,7 +5576,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-function-agent-core"
-version = "0.5.130"
+version = "0.5.131"
 dependencies = [
  "anyhow",
  "base64",
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-node"
-version = "0.5.130"
+version = "0.5.131"
 dependencies = [
  "anyhow",
  "base64",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "tensorlake-rust-cloud-sdk-py"
-version = "0.5.130"
+version = "0.5.131"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["crates/gsvc-mount", "crates/gsvc-codec", "crates/gsvc-fs-client"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.130"
+version = "0.5.131"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -372,8 +372,9 @@ Sign up at [cloud.tensorlake.ai](https://cloud.tensorlake.ai/), run `pip install
 
 ### GPU model names
 
-Sandbox GPU requests also accept `RTX-PRO-6000-BLACKWELL-SERVER` and `L40`
-in the Python, TypeScript, and Rust SDKs and the CLI `--gpu-model` option.
-Python exposes `GpuModel.RTX_PRO_6000_BLACKWELL_SERVER` and `GpuModel.L40`.
-These names request exact models; L40 does not select L40S. The server and
+Sandbox GPU requests also accept `RTX-PRO-6000` and `L40`
+in the Python, TypeScript, and Rust SDKs and the CLI `--gpu` option.
+Python exposes `GpuModel.RTX_PRO_6000` and `GpuModel.L40`.
+`RTX-PRO-6000` selects the 96 GB Blackwell Server Edition, not the workstation
+editions. These names request exact models; L40 does not select L40S. The server and
 dataplane must support the requested model and have matching capacity.

--- a/README.md
+++ b/README.md
@@ -369,3 +369,11 @@ Sign up at [cloud.tensorlake.ai](https://cloud.tensorlake.ai/), run `pip install
 * [Sandbox Documentation](https://docs.tensorlake.ai/sandboxes/introduction)
 * [Orchestrate Documentation](https://docs.tensorlake.ai/applications/quickstart)
 * [`tl git mount` repository and subtree workflow](docs/git-mount.md)
+
+### GPU model names
+
+Sandbox GPU requests also accept `RTX-PRO-6000-BLACKWELL-SERVER` and `L40`
+in the Python, TypeScript, and Rust SDKs and the CLI `--gpu-model` option.
+Python exposes `GpuModel.RTX_PRO_6000_BLACKWELL_SERVER` and `GpuModel.L40`.
+These names request exact models; L40 does not select L40S. The server and
+dataplane must support the requested model and have matching capacity.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1065,8 +1065,8 @@ enum GpuModelArg {
     A6000,
     #[value(name = "A10")]
     A10,
-    #[value(name = "RTX-PRO-6000-BLACKWELL-SERVER")]
-    RtxPro6000BlackwellServer,
+    #[value(name = "RTX-PRO-6000")]
+    RtxPro6000,
     #[value(name = "L40")]
     L40,
 }
@@ -1080,7 +1080,7 @@ impl GpuModelArg {
             Self::T4 => "T4",
             Self::A6000 => "A6000",
             Self::A10 => "A10",
-            Self::RtxPro6000BlackwellServer => "RTX-PRO-6000-BLACKWELL-SERVER",
+            Self::RtxPro6000 => "RTX-PRO-6000",
             Self::L40 => "L40",
         }
     }
@@ -4400,7 +4400,7 @@ mod tests {
             "T4",
             "A6000",
             "A10",
-            "RTX-PRO-6000-BLACKWELL-SERVER",
+            "RTX-PRO-6000",
             "L40",
         ] {
             let cli = Cli::try_parse_from([

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1065,6 +1065,10 @@ enum GpuModelArg {
     A6000,
     #[value(name = "A10")]
     A10,
+    #[value(name = "RTX-PRO-6000-BLACKWELL-SERVER")]
+    RtxPro6000BlackwellServer,
+    #[value(name = "L40")]
+    L40,
 }
 
 impl GpuModelArg {
@@ -1076,6 +1080,8 @@ impl GpuModelArg {
             Self::T4 => "T4",
             Self::A6000 => "A6000",
             Self::A10 => "A10",
+            Self::RtxPro6000BlackwellServer => "RTX-PRO-6000-BLACKWELL-SERVER",
+            Self::L40 => "L40",
         }
     }
 }
@@ -4387,7 +4393,16 @@ mod tests {
 
     #[test]
     fn sbx_create_parses_gpu_request_with_explicit_model() {
-        for model in ["A100-40GB", "A100-80GB", "H100", "T4", "A6000", "A10"] {
+        for model in [
+            "A100-40GB",
+            "A100-80GB",
+            "H100",
+            "T4",
+            "A6000",
+            "A10",
+            "RTX-PRO-6000-BLACKWELL-SERVER",
+            "L40",
+        ] {
             let cli = Cli::try_parse_from([
                 "tl",
                 "sbx",

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -133,16 +133,22 @@ pub enum GpuModel {
     A6000,
     #[serde(rename = "A10")]
     A10,
+    #[serde(rename = "RTX-PRO-6000-BLACKWELL-SERVER")]
+    RtxPro6000BlackwellServer,
+    #[serde(rename = "L40")]
+    L40,
 }
 
 impl GpuModel {
-    pub const ALL: [Self; 6] = [
+    pub const ALL: [Self; 8] = [
         Self::A10040Gb,
         Self::A10080Gb,
         Self::H100,
         Self::T4,
         Self::A6000,
         Self::A10,
+        Self::RtxPro6000BlackwellServer,
+        Self::L40,
     ];
 
     pub const fn as_str(self) -> &'static str {
@@ -153,6 +159,8 @@ impl GpuModel {
             Self::T4 => "T4",
             Self::A6000 => "A6000",
             Self::A10 => "A10",
+            Self::RtxPro6000BlackwellServer => "RTX-PRO-6000-BLACKWELL-SERVER",
+            Self::L40 => "L40",
         }
     }
 }
@@ -1418,7 +1426,16 @@ mod tests {
 
     #[test]
     fn gpu_models_use_server_wire_values() {
-        let wire_values = ["A100-40GB", "A100-80GB", "H100", "T4", "A6000", "A10"];
+        let wire_values = [
+            "A100-40GB",
+            "A100-80GB",
+            "H100",
+            "T4",
+            "A6000",
+            "A10",
+            "RTX-PRO-6000-BLACKWELL-SERVER",
+            "L40",
+        ];
         for (model, wire_value) in GpuModel::ALL.into_iter().zip(wire_values) {
             assert_eq!(model.to_string(), wire_value);
             assert_eq!(wire_value.parse::<GpuModel>().unwrap(), model);

--- a/crates/cloud-sdk/src/sandboxes/models.rs
+++ b/crates/cloud-sdk/src/sandboxes/models.rs
@@ -133,8 +133,8 @@ pub enum GpuModel {
     A6000,
     #[serde(rename = "A10")]
     A10,
-    #[serde(rename = "RTX-PRO-6000-BLACKWELL-SERVER")]
-    RtxPro6000BlackwellServer,
+    #[serde(rename = "RTX-PRO-6000")]
+    RtxPro6000,
     #[serde(rename = "L40")]
     L40,
 }
@@ -147,7 +147,7 @@ impl GpuModel {
         Self::T4,
         Self::A6000,
         Self::A10,
-        Self::RtxPro6000BlackwellServer,
+        Self::RtxPro6000,
         Self::L40,
     ];
 
@@ -159,7 +159,7 @@ impl GpuModel {
             Self::T4 => "T4",
             Self::A6000 => "A6000",
             Self::A10 => "A10",
-            Self::RtxPro6000BlackwellServer => "RTX-PRO-6000-BLACKWELL-SERVER",
+            Self::RtxPro6000 => "RTX-PRO-6000",
             Self::L40 => "L40",
         }
     }
@@ -1433,7 +1433,7 @@ mod tests {
             "T4",
             "A6000",
             "A10",
-            "RTX-PRO-6000-BLACKWELL-SERVER",
+            "RTX-PRO-6000",
             "L40",
         ];
         for (model, wire_value) in GpuModel::ALL.into_iter().zip(wire_values) {

--- a/crates/gsvc-fs-client/Cargo.toml
+++ b/crates/gsvc-fs-client/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "gsvc-fs-client"
-version = "0.5.130"
+version = "0.5.131"
 edition = "2024"
 license = "Apache-2.0"
 description = "Resolution placeholder for TensorLake private filesystem client code"

--- a/crates/rust-cloud-sdk-py/pyproject.toml
+++ b/crates/rust-cloud-sdk-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tensorlake-rust-cloud-sdk"
-version = "0.5.130"
+version = "0.5.131"
 description = "PyO3 bindings for Tensorlake Rust cloud client"
 requires-python = ">=3.10"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tensorlake"
-version = "0.5.130"
+version = "0.5.131"
 description = "Tensorlake SDK for agent sandboxes and sandbox-native orchestration"
 readme = "README.md"
 authors = [{ name = "Tensorlake Inc.", email = "support@tensorlake.ai" }]

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -172,6 +172,8 @@ class GpuModel(str, Enum):
     T4 = "T4"
     A6000 = "A6000"
     A10 = "A10"
+    RTX_PRO_6000_BLACKWELL_SERVER = "RTX-PRO-6000-BLACKWELL-SERVER"
+    L40 = "L40"
 
 
 class GpuRequest(BaseModel):

--- a/src/tensorlake/sandbox/models.py
+++ b/src/tensorlake/sandbox/models.py
@@ -172,7 +172,7 @@ class GpuModel(str, Enum):
     T4 = "T4"
     A6000 = "A6000"
     A10 = "A10"
-    RTX_PRO_6000_BLACKWELL_SERVER = "RTX-PRO-6000-BLACKWELL-SERVER"
+    RTX_PRO_6000 = "RTX-PRO-6000"
     L40 = "L40"
 
 

--- a/typescript/npm/darwin-arm64/package.json
+++ b/typescript/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-darwin-arm64",
-  "version": "0.5.130",
+  "version": "0.5.131",
   "description": "Tensorlake native Node.js binding for macOS arm64",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64-musl/package.json
+++ b/typescript/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-arm64-musl",
-  "version": "0.5.130",
+  "version": "0.5.131",
   "description": "Tensorlake native Node.js binding for Linux arm64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-arm64/package.json
+++ b/typescript/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-arm64-gnu",
-  "version": "0.5.130",
+  "version": "0.5.131",
   "description": "Tensorlake native Node.js binding for Linux arm64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64-musl/package.json
+++ b/typescript/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-x64-musl",
-  "version": "0.5.130",
+  "version": "0.5.131",
   "description": "Tensorlake native Node.js binding for Linux x64 (musl)",
   "repository": {
     "type": "git",

--- a/typescript/npm/linux-x64/package.json
+++ b/typescript/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-linux-x64-gnu",
-  "version": "0.5.130",
+  "version": "0.5.131",
   "description": "Tensorlake native Node.js binding for Linux x64 (glibc)",
   "repository": {
     "type": "git",

--- a/typescript/npm/win32-x64/package.json
+++ b/typescript/npm/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake-native-win32-x64",
-  "version": "0.5.130",
+  "version": "0.5.131",
   "description": "Tensorlake native Node.js binding for Windows x64",
   "repository": {
     "type": "git",

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tensorlake",
-  "version": "0.5.130",
+  "version": "0.5.131",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tensorlake",
-      "version": "0.5.130",
+      "version": "0.5.131",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.0",
@@ -39,12 +39,12 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "tensorlake-native-darwin-arm64": "0.5.130",
-        "tensorlake-native-linux-arm64-gnu": "0.5.130",
-        "tensorlake-native-linux-arm64-musl": "0.5.130",
-        "tensorlake-native-linux-x64-gnu": "0.5.130",
-        "tensorlake-native-linux-x64-musl": "0.5.130",
-        "tensorlake-native-win32-x64": "0.5.130"
+        "tensorlake-native-darwin-arm64": "0.5.131",
+        "tensorlake-native-linux-arm64-gnu": "0.5.131",
+        "tensorlake-native-linux-arm64-musl": "0.5.131",
+        "tensorlake-native-linux-x64-gnu": "0.5.131",
+        "tensorlake-native-linux-x64-musl": "0.5.131",
+        "tensorlake-native-win32-x64": "0.5.131"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3250,8 +3250,8 @@
       }
     },
     "node_modules/tensorlake-native-darwin-arm64": {
-      "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.130.tgz",
+      "version": "0.5.131",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-darwin-arm64/-/tensorlake-native-darwin-arm64-0.5.131.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3265,8 +3265,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-arm64-gnu": {
-      "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.130.tgz",
+      "version": "0.5.131",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-gnu/-/tensorlake-native-linux-arm64-gnu-0.5.131.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3283,8 +3283,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-arm64-musl": {
-      "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.130.tgz",
+      "version": "0.5.131",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-arm64-musl/-/tensorlake-native-linux-arm64-musl-0.5.131.tgz",
       "cpu": [
         "arm64"
       ],
@@ -3301,8 +3301,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-x64-gnu": {
-      "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.130.tgz",
+      "version": "0.5.131",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-gnu/-/tensorlake-native-linux-x64-gnu-0.5.131.tgz",
       "cpu": [
         "x64"
       ],
@@ -3319,8 +3319,8 @@
       }
     },
     "node_modules/tensorlake-native-linux-x64-musl": {
-      "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.130.tgz",
+      "version": "0.5.131",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-linux-x64-musl/-/tensorlake-native-linux-x64-musl-0.5.131.tgz",
       "cpu": [
         "x64"
       ],
@@ -3337,8 +3337,8 @@
       }
     },
     "node_modules/tensorlake-native-win32-x64": {
-      "version": "0.5.130",
-      "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.130.tgz",
+      "version": "0.5.131",
+      "resolved": "https://registry.npmjs.org/tensorlake-native-win32-x64/-/tensorlake-native-win32-x64-0.5.131.tgz",
       "cpu": [
         "x64"
       ],

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensorlake",
-  "version": "0.5.130",
+  "version": "0.5.131",
   "description": "TensorLake SDK for applications, sandboxes, and cloud services",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -96,11 +96,11 @@
     "ws": "^8.20.0"
   },
   "optionalDependencies": {
-    "tensorlake-native-darwin-arm64": "0.5.130",
-    "tensorlake-native-linux-arm64-gnu": "0.5.130",
-    "tensorlake-native-linux-arm64-musl": "0.5.130",
-    "tensorlake-native-linux-x64-gnu": "0.5.130",
-    "tensorlake-native-linux-x64-musl": "0.5.130",
-    "tensorlake-native-win32-x64": "0.5.130"
+    "tensorlake-native-darwin-arm64": "0.5.131",
+    "tensorlake-native-linux-arm64-gnu": "0.5.131",
+    "tensorlake-native-linux-arm64-musl": "0.5.131",
+    "tensorlake-native-linux-x64-gnu": "0.5.131",
+    "tensorlake-native-linux-x64-musl": "0.5.131",
+    "tensorlake-native-win32-x64": "0.5.131"
   }
 }

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -53,6 +53,8 @@ const GPU_MODELS = new Set<string>([
   "H100",
   "T4",
   "A6000",
+  "RTX-PRO-6000-BLACKWELL-SERVER",
+  "L40",
   "A10",
 ]);
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -53,7 +53,7 @@ const GPU_MODELS = new Set<string>([
   "H100",
   "T4",
   "A6000",
-  "RTX-PRO-6000-BLACKWELL-SERVER",
+  "RTX-PRO-6000",
   "L40",
   "A10",
 ]);

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -80,7 +80,7 @@ export type GpuModel =
   | "H100"
   | "T4"
   | "A6000"
-  | "RTX-PRO-6000-BLACKWELL-SERVER"
+  | "RTX-PRO-6000"
   | "L40"
   | "A10";
 

--- a/typescript/src/models.ts
+++ b/typescript/src/models.ts
@@ -80,6 +80,8 @@ export type GpuModel =
   | "H100"
   | "T4"
   | "A6000"
+  | "RTX-PRO-6000-BLACKWELL-SERVER"
+  | "L40"
   | "A10";
 
 /** A homogeneous GPU allocation for a sandbox. */

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -204,7 +204,7 @@ describe("SandboxClient", () => {
       "H100",
       "T4",
       "A6000",
-      "RTX-PRO-6000-BLACKWELL-SERVER",
+      "RTX-PRO-6000",
       "L40",
       "A10",
     ] satisfies GpuModel[])("creates a %s GPU sandbox", async (model) => {

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -204,6 +204,8 @@ describe("SandboxClient", () => {
       "H100",
       "T4",
       "A6000",
+      "RTX-PRO-6000-BLACKWELL-SERVER",
+      "L40",
       "A10",
     ] satisfies GpuModel[])("creates a %s GPU sandbox", async (model) => {
       const stub = installNativeStub({


### PR DESCRIPTION
Sandbox requests currently reject RTX PRO 6000 Blackwell Server Edition and NVIDIA L40. Add `RTX-PRO-6000` and `L40` to the existing Python, TypeScript, and Rust SDK model lists and CLI `--gpu-model` choices. L40 remains distinct from L40S; this keeps the current enum design.

Validation (light pass requested):
- Rust GPU SDK/CLI tests: 14 passed.
- TypeScript client tests: 92 passed; typecheck and lint on changed TypeScript files passed.
- Python GPU request serialization: both new models and A6000 passed.
- The broader Python client suite could not run successfully without the native Rust client extension. Repository-wide TypeScript lint reports existing errors in untouched fixture/get-or-create files.

Requires matching server/dataplane support and capacity. No deployment or release is included.


Public GPU requests now use `RTX-PRO-6000`, meaning the 96 GB Blackwell Server Edition. Physical discovery names, protobuf values, and Platform API billing identifiers are unchanged. The server still recognizes the old long name when processing historical usage. This rename has not been deployed.
